### PR TITLE
Fix URL to xk6-client-prometheus-remote

### DIFF
--- a/src/data/extensions/extensions.js
+++ b/src/data/extensions/extensions.js
@@ -254,7 +254,7 @@ const extensions = [
   {
     name: 'xk6-client-prometheus-remote',
     description:
-      'A k6 extension for testing the performance of Promethrus Remote Write.',
+      'A k6 extension for testing the performance of Prometheus Remote Write.',
     url: 'https://github.com/grafana/xk6-client-prometheus-remote',
     logo: '',
     author: {


### PR DESCRIPTION
This commit only changes the name and description of the `xk6-client-prometheus-remote` extension. 
