### PR TITLE
Component for extension installation instructions

### DIFF
--- a/src/components/shared/installation-instructions/index.js
+++ b/src/components/shared/installation-instructions/index.js
@@ -1,0 +1,3 @@
+import InstallationInstructions from './installation-instructions.view';
+
+export default InstallationInstructions;

--- a/src/components/shared/installation-instructions/installation-instructions.view.js
+++ b/src/components/shared/installation-instructions/installation-instructions.view.js
@@ -1,0 +1,27 @@
+/* eslint-disable max-len */
+import Blockquote from 'components/shared/blockquote';
+import { Code } from 'components/shared/code';
+import React from 'react';
+
+const InstallationInstructions = ({ extensionUrl }) => (
+  <>
+    <p>
+      To build a k6 binary with the extension, first, ensure you have installed{' '}
+      <a href="https://golang.org/doc/install">Go</a> and{' '}
+      <a href="https://git-scm.com/">Git</a>; the following steps are:
+    </p>
+    <Code>
+      <pre className="language-bash">
+        {`# Install xk6\ngo install go.k6.io/xk6/cmd/xk6@latest\n\n# Build the k6 binary\nxk6 build --with ${extensionUrl}\n\n... [INFO] Build environment ready\n... [INFO] Building k6\n... [INFO] Build complete: ./k6`}
+      </pre>
+    </Code>
+    <p>xk6 will create the k6 binary in the local folder.</p>
+    <Blockquote>
+      <p>
+        To learn more about how to build custom k6 versions, check out{' '}
+        <a href="https://github.com/grafana/xk6">xk6</a>
+      </p>
+    </Blockquote>
+  </>
+);
+export default InstallationInstructions;

--- a/src/components/templates/doc-page/doc-page-content/doc-page-content.view.js
+++ b/src/components/templates/doc-page/doc-page-content/doc-page-content.view.js
@@ -9,6 +9,7 @@ import { HeadingLandmark } from 'components/shared/heading';
 import BrowserCompatibility from 'components/shared/browser-compatibility';
 import BrowserClassList from 'components/shared/browser-class-list';
 import BrowserWIP from 'components/shared/browser-wip';
+import InstallationInstructions from 'components/shared/installation-instructions';
 import LdScript from 'components/shared/ld-script';
 import { Link } from 'components/shared/link';
 import TableWrapper from 'components/shared/table-wrapper';
@@ -33,6 +34,7 @@ const componentsForNativeReplacement = {
   BrowserCompatibility,
   BrowserClassList,
   BrowserWIP,
+  InstallationInstructions,
 };
 
 export const DocPageContent = ({

--- a/src/data/markdown/docs/30 xk6-browser/30 xk6-browser.md
+++ b/src/data/markdown/docs/30 xk6-browser/30 xk6-browser.md
@@ -43,25 +43,9 @@ The quickest way to get started is to [download a release binary from GitHub](ht
 
 ### Build from source
 
-If you're more adventurous or want to get the latest changes of the xk6-browser extension, you can also build from source.
+If you're more adventurous or want to get the latest changes of the xk6-browser extension, you can also build from source. 
 
-To build a k6 binary with the extension, first, ensure you have installed [Go](https://golang.org/doc/install) and [Git](https://git-scm.com/); the following steps are:
-
-```bash
-# Install xk6
-go install go.k6.io/xk6/cmd/xk6@latest
-
-# Build the k6 binary
-xk6 build --with github.com/grafana/xk6-browser
-
-... [INFO] Build environment ready
-... [INFO] Building k6
-... [INFO] Build complete: ./k6
-```
-
-xk6 will create the k6 binary in the local folder. 
-
-> To learn more about how to build custom k6 versions, check out [xk6](https://github.com/grafana/xk6). 
+<InstallationInstructions extensionUrl="github.com/grafana/xk6-browser"/>
 
 ## Browser-level APIs
 

--- a/src/data/markdown/translated-guides/en/04 Results visualization/05 Grafana Cloud.md
+++ b/src/data/markdown/translated-guides/en/04 Results visualization/05 Grafana Cloud.md
@@ -30,23 +30,7 @@ On the Password / API Key section, create and copy an API key of `MetricsPublish
 
 To output k6 metrics to Prometheus, you have to run a k6 version built with the [extension for Prometheus remote write](https://github.com/grafana/xk6-output-prometheus-remote).
 
-To build a k6 binary with the extension, first, ensure you have installed [Go](https://golang.org/doc/install) and [Git](https://git-scm.com/); the following steps are:
-
-```shell
-# Install xk6
-go install go.k6.io/xk6/cmd/xk6@latest
-
-# Build k6 binary
-xk6 build --with github.com/grafana/xk6-output-prometheus-remote
-
-... [INFO] Build environment ready
-... [INFO] Building k6
-... [INFO] Build complete: ./k6
-```
-
-xk6 will create the k6 binary in the local folder. 
-
-> To learn more about how to build custom k6 versions, check out [xk6](https://github.com/grafana/xk6). 
+<InstallationInstructions extensionUrl="github.com/grafana/xk6-output-prometheus-remote"/>
 
 ## Run the test
 

--- a/src/data/markdown/translated-guides/en/04 Results visualization/10 Prometheus.md
+++ b/src/data/markdown/translated-guides/en/04 Results visualization/10 Prometheus.md
@@ -7,23 +7,7 @@ k6 supports sending test result metrics to a Prometheus Remote Write endpoint vi
 
 ## Instructions
 
-To build a k6 binary with the PRW extension, first, ensure you have installed [Go](https://golang.org/doc/install) and [Git](https://git-scm.com/); the following steps are:
-
-```shell
-# Install xk6
-go install go.k6.io/xk6/cmd/xk6@latest
-
-# Build k6 binary
-xk6 build --with github.com/grafana/xk6-output-prometheus-remote
-
-... [INFO] Build environment ready
-... [INFO] Building k6
-... [INFO] Build complete: ./k6
-```
-
-xk6 will create the k6 binary in the local folder. 
-
-> To learn more about how to build custom k6 versions, check out [xk6](https://github.com/grafana/xk6). 
+<InstallationInstructions extensionUrl="github.com/grafana/xk6-output-prometheus-remote"/>
 
 
 Then run the test with the new binary as follows:


### PR DESCRIPTION
This PR adds component for installation instructions.

Usage example (in `.md` file):
`<InstallationInstructions extensionUrl="github.com/grafana/xk6-browser"/>`

Result:
![image](https://user-images.githubusercontent.com/10406201/146344284-5c6c8603-ef77-4532-ae50-f40b27c54510.png)


Affected pages:
https://mdr-ci.staging.k6.io/docs/refs/pull/532/merge/results-visualization/prometheus/
https://mdr-ci.staging.k6.io/docs/refs/pull/532/merge/results-visualization/grafana-cloud/
https://mdr-ci.staging.k6.io/docs/refs/pull/532/merge/javascript-api/xk6-browser/