### PR TITLE
Clarified the iterationInTest description

### DIFF
--- a/src/data/markdown/docs/02 javascript api/06 k6-execution.md
+++ b/src/data/markdown/docs/02 javascript api/06 k6-execution.md
@@ -39,29 +39,29 @@ export default function() {
 ### scenario
 | Field               | Type    | Description                                                              |
 |---------------------|---------|--------------------------------------------------------------------------|
-| name                | string  | The assigned name of the running scenario.                                |
-| executor            | string  | The name of the running [Executor](https://k6.io/docs/using-k6/scenarios/#executors) type.                                                |
-| startTime           | integer | The Unix timestamp in milliseconds when the scenario started.                                                                           |
-| progress            | float   | Percentage in a 0 to 1 interval of the scenario progress.                    |
+| name                | string  | The assigned name of the running scenario. |
+| executor            | string  | The name of the running [Executor](https://k6.io/docs/using-k6/scenarios/#executors) type. |
+| startTime           | integer | The Unix timestamp in milliseconds when the scenario started. |
+| progress            | float   | Percentage in a 0 to 1 interval of the scenario progress. |
 | iterationInInstance | integer | The unique and zero-based sequential number of the current iteration in the scenario, across the current instance. |
-| iterationInTest     | integer | The unique and zero-based sequential number of the current iteration in the scenario, across the entire test. It is unique in all k6 execution modes - in local, cloud and distributed/segmented test runs. However, while every instance will get non-overlapping index values in cloud/distributed tests, they might iterate over them at different speeds, so the values won't be sequential across them. |
+| iterationInTest     | integer | The unique and zero-based sequential number of the current iteration in the scenario. It is unique in all k6 execution modes - in local, cloud and distributed/segmented test runs. However, while every instance will get non-overlapping index values in cloud/distributed tests, they might iterate over them at different speeds, so the values won't be sequential across them. |
 
 ### instance
-| Field               | Type    | Description                                                              |
-|---------------------|---------|--------------------------------------------------------------------------|
-| iterationsInterrupted                | integer  | The number of prematurely interrupted iterations in the current instance. |
-| iterationsCompleted     | integer | The number of completed iterations in the current instance.  |
-| vusActive            | integer  | The number of active VUs.                                                |
-| vusInitialized           | integer | The number of currently initialized VUs.                                                                           |
-| currentTestRunDuration            | float   | The time passed from the start of the current test run in milliseconds.                    |
+| Field                  | Type    | Description                                                              |
+|------------------------|---------|--------------------------------------------------------------------------|
+| iterationsInterrupted  | integer | The number of prematurely interrupted iterations in the current instance. |
+| iterationsCompleted    | integer | The number of completed iterations in the current instance. |
+| vusActive              | integer | The number of active VUs. |
+| vusInitialized         | integer | The number of currently initialized VUs. |
+| currentTestRunDuration | float   | The time passed from the start of the current test run in milliseconds. |
 
 ### vu 
 | Field               | Type    | Description                                                              |
 |---------------------|---------|--------------------------------------------------------------------------|
-| iterationInInstance | integer | The identifier of the iteration in the current instance.                                                                 |
-| iterationInScenario | integer | The identifier of the iteration in the current scenario.                  |
-| idInInstance        | integer | The identifier of the VU across the instance.                            |
-| idInTest            | integer | The globally unique (across the whole test run) identifier of the VU.                                  |
+| iterationInInstance | integer | The identifier of the iteration in the current instance. |
+| iterationInScenario | integer | The identifier of the iteration in the current scenario. |
+| idInInstance        | integer | The identifier of the VU across the instance. |
+| idInTest            | integer | The globally unique (across the whole test run) identifier of the VU. |
 
 ### Examples and use cases
 **Get unique data once**


### PR DESCRIPTION
`iterationInTest` is unique only across the current scenario and not for the entire test/cross scenarios.

Inspired from [this forum question](https://community.k6.io/t/when-parameterizing-data-how-do-i-not-use-the-same-data-more-than-once-in-a-test/42/17) 