### PR TITLE
[fix] broken link for gracefulStop option

### DIFF
--- a/src/data/markdown/translated-guides/en/02 Using k6/14 Scenarios.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/14 Scenarios.md
@@ -79,7 +79,7 @@ Possible values for `executor` are the executor name separated by hyphens.
 | -------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
 | executor<sup>(required)</sup> ️  | string | Unique executor name. See the list of possible values in the [executors](#executors) section.                                                  | -           |
 | startTime    | string | Time offset since the start of the test, at which point this scenario should begin execution.                                                  | `"0s"`      |
-| gracefulStop | string | Time to wait for iterations to finish executing before stopping them forcefully. See the [gracefulStop](#graceful-stop-and-ramp-down) section. | `"30s"`     |
+| gracefulStop | string | Time to wait for iterations to finish executing before stopping them forcefully. Read more about gracefully stopping a test run [here](/using-k6/scenarios/graceful-stop/). | `"30s"`     |
 | exec         | string | Name of exported JS function to execute.                                                                                                       | `"default"` |
 | env          | object | Environment variables specific to this scenario.                                                                                               | `{}`        |
 | tags         | object | [Tags](/using-k6/tags-and-groups) specific to this scenario.                                                                                   | `{}`        |


### PR DESCRIPTION
The docs for the `gracefulStop` appears to have been moved to its own page, but I found a link to the old section. This PR updates the link and changes the copy to match.

@ppcano I'd need some help with the spanish translation. 😅 