### PR TITLE
 Update installation page

### DIFF
--- a/src/components/shared/collapsible/collapsible.module.scss
+++ b/src/components/shared/collapsible/collapsible.module.scss
@@ -33,7 +33,7 @@
   background: $color-additional-3;
   padding: 12px 50px 13px 25px;
   color: $color-primary;
-  font-size: 25px;
+  font-size: 18px;
   line-height: 35px;
   border-bottom: 1px solid transparent;
   animation: borderFadeIn 0.3s;

--- a/src/data/markdown/translated-guides/en/01 Getting started/02 Installation.md
+++ b/src/data/markdown/translated-guides/en/01 Getting started/02 Installation.md
@@ -112,3 +112,7 @@ docker pull loadimpact/k6
 Download a prebuilt binary from our [Releases page](https://github.com/k6io/k6/releases),
 and place it in your `PATH` to run `k6` from any location.
 
+## Using k6 extensions
+
+If you use one or more [k6 extensions](/extensions), you need a k6 binary built with your desired extension/s. Head over to the [bundle builder page](/extensions/bundle-builder/) to get started.
+

--- a/src/data/markdown/translated-guides/en/01 Getting started/02 Installation.md
+++ b/src/data/markdown/translated-guides/en/01 Getting started/02 Installation.md
@@ -7,35 +7,61 @@ excerpt: 'Instructions to install k6 in Linux, Mac, Windows. Use the Docker cont
 
 ### Debian/Ubuntu
 
-> #### 🧠 If you are using an image that lacks `ca-certificates` or `gnupg2`
-> 
-> Some images don't come bundled with the `ca-certificates` and `gnupg2` packages
-> out of the box. If you are using such an image, you first need to install these
-> packages with the following command:
-> 
-> ```bash
-> $ sudo apt-get update && sudo apt-get install ca-certificates gnupg2 -y
-> ```
-
 ```bash
-$ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
-$ echo "deb https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
-$ sudo apt-get update
-$ sudo apt-get install k6
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
+echo "deb https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
+sudo apt-get update
+sudo apt-get install k6
 ```
 
-> #### ⚠️ If you are behind a firewall or proxy
->
-> There have been reports of users being unable to download the key from Ubuntu's
-> keyserver using the `apt-key` command due to firewalls or proxies blocking their
-> requests. If you experience this issue, you may try this alternative approach
-> instead:
->
-> ```bash
-> $ curl -s https://dl.k6.io/key.gpg | sudo apt-key add -
-> ```
->
-> Then confirm that the key with the above ID is shown in the output of `sudo apt-key list`.
+<Collapsible title="Using an image that lacks ca-certificates or gnupg2">
+
+Some images don't come bundled with the `ca-certificates` and `gnupg2` packages
+out of the box. If you are using such an image, you first need to install these
+packages. The complete commands are as follow:
+
+```bash
+sudo apt-get update && sudo apt-get install ca-certificates gnupg2 -y
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
+echo "deb https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
+sudo apt-get update
+sudo apt-get install k6
+```
+
+</Collapsible>
+
+<Collapsible title="Behind a firewall or proxy">
+
+There have been reports of users being unable to download the key from Ubuntu's
+keyserver using the `apt-key` command due to firewalls or proxies blocking their
+requests. If you experience this issue, you may try this alternative approach
+instead:
+
+```bash
+curl -s https://dl.k6.io/key.gpg | sudo apt-key add -
+```
+
+Then confirm that the key with the above ID is shown in the output of `sudo apt-key list`.
+</Collapsible>
+
+<Collapsible title="Using the old Bintray repository">
+
+The Bintray k6 repositories [stopped working May 1st, 2021](https://k6.io/blog/sunsetting-bintray/)
+and you should switch to our own repositories following the instructions above.
+
+On Debian/Ubuntu you can remove the Bintray repository with:
+```bash
+sudo sed -i '/dl\.bintray\.com\/loadimpact\/deb/d' /etc/apt/sources.list
+sudo apt-key del 379CE192D401AB61
+sudo apt-get update
+```
+
+And on Fedora/CentOS with:
+```bash
+sudo rm /etc/yum.repos.d/bintray-loadimpact-rpm.repo
+```
+
+</Collapsible>
 
 
 ### Fedora/CentOS
@@ -43,39 +69,26 @@ $ sudo apt-get install k6
 Using `dnf` or `yum` on older versions:
 
 ```bash
-$ sudo dnf install https://dl.k6.io/rpm/repo.rpm
-$ sudo dnf install k6
+sudo dnf install https://dl.k6.io/rpm/repo.rpm
+sudo dnf install k6
 ```
+
+<Collapsible title="CentOS versions older than 8">
 
 CentOS versions older than 8 don't support the PGP V4 signature we use, so you'll need to disable the verification by installing k6 with:
 ```bash
-$ sudo yum install --nogpgcheck k6
+sudo yum install --nogpgcheck k6
 ```
 
-> #### ⚠️ Note about Bintray
->
-> The Bintray k6 repositories [stopped working May 1st, 2021](https://k6.io/blog/sunsetting-bintray/)
-> and you should switch to our own repositories following the instructions above.
->
-> On Debian/Ubuntu you can remove the Bintray repository with:
-> ```bash
-> $ sudo sed -i '/dl\.bintray\.com\/loadimpact\/deb/d' /etc/apt/sources.list
-> $ sudo apt-key del 379CE192D401AB61
-> $ sudo apt-get update
-> ```
->
-> And on Fedora/CentOS with:
-> ```bash
-> $ sudo rm /etc/yum.repos.d/bintray-loadimpact-rpm.repo
-> ```
+</Collapsible>
 
 
-## macOS
+## MacOS
 
 Using [Homebrew](https://brew.sh/):
 
 ```bash
-$ brew install k6
+brew install k6
 ```
 
 ## Windows
@@ -88,13 +101,14 @@ choco install k6
 
 Otherwise you can manually download and install the [latest official `.msi` package](https://dl.k6.io/msi/k6-latest-amd64.msi).
 
-## Binaries
+## Docker
+
+```bash
+docker pull loadimpact/k6
+```
+
+## Download the k6 binary
 
 Download a prebuilt binary from our [Releases page](https://github.com/k6io/k6/releases),
 and place it in your `PATH` to run `k6` from any location.
 
-## Docker
-
-```bash
-$ docker pull loadimpact/k6
-```

--- a/src/data/markdown/translated-guides/en/01 Getting started/02 Installation.md
+++ b/src/data/markdown/translated-guides/en/01 Getting started/02 Installation.md
@@ -14,55 +14,6 @@ sudo apt-get update
 sudo apt-get install k6
 ```
 
-<Collapsible title="Using an image that lacks ca-certificates or gnupg2">
-
-Some images don't come bundled with the `ca-certificates` and `gnupg2` packages
-out of the box. If you are using such an image, you first need to install these
-packages. The complete commands are as follow:
-
-```bash
-sudo apt-get update && sudo apt-get install ca-certificates gnupg2 -y
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
-echo "deb https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
-sudo apt-get update
-sudo apt-get install k6
-```
-
-</Collapsible>
-
-<Collapsible title="Behind a firewall or proxy">
-
-There have been reports of users being unable to download the key from Ubuntu's
-keyserver using the `apt-key` command due to firewalls or proxies blocking their
-requests. If you experience this issue, you may try this alternative approach
-instead:
-
-```bash
-curl -s https://dl.k6.io/key.gpg | sudo apt-key add -
-```
-
-Then confirm that the key with the above ID is shown in the output of `sudo apt-key list`.
-</Collapsible>
-
-<Collapsible title="Using the old Bintray repository">
-
-The Bintray k6 repositories [stopped working May 1st, 2021](https://k6.io/blog/sunsetting-bintray/)
-and you should switch to our own repositories following the instructions above.
-
-On Debian/Ubuntu you can remove the Bintray repository with:
-```bash
-sudo sed -i '/dl\.bintray\.com\/loadimpact\/deb/d' /etc/apt/sources.list
-sudo apt-key del 379CE192D401AB61
-sudo apt-get update
-```
-
-And on Fedora/CentOS with:
-```bash
-sudo rm /etc/yum.repos.d/bintray-loadimpact-rpm.repo
-```
-
-</Collapsible>
-
 
 ### Fedora/CentOS
 
@@ -73,14 +24,6 @@ sudo dnf install https://dl.k6.io/rpm/repo.rpm
 sudo dnf install k6
 ```
 
-<Collapsible title="CentOS versions older than 8">
-
-CentOS versions older than 8 don't support the PGP V4 signature we use, so you'll need to disable the verification by installing k6 with:
-```bash
-sudo yum install --nogpgcheck k6
-```
-
-</Collapsible>
 
 
 ## MacOS
@@ -116,3 +59,6 @@ and place it in your `PATH` to run `k6` from any location.
 
 If you use one or more [k6 extensions](/extensions), you need a k6 binary built with your desired extension/s. Head over to the [bundle builder page](/extensions/bundle-builder/) to get started.
 
+## Troubleshooting 
+
+If the installation fails, check the [list of common installation issues](/getting-started/installation/troubleshooting/).

--- a/src/data/markdown/translated-guides/en/01 Getting started/02 Installation/01 Troubleshooting.md
+++ b/src/data/markdown/translated-guides/en/01 Getting started/02 Installation/01 Troubleshooting.md
@@ -1,0 +1,59 @@
+---
+title: 'Troubleshooting'
+excerpt: 'Instructions to fix the most common installation issues.'
+---
+
+## Distro lacks ca-certificates or gnupg2
+
+Some Linux distributions don't come bundled with the `ca-certificates` and `gnupg2` packages
+out of the box. If you are using such an image, you first need to install these
+packages. The complete commands are as follow:
+
+```bash
+sudo apt-get update && sudo apt-get install ca-certificates gnupg2 -y
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
+echo "deb https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
+sudo apt-get update
+sudo apt-get install k6
+```
+
+
+## Behind a firewall or proxy
+
+There have been reports of users being unable to download the key from Ubuntu's
+keyserver using the `apt-key` command due to firewalls or proxies blocking their
+requests. If you experience this issue, you may try this alternative approach
+instead:
+
+```bash
+curl -s https://dl.k6.io/key.gpg | sudo apt-key add -
+```
+
+Then confirm that the key with the above ID is shown in the output of `sudo apt-key list`.
+
+## Using the old Bintray repository
+
+The Bintray k6 repositories [stopped working May 1st, 2021](https://k6.io/blog/sunsetting-bintray/)
+and you should switch to our own repositories following the instructions above.
+
+On Debian/Ubuntu you can remove the Bintray repository with:
+```bash
+sudo sed -i '/dl\.bintray\.com\/loadimpact\/deb/d' /etc/apt/sources.list
+sudo apt-key del 379CE192D401AB61
+sudo apt-get update
+```
+
+And on Fedora/CentOS with:
+```bash
+sudo rm /etc/yum.repos.d/bintray-loadimpact-rpm.repo
+```
+
+
+
+## CentOS versions older than 8
+
+CentOS versions older than 8 don't support the PGP V4 signature we use, so you'll need to disable the verification by installing k6 with:
+
+```bash
+sudo yum install --nogpgcheck k6
+```


### PR DESCRIPTION
The current installation page is a little overloaded with info for edge cases. This PR does a few cosmetic changes.

## Current version

<img width="551" alt="Screenshot 2021-11-15 at 12 44 51" src="https://user-images.githubusercontent.com/825430/141776596-222b9927-6188-4584-90ff-71fef75a2e5c.png">


## Proposal

<img width="798" alt="Screenshot 2021-11-15 at 12 59 33" src="https://user-images.githubusercontent.com/825430/141778541-a1eed53c-60b5-4ceb-b45f-4be79c3ad4b2.png">


