### PR TITLE
feat: add showCopyButton prop for CodeGroup component (defaults to true)

### DIFF
--- a/src/components/shared/code/code-group.js
+++ b/src/components/shared/code/code-group.js
@@ -37,7 +37,7 @@ const CodeGroup = ({
               showLineNumbers={lineNumbers[i]}
               key={i}
               showHeightToggler={heightTogglers[i]}
-              showCopyButton={showCopyButton}
+              showCopyButton={showCopyButton[i]}
             >
               {child.props.children}
             </Code>
@@ -53,7 +53,7 @@ CodeGroup.propTypes = {
   labels: PropTypes.arrayOf(PropTypes.string),
   lineNumbers: PropTypes.arrayOf(PropTypes.bool),
   heightTogglers: PropTypes.arrayOf(PropTypes.bool),
-  showCopyButton: PropTypes.bool,
+  showCopyButton: PropTypes.arrayOf(PropTypes.bool),
 };
 
 CodeGroup.defaultProps = {
@@ -61,7 +61,7 @@ CodeGroup.defaultProps = {
   labels: [],
   lineNumbers: [],
   heightTogglers: [],
-  showCopyButton: true,
+  showCopyButton: [],
 };
 
 export default CodeGroup;

--- a/src/components/shared/code/code-group.js
+++ b/src/components/shared/code/code-group.js
@@ -4,7 +4,13 @@ import React, { useState } from 'react';
 import Code from './code';
 import styles from './code-group.module.scss';
 
-const CodeGroup = ({ children, labels, lineNumbers, heightTogglers }) => {
+const CodeGroup = ({
+  children,
+  labels,
+  lineNumbers,
+  heightTogglers,
+  showCopyButton,
+}) => {
   const [currentIndex, setCurrentIndex] = useState(0);
   return (
     <div className={styles.wrapper}>
@@ -31,6 +37,7 @@ const CodeGroup = ({ children, labels, lineNumbers, heightTogglers }) => {
               showLineNumbers={lineNumbers[i]}
               key={i}
               showHeightToggler={heightTogglers[i]}
+              showCopyButton={showCopyButton}
             >
               {child.props.children}
             </Code>
@@ -46,6 +53,7 @@ CodeGroup.propTypes = {
   labels: PropTypes.arrayOf(PropTypes.string),
   lineNumbers: PropTypes.arrayOf(PropTypes.bool),
   heightTogglers: PropTypes.arrayOf(PropTypes.bool),
+  showCopyButton: PropTypes.bool,
 };
 
 CodeGroup.defaultProps = {
@@ -53,6 +61,7 @@ CodeGroup.defaultProps = {
   labels: [],
   lineNumbers: [],
   heightTogglers: [],
+  showCopyButton: true,
 };
 
 export default CodeGroup;

--- a/src/components/shared/code/code.js
+++ b/src/components/shared/code/code.js
@@ -28,7 +28,12 @@ const getLanguageDeclaration = (str) => {
   return 'plain';
 };
 
-const Code = ({ children, showLineNumbers, showHeightToggler }) => {
+const Code = ({
+  children,
+  showLineNumbers,
+  showHeightToggler,
+  showCopyButton,
+}) => {
   if (!children) return null;
 
   const containerRef = useRef(null);
@@ -69,8 +74,17 @@ const Code = ({ children, showLineNumbers, showHeightToggler }) => {
     copyBtnContent = copyBtnContent.replace(/^\$\s/gm, '');
   }
 
+  const Wrapper = ({ children }) => (
+    <>
+      {showCopyButton && (
+        <WithCopyButton dataToCopy={copyBtnContent}>{children}</WithCopyButton>
+      )}
+      {!showCopyButton && <>{children}</>}
+    </>
+  );
+
   return (
-    <WithCopyButton dataToCopy={copyBtnContent}>
+    <Wrapper>
       <Highlight
         {...defaultProps}
         code={children.props?.children}
@@ -111,7 +125,7 @@ const Code = ({ children, showLineNumbers, showHeightToggler }) => {
       </Highlight>
       <div className={styles.overlay} style={overlayStyles} />
       {toggler}
-    </WithCopyButton>
+    </Wrapper>
   );
 };
 
@@ -119,12 +133,14 @@ Code.propTypes = {
   children: PropTypes.node,
   showLineNumbers: PropTypes.bool,
   showHeightToggler: PropTypes.bool,
+  showCopyButton: PropTypes.bool,
 };
 
 Code.defaultProps = {
   children: null,
   showLineNumbers: false,
   showHeightToggler: false,
+  showCopyButton: true,
 };
 
 export default Code;


### PR DESCRIPTION
This PR adds `showCopyButton` prop for `CodeBlock` component (defaults to `true` for each `Code` part).

**Screenshots**
`<CodeGroup labels={["CLI", "Docker"]} showCopyButton={[false, true]}>` results in:
![image](https://user-images.githubusercontent.com/10406201/131359505-1356f082-dc0d-4b45-9ad5-ded43fe75297.png)
![image](https://user-images.githubusercontent.com/10406201/131359555-419a2469-53a1-444e-89f2-202099300924.png)
