### PR TITLE
Remove callouts as New for older releases

### DIFF
--- a/src/data/markdown/translated-guides/en/02 Using k6/05 Options.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/05 Options.md
@@ -259,8 +259,6 @@ export const options = {
 
 ## Block Hostnames
 
-> _New in v0.29.0_
-
 Blocks hostnames based on a list glob match strings. The pattern matching string can have a single
 `*` at the beginning such as `*.example.com` that will match anything before that such as
 `test.example.com` and `test.test.example.com`.
@@ -371,8 +369,6 @@ export const options = {
 
 ## DNS
 
-> _New in v0.29.0_
-
 This is a composite option that provides control of DNS resolution behavior with
 configuration for cache expiration (TTL), IP selection strategy and IP version
 preference. The TTL field in the DNS record is currently not read by k6, so the
@@ -476,8 +472,6 @@ export const options = {
 </CodeGroup>
 
 ## Execution Segment
-
-> _New in v0.27.0_
 
 These options specify how to partition the test run and which segment to run.
 If defined, k6 will scale the number of VUs and iterations to be run for that
@@ -1163,8 +1157,6 @@ C:\k6> $env:K6_STAGES="5s:10,5m:20,10s:5"; k6 run script.js
 </CodeGroup>
 
 ## Summary export
-
-> _New in v0.26.0_
 
 Save the end-of-test summary report to a JSON file that includes data for all test metrics, checks and thresholds. This is useful to get the aggregated test results in a machine-readable format, for integration with dashboards, external alerts, CI pipelines, etc.
 

--- a/src/data/markdown/translated-guides/en/02 Using k6/14 Scenarios.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/14 Scenarios.md
@@ -4,12 +4,6 @@ excerpt: 'Scenarios allow us to make in-depth configurations to how VUs and iter
 hideFromSidebar: false
 ---
 
-> ### 🎉 New in v0.27.0
->
-> This feature is new as of version 0.27.0. Usage of this feature is optional and for the vast majority of users,
-> existing scripts and configurations will continue to work as before. For a list of breaking changes,
-> see the [k6 v0.27.0 release notes](https://github.com/grafana/k6/releases/tag/v0.27.0).
-
 Scenarios allow us to make in-depth configurations to how VUs and iterations are scheduled. This makes it possible to model diverse traffic patterns in load tests. Benefits of using scenarios include:
 
 - Multiple scenarios can be declared in the same script, and each one can

--- a/src/data/markdown/translated-guides/es/04 Results visualization/07 JSON.md
+++ b/src/data/markdown/translated-guides/es/04 Results visualization/07 JSON.md
@@ -134,8 +134,6 @@ Para casos más avanzados, consulte el [Manual de jq][jq_manual_url]
 
 ## Exportar los datos del resumen
 
-> _New in v0.26.0_
-
 Si no está interesado en cada una de las mediciones de las métricas individuales y, en cambio, desea ver sólo los datos agregados, exportar los datos del resumen de fin de la prueba a un archivo JSON puede ser una mejor opción que utilizar la salida JSON descrita en este documento. Para más detalles, consulte `--export-summary` y `handleSummary()` en la documentación del resumen de fin de la prueba.
 
 <CodeGroup labels={[ "stdout", "Other output"]}>


### PR DESCRIPTION
Some of the features called out as "New" are actually rather old (> 1 year) given latest release is v0.37.0.