### PR TITLE
fix: hide alternative js api modules from algolia

### DIFF
--- a/src/utils/algolia.js
+++ b/src/utils/algolia.js
@@ -33,6 +33,13 @@ const processMdxEntry = (
     return [];
   }
 
+  // hide alternative main modules
+  if (/alternative main modules/i.test(relativeDirectory)) {
+    // eslint-disable-next-line no-console
+    console.log('exluded from algolia indecies pages:', relativeDirectory);
+    return [];
+  }
+
   // @TODO: remove to enable sending spanish content to Algolia
   if (I18N_CONFIG.hideEsFromAlgoliaSearch) {
     if (/\/es\//i.test(relativeDirectory)) {


### PR DESCRIPTION
This PRs disables algolia indexing for alternative main modules (js api section)