### PR TITLE
Include Winget instructions to Update 02 installation.md

### DIFF
--- a/src/data/markdown/translated-guides/en/01 Getting started/02 Installation.md
+++ b/src/data/markdown/translated-guides/en/01 Getting started/02 Installation.md
@@ -42,6 +42,12 @@ If you use the [Chocolatey package manager](https://chocolatey.org/) you can ins
 choco install k6
 ```
 
+or if you use the [Windows Package Manager](https://github.com/microsoft/winget-cli) you can install from the unofficial [k6 manifests](https://github.com/vedantmgoyal2009/winget-pkgs/tree/master/manifests/k/k6/k6) with:  
+
+```
+winget install k6
+```
+
 Otherwise you can manually download and install the [latest official `.msi` package](https://dl.k6.io/msi/k6-latest-amd64.msi).
 
 ## Docker

--- a/src/data/markdown/translated-guides/en/01 Getting started/02 Installation.md
+++ b/src/data/markdown/translated-guides/en/01 Getting started/02 Installation.md
@@ -42,7 +42,7 @@ If you use the [Chocolatey package manager](https://chocolatey.org/) you can ins
 choco install k6
 ```
 
-or if you use the [Windows Package Manager](https://github.com/microsoft/winget-cli) you can install from the unofficial [k6 manifests](https://github.com/vedantmgoyal2009/winget-pkgs/tree/master/manifests/k/k6/k6) with:  
+or if you use the [Windows Package Manager](https://github.com/microsoft/winget-cli) you can install the official packages from the k6 manifests [(created by the community)](https://github.com/microsoft/winget-pkgs/tree/master/manifests/k/k6/k6) with:  
 
 ```
 winget install k6


### PR DESCRIPTION
Include the Windows Package Manager instruction to install K6.

This helps clarify which package to install, as a search with "k6" returns multiple results, and could possibly lead to confusion in the future. 

![image](https://user-images.githubusercontent.com/10888984/144773310-6c19eed6-7e9f-4c74-9036-1e6a169bae24.png)
