### PR TITLE
fix: make suggest edits link clickable for jslib and xk6-browser

### DIFF
--- a/src/components/pages/doc-page/doc-page-title-group/doc-page-title-group.module.scss
+++ b/src/components/pages/doc-page/doc-page-title-group/doc-page-title-group.module.scss
@@ -1,6 +1,7 @@
 .wrapper {
   display: flex;
   position: relative;
+  z-index: 2;
   max-width: calc(100% - 325px);
   margin: 15px 0 50px;
   @include lg-down {


### PR DESCRIPTION
This PR changes `z-index` of page title to make `suggest edits` link clickable when right side has a github button.

![image](https://user-images.githubusercontent.com/10406201/143820277-da58919c-cbf7-459a-80a0-293b414d46c4.png)
