### PR TITLE
skip pr deploy for PRs from forked repos

### DIFF
--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -100,6 +100,7 @@ jobs:
     name: Deploy pull request
     runs-on: ubuntu-latest
     needs: [build]
+    if: github.event.pull_request.head.repo.full_name == github.repository
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.PR_CI_AWS_ACCESS_KEY }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.PR_CI_AWS_SECRET_KEY }}


### PR DESCRIPTION
This PR updates `pr-deploy` workflow to skip deploying of PRs from forks (because it will fail since they don't have access to secrets)