### PR TITLE
Docker hub repository grafana/k6

### DIFF
--- a/src/data/markdown/docs/03 cloud/01 Creating and running a test/02 Cloud tests from the CLI.md
+++ b/src/data/markdown/docs/03 cloud/01 Creating and running a test/02 Cloud tests from the CLI.md
@@ -48,7 +48,7 @@ Reasons for triggering cloud tests from the k6 CLI include:
    # Note the difference in specifying the `K6_CLOUD_TOKEN` environment variable
    # using the `docker run -e` option.
 
-   $ docker run -i -e K6_CLOUD_TOKEN=<API_TOKEN> loadimpact/k6 cloud - <script.js
+   $ docker run -i -e K6_CLOUD_TOKEN=<API_TOKEN> grafana/k6 cloud - <script.js
 
    # When passing the script via stdin there is no way for the containerized k6 process
 
@@ -72,7 +72,7 @@ Reasons for triggering cloud tests from the k6 CLI include:
 
    # b) mount the local filesystem as a Docker volume:
 
-   $ docker run -i -e ... -v "$PWD/script.js:/script.js" loadimpact/k6 cloud /script.js
+   $ docker run -i -e ... -v "$PWD/script.js:/script.js" grafana/k6 cloud /script.js
    ```
 
    </CodeGroup>

--- a/src/data/markdown/docs/03 cloud/04 Integrations/04 Token.md
+++ b/src/data/markdown/docs/03 cloud/04 Integrations/04 Token.md
@@ -14,7 +14,7 @@ Below are some examples on how to utilize the token to authenticate.
 
 > #### Docker Users
 >
-> If you're running k6 in a Docker container you'll need to make sure that the k6 config file where the k6 Cloud API authentication information is stored to is persisted via a Docker volume to the host machine, using the `-c/--config PATH/TO/CONFIG_FILE` CLI flag, e.g. `docker run -i -v /path/on-host:/path/in-container/ loadimpact/k6 login cloud -c /path/in-container/config.json`.
+> If you're running k6 in a Docker container you'll need to make sure that the k6 config file where the k6 Cloud API authentication information is stored to is persisted via a Docker volume to the host machine, using the `-c/--config PATH/TO/CONFIG_FILE` CLI flag, e.g. `docker run -i -v /path/on-host:/path/in-container/ grafana/k6 login cloud -c /path/in-container/config.json`.
 
 > #### Integrating with CI
 >

--- a/src/data/markdown/translated-guides/en/01 Getting started/02 Installation.md
+++ b/src/data/markdown/translated-guides/en/01 Getting started/02 Installation.md
@@ -53,7 +53,7 @@ Otherwise you can manually download and install the [latest official `.msi` pack
 ## Docker
 
 ```bash
-docker pull loadimpact/k6
+docker pull grafana/k6
 ```
 
 ## Download the k6 binary

--- a/src/data/markdown/translated-guides/en/01 Getting started/03 Running k6.md
+++ b/src/data/markdown/translated-guides/en/01 Getting started/03 Running k6.md
@@ -37,11 +37,11 @@ $ k6 run script.js
 # pipe the actual file into the container with `<` or equivalent. This will
 # cause the file to be redirected into the container and be read by k6.
 
-$ docker run -i loadimpact/k6 run - <script.js
+$ docker run -i grafana/k6 run - <script.js
 ```
 
 ```bash
-PS C:\> cat script.js | docker run -i loadimpact/k6 run -
+PS C:\> cat script.js | docker run -i grafana/k6 run -
 ```
 
 </CodeGroup>
@@ -57,11 +57,11 @@ $ k6 run --vus 10 --duration 30s script.js
 ```
 
 ```bash
-$ docker run -i loadimpact/k6 run --vus 10 --duration 30s - <script.js
+$ docker run -i grafana/k6 run --vus 10 --duration 30s - <script.js
 ```
 
 ```bash
-PS C:\> cat script.js | docker run -i loadimpact/k6 run --vus 10 --duration 30s -
+PS C:\> cat script.js | docker run -i grafana/k6 run --vus 10 --duration 30s -
 ```
 
 </CodeGroup>
@@ -142,11 +142,11 @@ $ k6 run script.js
 ```
 
 ```bash
-$ docker run -i loadimpact/k6 run - <script.js
+$ docker run -i grafana/k6 run - <script.js
 ```
 
 ```bash
-PS C:\> cat script.js | docker run -i loadimpact/k6 run -
+PS C:\> cat script.js | docker run -i grafana/k6 run -
 ```
 
 </CodeGroup>

--- a/src/data/markdown/translated-guides/en/02 Using k6/07 Modules.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/07 Modules.md
@@ -366,7 +366,7 @@ To run index.js and make the modules available for import we execute the followi
 <CodeGroup labels={[]} lineNumbers={[false]}>
 
 ```bash
-$ docker run -v /home/k6/example/src:/src -i loadimpact/k6 run /src/index.js
+$ docker run -v /home/k6/example/src:/src -i grafana/k6 run /src/index.js
 ```
 
 </CodeGroup>

--- a/src/data/markdown/translated-guides/en/04 Results visualization/00 End-of-test Summary.md
+++ b/src/data/markdown/translated-guides/en/04 Results visualization/00 End-of-test Summary.md
@@ -62,7 +62,7 @@ You can also send the generated reports to a remote server by making an HTTP req
 
 ```javascript
 import http from 'k6/http';
-import k6example from 'https://raw.githubusercontent.com/loadimpact/k6/master/samples/thresholds_readme_example.js';
+import k6example from 'https://raw.githubusercontent.com/grafana/k6/master/samples/thresholds_readme_example.js';
 export default k6example; // use some predefined example to generate some data
 export const options = { vus: 5, iterations: 10 };
 

--- a/src/data/markdown/translated-guides/en/04 Results visualization/06 InfluxDB - Grafana.md
+++ b/src/data/markdown/translated-guides/en/04 Results visualization/06 InfluxDB - Grafana.md
@@ -39,7 +39,7 @@ $ k6 run --out influxdb=http://localhost:8086/myk6db script.js
 ```
 
 ```bash
-$ docker run -i loadimpact/k6 run --out influxdb=http://localhost:8086/myk6db - <script.js
+$ docker run -i grafana/k6 run --out influxdb=http://localhost:8086/myk6db - <script.js
 ```
 
 </CodeGroup>

--- a/src/data/markdown/translated-guides/en/04 Results visualization/07 JSON.md
+++ b/src/data/markdown/translated-guides/en/04 Results visualization/07 JSON.md
@@ -15,7 +15,7 @@ $ k6 run --out json=my_test_result.json script.js
 $ docker run -it --rm \
     -v <scriptdir>:/scripts \
     -v <outputdir>:/jsonoutput \
-    loadimpact/k6 run --out json=/jsonoutput/my_test_result.json /scripts/script.js
+    grafana/k6 run --out json=/jsonoutput/my_test_result.json /scripts/script.js
 
 # Note that the docker user must have permission to write to <outputdir>!
 ```
@@ -34,7 +34,7 @@ $ k6 run --out json=my_test_result.gz script.js
 $ docker run -it --rm \
     -v <scriptdir>:/scripts \
     -v <outputdir>:/jsonoutput \
-    loadimpact/k6 run --out json=/jsonoutput/my_test_result.gz /scripts/script.js
+    grafana/k6 run --out json=/jsonoutput/my_test_result.gz /scripts/script.js
 
 # Note that the docker user must have permission to write to <outputdir>!
 ```

--- a/src/data/markdown/translated-guides/es/01 Getting started/02 Installation.md
+++ b/src/data/markdown/translated-guides/es/01 Getting started/02 Installation.md
@@ -90,5 +90,5 @@ Descarga un binario preconstruido de nuestra [página de releases](https://githu
 ## Docker
 
 ```bash
-$ docker pull loadimpact/k6
+$ docker pull grafana/k6
 ```

--- a/src/data/markdown/translated-guides/es/01 Getting started/03 Running k6.md
+++ b/src/data/markdown/translated-guides/es/01 Getting started/03 Running k6.md
@@ -32,11 +32,11 @@ $ k6 run script.js
 ```bash
 # Al usar la imagen del docker "k6", no se puede simplemente especificar el nombre del archivo, ya que el archivo no estará disponible para el contenedor(docker) mientras este se ejecuta. En su lugar debe decirle a K6 que lea "STDIN" pasando el nombre del archivo como "-". Luego ponga el archivo en el contenedor con `<` o el equivalente. Esto hará que el archivo sea redirigido al contenedor y sea leído por k6.
 
-$ docker run -i loadimpact/k6 run - <script.js
+$ docker run -i grafana/k6 run - <script.js
 ```
 
 ```bash
-PS C:\> cat script.js | docker run -i loadimpact/k6 run -
+PS C:\> cat script.js | docker run -i grafana/k6 run -
 ```
 
 </CodeGroup>
@@ -53,11 +53,11 @@ $ k6 run --vus 10 --duration 30s script.js
 ```
 
 ```bash
-$ docker run -i loadimpact/k6 run --vus 10 --duration 30s - <script.js
+$ docker run -i grafana/k6 run --vus 10 --duration 30s - <script.js
 ```
 
 ```bash
-PS C:\> cat script.js | docker run -i loadimpact/k6 run --vus 10 --duration 30s -
+PS C:\> cat script.js | docker run -i grafana/k6 run --vus 10 --duration 30s -
 ```
 
 </CodeGroup>
@@ -130,11 +130,11 @@ $ k6 run script.js
 ```
 
 ```bash
-$ docker run -i loadimpact/k6 run - <script.js
+$ docker run -i grafana/k6 run - <script.js
 ```
 
 ```bash
-PS C:\> cat script.js | docker run -i loadimpact/k6 run -
+PS C:\> cat script.js | docker run -i grafana/k6 run -
 ```
 
 </CodeGroup>

--- a/src/data/markdown/translated-guides/es/02 Using k6/07 Modules.md
+++ b/src/data/markdown/translated-guides/es/02 Using k6/07 Modules.md
@@ -116,7 +116,7 @@ Para ejecutar index.js y hacer que los módulos estén disponibles para su impor
 <CodeGroup labels={[]} lineNumbers={[false]}>
 
 ```bash
-$ docker run -v /home/k6/example/src:/src -i loadimpact/k6 run /src/index.js
+$ docker run -v /home/k6/example/src:/src -i grafana/k6 run /src/index.js
 ```
 
 </CodeGroup>

--- a/src/data/markdown/translated-guides/es/04 Results visualization/00 End-of-test Summary.md
+++ b/src/data/markdown/translated-guides/es/04 Results visualization/00 End-of-test Summary.md
@@ -71,7 +71,7 @@ Además de personalizar el resumen CLI de fin de prueba (si se exporta `handleSu
 
 ```javascript
 import http from 'k6/http';
-import k6example from 'https://raw.githubusercontent.com/loadimpact/k6/master/samples/thresholds_readme_example.js';
+import k6example from 'https://raw.githubusercontent.com/grafana/k6/master/samples/thresholds_readme_example.js';
 export default k6example; // use some predefined example to generate some data
 export const options = { vus: 5, iterations: 10 };
 

--- a/src/data/markdown/translated-guides/es/04 Results visualization/06 InfluxDB - Grafana.md
+++ b/src/data/markdown/translated-guides/es/04 Results visualization/06 InfluxDB - Grafana.md
@@ -38,7 +38,7 @@ $ k6 run --out influxdb=http://localhost:8086/myk6db script.js
 ```
 
 ```bash
-$ docker run -i loadimpact/k6 run --out influxdb=http://localhost:8086/myk6db - <script.js
+$ docker run -i grafana/k6 run --out influxdb=http://localhost:8086/myk6db - <script.js
 ```
 
 </CodeGroup>

--- a/src/data/markdown/translated-guides/es/04 Results visualization/07 JSON.md
+++ b/src/data/markdown/translated-guides/es/04 Results visualization/07 JSON.md
@@ -15,7 +15,7 @@ $ k6 run --out json=my_test_result.json script.js
 $ docker run -it --rm \
     -v <scriptdir>:/scripts \
     -v <outputdir>:/jsonoutput \
-    loadimpact/k6 run --out json=/jsonoutput/my_test_result.json /scripts/script.js
+    grafana/k6 run --out json=/jsonoutput/my_test_result.json /scripts/script.js
 
 # El usuario de docker debe tener permiso de escritura en <outputdir>!
 ```
@@ -34,7 +34,7 @@ $ k6 run --out json=my_test_result.gz script.js
 $ docker run -it --rm \
     -v <scriptdir>:/scripts \
     -v <outputdir>:/jsonoutput \
-    loadimpact/k6 run --out json=/jsonoutput/my_test_result.gz /scripts/script.js
+    grafana/k6 run --out json=/jsonoutput/my_test_result.gz /scripts/script.js
 
 # El usuario de docker debe tener permiso de escritura en <outputdir>!
 ```


### PR DESCRIPTION
Migrating documentation examples from the `loadimpact/k6` to the `grafana/k6` docker hub repository