### PR TITLE
place search inbox under header on smaller screens

### DIFF
--- a/src/components/shared/page-info/page-info.module.scss
+++ b/src/components/shared/page-info/page-info.module.scss
@@ -1,7 +1,7 @@
 .container {
   margin-bottom: 47.5px;
   margin-top: 115px;
-  @include lg-down {
+  @include xl-down {
     margin-top: 160px;
   }
   @include sm-down {

--- a/src/components/templates/doc-page/doc-page.module.scss
+++ b/src/components/templates/doc-page/doc-page.module.scss
@@ -1,6 +1,6 @@
 .container {
   margin-top: 115px;
-  @include lg-down {
+  @include xl-down {
     margin-top: 185px;
   }
   @include md-down {

--- a/src/layouts/doc-layout/doc-layout.module.scss
+++ b/src/layouts/doc-layout/doc-layout.module.scss
@@ -40,6 +40,10 @@
     display: none;
   }
 }
+.header-nav {
+  // to display JS API nested menu above search
+  z-index: 1;
+}
 .search-box {
   padding-bottom: 5px;
 }

--- a/src/layouts/doc-layout/doc-layout.view.js
+++ b/src/layouts/doc-layout/doc-layout.view.js
@@ -355,7 +355,9 @@ export const DocLayout = ({
 
       <main className={styles.main}>
         <Header>
-          <div className={'col-xl-8 col-lg-12 d-md-flex col-md-12 d-none'}>
+          <div
+            className={`col-xxl-8 col-12 d-md-flex d-none ${styles.headerNav}`}
+          >
             <HeaderNav links={links} />
             <div className={styles.controls}>
               {!!version && (
@@ -381,7 +383,7 @@ export const DocLayout = ({
             )}
             <Burger onClick={() => setIsMobileNavVisible(true)} />
           </div>
-          <div className={`col-xl-4 col-12 ${styles.searchBox}`}>
+          <div className={`col-xxl-4 col-12 ${styles.searchBox}`}>
             <SearchBox collapse indices={searchIndices} />
           </div>
           <div className={'d-md-none col-12'}>

--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -1,3 +1,9 @@
+@mixin xl-down {
+  @media only screen and (max-width: $screen-xl-down) {
+    @content;
+  }
+}
+
 @mixin lg-down {
   @media only screen and (max-width: $screen-lg-down) {
     @content;

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -48,8 +48,9 @@ $color-additional-3: #f9f8fc;
 // Breakpoints
 $screen-xs-down: 575.98px;
 $screen-sm-down: 767.98px;
-$screen-md-down: 991.98px;
+$screen-md-down: 1023.98px;
 $screen-lg-down: 1199.98px;
+$screen-xl-down: 1479.98px;
 
 // Section spacing
 $spacing-sm-down: 70px;

--- a/src/styles/vendor/bootstrap-grid.scss
+++ b/src/styles/vendor/bootstrap-grid.scss
@@ -61,7 +61,7 @@
 }
 
 .no-gutters > .col,
-.no-gutters > [class*="col-"] {
+.no-gutters > [class*='col-'] {
   padding-right: 0;
   padding-left: 0;
 }
@@ -135,7 +135,21 @@
 .col-xl-11,
 .col-xl-12,
 .col-xl,
-.col-xl-auto {
+.col-xl-auto,
+.col-xxl-1,
+.col-xxl-2,
+.col-xxl-3,
+.col-xxl-4,
+.col-xxl-5,
+.col-xxl-6,
+.col-xxl-7,
+.col-xxl-8,
+.col-xxl-9,
+.col-xxl-10,
+.col-xxl-11,
+.col-xxl-12,
+.col-xxl,
+.col-xxl-auto {
   position: relative;
   width: 100%;
   padding: 12.5px;
@@ -1031,6 +1045,178 @@
     margin-left: 83.333333%;
   }
   .offset-xl-11 {
+    margin-left: 91.666667%;
+  }
+}
+
+@media (min-width: 1480px) {
+  .col-xxl {
+    -ms-flex-preferred-size: 0;
+    flex-basis: 0;
+    -ms-flex-positive: 1;
+    flex-grow: 1;
+    max-width: 100%;
+  }
+  .col-xxl-auto {
+    -ms-flex: 0 0 auto;
+    flex: 0 0 auto;
+    width: auto;
+    max-width: 100%;
+  }
+  .col-xxl-1 {
+    -ms-flex: 0 0 8.333333%;
+    flex: 0 0 8.333333%;
+    max-width: 8.333333%;
+  }
+  .col-xxl-2 {
+    -ms-flex: 0 0 16.666667%;
+    flex: 0 0 16.666667%;
+    max-width: 16.666667%;
+  }
+  .col-xxl-3 {
+    -ms-flex: 0 0 25%;
+    flex: 0 0 25%;
+    max-width: 25%;
+  }
+  .col-xxl-4 {
+    -ms-flex: 0 0 33.333333%;
+    flex: 0 0 33.333333%;
+    max-width: 33.333333%;
+  }
+  .col-xxl-5 {
+    -ms-flex: 0 0 41.666667%;
+    flex: 0 0 41.666667%;
+    max-width: 41.666667%;
+  }
+  .col-xxl-6 {
+    -ms-flex: 0 0 50%;
+    flex: 0 0 50%;
+    max-width: 50%;
+  }
+  .col-xxl-7 {
+    -ms-flex: 0 0 58.333333%;
+    flex: 0 0 58.333333%;
+    max-width: 58.333333%;
+  }
+  .col-xxl-8 {
+    -ms-flex: 0 0 66.666667%;
+    flex: 0 0 66.666667%;
+    max-width: 66.666667%;
+  }
+  .col-xxl-9 {
+    -ms-flex: 0 0 75%;
+    flex: 0 0 75%;
+    max-width: 75%;
+  }
+  .col-xxl-10 {
+    -ms-flex: 0 0 83.333333%;
+    flex: 0 0 83.333333%;
+    max-width: 83.333333%;
+  }
+  .col-xxl-11 {
+    -ms-flex: 0 0 91.666667%;
+    flex: 0 0 91.666667%;
+    max-width: 91.666667%;
+  }
+  .col-xxl-12 {
+    -ms-flex: 0 0 100%;
+    flex: 0 0 100%;
+    max-width: 100%;
+  }
+  .order-xxl-first {
+    -ms-flex-order: -1;
+    order: -1;
+  }
+  .order-xxl-last {
+    -ms-flex-order: 13;
+    order: 13;
+  }
+  .order-xxl-0 {
+    -ms-flex-order: 0;
+    order: 0;
+  }
+  .order-xxl-1 {
+    -ms-flex-order: 1;
+    order: 1;
+  }
+  .order-xxl-2 {
+    -ms-flex-order: 2;
+    order: 2;
+  }
+  .order-xxl-3 {
+    -ms-flex-order: 3;
+    order: 3;
+  }
+  .order-xxl-4 {
+    -ms-flex-order: 4;
+    order: 4;
+  }
+  .order-xxl-5 {
+    -ms-flex-order: 5;
+    order: 5;
+  }
+  .order-xxl-6 {
+    -ms-flex-order: 6;
+    order: 6;
+  }
+  .order-xxl-7 {
+    -ms-flex-order: 7;
+    order: 7;
+  }
+  .order-xxl-8 {
+    -ms-flex-order: 8;
+    order: 8;
+  }
+  .order-xxl-9 {
+    -ms-flex-order: 9;
+    order: 9;
+  }
+  .order-xxl-10 {
+    -ms-flex-order: 10;
+    order: 10;
+  }
+  .order-xxl-11 {
+    -ms-flex-order: 11;
+    order: 11;
+  }
+  .order-xxl-12 {
+    -ms-flex-order: 12;
+    order: 12;
+  }
+  .offset-xxl-0 {
+    margin-left: 0;
+  }
+  .offset-xxl-1 {
+    margin-left: 8.333333%;
+  }
+  .offset-xxl-2 {
+    margin-left: 16.666667%;
+  }
+  .offset-xxl-3 {
+    margin-left: 25%;
+  }
+  .offset-xxl-4 {
+    margin-left: 33.333333%;
+  }
+  .offset-xxl-5 {
+    margin-left: 41.666667%;
+  }
+  .offset-xxl-6 {
+    margin-left: 50%;
+  }
+  .offset-xxl-7 {
+    margin-left: 58.333333%;
+  }
+  .offset-xxl-8 {
+    margin-left: 66.666667%;
+  }
+  .offset-xxl-9 {
+    margin-left: 75%;
+  }
+  .offset-xxl-10 {
+    margin-left: 83.333333%;
+  }
+  .offset-xxl-11 {
     margin-left: 91.666667%;
   }
 }


### PR DESCRIPTION
Fixes #543 

On screens smaller that 1480px move search input below header to avoid overlapping.

1440px:
![image](https://user-images.githubusercontent.com/10406201/149495961-8c3e4bd1-857a-41cd-b5b2-866e499cb661.png)
