### PR TITLE
Fix wrong mention that --quiet has JS or ENV variable support

### DIFF
--- a/src/data/markdown/translated-guides/en/02 Using k6/05 Options.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/05 Options.md
@@ -866,9 +866,9 @@ export let options = {
 
 A boolean, true or false, that disables the progress update bar on the console output. Available in `k6 run` and `k6 cloud` commands.
 
-| Env         | CLI              | Code / Config file | Default |
-| ----------- | ---------------- | ------------------ | ------- |
-| `K6_QUIET`  | `--quiet`, `-q`  | `quiet`            | `false` |
+| Env | CLI              | Code / Config file | Default |
+| --- | ---------------- | ------------------ | ------- |
+| N/A | `--quiet`, `-q`  | N/A                | `false` |
 
 <CodeGroup labels={[]} lineNumbers={[true]}>
 

--- a/src/data/markdown/translated-guides/es/02 Using k6/05 Options.md
+++ b/src/data/markdown/translated-guides/es/02 Using k6/05 Options.md
@@ -776,9 +776,9 @@ export let options = {
 
 Un booleano, verdadero o falso, que deshabilita la barra de progreso en la salida del terminal. Disponible en los commands `k6 run` y `k6 cloud`.
 
-| Env         | CLI              | Code / Config file | Default |
-| ----------- | ---------------- | ------------------ | ------- |
-| `K6_QUIET`  | `--quiet`, `-q`  | `quiet`            | `false` |
+| Env | CLI              | Code / Config file | Default |
+| --- | ---------------- | ------------------ | ------- |
+| N/A | `--quiet`, `-q`  | N/A                | `false` |
 
 <CodeGroup labels={[]} lineNumbers={[true]}>
 


### PR DESCRIPTION
Quiet can currently be configured only through the CLI flags, [there's a TODO to add an env variable](https://github.com/grafana/k6/blob/e0d8d9336f77fd8b4dc50c840ac7aedfac43574b/cmd/root.go#L71-L72) (and it probably won't ever be configurable from the JS/JSON options, since it needs to take affect before the script file is read)

Previous PR/issue: https://github.com/grafana/k6-docs/pull/417 / https://github.com/grafana/k6-docs/issues/315 