### PR TITLE
chore: skip deploy for PRs from dependabot

### DIFF
--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -100,7 +100,7 @@ jobs:
     name: Deploy pull request
     runs-on: ubuntu-latest
     needs: [build]
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.PR_CI_AWS_ACCESS_KEY }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.PR_CI_AWS_SECRET_KEY }}


### PR DESCRIPTION
This PR changes `pr-deploy` actions to skip deploy step for PRs from dependabot (since it doesn't have access to secrets since 1st March: [link](https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/))