### PR TITLE
FEAT: Issue 465: Add Documentation Template as per new Github Issue Forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation.yaml
@@ -1,0 +1,32 @@
+name: "📚 Documentation"
+description: "Report an issue related to documentation"
+title: "📚 Documentation: "
+labels: [documentation]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to make our documentation better 🙏
+  - type: textarea
+    id: issue-description
+    validations:
+      required: true
+    attributes:
+      label: "💭 Description"
+      description: "A clear and concise description of what the issue is."
+      placeholder: "Documentation should ..."
+  - type: checkboxes
+    id: no-duplicate-issues
+    attributes:
+      label: "👀 Have you spent some time to check if this issue has been raised before?"
+      description: "Have you Googled for a similar issue or checked our older issues for a similar bug?"
+      options:
+        - label: "I checked and didn't find similar issue"
+          required: true
+  - type: checkboxes
+    id: read-code-of-conduct
+    attributes:
+      label: "🏢 Have you read the Code of Conduct?"
+      options:
+        - label: "I have read the [Code of Conduct](https://github.com/grafana/k6-docs/blob/main/CODE_OF_CONDUCT.md)"
+          required: true


### PR DESCRIPTION
# Linked Issue
It fixes https://github.com/grafana/k6-docs/issues/465

# Description
This PR adds the Issue template for `Documentation` requests to use the latest Github Issue forms.

# Methodology
A respective `yaml` file has been added that would be used to provide the newest template for any issue requests.