### PR TITLE
Docs/k6 options

### DIFF
--- a/src/data/markdown/translated-guides/en/02 Using k6/05 Options.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/05 Options.md
@@ -179,7 +179,9 @@ and `k6 cloud ...` that can be used to override options specified in the code.
 
 ### Address
 
-Address of the API server. When executing scripts with `k6 run` an HTTP server with a REST API is spun up, which can be used to control some of the parameters of the test execution. By default, the server listens on `localhost:6565`. Read more on [k6 REST API](/misc/k6-rest-api).
+Address of the API server. When executing scripts with `k6 run` an HTTP server with a REST API is spun up,
+which can be used to control some of the parameters of the test execution.
+By default, the server listens on `localhost:6565`. Read more on [k6 REST API](/misc/k6-rest-api).
 
 | Env | CLI               | Code / Config file | Default          |
 | --- | ----------------- | ------------------ | ---------------- |


### PR DESCRIPTION
Addition of the following K6 options:

- `--no-setup`
- `--no-teardown`
- `--console-output-string`
- `--exit-on-running`
- `--show-logs`
- `--address`
- `--no-color`
- `--verbose`