### PR TITLE
Fixed local-ips range example

### DIFF
--- a/src/data/markdown/translated-guides/en/02 Using k6/05 Options.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/05 Options.md
@@ -690,7 +690,7 @@ Available in the `k6 run` command.
 <CodeGroup labels={[]}>
 
 ```bash
-$ k6 run --local-ips=192.168.20.12-192.168.20-15,192.168.10.0/27 script.js
+$ k6 run --local-ips=192.168.20.12-192.168.20.15,192.168.10.0/27 script.js
 ```
 
 </CodeGroup>


### PR DESCRIPTION
Small fix of the example for the `local-ips` option.