### PR TITLE
Add support for keepUrlTag doc update

### DIFF
--- a/src/data/markdown/translated-guides/en/04 Results visualization/10 Prometheus.md
+++ b/src/data/markdown/translated-guides/en/04 Results visualization/10 Prometheus.md
@@ -50,6 +50,7 @@ Here is the full list of options that can be configured and passed to the extens
 | `K6_CA_CERT_FILE`                        | Location of the CA certificate file required by the endpoint. Optional. |
 | `K6_KEEP_TAGS`                           | Boolean option whether to send k6 tags as labels for each metric. The default value is `true`. |
 | `K6_KEEP_NAME_TAG`                       | Boolean option whether to add `name` k6 tag to labels for each metric. Note: see [HTTP Requests Tags](/using-k6/http-requests#http-request-tags) for explanation on values of `name` tag when HTTP requests are made. The default value is `false`. |
+| `K6_KEEP_URL_TAG`                       | Boolean option whether to send `url` k6 tag to labels for each metric. Note: see [HTTP Requests URL Grouping](/using-k6/http-requests#url-grouping) for explanation on values of `url` tag why you might want to use name instead of url to reduce cardinality. The default value is `true`. |
 
 ## See also
 


### PR DESCRIPTION
Relates to: https://github.com/grafana/xk6-output-prometheus-remote/pull/17

Adds supporting documentation for this feature