### PR TITLE
Add example for Scenarios output

### DIFF
--- a/src/data/markdown/translated-guides/en/02 Using k6/14 Scenarios.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/14 Scenarios.md
@@ -83,3 +83,76 @@ Possible values for `executor` are the executor name separated by hyphens.
 | exec         | string | Name of exported JS function to execute.                                                                                                       | `"default"` |
 | env          | object | Environment variables specific to this scenario.                                                                                               | `{}`        |
 | tags         | object | [Tags](/using-k6/tags-and-groups) specific to this scenario.                                                                                   | `{}`        |
+
+## Example
+
+The following script defines two minimal scenarios:
+
+<CodeGroup labels={[]} lineNumbers={[true]}>
+
+```bash
+import http from 'k6/http';
+
+export const options = {
+  scenarios: {
+    example_scenario: {
+      executor: 'shared-iterations',
+      startTime: '0s'
+    },
+    another_scenario: {
+      executor: 'shared-iterations',
+      startTime: '5s'
+    },
+  },
+};
+
+export default function () {
+  http.get('https://google.com/');
+}
+```
+
+</CodeGroup>
+
+Running the above script with `k6 run script.js`, additional information is added to the output as follows:
+
+<CodeGroup labels={[]} lineNumbers={[true]}>
+
+```bash
+          /\      |‾‾| /‾‾/   /‾‾/
+     /\  /  \     |  |/  /   /  /
+    /  \/    \    |     (   /   ‾‾\
+   /          \   |  |\  \ |  (‾)  |
+  / __________ \  |__| \__\ \_____/ .io
+
+  execution: local
+     script: .\scenario_example.js
+     output: -
+
+  scenarios: (100.00%) 2 scenarios, 2 max VUs, 10m35s max duration (incl. graceful stop):
+           * example_scenario: 1 iterations shared among 1 VUs (maxDuration: 10m0s, gracefulStop: 30s)
+           * another_scenario: 1 iterations shared among 1 VUs (maxDuration: 10m0s, startTime: 5s, gracefulStop: 30s)
+
+
+running (00m05.2s), 0/2 VUs, 2 complete and 0 interrupted iterations
+example_scenario ✓ [======================================] 1 VUs  00m00.2s/10m0s  1/1 shared iters
+another_scenario ✓ [======================================] 1 VUs  00m00.2s/10m0s  1/1 shared iters
+
+     data_received..................: 54 kB  11 kB/s
+     data_sent......................: 2.5 kB 486 B/s
+     http_req_blocked...............: avg=53.45ms  min=46.56ms  med=48.42ms  max=70.4ms   p(90)=64.25ms  p(95)=67.32ms
+     http_req_connecting............: avg=19.95ms  min=18.62ms  med=19.93ms  max=21.3ms   p(90)=21.26ms  p(95)=21.28ms
+     http_req_duration..............: avg=46.16ms  min=25.82ms  med=45.6ms   max=67.6ms   p(90)=65.63ms  p(95)=66.61ms
+       { expected_response:true }...: avg=46.16ms  min=25.82ms  med=45.6ms   max=67.6ms   p(90)=65.63ms  p(95)=66.61ms
+     http_req_failed................: 0.00%  ✓ 0        ✗ 4
+     http_req_receiving.............: avg=3.56ms   min=305.8µs  med=3.05ms   max=7.84ms   p(90)=7.01ms   p(95)=7.43ms
+     http_req_sending...............: avg=132.85µs min=0s       med=0s       max=531.4µs  p(90)=371.98µs p(95)=451.68µs
+     http_req_tls_handshaking.......: avg=32.68ms  min=27.63ms  med=27.99ms  max=47.09ms  p(90)=41.43ms  p(95)=44.26ms
+     http_req_waiting...............: avg=42.46ms  min=24.78ms  med=42.64ms  max=59.75ms  p(90)=58.45ms  p(95)=59.1ms
+     http_reqs......................: 4      0.771306/s
+     iteration_duration.............: avg=199.23ms min=182.79ms med=199.23ms max=215.67ms p(90)=212.38ms p(95)=214.03ms
+     iterations.....................: 2      0.385653/s
+     vus............................: 0      min=0      max=0
+     vus_max........................: 2      min=2      max=2
+```
+
+</CodeGroup>


### PR DESCRIPTION
This PR adds an `Example` section to the _Scenarios_ documentation, indicating how additional information about scenarios is added to the console output.

Closes #329.