### PR TITLE
feat: hide ToC scrollbar when content is not scrollable

### DIFF
--- a/src/components/pages/doc-page/table-of-contents/table-of-contents.module.scss
+++ b/src/components/pages/doc-page/table-of-contents/table-of-contents.module.scss
@@ -9,7 +9,7 @@
   margin-right: -30px;
 
   overflow-x: hidden;
-  overflow-y: scroll;
+  overflow-y: auto;
 
   @include lg-down {
     display: none;


### PR DESCRIPTION
This PR fixes #541 by hiding Table of Contents scrollbar when the content doesn't overflow height.