### PR TITLE
feat(styles): add margins betwee paragraphs and blocks in complex <li>s

### DIFF
--- a/src/components/blocks/html-content/html-content.module.scss
+++ b/src/components/blocks/html-content/html-content.module.scss
@@ -96,4 +96,16 @@
   & * + li {
     margin-top: 5px;
   }
+
+  // margin between paragraphs, images and code blocks inside <li>
+  & li > * + p,
+  & li > * + div {
+    margin-top: 15px;
+  }
+
+  // margin after <li>s with complex children (paragraphs, images, code blocks)
+  & li > p:last-child,
+  & li > div:last-child {
+    margin-bottom: 25px;
+  }
 }


### PR DESCRIPTION
This PR add margins between `li`s that have multiple blocks inside (e.g. paragraphs, code blocks, images) and margins between those blocks inside `li`s.

(same changes for blog https://github.com/grafana/k6-blog/pull/186)