### PR TITLE
[docs] Change url(url) -> url`url` on http.url

### DIFF
--- a/src/data/markdown/docs/02 javascript api/08 k6-http.md
+++ b/src/data/markdown/docs/02 javascript api/08 k6-http.md
@@ -17,8 +17,8 @@ The k6/http module contains functionality for performing HTTP transactions.
 | [post( url, [body], [params] )](/javascript-api/k6-http/post-url-body-params)  | Issue an HTTP POST request. |
 | [put( url, [body], [params] )](/javascript-api/k6-http/put-url-body-params)  | Issue an HTTP PUT request. |
 | [request( method, url, [body], [params] )](/javascript-api/k6-http/request-method-url-body-params)  | Issue any type of HTTP request. |
-| [url( url )](/javascript-api/k6-http/url-url) | Creates a URL with a name tag. Read more on [URL Grouping](/using-k6/http-requests#url-grouping). |
 | [setResponseCallback(expectedStatuses)](/javascript-api/k6-http/setresponsecallback-callback)  | Sets a response callback to mark responses as expected. |
+| [url\`url\`](/javascript-api/k6-http/urlurl) | Creates a URL with a name tag. Read more on [URL Grouping](/using-k6/http-requests#url-grouping). |
 | [expectedStatuses( statusCodes )](/javascript-api/k6-http/expectedstatuses-statuses)  | Create a callback for setResponseCallback that checks status codes. |
 
 | Class | Description |

--- a/src/data/markdown/docs/02 javascript api/08 k6-http/10-url- url- .md
+++ b/src/data/markdown/docs/02 javascript api/08 k6-http/10-url- url- .md
@@ -1,5 +1,5 @@
 ---
-title: 'url( url )'
+title: 'url`url`'
 description: 'Creates a URL with a name tag.'
 excerpt: 'Creates a URL with a name tag.'
 ---


### PR DESCRIPTION
Change _url(url)_ to _url\`url\`_.

![Screenshot 2021-10-06 at 17 21 26](https://user-images.githubusercontent.com/10167318/136221968-6af3f230-8bcd-47f1-aa42-d3f78b5a6138.png)


