### PR TITLE
Add info about __VU variable max values based on instance tiers. 

### DIFF
--- a/src/data/markdown/docs/03 cloud/07 Cloud FAQ/01 General.md
+++ b/src/data/markdown/docs/03 cloud/07 Cloud FAQ/01 General.md
@@ -338,6 +338,8 @@ For example, if you start a test with 900VUs, we will use 3x Tier 1 servers. Tha
 
 If you start a test with 1000VUs in a single load zone, we will use 1x Tier 2 server. If the same test is started in 2 load zones, there will be 500VUs per load zone and 4x Tier 1 servers will be used.
 
+> Note that these are the _defaults_. If your tests have specific requirements, please contact k6 support for a custom solution.
+
 ---
 
 ### Data uploads with k6 Cloud

--- a/src/data/markdown/translated-guides/en/02 Using k6/12 Execution context variables.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/12 Execution context variables.md
@@ -41,21 +41,20 @@ A numeric counter with the current iteration number for a specific VU. Zero-base
 
 Current VU number in use. The value is assigned incrementally for each new VU instance, starting from one. The variable will be 0 while executing the setup and teardown functions.
 
-It's important to remember that this value is shown _per server instance running you test_. How many servers we use depends on the size of your test and how you spread it across different load zones. So for a larger test, the value of `__VU` will likely not reflect the actual _total_ number of VUs in your test at a given moment.
+### ⚠️ To note when running in the k6 Cloud
 
-- For tests using **1-999** VUs per load zone, we use server instances that handle 300 VU's per machine. So for a 900 VU test using one load zone, there will be three instances and the value of `__VU` will vary from 1-300 per machine.
-- For tests using **1000-4001** VUs per load zone, we use server instances that handle 1200 VUs per machine. So for a 1000 VU, 1-load-zone test, your `__VU` value will go all the way to 1000.
+When you run your tests in the [k6 Cloud](/cloud) you will have additional [environment variables](/using-k6/environment-variables) that will tell you on which server, load zone and distribution of the test you are currently executing. You can read more about them [here](/using-k6/environment-variables). 
+
+The **\_\_VU** environment variable may also behave differently while running a test in the cloud. This is because the **\_\_VU** value is shown _per server instance running you test_. How many servers we use depends on the size of your test and how you spread it across different load zones. So for a larger test, the value of **\_\_VU** will likely not reflect the actual _total_ number of VUs in your test at a given moment.
+
+- For tests using **1-999** VUs per load zone, we use server instances that handle 300 VU's per machine. So for a 900 VU test using one load zone, there will be three instances and the value of **\_\_VU** will vary from 1-300 per machine.
+- For tests using **1000-4001** VUs per load zone, we use server instances that handle 1200 VUs per machine. So for a 1000 VU, 1-load-zone test, your **\_\_VU** value will go all the way to 1000.
 - For tests with **>4001** VUs per load zone, we use instances that handle 5000 VUs per machine.
 
-As an example, if you run a 1000 VU test evenly distributed over two load zones, there are 500 VUs per load zone. Since this is in the 1-999 VU bracket, we'll use server instances that handle 300VUs apiece. This means 2 instances per load zone and your individual `__VU` values will thus vary from 1 to 250.
+> Note that these are the _defaults_. If you have specific requirements, please contact k6 support for a custom solution.
 
+As an example, if you run a 1000 VU test evenly distributed over two load zones, there are 500 VUs per load zone. Since this is in the 1-999 VU bracket, we'll use server instances that handle 300VUs apiece. This means 2 instances per load zone and your individual **\_\_VU** values will thus vary from 1 to 250.
 
-> ### ⚠️ Additional context information available in the k6 Cloud
->
-> If you are running a test in [k6 Cloud](/cloud) you will have additional
-> [environment variables](/using-k6/environment-variables) that will tell you on which server, load zone
-> and distribution of the test you are currently executing. You can read more about them
-> [here](/using-k6/environment-variables)
 
 ## k6 Test Coordinator
 

--- a/src/data/markdown/translated-guides/en/02 Using k6/12 Execution context variables.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/12 Execution context variables.md
@@ -31,8 +31,7 @@ $ k6 run --vus 10 --iterations 100 script.js
 
 ## \_\_VU and \_\_ITER
 
-**\_\_VU** and **\_\_ITER** are both global variables with execution context information that k6 makes
-available to the test script.
+**\_\_VU** and **\_\_ITER** are both global variables with execution context information that k6 makes available to the test script.
 
 ### \_\_ITER
 
@@ -40,8 +39,16 @@ A numeric counter with the current iteration number for a specific VU. Zero-base
 
 ### \_\_VU
 
-Current VU number. The value is assigned incrementally for each new VU instance. One-based.
-However, VU number is 0 while executing the setup and teardown functions.
+Current VU number in use. The value is assigned incrementally for each new VU instance, starting from one. The variable will be 0 while executing the setup and teardown functions.
+
+It's important to remember that this value is shown _per server instance running you test_. How many servers we use depends on the size of your test and how you spread it across different load zones. So for a larger test, the value of `__VU` will likely not reflect the actual _total_ number of VUs in your test at a given moment.
+
+- For tests using **1-999** VUs per load zone, we use server instances that handle 300 VU's per machine. So for a 900 VU test using one load zone, there will be three instances and the value of `__VU` will vary from 1-300 per machine.
+- For tests using **1000-4001** VUs per load zone, we use server instances that handle 1200 VUs per machine. So for a 1000 VU, 1-load-zone test, your `__VU` value will go all the way to 1000.
+- For tests with **>4001** VUs per load zone, we use instances that handle 5000 VUs per machine.
+
+As an example, if you run a 1000 VU test evenly distributed over two load zones, there are 500 VUs per load zone. Since this is in the 1-999 VU bracket, we'll use server instances that handle 300VUs apiece. This means 2 instances per load zone and your individual `__VU` values will thus vary from 1 to 250.
+
 
 > ### ⚠️ Additional context information available in the k6 Cloud
 >

--- a/src/data/markdown/translated-guides/en/02 Using k6/12 Execution context variables.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/12 Execution context variables.md
@@ -41,19 +41,11 @@ A numeric counter with the current iteration number for a specific VU. Zero-base
 
 Current VU number in use. The value is assigned incrementally for each new VU instance, starting from one. The variable will be 0 while executing the setup and teardown functions.
 
-### ⚠️ To note when running in the k6 Cloud
-
-When you run your tests in the [k6 Cloud](/cloud) you will have additional [environment variables](/using-k6/environment-variables) that will tell you on which server, load zone and distribution of the test you are currently executing. You can read more about them [here](/using-k6/environment-variables). 
-
-The **\_\_VU** environment variable may also behave differently while running a test in the cloud. This is because the **\_\_VU** value is shown _per server instance running you test_. How many servers we use depends on the size of your test and how you spread it across different load zones. So for a larger test, the value of **\_\_VU** will likely not reflect the actual _total_ number of VUs in your test at a given moment.
-
-- For tests using **1-999** VUs per load zone, we use server instances that handle 300 VU's per machine. So for a 900 VU test using one load zone, there will be three instances and the value of **\_\_VU** will vary from 1-300 per machine.
-- For tests using **1000-4001** VUs per load zone, we use server instances that handle 1200 VUs per machine. So for a 1000 VU, 1-load-zone test, your **\_\_VU** value will go all the way to 1000.
-- For tests with **>4001** VUs per load zone, we use instances that handle 5000 VUs per machine.
-
-> Note that these are the _defaults_. If you have specific requirements, please contact k6 support for a custom solution.
-
-As an example, if you run a 1000 VU test evenly distributed over two load zones, there are 500 VUs per load zone. Since this is in the 1-999 VU bracket, we'll use server instances that handle 300VUs apiece. This means 2 instances per load zone and your individual **\_\_VU** values will thus vary from 1 to 250.
+> ### ⚠️ Running in the k6 Cloud
+>
+>When you run your tests in the [k6 Cloud](/cloud), the **\_\_VU** value you get will be per server/load generator. You can read the details in the (cloud docs)[/cloud/cloud-faq/general-questions/#how-many-vus-can-be-run-from-the-same-dedicated-ip].
+>
+>In k6-cloud you will also have additional [environment variables](/cloud/creating-and-running-a-test/cloud-tests-from-the-cli/#environment-variables) that will tell you on which server, load zone and distribution of the test you are currently executing.
 
 
 ## k6 Test Coordinator


### PR DESCRIPTION
Resolves #332.

I ended up adding more of the 'math' to this (despite the recommendation in the ticket) since that seemed prudent to understand what was going on. 

As a note - the 'staging' version of the docs doesn't seem to have a freeform search? It's often a nightmare to figure out just where these pages are actually ending up in the final documentation and the naming scheme of individual files is beyond confusing ... 