### PR TITLE
fix: show footer navigation for pages with custom slugs

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -234,7 +234,7 @@ function generateSidebar({ nodes, type = 'docs' }) {
       unorderify(stripDirectoryPath(relativeDirectory, type)),
       unorderify(name),
       {
-        path: slug || dotifyVersion(pageSlug),
+        path: slug ? addTrailingSlash(slug) : dotifyVersion(pageSlug),
         title,
         redirect: replaceRestApiRedirect({ isProduction, title, redirect }),
         redirectTarget,

--- a/src/templates/doc-page.js
+++ b/src/templates/doc-page.js
@@ -47,9 +47,13 @@ export default function DocPage(props) {
     sidebarTree.name === 'es' ||
     sidebarTree.name === 'en'
   ) {
+    const slugWithSlash = frontmatter.slug.startsWith('/')
+      ? frontmatter.slug
+      : `/${frontmatter.slug}`;
     const flatSidebar = flattenSidebarTree(sidebarTree);
+
     const currentIndex = flatSidebar.findIndex(
-      (elem) => elem.path === `/${frontmatter.slug}`,
+      (elem) => elem.path === slugWithSlash,
     );
 
     if (currentIndex > 0) {


### PR DESCRIPTION
This PR fixes display of `prev`/`next` footer links on [https://k6.io/docs/cloud/analyzing-results/logs](https://k6.io/docs/cloud/analyzing-results/logs) page.
