### PR TITLE
Feat: xk6 browser components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "dateformat": "^4.5.1",
         "dotenv": "^10.0.0",
         "gatsby": "^3.6.2",
-        "gatsby-image": "^3.6.0",
         "gatsby-plugin-algolia": "^0.20.1",
         "gatsby-plugin-catch-links": "^3.6.0",
         "gatsby-plugin-google-analytics": "^3.6.0",
@@ -13618,19 +13617,6 @@
         "node": ">=12.13.0"
       }
     },
-    "node_modules/gatsby-image": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/gatsby-image/-/gatsby-image-3.6.0.tgz",
-      "integrity": "sha512-1Hh4VWmNBAig3WOwNKwgkmXxg2SYPbGZ11qJBzGp0igfQsBnNw1XkmfDwACfhIbxRSKSaN6gbgQgOOpQau4NtA==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "object-fit-images": "^3.2.4",
-        "prop-types": "^15.7.2"
-      },
-      "engines": {
-        "node": ">=12.13.0"
-      }
-    },
     "node_modules/gatsby-legacy-polyfills": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/gatsby-legacy-polyfills/-/gatsby-legacy-polyfills-1.6.0.tgz",
@@ -21705,11 +21691,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/object-fit-images": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/object-fit-images/-/object-fit-images-3.2.4.tgz",
-      "integrity": "sha512-G+7LzpYfTfqUyrZlfrou/PLLLAPNC52FTy5y1CBywX+1/FkxIloOyQXBmZ3Zxa2AWO+lMF0JTuvqbr7G5e5CWg=="
     },
     "node_modules/object-inspect": {
       "version": "1.10.3",
@@ -41525,16 +41506,6 @@
         "@babel/runtime": "^7.12.5"
       }
     },
-    "gatsby-image": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/gatsby-image/-/gatsby-image-3.6.0.tgz",
-      "integrity": "sha512-1Hh4VWmNBAig3WOwNKwgkmXxg2SYPbGZ11qJBzGp0igfQsBnNw1XkmfDwACfhIbxRSKSaN6gbgQgOOpQau4NtA==",
-      "requires": {
-        "@babel/runtime": "^7.12.5",
-        "object-fit-images": "^3.2.4",
-        "prop-types": "^15.7.2"
-      }
-    },
     "gatsby-legacy-polyfills": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/gatsby-legacy-polyfills/-/gatsby-legacy-polyfills-1.6.0.tgz",
@@ -47635,11 +47606,6 @@
           }
         }
       }
-    },
-    "object-fit-images": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/object-fit-images/-/object-fit-images-3.2.4.tgz",
-      "integrity": "sha512-G+7LzpYfTfqUyrZlfrou/PLLLAPNC52FTy5y1CBywX+1/FkxIloOyQXBmZ3Zxa2AWO+lMF0JTuvqbr7G5e5CWg=="
     },
     "object-inspect": {
       "version": "1.10.3",

--- a/src/components/shared/browser-class-list/browser-class-list.view.js
+++ b/src/components/shared/browser-class-list/browser-class-list.view.js
@@ -1,0 +1,79 @@
+import Glossary from 'components/pages/doc-page/glossary';
+import { Link } from 'gatsby';
+import React from 'react';
+import { HeadingLandmark } from 'components/shared/heading';
+
+const links = [
+  {
+    title: 'Browser',
+    url: '/javascript-api/k6-x-browser/browser/',
+  },
+  {
+    title: 'BrowserContext',
+    url: '/javascript-api/k6-x-browser/browsercontext/',
+  },
+  {
+    title: 'BrowserType',
+    url: '/javascript-api/k6-x-browser/browsertype/',
+  },
+  {
+    title: 'ElementHandle',
+    url: '/javascript-api/k6-x-browser/elementhandle/',
+  },
+  {
+    title: 'Frame',
+    url: '/javascript-api/k6-x-browser/frame/',
+  },
+  {
+    title: 'JSHandle',
+    url: '/javascript-api/k6-x-browser/jshandle',
+  },
+  {
+    title: 'Keyboard',
+    url: '/javascript-api/k6-x-browser/keyboard',
+  },
+  {
+    title: 'Mouse',
+    url: '/javascript-api/k6-x-browser/mouse/',
+  },
+  {
+    title: 'Page',
+    url: '/javascript-api/k6-x-browser/page/',
+  },
+  {
+    title: 'Request',
+    url: '/javascript-api/k6-x-browser/request/',
+  },
+  {
+    title: 'Response',
+    url: '/javascript-api/k6-x-browser/response/',
+  },
+  {
+    title: 'Browser',
+    url: '/javascript-api/k6-x-browser/browser/',
+  },
+  {
+    title: 'Touchscreen',
+    url: '/javascript-api/k6-x-browser/touchscreen/',
+  },
+];
+
+const BrowserClassList = () => {
+  const Wrapper = HeadingLandmark('h3');
+
+  return (
+    <>
+      <Wrapper>Browser APIs</Wrapper>
+      <Glossary>
+        <ul>
+          {links.map(({ title, url }) => (
+            <li key={title}>
+              <Link to={url}>{title}</Link>
+            </li>
+          ))}
+        </ul>
+      </Glossary>
+    </>
+  );
+};
+export default BrowserClassList;

--- a/src/components/shared/browser-class-list/index.js
+++ b/src/components/shared/browser-class-list/index.js
@@ -1,0 +1,3 @@
+import BrowserClassList from './browser-class-list.view';
+
+export default BrowserClassList;

--- a/src/components/shared/browser-compatibility/browser-compatibility.view.js
+++ b/src/components/shared/browser-compatibility/browser-compatibility.view.js
@@ -1,0 +1,26 @@
+import Blockquote from 'components/shared/blockquote';
+import { Link } from 'gatsby';
+import React from 'react';
+
+const BrowserCompatibility = () => (
+  <Blockquote>
+    <p>
+      {' '}
+      <strong>⚠️ Compatibility</strong>
+    </p>
+    <p>
+      The <Link to="/javascript-api/k6-x-browser/">xk6-browser API</Link> aims
+      for rough compatibility with the{' '}
+      <a href="https://playwright.dev/docs/api/class-playwright">
+        Playwright API for NodeJS
+      </a>
+      .
+    </p>
+    <p>
+      Because k6 does not run in NodeJS, the xk6-browser API will slightly
+      differ from its Playwright counterpart.
+    </p>
+    <p>Note that k6 APIs are synchronous.</p>
+  </Blockquote>
+);
+export default BrowserCompatibility;

--- a/src/components/shared/browser-compatibility/index.js
+++ b/src/components/shared/browser-compatibility/index.js
@@ -1,0 +1,3 @@
+import BrowserCompatibility from './browser-compatibility.view';
+
+export default BrowserCompatibility;

--- a/src/components/shared/browser-wip/browser-wip.js
+++ b/src/components/shared/browser-wip/browser-wip.js
@@ -1,0 +1,10 @@
+import { CodeInline } from 'components/shared/code';
+import React from 'react';
+
+const BrowserWIP = () => (
+  <p>
+    🚧 <CodeInline>xk6-browser</CodeInline> is in Beta - we are working to cover
+    more Playwright APIs.
+  </p>
+);
+export default BrowserWIP;

--- a/src/components/shared/browser-wip/index.js
+++ b/src/components/shared/browser-wip/index.js
@@ -1,0 +1,3 @@
+import BrowserWIP from './browser-wip';
+
+export default BrowserWIP;

--- a/src/components/templates/doc-page/doc-page-content/doc-page-content.view.js
+++ b/src/components/templates/doc-page/doc-page-content/doc-page-content.view.js
@@ -8,6 +8,7 @@ import Collapsible from 'components/shared/collapsible';
 import { HeadingLandmark } from 'components/shared/heading';
 import BrowserCompatibility from 'components/shared/browser-compatibility';
 import BrowserClassList from 'components/shared/browser-class-list';
+import BrowserWIP from 'components/shared/browser-wip';
 import LdScript from 'components/shared/ld-script';
 import { Link } from 'components/shared/link';
 import TableWrapper from 'components/shared/table-wrapper';
@@ -31,6 +32,7 @@ const componentsForNativeReplacement = {
   CodeInline,
   BrowserCompatibility,
   BrowserClassList,
+  BrowserWIP,
 };
 
 export const DocPageContent = ({ label, content, mod, version }) => {

--- a/src/components/templates/doc-page/doc-page-content/doc-page-content.view.js
+++ b/src/components/templates/doc-page/doc-page-content/doc-page-content.view.js
@@ -7,6 +7,7 @@ import { Code, CodeInline, CodeGroup } from 'components/shared/code';
 import Collapsible from 'components/shared/collapsible';
 import { HeadingLandmark } from 'components/shared/heading';
 import BrowserCompatibility from 'components/shared/browser-compatibility';
+import BrowserClassList from 'components/shared/browser-class-list';
 import LdScript from 'components/shared/ld-script';
 import { Link } from 'components/shared/link';
 import TableWrapper from 'components/shared/table-wrapper';
@@ -29,6 +30,7 @@ const componentsForNativeReplacement = {
   Collapsible,
   CodeInline,
   BrowserCompatibility,
+  BrowserClassList,
 };
 
 export const DocPageContent = ({ label, content, mod, version }) => {

--- a/src/components/templates/doc-page/doc-page-content/doc-page-content.view.js
+++ b/src/components/templates/doc-page/doc-page-content/doc-page-content.view.js
@@ -6,6 +6,7 @@ import Blockquote from 'components/shared/blockquote';
 import { Code, CodeInline, CodeGroup } from 'components/shared/code';
 import Collapsible from 'components/shared/collapsible';
 import { HeadingLandmark } from 'components/shared/heading';
+import BrowserCompatibility from 'components/shared/browser-compatibility';
 import LdScript from 'components/shared/ld-script';
 import { Link } from 'components/shared/link';
 import TableWrapper from 'components/shared/table-wrapper';
@@ -27,6 +28,7 @@ const componentsForNativeReplacement = {
   CodeGroup,
   Collapsible,
   CodeInline,
+  BrowserCompatibility,
 };
 
 export const DocPageContent = ({ label, content, mod, version }) => {

--- a/src/data/markdown/docs/02 javascript api/30 k6-x-browser/01-browser.md
+++ b/src/data/markdown/docs/02 javascript api/30 k6-x-browser/01-browser.md
@@ -22,7 +22,7 @@ excerpt: "xk6-browser: Browser Class"
 - [startTracing()](https://playwright.dev/docs/api/class-browser#browser-start-tracing)
 - [stopTracing()](https://playwright.dev/docs/api/class-browser#browser-stop-tracing)
 
-🚧 `xk6-browser` is in Beta - we are working to cover more Playwright APIs.
+<BrowserWIP/>
 
 ## Examples
 

--- a/src/data/markdown/docs/02 javascript api/30 k6-x-browser/01-browser.md
+++ b/src/data/markdown/docs/02 javascript api/30 k6-x-browser/01-browser.md
@@ -56,22 +56,4 @@ export default function () {
 }
 ```
 
-### Browser APIs
-
-<Glossary>
-
--  [Browser](/javascript-api/k6-x-browser/browser/)
--  [BrowserContext](/javascript-api/k6-x-browser/browsercontext/)
--  [BrowserType](/javascript-api/k6-x-browser/browsertype/)
--  [ElementHandle](/javascript-api/k6-x-browser/elementhandle/)
--  [Frame](/javascript-api/k6-x-browser/frame/)
--  [JSHandle](/javascript-api/k6-x-browser/jshandle)
--  [Keyboard](/javascript-api/k6-x-browser/keyboard)
--  [Mouse](/javascript-api/k6-x-browser/mouse/)
--  [Page](/javascript-api/k6-x-browser/page/)
--  [Request](/javascript-api/k6-x-browser/request/)
--  [Response](/javascript-api/k6-x-browser/response/)
--  [Browser](/javascript-api/k6-x-browser/browser/)
--  [Touchscreen](/javascript-api/k6-x-browser/touchscreen/)
-
-</Glossary>
+<BrowserClassList/>

--- a/src/data/markdown/docs/02 javascript api/30 k6-x-browser/01-browser.md
+++ b/src/data/markdown/docs/02 javascript api/30 k6-x-browser/01-browser.md
@@ -3,13 +3,7 @@ title: "Browser"
 excerpt: "xk6-browser: Browser Class"
 ---
 
-> ️ **️⚠️ Compatibility**
-> 
-> The [xk6-browser API](/javascript-api/k6-x-browser/) aims for rough compatibility with the [Playwright API for NodeJS](https://playwright.dev/docs/api/class-playwright). 
-> 
-> Because k6 does not run in NodeJS, the xk6-browser API will slightly differ from its Playwright counterpart.
-> 
-> Note that k6 APIs are synchronous.
+<BrowserCompatibility/>
 
 ## Supported APIs
 

--- a/src/data/markdown/docs/02 javascript api/30 k6-x-browser/02-browser-context.md
+++ b/src/data/markdown/docs/02 javascript api/30 k6-x-browser/02-browser-context.md
@@ -43,7 +43,7 @@ The next APIs depends on event-loop support in k6:
 
 </Glossary>
 
-🚧 `xk6-browser` is in Beta - we are working to cover more Playwright APIs.
+<BrowserWIP/>
 
 ## Examples
 

--- a/src/data/markdown/docs/02 javascript api/30 k6-x-browser/02-browser-context.md
+++ b/src/data/markdown/docs/02 javascript api/30 k6-x-browser/02-browser-context.md
@@ -3,13 +3,7 @@ title: "BrowserContext"
 excerpt: "xk6-browser: BrowserContext Class"
 ---
 
-> ️ **️⚠️ Compatibility**
-> 
-> The [xk6-browser API](/javascript-api/k6-x-browser/) aims for rough compatibility with the [Playwright API for NodeJS](https://playwright.dev/docs/api/class-playwright). 
-> 
-> Because k6 does not run in NodeJS, the xk6-browser API will slightly differ from its Playwright counterpart.
-> 
-> Note that k6 APIs are synchronous.
+<BrowserCompatibility/>
 
 ## Supported APIs
 

--- a/src/data/markdown/docs/02 javascript api/30 k6-x-browser/02-browser-context.md
+++ b/src/data/markdown/docs/02 javascript api/30 k6-x-browser/02-browser-context.md
@@ -60,22 +60,4 @@ export default function () {
 }
 ```
 
-### Browser APIs
-
-<Glossary>
-
--  [Browser](/javascript-api/k6-x-browser/browser/)
--  [BrowserContext](/javascript-api/k6-x-browser/browsercontext/)
--  [BrowserType](/javascript-api/k6-x-browser/browsertype/)
--  [ElementHandle](/javascript-api/k6-x-browser/elementhandle/)
--  [Frame](/javascript-api/k6-x-browser/frame/)
--  [JSHandle](/javascript-api/k6-x-browser/jshandle)
--  [Keyboard](/javascript-api/k6-x-browser/keyboard)
--  [Mouse](/javascript-api/k6-x-browser/mouse/)
--  [Page](/javascript-api/k6-x-browser/page/)
--  [Request](/javascript-api/k6-x-browser/request/)
--  [Response](/javascript-api/k6-x-browser/response/)
--  [Browser](/javascript-api/k6-x-browser/browser/)
--  [Touchscreen](/javascript-api/k6-x-browser/touchscreen/)
-
-</Glossary>
+<BrowserClassList/>

--- a/src/data/markdown/docs/02 javascript api/30 k6-x-browser/03-browser-type.md
+++ b/src/data/markdown/docs/02 javascript api/30 k6-x-browser/03-browser-type.md
@@ -49,22 +49,4 @@ export default function () {
 }
 ```
 
-### Browser APIs
-
-<Glossary>
-
--  [Browser](/javascript-api/k6-x-browser/browser/)
--  [BrowserContext](/javascript-api/k6-x-browser/browsercontext/)
--  [BrowserType](/javascript-api/k6-x-browser/browsertype/)
--  [ElementHandle](/javascript-api/k6-x-browser/elementhandle/)
--  [Frame](/javascript-api/k6-x-browser/frame/)
--  [JSHandle](/javascript-api/k6-x-browser/jshandle)
--  [Keyboard](/javascript-api/k6-x-browser/keyboard)
--  [Mouse](/javascript-api/k6-x-browser/mouse/)
--  [Page](/javascript-api/k6-x-browser/page/)
--  [Request](/javascript-api/k6-x-browser/request/)
--  [Response](/javascript-api/k6-x-browser/response/)
--  [Browser](/javascript-api/k6-x-browser/browser/)
--  [Touchscreen](/javascript-api/k6-x-browser/touchscreen/)
-
-</Glossary>
+<BrowserClassList/>

--- a/src/data/markdown/docs/02 javascript api/30 k6-x-browser/03-browser-type.md
+++ b/src/data/markdown/docs/02 javascript api/30 k6-x-browser/03-browser-type.md
@@ -25,7 +25,7 @@ excerpt: "xk6-browser: BrowserType Class"
   
 </Glossary>
 
-🚧 `xk6-browser` is in Beta - we are working to cover more Playwright APIs.
+<BrowserWIP/>
 
 ## Examples
 

--- a/src/data/markdown/docs/02 javascript api/30 k6-x-browser/03-browser-type.md
+++ b/src/data/markdown/docs/02 javascript api/30 k6-x-browser/03-browser-type.md
@@ -3,13 +3,7 @@ title: "BrowserType"
 excerpt: "xk6-browser: BrowserType Class"
 ---
 
-> ️ **️⚠️ Compatibility**
-> 
-> The [xk6-browser API](/javascript-api/k6-x-browser/) aims for rough compatibility with the [Playwright API for NodeJS](https://playwright.dev/docs/api/class-playwright). 
-> 
-> Because k6 does not run in NodeJS, the xk6-browser API will slightly differ from its Playwright counterpart.
-> 
-> Note that k6 APIs are synchronous.
+<BrowserCompatibility/>
 
 ## Supported APIs
 

--- a/src/data/markdown/docs/02 javascript api/30 k6-x-browser/04-element-handle.md
+++ b/src/data/markdown/docs/02 javascript api/30 k6-x-browser/04-element-handle.md
@@ -3,13 +3,7 @@ title: "ElementHandle"
 excerpt: "xk6-browser: ElementHandle Class"
 ---
 
-> ️ **️⚠️ Compatibility**
-> 
-> The [xk6-browser API](/javascript-api/k6-x-browser/) aims for rough compatibility with the [Playwright API for NodeJS](https://playwright.dev/docs/api/class-playwright). 
-> 
-> Because k6 does not run in NodeJS, the xk6-browser API will slightly differ from its Playwright counterpart.
-> 
-> Note that k6 APIs are synchronous.
+<BrowserCompatibility/>
 
 
 ## Supported APIs

--- a/src/data/markdown/docs/02 javascript api/30 k6-x-browser/04-element-handle.md
+++ b/src/data/markdown/docs/02 javascript api/30 k6-x-browser/04-element-handle.md
@@ -101,22 +101,4 @@ export default function () {
 </CodeGroup>
 
 
-### Browser APIs
-
-<Glossary>
-
--  [Browser](/javascript-api/k6-x-browser/browser/)
--  [BrowserContext](/javascript-api/k6-x-browser/browsercontext/)
--  [BrowserType](/javascript-api/k6-x-browser/browsertype/)
--  [ElementHandle](/javascript-api/k6-x-browser/elementhandle/)
--  [Frame](/javascript-api/k6-x-browser/frame/)
--  [JSHandle](/javascript-api/k6-x-browser/jshandle)
--  [Keyboard](/javascript-api/k6-x-browser/keyboard)
--  [Mouse](/javascript-api/k6-x-browser/mouse/)
--  [Page](/javascript-api/k6-x-browser/page/)
--  [Request](/javascript-api/k6-x-browser/request/)
--  [Response](/javascript-api/k6-x-browser/response/)
--  [Browser](/javascript-api/k6-x-browser/browser/)
--  [Touchscreen](/javascript-api/k6-x-browser/touchscreen/)
-
-</Glossary>
+<BrowserClassList/>

--- a/src/data/markdown/docs/02 javascript api/30 k6-x-browser/04-element-handle.md
+++ b/src/data/markdown/docs/02 javascript api/30 k6-x-browser/04-element-handle.md
@@ -21,7 +21,7 @@ Support for the [`ElementHandle` Playwright API](https://playwright.dev/docs/api
 
 </Glossary>
 
-🚧 `xk6-browser` is in Beta - we are working to cover more Playwright APIs.
+<BrowserWIP/>
 
 ## Examples
 

--- a/src/data/markdown/docs/02 javascript api/30 k6-x-browser/05-frame.md
+++ b/src/data/markdown/docs/02 javascript api/30 k6-x-browser/05-frame.md
@@ -23,6 +23,6 @@ Support for the [`Frame` Playwright API](https://playwright.dev/docs/api/class-f
 
 </Glossary>
 
-🚧 `xk6-browser` is in Beta - we are working to cover more Playwright APIs.
+<BrowserWIP/>
 
 <BrowserClassList/>

--- a/src/data/markdown/docs/02 javascript api/30 k6-x-browser/05-frame.md
+++ b/src/data/markdown/docs/02 javascript api/30 k6-x-browser/05-frame.md
@@ -3,13 +3,7 @@ title: "Frame"
 excerpt: "xk6-browser: Frame Class"
 ---
 
-> ️ **️⚠️ Compatibility**
-> 
-> The [xk6-browser API](/javascript-api/k6-x-browser/) aims for rough compatibility with the [Playwright API for NodeJS](https://playwright.dev/docs/api/class-playwright). 
-> 
-> Because k6 does not run in NodeJS, the xk6-browser API will slightly differ from its Playwright counterpart.
-> 
-> Note that k6 APIs are synchronous.
+<BrowserCompatibility/>
 
 ## Supported APIs
 

--- a/src/data/markdown/docs/02 javascript api/30 k6-x-browser/05-frame.md
+++ b/src/data/markdown/docs/02 javascript api/30 k6-x-browser/05-frame.md
@@ -25,22 +25,4 @@ Support for the [`Frame` Playwright API](https://playwright.dev/docs/api/class-f
 
 🚧 `xk6-browser` is in Beta - we are working to cover more Playwright APIs.
 
-### Browser APIs
-
-<Glossary>
-
--  [Browser](/javascript-api/k6-x-browser/browser/)
--  [BrowserContext](/javascript-api/k6-x-browser/browsercontext/)
--  [BrowserType](/javascript-api/k6-x-browser/browsertype/)
--  [ElementHandle](/javascript-api/k6-x-browser/elementhandle/)
--  [Frame](/javascript-api/k6-x-browser/frame/)
--  [JSHandle](/javascript-api/k6-x-browser/jshandle)
--  [Keyboard](/javascript-api/k6-x-browser/keyboard)
--  [Mouse](/javascript-api/k6-x-browser/mouse/)
--  [Page](/javascript-api/k6-x-browser/page/)
--  [Request](/javascript-api/k6-x-browser/request/)
--  [Response](/javascript-api/k6-x-browser/response/)
--  [Browser](/javascript-api/k6-x-browser/browser/)
--  [Touchscreen](/javascript-api/k6-x-browser/touchscreen/)
-
-</Glossary>
+<BrowserClassList/>

--- a/src/data/markdown/docs/02 javascript api/30 k6-x-browser/06-js-handle.md
+++ b/src/data/markdown/docs/02 javascript api/30 k6-x-browser/06-js-handle.md
@@ -9,22 +9,4 @@ excerpt: "xk6-browser: JSHandle Class"
 
 Support for the [`JSHandle` Playwright API](https://playwright.dev/docs/api/class-jshandle/).
 
-### Browser APIs
-
-<Glossary>
-
--  [Browser](/javascript-api/k6-x-browser/browser/)
--  [BrowserContext](/javascript-api/k6-x-browser/browsercontext/)
--  [BrowserType](/javascript-api/k6-x-browser/browsertype/)
--  [ElementHandle](/javascript-api/k6-x-browser/elementhandle/)
--  [Frame](/javascript-api/k6-x-browser/frame/)
--  [JSHandle](/javascript-api/k6-x-browser/jshandle)
--  [Keyboard](/javascript-api/k6-x-browser/keyboard)
--  [Mouse](/javascript-api/k6-x-browser/mouse/)
--  [Page](/javascript-api/k6-x-browser/page/)
--  [Request](/javascript-api/k6-x-browser/request/)
--  [Response](/javascript-api/k6-x-browser/response/)
--  [Browser](/javascript-api/k6-x-browser/browser/)
--  [Touchscreen](/javascript-api/k6-x-browser/touchscreen/)
-
-</Glossary>
+<BrowserClassList/>

--- a/src/data/markdown/docs/02 javascript api/30 k6-x-browser/06-js-handle.md
+++ b/src/data/markdown/docs/02 javascript api/30 k6-x-browser/06-js-handle.md
@@ -3,13 +3,7 @@ title: "JSHandle"
 excerpt: "xk6-browser: JSHandle Class"
 ---
 
-> ️ **️⚠️ Compatibility**
-> 
-> The [xk6-browser API](/javascript-api/k6-x-browser/) aims for rough compatibility with the [Playwright API for NodeJS](https://playwright.dev/docs/api/class-playwright). 
-> 
-> Because k6 does not run in NodeJS, the xk6-browser API will slightly differ from its Playwright counterpart.
-> 
-> Note that k6 APIs are synchronous.
+<BrowserCompatibility/>
 
 ## Supported APIs
 

--- a/src/data/markdown/docs/02 javascript api/30 k6-x-browser/07-keyboard.md
+++ b/src/data/markdown/docs/02 javascript api/30 k6-x-browser/07-keyboard.md
@@ -3,13 +3,7 @@ title: "Keyboard"
 excerpt: "xk6-browser: Keyboard Class"
 ---
 
-> ️ **️⚠️ Compatibility**
-> 
-> The [xk6-browser API](/javascript-api/k6-x-browser/) aims for rough compatibility with the [Playwright API for NodeJS](https://playwright.dev/docs/api/class-playwright). 
-> 
-> Because k6 does not run in NodeJS, the xk6-browser API will slightly differ from its Playwright counterpart.
-> 
-> Note that k6 APIs are synchronous.
+<BrowserCompatibility/>
 
 ## Supported APIs
 

--- a/src/data/markdown/docs/02 javascript api/30 k6-x-browser/07-keyboard.md
+++ b/src/data/markdown/docs/02 javascript api/30 k6-x-browser/07-keyboard.md
@@ -9,22 +9,4 @@ excerpt: "xk6-browser: Keyboard Class"
 
 Support for the [`Keyboard` Playwright API](https://playwright.dev/docs/api/class-keyboard/).
 
-### Browser APIs
-
-<Glossary>
-
--  [Browser](/javascript-api/k6-x-browser/browser/)
--  [BrowserContext](/javascript-api/k6-x-browser/browsercontext/)
--  [BrowserType](/javascript-api/k6-x-browser/browsertype/)
--  [ElementHandle](/javascript-api/k6-x-browser/elementhandle/)
--  [Frame](/javascript-api/k6-x-browser/frame/)
--  [JSHandle](/javascript-api/k6-x-browser/jshandle)
--  [Keyboard](/javascript-api/k6-x-browser/keyboard)
--  [Mouse](/javascript-api/k6-x-browser/mouse/)
--  [Page](/javascript-api/k6-x-browser/page/)
--  [Request](/javascript-api/k6-x-browser/request/)
--  [Response](/javascript-api/k6-x-browser/response/)
--  [Browser](/javascript-api/k6-x-browser/browser/)
--  [Touchscreen](/javascript-api/k6-x-browser/touchscreen/)
-
-</Glossary>
+<BrowserClassList/>

--- a/src/data/markdown/docs/02 javascript api/30 k6-x-browser/08-launcher.md
+++ b/src/data/markdown/docs/02 javascript api/30 k6-x-browser/08-launcher.md
@@ -40,22 +40,4 @@ export default function () {
 }
 ```
 
-### Browser APIs
-
-<Glossary>
-
--  [Browser](/javascript-api/k6-x-browser/browser/)
--  [BrowserContext](/javascript-api/k6-x-browser/browsercontext/)
--  [BrowserType](/javascript-api/k6-x-browser/browsertype/)
--  [ElementHandle](/javascript-api/k6-x-browser/elementhandle/)
--  [Frame](/javascript-api/k6-x-browser/frame/)
--  [JSHandle](/javascript-api/k6-x-browser/jshandle)
--  [Keyboard](/javascript-api/k6-x-browser/keyboard)
--  [Mouse](/javascript-api/k6-x-browser/mouse/)
--  [Page](/javascript-api/k6-x-browser/page/)
--  [Request](/javascript-api/k6-x-browser/request/)
--  [Response](/javascript-api/k6-x-browser/response/)
--  [Browser](/javascript-api/k6-x-browser/browser/)
--  [Touchscreen](/javascript-api/k6-x-browser/touchscreen/)
-
-</Glossary>
+<BrowserClassList/>

--- a/src/data/markdown/docs/02 javascript api/30 k6-x-browser/08-mouse.md
+++ b/src/data/markdown/docs/02 javascript api/30 k6-x-browser/08-mouse.md
@@ -3,13 +3,7 @@ title: "Mouse"
 excerpt: "xk6-browser: Mouse Class"
 ---
 
-> ️ **️⚠️ Compatibility**
-> 
-> The [xk6-browser API](/javascript-api/k6-x-browser/) aims for rough compatibility with the [Playwright API for NodeJS](https://playwright.dev/docs/api/class-playwright). 
-> 
-> Because k6 does not run in NodeJS, the xk6-browser API will slightly differ from its Playwright counterpart.
-> 
-> Note that k6 APIs are synchronous.
+<BrowserCompatibility/>
 
 ## Supported APIs
 

--- a/src/data/markdown/docs/02 javascript api/30 k6-x-browser/08-mouse.md
+++ b/src/data/markdown/docs/02 javascript api/30 k6-x-browser/08-mouse.md
@@ -9,22 +9,4 @@ excerpt: "xk6-browser: Mouse Class"
 
 Support for the [`Mouse` Playwright API](https://playwright.dev/docs/api/class-mouse/).
 
-### Browser APIs
-
-<Glossary>
-
--  [Browser](/javascript-api/k6-x-browser/browser/)
--  [BrowserContext](/javascript-api/k6-x-browser/browsercontext/)
--  [BrowserType](/javascript-api/k6-x-browser/browsertype/)
--  [ElementHandle](/javascript-api/k6-x-browser/elementhandle/)
--  [Frame](/javascript-api/k6-x-browser/frame/)
--  [JSHandle](/javascript-api/k6-x-browser/jshandle)
--  [Keyboard](/javascript-api/k6-x-browser/keyboard)
--  [Mouse](/javascript-api/k6-x-browser/mouse/)
--  [Page](/javascript-api/k6-x-browser/page/)
--  [Request](/javascript-api/k6-x-browser/request/)
--  [Response](/javascript-api/k6-x-browser/response/)
--  [Browser](/javascript-api/k6-x-browser/browser/)
--  [Touchscreen](/javascript-api/k6-x-browser/touchscreen/)
-
-</Glossary>
+<BrowserClassList/>

--- a/src/data/markdown/docs/02 javascript api/30 k6-x-browser/09-page.md
+++ b/src/data/markdown/docs/02 javascript api/30 k6-x-browser/09-page.md
@@ -82,22 +82,4 @@ export default function () {
 }
 ```
 
-### Browser APIs
-
-<Glossary>
-
--  [Browser](/javascript-api/k6-x-browser/browser/)
--  [BrowserContext](/javascript-api/k6-x-browser/browsercontext/)
--  [BrowserType](/javascript-api/k6-x-browser/browsertype/)
--  [ElementHandle](/javascript-api/k6-x-browser/elementhandle/)
--  [Frame](/javascript-api/k6-x-browser/frame/)
--  [JSHandle](/javascript-api/k6-x-browser/jshandle)
--  [Keyboard](/javascript-api/k6-x-browser/keyboard)
--  [Mouse](/javascript-api/k6-x-browser/mouse/)
--  [Page](/javascript-api/k6-x-browser/page/)
--  [Request](/javascript-api/k6-x-browser/request/)
--  [Response](/javascript-api/k6-x-browser/response/)
--  [Browser](/javascript-api/k6-x-browser/browser/)
--  [Touchscreen](/javascript-api/k6-x-browser/touchscreen/)
-
-</Glossary>
+<BrowserClassList/>

--- a/src/data/markdown/docs/02 javascript api/30 k6-x-browser/09-page.md
+++ b/src/data/markdown/docs/02 javascript api/30 k6-x-browser/09-page.md
@@ -47,7 +47,7 @@ The next APIs depends on event-loop support in k6:
 
 
 
-🚧 `xk6-browser` is in Beta - we are working to cover more Playwright APIs.
+<BrowserWIP/>
 
 
 ## Examples

--- a/src/data/markdown/docs/02 javascript api/30 k6-x-browser/09-page.md
+++ b/src/data/markdown/docs/02 javascript api/30 k6-x-browser/09-page.md
@@ -3,13 +3,7 @@ title: "Page"
 excerpt: "xk6-browser: Page Class"
 ---
 
-> ️ **️⚠️ Compatibility**
-> 
-> The [xk6-browser API](/javascript-api/k6-x-browser/) aims for rough compatibility with the [Playwright API for NodeJS](https://playwright.dev/docs/api/class-playwright). 
-> 
-> Because k6 does not run in NodeJS, the xk6-browser API will slightly differ from its Playwright counterpart.
-> 
-> Note that k6 APIs are synchronous.
+<BrowserCompatibility/>
 
 ## Supported APIs
 

--- a/src/data/markdown/docs/02 javascript api/30 k6-x-browser/10-request.md
+++ b/src/data/markdown/docs/02 javascript api/30 k6-x-browser/10-request.md
@@ -16,6 +16,6 @@ Support for the [`Request` Playwright API](https://playwright.dev/docs/api/class
 - [redirectedFrom()](https://playwright.dev/docs/api/class-request/#request-redirected-from)
 - [redirectedTo()](https://playwright.dev/docs/api/class-request/#request-redirected-to)
 
-🚧 `xk6-browser` is in Beta - we are working to cover more Playwright APIs.
+<BrowserWIP/>
 
 <BrowserClassList/>

--- a/src/data/markdown/docs/02 javascript api/30 k6-x-browser/10-request.md
+++ b/src/data/markdown/docs/02 javascript api/30 k6-x-browser/10-request.md
@@ -18,22 +18,4 @@ Support for the [`Request` Playwright API](https://playwright.dev/docs/api/class
 
 🚧 `xk6-browser` is in Beta - we are working to cover more Playwright APIs.
 
-### Browser APIs
-
-<Glossary>
-
--  [Browser](/javascript-api/k6-x-browser/browser/)
--  [BrowserContext](/javascript-api/k6-x-browser/browsercontext/)
--  [BrowserType](/javascript-api/k6-x-browser/browsertype/)
--  [ElementHandle](/javascript-api/k6-x-browser/elementhandle/)
--  [Frame](/javascript-api/k6-x-browser/frame/)
--  [JSHandle](/javascript-api/k6-x-browser/jshandle)
--  [Keyboard](/javascript-api/k6-x-browser/keyboard)
--  [Mouse](/javascript-api/k6-x-browser/mouse/)
--  [Page](/javascript-api/k6-x-browser/page/)
--  [Request](/javascript-api/k6-x-browser/request/)
--  [Response](/javascript-api/k6-x-browser/response/)
--  [Browser](/javascript-api/k6-x-browser/browser/)
--  [Touchscreen](/javascript-api/k6-x-browser/touchscreen/)
-
-</Glossary>
+<BrowserClassList/>

--- a/src/data/markdown/docs/02 javascript api/30 k6-x-browser/10-request.md
+++ b/src/data/markdown/docs/02 javascript api/30 k6-x-browser/10-request.md
@@ -3,13 +3,7 @@ title: "Request"
 excerpt: "xk6-browser: Request Class"
 ---
 
-> ️ **️⚠️ Compatibility**
-> 
-> The [xk6-browser API](/javascript-api/k6-x-browser/) aims for rough compatibility with the [Playwright API for NodeJS](https://playwright.dev/docs/api/class-playwright). 
-> 
-> Because k6 does not run in NodeJS, the xk6-browser API will slightly differ from its Playwright counterpart.
-> 
-> Note that k6 APIs are synchronous.
+<BrowserCompatibility/>
 
 ## Supported APIs
 

--- a/src/data/markdown/docs/02 javascript api/30 k6-x-browser/11-response.md
+++ b/src/data/markdown/docs/02 javascript api/30 k6-x-browser/11-response.md
@@ -3,13 +3,7 @@ title: "Response"
 excerpt: "xk6-browser: Response Class"
 ---
 
-> ️ **️⚠️ Compatibility**
-> 
-> The [xk6-browser API](/javascript-api/k6-x-browser/) aims for rough compatibility with the [Playwright API for NodeJS](https://playwright.dev/docs/api/class-playwright). 
-> 
-> Because k6 does not run in NodeJS, the xk6-browser API will slightly differ from its Playwright counterpart.
-> 
-> Note that k6 APIs are synchronous.
+<BrowserCompatibility/>
 
 
 ## Supported APIs

--- a/src/data/markdown/docs/02 javascript api/30 k6-x-browser/11-response.md
+++ b/src/data/markdown/docs/02 javascript api/30 k6-x-browser/11-response.md
@@ -14,22 +14,4 @@ Support for the [`Response` Playwright API](https://playwright.dev/docs/api/clas
 
 - [finished()](https://playwright.dev/docs/api/class-response/#response-finished): dependent on event-loop support in k6.
 
-### Browser APIs
-
-<Glossary>
-
--  [Browser](/javascript-api/k6-x-browser/browser/)
--  [BrowserContext](/javascript-api/k6-x-browser/browsercontext/)
--  [BrowserType](/javascript-api/k6-x-browser/browsertype/)
--  [ElementHandle](/javascript-api/k6-x-browser/elementhandle/)
--  [Frame](/javascript-api/k6-x-browser/frame/)
--  [JSHandle](/javascript-api/k6-x-browser/jshandle)
--  [Keyboard](/javascript-api/k6-x-browser/keyboard)
--  [Mouse](/javascript-api/k6-x-browser/mouse/)
--  [Page](/javascript-api/k6-x-browser/page/)
--  [Request](/javascript-api/k6-x-browser/request/)
--  [Response](/javascript-api/k6-x-browser/response/)
--  [Browser](/javascript-api/k6-x-browser/browser/)
--  [Touchscreen](/javascript-api/k6-x-browser/touchscreen/)
-
-</Glossary>
+<BrowserClassList/>

--- a/src/data/markdown/docs/02 javascript api/30 k6-x-browser/12-touchscreen.md
+++ b/src/data/markdown/docs/02 javascript api/30 k6-x-browser/12-touchscreen.md
@@ -3,13 +3,7 @@ title: "Touchscreen"
 excerpt: "xk6-browser: Touchscreen Class"
 ---
 
-> ️ **️⚠️ Compatibility**
-> 
-> The [xk6-browser API](/javascript-api/k6-x-browser/) aims for rough compatibility with the [Playwright API for NodeJS](https://playwright.dev/docs/api/class-playwright). 
-> 
-> Because k6 does not run in NodeJS, the xk6-browser API will slightly differ from its Playwright counterpart.
-> 
-> Note that k6 APIs are synchronous.
+<BrowserCompatibility/>
 
 ## Supported APIs
 

--- a/src/data/markdown/docs/02 javascript api/30 k6-x-browser/12-touchscreen.md
+++ b/src/data/markdown/docs/02 javascript api/30 k6-x-browser/12-touchscreen.md
@@ -9,22 +9,4 @@ excerpt: "xk6-browser: Touchscreen Class"
 
 Support for the [`Touchscreen` Playwright API](https://playwright.dev/docs/api/class-touchscreen/).
 
-### Browser APIs
-
-<Glossary>
-
--  [Browser](/javascript-api/k6-x-browser/browser/)
--  [BrowserContext](/javascript-api/k6-x-browser/browsercontext/)
--  [BrowserType](/javascript-api/k6-x-browser/browsertype/)
--  [ElementHandle](/javascript-api/k6-x-browser/elementhandle/)
--  [Frame](/javascript-api/k6-x-browser/frame/)
--  [JSHandle](/javascript-api/k6-x-browser/jshandle)
--  [Keyboard](/javascript-api/k6-x-browser/keyboard)
--  [Mouse](/javascript-api/k6-x-browser/mouse/)
--  [Page](/javascript-api/k6-x-browser/page/)
--  [Request](/javascript-api/k6-x-browser/request/)
--  [Response](/javascript-api/k6-x-browser/response/)
--  [Browser](/javascript-api/k6-x-browser/browser/)
--  [Touchscreen](/javascript-api/k6-x-browser/touchscreen/)
-
-</Glossary>
+<BrowserClassList/>


### PR DESCRIPTION
This PR adds `BrowserCompatibility`, `BrowserClassList` and `BrowserWIP` reusable components.

**Screenshots**
![image](https://user-images.githubusercontent.com/10406201/140658638-bf4f79d7-39a0-4103-b6a9-c16cfb30b608.png)
![image](https://user-images.githubusercontent.com/10406201/140658645-b63667a2-28f6-4bba-8423-eed2c133d7ef.png)
