### PR TITLE
separate search index entry for each extension

### DIFF
--- a/src/utils/algolia.js
+++ b/src/utils/algolia.js
@@ -108,21 +108,14 @@ const flatten = (arr, kind = 'docs') => {
 };
 
 // custom index entry for extensions page
-const processExtensions = (extensionsList) => {
-  const reducer = (prev, { name, description }) =>
-    [prev, name, description].join('\n');
-  const content = extensionsList.reduce(reducer, []);
-
-  return [
-    {
-      title: 'k6 Extensions',
-      objectID: 'explore-extensions-page',
-      slug: '/extensions/',
-      content,
-      _tags: ['en', 'es'],
-    },
-  ];
-};
+const processExtensions = (extensionsList) =>
+  extensionsList.map((extension) => ({
+    title: extension.name,
+    objectID: `extensions-${extension.name}`,
+    slug: '/extensions/',
+    content: extension.description,
+    _tags: ['en', 'es'],
+  }));
 
 // main query
 const docPagesQuery = `{


### PR DESCRIPTION
This PR adds separate search index entry for each extension. All extension results lead to the Extensions page.

![image](https://user-images.githubusercontent.com/10406201/151393091-5ce8f464-9731-4dcd-9a3e-66c2a3d09480.png)
