### PR TITLE
Show docker example for output JSON data

### DIFF
--- a/src/data/markdown/translated-guides/en/04 Results visualization/07 JSON.md
+++ b/src/data/markdown/translated-guides/en/04 Results visualization/07 JSON.md
@@ -5,13 +5,23 @@ excerpt: 'You can also make k6 output detailed statistics in JSON format by usin
 
 You can also make k6 output detailed statistics in JSON format by using the `--out/-o` option for `k6 run`, like this:
 
-<CodeGroup labels={["CLI"]}>
+<CodeGroup labels={["CLI", "Docker"]}>
 
 ```bash
 $ k6 run --out json=my_test_result.json script.js
 ```
 
+```bash
+$ docker run -it --rm \
+    -v <scriptdir>:/scripts \
+    -v <outputdir>:/jsonoutput \
+    loadimpact/k6 run --out json=/jsonoutput/my_test_result.json /scripts/script.js
+
+# Note that the docker user must have permission to write to <outputdir>!
+```
+
 </CodeGroup>
+
 
 ## JSON format
 


### PR DESCRIPTION
This aims to resolve https://github.com/grafana/k6-docs/issues/321 .

This adds a pane explaining how to output JSON data when running k6 from docker. I also tested this but made the instruction OS-generic by generalizing the names for input/outputdirs (the `$PWD` doesn't exist for Windows shells in the same way after all). 