### PR TITLE
Update node version to fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # base image
-FROM node:12-slim
+FROM node:14-slim
 
 EXPOSE 8000
 


### PR DESCRIPTION
Got this error when following the `README.md` to build the documentation locally.

![Screenshot from 2021-11-24 16-52-02](https://user-images.githubusercontent.com/3510723/143281196-93beb13e-10c9-46a0-80a9-bf1327a110fb.png)

Upgrading node version in base image fixed the issue and I could happily build and see the docs locally.
