### PR TITLE
Remove xk6-zmq

### DIFF
--- a/src/data/doc-extensions/extensions.json
+++ b/src/data/doc-extensions/extensions.json
@@ -115,20 +115,6 @@
       ]
     },
     {
-      "name": "xk6-zmq",
-      "description": "ZeroMQ",
-      "url": "https://github.com/dgzlopes/xk6-zmq",
-      "logo": "",
-      "author": {
-        "name": "Daniel González",
-        "url": "https://github.com/dgzlopes"
-      },
-      "official": false,
-      "categories": [
-        "Messaging"
-      ]
-    },
-    {
       "name": "xk6-datadog",
       "description": "Query Datadog metrics",
       "url": "https://github.com/dgzlopes/xk6-datadog",


### PR DESCRIPTION
The extension has been unmaintained for a while (it's not buildable since May).

I've archived the repo and on this PR, I'm removing it from the extension list.