### PR TITLE
Update xk6 path in Prometheus instructions

### DIFF
--- a/src/data/markdown/translated-guides/en/04 Results visualization/10 Prometheus.md
+++ b/src/data/markdown/translated-guides/en/04 Results visualization/10 Prometheus.md
@@ -13,7 +13,7 @@ First, build a new k6 binary with the PRW extension, using [xk6](https://github.
 
 ```bash
 # Install xk6
-go install github.com/grafana/xk6/cmd/xk6@latest
+go install go.k6.io/xk6/cmd/xk6@latest
 
 # build k6 binary
 xk6 build --with github.com/grafana/xk6-output-prometheus-remote


### PR DESCRIPTION
The Prometheus docs still have the old download path for xk6, which has been updated as described here: https://github.com/grafana/k6/issues/1921.