### PR TITLE
feat: Code copy button on hover

### DIFF
--- a/src/components/shared/with-copy-button/with-copy-button.module.scss
+++ b/src/components/shared/with-copy-button/with-copy-button.module.scss
@@ -1,8 +1,15 @@
 .wrapper {
   position: relative;
+
+  @include hover-supported {
+    & .copy-button {
+      opacity: 1;
+    }
+  }
 }
 
 .copy-button {
+  opacity: 0;
   position: absolute;
   top: 10px;
   right: 10px;
@@ -18,4 +25,10 @@
   color: $color-tertiary;
   text-transform: uppercase;
   cursor: pointer;
+  transition: opacity 0.3s;
+
+  // always display the button if device has no hover
+  @media (hover: none) {
+    opacity: 1;
+  }
 }


### PR DESCRIPTION
This PR adds logic to only display `Copy` button on hover.
The `showCopyButton` logic is preserved (if it's set to `false`, Copy button is not available).