### PR TITLE
WIP: use main branch in github actions

### DIFF
--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -10,7 +10,7 @@ env:
 
 on:
   pull_request:
-    branches: master
+    branches: main
 
 jobs:
   update-dependencies:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -3,7 +3,7 @@ name: Staging
 on:
   push:
     branches:
-      - master
+      - main
 
 env:
   ALGOLIA_ADMIN_KEY: ${{ secrets.STAGING_CI_ALGOLIA_ADMIN_KEY }}


### PR DESCRIPTION
This PR replaces master branch to main in github actions. Should be merged after master is renamed.