### PR TITLE
Fix one-liner envvars for Windows powershell/cmd. Resolve #341.

### DIFF
--- a/src/data/markdown/translated-guides/en/02 Using k6/05 Options.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/05 Options.md
@@ -138,12 +138,24 @@ You can also set the same options through a config file:
 
 Or set some of the previous options via environment variables and command-line flags:
 
-<CodeGroup labels={["Bash"]} lineNumbers={[true]}>
+<CodeGroup labels={["Bash", "Windows: CMD", "Windows: PowerShell"]} lineNumbers={[false]}>
 
 ```bash
-$ K6_NO_CONNECTION_REUSE=true K6_USER_AGENT="MyK6UserAgentString/1.0" k6 run ~/script.js
+$ K6_NO_CONNECTION_REUSE=true K6_USER_AGENT="MyK6UserAgentString/1.0" k6 run script.js
 
-$ k6 run --no-connection-reuse --user-agent "MyK6UserAgentString/1.0" ~/script.js
+$ k6 run --no-connection-reuse --user-agent "MyK6UserAgentString/1.0" script.js
+```
+
+```bash
+c:\\k6> set "K6_NO_CONNECTION_REUSE=true" && set "K6_USER_AGENT=MyK6UserAgentString/1.0" && k6 run script.js
+
+c:\\k6> k6 run --no-connection-reuse --user-agent "MyK6UserAgentString/1.0" script.js
+```
+
+```bash
+c:\\k6> $env:K6_NO_CONNECTION_REUSE=true ; $env:K6_USER_AGENT="MyK6UserAgentString/1.0" ; k6 -run script.js
+
+c:\\k6> k6 run --no-connection-reuse --user-agent "MyK6UserAgentString/1.0" script.js
 ```
 
 </CodeGroup>
@@ -507,7 +519,7 @@ Pass the real system [environment variables](/using-k6/environment-variables) to
 | --- | --------------------------- | ------------------ | ---------------------------------------------------------------------------------------------------- |
 | N/A | `--include-system-env-vars` | N/A                | `true` for `k6 run`, but `false` for all other commands to prevent inadvertent sensitive data leaks. |
 
-<CodeGroup labels={[ "Shell" ]} lineNumbers={[true]}>
+<CodeGroup labels={["Shell" ]} lineNumbers={[false]}>
 
 ```bash
 $ k6 run --include-system-env-vars ~/script.js
@@ -957,7 +969,7 @@ It is a shortcut option for a single [scenario](/using-k6/scenarios) with a [ram
 | ----------- | ------------------------------------------------------- | ------------------ | ------------------------------ |
 | `K6_STAGES` | `--stage <duration>:<target>`, `-s <duration>:<target>` | `stages`           | Based on `vus` and `duration`. |
 
-<CodeGroup labels={["Code", "Shell"]} lineNumbers={[true]}>
+<CodeGroup labels={["Code", "Bash", "Windows: CMD", "Windows: PowerShell"]} lineNumbers={[true]}>
 
 ```javascript
 // The following config would have k6 ramping up from 1 to 10 VUs for 3 minutes,
@@ -981,6 +993,24 @@ $ k6 run --stage 5s:10,5m:20,10s:5 ~/script.js
 # or...
 
 $ K6_STAGES="5s:10,5m:20,10s:5" k6 run ~/script.js
+```
+
+```bash
+c://k6> k6 run --stage 5s:10,5m:20,10s:5 ~/script.js
+
+# or...
+
+c://k6> set "K6_STAGES=5s:10,5m:20,10s:5" && k6 run ~/script.js
+
+```
+
+```bash
+c://k6> k6 run --stage 5s:10,5m:20,10s:5 ~/script.js
+
+# or...
+
+c://k6> $env:K6_STAGES="5s:10,5m:20,10s:5" ; k6 run ~/script.js
+
 ```
 
 </CodeGroup>

--- a/src/data/markdown/translated-guides/en/02 Using k6/05 Options.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/05 Options.md
@@ -153,7 +153,7 @@ C:\k6> k6 run --no-connection-reuse --user-agent "MyK6UserAgentString/1.0" scrip
 ```
 
 ```bash
-PS C:\k6> $env:K6_NO_CONNECTION_REUSE=true; $env:K6_USER_AGENT="MyK6UserAgentString/1.0"; k6 -run script.js
+PS C:\k6> $env:K6_NO_CONNECTION_REUSE=true; $env:K6_USER_AGENT="MyK6UserAgentString/1.0"; k6 run script.js
 
 PS C:\k6> k6 run --no-connection-reuse --user-agent "MyK6UserAgentString/1.0" script.js
 ```
@@ -969,7 +969,7 @@ It is a shortcut option for a single [scenario](/using-k6/scenarios) with a [ram
 | ----------- | ------------------------------------------------------- | ------------------ | ------------------------------ |
 | `K6_STAGES` | `--stage <duration>:<target>`, `-s <duration>:<target>` | `stages`           | Based on `vus` and `duration`. |
 
-<CodeGroup labels={["Code", "Bash", "Windows: CMD", "Windows: PowerShell"]} lineNumbers={[true]}>
+<CodeGroup labels={["Code", "Bash", "Windows: CMD", "Windows: PowerShell"]} lineNumbers={[false]}>
 
 ```javascript
 // The following config would have k6 ramping up from 1 to 10 VUs for 3 minutes,
@@ -988,28 +988,28 @@ export let options = {
 ```
 
 ```bash
-$ k6 run --stage 5s:10,5m:20,10s:5 ~/script.js
+$ k6 run --stage 5s:10,5m:20,10s:5 script.js
 
 # or...
 
-$ K6_STAGES="5s:10,5m:20,10s:5" k6 run ~/script.js
+$ K6_STAGES="5s:10,5m:20,10s:5" k6 run script.js
 ```
 
 ```bash
-C:\k6> k6 run --stage 5s:10,5m:20,10s:5 ~/script.js
+C:\k6> k6 run --stage 5s:10,5m:20,10s:5 script.js
 
 # or...
 
-C:\k6> set "K6_STAGES=5s:10,5m:20,10s:5" && k6 run ~/script.js
+C:\k6> set "K6_STAGES=5s:10,5m:20,10s:5" && k6 run script.js
 
 ```
 
 ```bash
-C:\k6> k6 run --stage 5s:10,5m:20,10s:5 ~/script.js
+C:\k6> k6 run --stage 5s:10,5m:20,10s:5 script.js
 
 # or...
 
-C:\k6> $env:K6_STAGES="5s:10,5m:20,10s:5"; k6 run ~/script.js
+C:\k6> $env:K6_STAGES="5s:10,5m:20,10s:5"; k6 run script.js
 
 ```
 
@@ -1029,14 +1029,32 @@ Available in the `k6 run` command.
 | ------------------- | ----------------------------- | ------------------ | ------- |
 | `K6_SUMMARY_EXPORT` | `--summary-export <filename>` | N/A                | `null`  |
 
-<CodeGroup labels={[ "Shell" ]} lineNumbers={[true]}>
+<CodeGroup labels={["Bash", "Windows: CMD", "Windows: PowerShell"]} lineNumbers={[false]}>
 
 ```bash
-$ k6 run --summary-export export.json ~/script.js
+$ k6 run --summary-export export.json script.js
 
 # or...
 
-$ K6_SUMMARY_EXPORT="export.json" k6 run ~/script.js
+$ K6_SUMMARY_EXPORT="export.json" k6 run script.js
+```
+
+```bash
+C:\k6> k6 run --summary-export export.json script.js
+
+# or...
+
+C:\k6> set "K6_SUMMARY_EXPORT=export.json" && k6 run script.js
+
+```
+
+```bash
+C:\k6> k6 run --summary-export export.json script.js
+
+# or...
+
+C:\k6> $env:K6_SUMMARY_EXPORT="export.json"; k6 run script.js
+
 ```
 
 </CodeGroup>

--- a/src/data/markdown/translated-guides/en/02 Using k6/05 Options.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/05 Options.md
@@ -147,15 +147,15 @@ $ k6 run --no-connection-reuse --user-agent "MyK6UserAgentString/1.0" script.js
 ```
 
 ```bash
-c:\\k6> set "K6_NO_CONNECTION_REUSE=true" && set "K6_USER_AGENT=MyK6UserAgentString/1.0" && k6 run script.js
+C:\k6> set "K6_NO_CONNECTION_REUSE=true" && set "K6_USER_AGENT=MyK6UserAgentString/1.0" && k6 run script.js
 
-c:\\k6> k6 run --no-connection-reuse --user-agent "MyK6UserAgentString/1.0" script.js
+C:\k6> k6 run --no-connection-reuse --user-agent "MyK6UserAgentString/1.0" script.js
 ```
 
 ```bash
-c:\\k6> $env:K6_NO_CONNECTION_REUSE=true ; $env:K6_USER_AGENT="MyK6UserAgentString/1.0" ; k6 -run script.js
+PS C:\k6> $env:K6_NO_CONNECTION_REUSE=true; $env:K6_USER_AGENT="MyK6UserAgentString/1.0"; k6 -run script.js
 
-c:\\k6> k6 run --no-connection-reuse --user-agent "MyK6UserAgentString/1.0" script.js
+PS C:\k6> k6 run --no-connection-reuse --user-agent "MyK6UserAgentString/1.0" script.js
 ```
 
 </CodeGroup>
@@ -996,20 +996,20 @@ $ K6_STAGES="5s:10,5m:20,10s:5" k6 run ~/script.js
 ```
 
 ```bash
-c://k6> k6 run --stage 5s:10,5m:20,10s:5 ~/script.js
+C:\k6> k6 run --stage 5s:10,5m:20,10s:5 ~/script.js
 
 # or...
 
-c://k6> set "K6_STAGES=5s:10,5m:20,10s:5" && k6 run ~/script.js
+C:\k6> set "K6_STAGES=5s:10,5m:20,10s:5" && k6 run ~/script.js
 
 ```
 
 ```bash
-c://k6> k6 run --stage 5s:10,5m:20,10s:5 ~/script.js
+C:\k6> k6 run --stage 5s:10,5m:20,10s:5 ~/script.js
 
 # or...
 
-c://k6> $env:K6_STAGES="5s:10,5m:20,10s:5" ; k6 run ~/script.js
+C:\k6> $env:K6_STAGES="5s:10,5m:20,10s:5"; k6 run ~/script.js
 
 ```
 

--- a/src/data/markdown/translated-guides/en/02 Using k6/11 Environment variables.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/11 Environment variables.md
@@ -39,11 +39,11 @@ $ MY_HOSTNAME=test.k6.io k6 run script.js
 ```
 
 ```bash
-c:\\k6> set MY_HOSTNAME=\"test.k6.io\"\nc:\\k6> k6 run script.js
+c:\\k6> set "MY_HOSTNAME=test.k6.io" && k6 run script.js
 ```
 
 ```bash
-c:\\k6> $env:MY_HOSTNAME = \"test.k6.io\"\nc:\\k6> k6 run script.js
+c:\\k6> $env:MY_HOSTNAME = "test.k6.io" ; k6 run script.js
 ```
 
 </CodeGroup>

--- a/src/data/markdown/translated-guides/en/02 Using k6/11 Environment variables.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/11 Environment variables.md
@@ -39,11 +39,11 @@ $ MY_HOSTNAME=test.k6.io k6 run script.js
 ```
 
 ```bash
-c:\\k6> set "MY_HOSTNAME=test.k6.io" && k6 run script.js
+C:\k6> set "MY_HOSTNAME=test.k6.io" && k6 run script.js
 ```
 
 ```bash
-c:\\k6> $env:MY_HOSTNAME = "test.k6.io" ; k6 run script.js
+PS C:\k6> $env:MY_HOSTNAME="test.k6.io"; k6 run script.js
 ```
 
 </CodeGroup>


### PR DESCRIPTION
This aims to resolve https://github.com/grafana/k6-docs/issues/341. That issue indicates problems with the Powershell one-liners, but looking at the code blocks suggested issues with the CMD blocks as well - notably they tried to specify the envvars on two lines using `\n` which was ignored in the verbatim field (all ended up as one line and looked very messy).  

To set up one-liner Windows CMD blocks, I referenced this: 
https://stackoverflow.com/questions/23420340/windows-command-prompt-using-a-variable-set-in-the-same-line-of-a-one-liner

I also updated the Powershell examples to use one-liners, using the links suggested in the issue:
https://stackoverflow.com/questions/1420719/powershell-setting-an-environment-variable-for-a-single-command-only

I however have no Windows machine easily available to test these examples. :/ 