### PR TITLE
Random string custom charset

### DIFF
--- a/src/data/markdown/docs/02 javascript api/02 k6/sleep- t -.md
+++ b/src/data/markdown/docs/02 javascript api/02 k6/sleep- t -.md
@@ -36,7 +36,7 @@ Using the [k6-utils](https://jslib.k6.io/k6-utils/) library to specify a range b
 ```javascript
 import { sleep } from 'k6';
 import http from 'k6/http';
-import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
+import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.2.0/index.js';
 
 export default function () {
   http.get('https://k6.io');

--- a/src/data/markdown/docs/05 Examples/01 Examples/04 correlation-and-dynamic-data.md
+++ b/src/data/markdown/docs/05 Examples/01 Examples/04 correlation-and-dynamic-data.md
@@ -119,7 +119,7 @@ The [jslib](/javascript-api/jslib/) [utils](/javascript-api/jslib/utils/) librar
 <CodeGroup labels={["extract-findBetween.js"]} lineNumbers={[true]}>
 
 ```javascript
-import { findBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
+import { findBetween } from 'https://jslib.k6.io/k6-utils/1.2.0/index.js';
 import { check } from 'k6';
 import http from 'k6/http';
 

--- a/src/data/markdown/docs/05 Examples/01 Examples/10 advanced-api-flow.md
+++ b/src/data/markdown/docs/05 Examples/01 Examples/10 advanced-api-flow.md
@@ -18,10 +18,10 @@ export const options = {
   },
 };
 
-function randomString(length) {
-  const charset = 'abcdefghijklmnopqrstuvwxyz';
+function randomString(length, charset='') {
+  if (!charset) charset = 'abcdefghijklmnopqrstuvwxyz';
   let res = '';
-  while (length--) res += charset[(Math.random() * charset.length) | 0];
+  while (length--) res += charset[Math.random() * charset.length | 0];
   return res;
 }
 

--- a/src/data/markdown/docs/05 Examples/01 Examples/13 websockets.md
+++ b/src/data/markdown/docs/05 Examples/01 Examples/13 websockets.md
@@ -6,14 +6,14 @@ excerpt: |
 
 Here's a load test for CrocoChat - a WebSocket chat API available on [https://test-api.k6.io/](https://test-api.k6.io/).
 
-Multiple VUs join a chat room and discuss various things for up to 1 minute, after which they disconnect. 
+Multiple VUs join a chat room and discuss various things for up to 1 minute, after which they disconnect.
 
-Each VU receives messages sent by all chat participants. 
+Each VU receives messages sent by all chat participants.
 
 <CodeGroup labels={["crocochat.js"]} lineNumbers={[true]}>
 
 ```javascript
-import { randomString, randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
+import { randomString, randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.2.0/index.js';
 import ws from 'k6/ws';
 import { check, sleep } from 'k6';
 

--- a/src/data/markdown/docs/05 Examples/01 Examples/19 functional testing.md
+++ b/src/data/markdown/docs/05 Examples/01 Examples/19 functional testing.md
@@ -46,7 +46,7 @@ This test goes through several steps. It creates a new user account, authenticat
 ```javascript
 import { describe } from 'https://jslib.k6.io/expect/0.0.5/index.js';
 import { Httpx, Request, Get, Post } from 'https://jslib.k6.io/httpx/0.0.4/index.js';
-import { randomIntBetween, randomItem } from "https://jslib.k6.io/k6-utils/1.1.0/index.js";
+import { randomIntBetween, randomItem } from "https://jslib.k6.io/k6-utils/1.2.0/index.js";
 
 export let options = {
   thresholds: {

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 utils.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 utils.md
@@ -3,9 +3,9 @@ title: "utils"
 excerpt: "A collection of small utility functions useful during load testing with k6. "
 ---
 
-The `utils` module contains number of small utility functions useful in every day load testing. 
+The `utils` module contains number of small utility functions useful in every day load testing.
 
-> ⭐️ Source code available on [GitHub](https://github.com/k6io/k6-jslib-utils). 
+> ⭐️ Source code available on [GitHub](https://github.com/k6io/k6-jslib-utils).
 > Please request features and report bugs through [GitHub issues](https://github.com/k6io/k6-jslib-utils/issues).
 
 
@@ -16,7 +16,7 @@ The `utils` module contains number of small utility functions useful in every da
 | -------- | ----------- |
 | [randomIntBetween(min, max)](/javascript-api/jslib/utils/randomintbetween-min-max)  | Random integer in a given range |
 | [randomItem(array)](/javascript-api/jslib/utils/randomitem-array)  | Random item from a given array |
-| [randomString(length)](/javascript-api/jslib/utils/randomstring-length)  | Random string of a given length |
+| [randomString(length, 'charset')](/javascript-api/jslib/utils/randomstring)  | Random string of a given length, optionally selected from a custom character set |
 | [uuidv4()](/javascript-api/jslib/utils/uuidv4)  | Random UUID v4 in a string representation |
 | [findBetween(content, left, right)](/javascript-api/jslib/utils/findbetween-content-left-right)  | Extract a string between two surrounding strings |
 
@@ -35,12 +35,12 @@ import {
   randomItem,
   uuidv4,
   findBetween,
-} from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
+} from 'https://jslib.k6.io/k6-utils/1.2.0/index.js';
 
 export default function () {
   const res = http.post(`https://test-api.k6.io/user/register/`, {
     first_name: randomItem(['Joe', 'Jane']), // random name
-    last_name: 'Smith',
+    last_name: `Jon${randomString(1,'aeiou')}s`, //random character from given list
     username: `user_${randomString(10)}@example.com`, // random email address,
     password: uuidv4(), // random password in form of uuid
   });

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 utils.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 utils.md
@@ -16,7 +16,7 @@ The `utils` module contains number of small utility functions useful in every da
 | -------- | ----------- |
 | [randomIntBetween(min, max)](/javascript-api/jslib/utils/randomintbetween-min-max)  | Random integer in a given range |
 | [randomItem(array)](/javascript-api/jslib/utils/randomitem-array)  | Random item from a given array |
-| [randomString(length, 'charset')](/javascript-api/jslib/utils/randomstring)  | Random string of a given length, optionally selected from a custom character set |
+| [randomString(length, charset)](/javascript-api/jslib/utils/randomstring-length-charset)  | Random string of a given length, optionally selected from a custom character set |
 | [uuidv4()](/javascript-api/jslib/utils/uuidv4)  | Random UUID v4 in a string representation |
 | [findBetween(content, left, right)](/javascript-api/jslib/utils/findbetween-content-left-right)  | Extract a string between two surrounding strings |
 

--- a/src/data/markdown/docs/20 jslib/01 jslib/02 httpx.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/02 httpx.md
@@ -55,7 +55,7 @@ This documentation is for the last version only. If you discover that some of th
 ```javascript
 import { fail } from 'k6';
 import { Httpx } from 'https://jslib.k6.io/httpx/0.0.3/index.js';
-import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
+import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.2.0/index.js';
 
 const USERNAME = `user${randomIntBetween(1, 100000)}@example.com`; // random email address
 const PASSWORD = 'superCroc2021';

--- a/src/data/markdown/docs/20 jslib/01 jslib/utils/01 randomIntBetween(min, max) copy.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/utils/01 randomIntBetween(min, max) copy.md
@@ -25,7 +25,7 @@ Function returns a random number between the specified range. The returned value
 
 ```javascript
 import { sleep } from 'k6';
-import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
+import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.2.0/index.js';
 
 export default function () {
   // code ...

--- a/src/data/markdown/docs/20 jslib/01 jslib/utils/02 randomItem(array).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/utils/02 randomItem(array).md
@@ -23,7 +23,7 @@ Function returns a random item from an array.
 <CodeGroup labels={[]}>
 
 ```javascript
-import { randomItem } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
+import { randomItem } from 'https://jslib.k6.io/k6-utils/1.2.0/index.js';
 
 const names = ['John', 'Jane', 'Bert', 'Ed'];
 

--- a/src/data/markdown/docs/20 jslib/01 jslib/utils/03 randomString(length).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/utils/03 randomString(length).md
@@ -1,21 +1,23 @@
 ---
-title: 'randomString(length)'
+title: 'randomString(length, 'charset')'
 description: 'Random string'
 excerpt: 'Random string'
 ---
 
-Function returns a random string of a given length.
+Function returns a random string of a given length, optionally selected from a custom character set.
+
 
 | Parameter     | Type   | Description |
 | ------------- | ------ |  --- |
 | length  | int  | Length of the random string |
+| charset  | string  | A customized list of characters |
 
 
 ### Returns
 
 | Type   | Description     |
 | -----  | --------------- |
-| any    | Random item from the array  |
+| any    | Random item(s) from the array of characters  |
 
 
 ### Example
@@ -23,11 +25,17 @@ Function returns a random string of a given length.
 <CodeGroup labels={[]}>
 
 ```javascript
-import { randomString } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
+import { randomString } from 'https://jslib.k6.io/k6-utils/1.2.0/index.js';
 
 export default function () {
-  const randomName = randomString(8);
-  console.log(`Hello, my name is ${randomName}`);
+  const randomFirstName = randomString(8);
+  console.log(`Hello, my first name is ${randomFirstName}`);
+
+  const randomLastName = randomString(10,'aeioubcdfghijpqrstuv');
+  console.log(`Hello, my last name is ${randomLastName}`);
+
+  const randomCharacterWeighted = randomString(1,'AAAABBBCCD');
+  console.log(`Chose a random character ${randomCharacterWeighted}`);
 }
 ```
 

--- a/src/data/markdown/docs/20 jslib/01 jslib/utils/03 randomString(length).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/utils/03 randomString(length).md
@@ -1,5 +1,5 @@
 ---
-title: 'randomString(length, 'charset')'
+title: 'randomString(length, charset)'
 description: 'Random string'
 excerpt: 'Random string'
 ---
@@ -7,10 +7,10 @@ excerpt: 'Random string'
 Function returns a random string of a given length, optionally selected from a custom character set.
 
 
-| Parameter     | Type   | Description |
-| ------------- | ------ |  --- |
-| length  | int  | Length of the random string |
-| charset  | string  | A customized list of characters |
+| Parameter     | Type    | Description |
+| ------------- | ------- | ----------- |
+| length        | int     | Length of the random string  |
+| charset       | string  | A customized list of characters  |
 
 
 ### Returns
@@ -31,10 +31,10 @@ export default function () {
   const randomFirstName = randomString(8);
   console.log(`Hello, my first name is ${randomFirstName}`);
 
-  const randomLastName = randomString(10,'aeioubcdfghijpqrstuv');
+  const randomLastName = randomString(10,`aeioubcdfghijpqrstuv`);
   console.log(`Hello, my last name is ${randomLastName}`);
 
-  const randomCharacterWeighted = randomString(1,'AAAABBBCCD');
+  const randomCharacterWeighted = randomString(1,`AAAABBBCCD`);
   console.log(`Chose a random character ${randomCharacterWeighted}`);
 }
 ```

--- a/src/data/markdown/docs/20 jslib/01 jslib/utils/04 uuidv4().md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/utils/04 uuidv4().md
@@ -18,7 +18,7 @@ Function returns a random uuid v4 in a string form.
 <CodeGroup labels={[]}>
 
 ```javascript
-import { uuidv4 } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
+import { uuidv4 } from 'https://jslib.k6.io/k6-utils/1.2.0/index.js';
 
 export default function () {
   const randomUUID = uuidv4();

--- a/src/data/markdown/docs/20 jslib/01 jslib/utils/05 findBetween(content, left, right).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/utils/05 findBetween(content, left, right).md
@@ -24,7 +24,7 @@ Function that returns a string from between two other strings.
 <CodeGroup labels={[]}>
 
 ```javascript
-import { findBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
+import { findBetween } from 'https://jslib.k6.io/k6-utils/1.2.0/index.js';
 
 export default function () {
   const response = '<div class="message">Login successful!</div>';

--- a/src/data/markdown/docs/20 jslib/20 jslib.md
+++ b/src/data/markdown/docs/20 jslib/20 jslib.md
@@ -22,7 +22,7 @@ The [jslib.k6.io](https://jslib.k6.io/) is a collection of external JavaScript l
 ```javascript
 import { check, sleep } from 'k6';
 import jsonpath from 'https://jslib.k6.io/jsonpath/1.0.2/index.js';
-import { randomIntBetween, randomItem, uuidv4 } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
+import { randomIntBetween, randomItem, uuidv4 } from 'https://jslib.k6.io/k6-utils/1.2.0/index.js';
 
 const testData = {
   user: {

--- a/src/data/markdown/translated-guides/en/02 Using k6/07 Modules.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/07 Modules.md
@@ -54,7 +54,7 @@ runtime, making it extremely important to **make sure the code is legit and trus
 it in a test script**.
 
 ```javascript
-import { randomItem } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
+import { randomItem } from 'https://jslib.k6.io/k6-utils/1.2.0/index.js';
 
 export default function () {
   randomItem();

--- a/src/data/markdown/translated-guides/es/02 Using k6/07 Modules.md
+++ b/src/data/markdown/translated-guides/es/02 Using k6/07 Modules.md
@@ -46,7 +46,7 @@ export default function () {
 Se accede a estos módulos a través de HTTP(S), desde una fuente como el [k6 JSLib](#the-jslib-repository) o desde cualquier servidor web de acceso público. Los módulos importados serán descargados y ejecutados en tiempo de ejecución, por lo que es extremadamente importante asegurarse de que el código es legítimo y de confianza antes de incluirlo en un script de prueba.
 
 ```javascript
-import { randomItem } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
+import { randomItem } from 'https://jslib.k6.io/k6-utils/1.2.0/index.js';
 
 export default function () {
   randomItem();

--- a/src/data/markdown/versioned-js-api/v0.32/javascript api/02 k6/sleep- t -.md
+++ b/src/data/markdown/versioned-js-api/v0.32/javascript api/02 k6/sleep- t -.md
@@ -42,7 +42,7 @@ Using the [k6-utils](https://jslib.k6.io/k6-utils/) library to specify a range b
 ```javascript
 import { sleep } from 'k6';
 import http from 'k6/http';
-import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
+import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.2.0/index.js';
 
 export default function () {
   http.get('https://k6.io');

--- a/src/data/markdown/versioned-js-api/v0.33/javascript api/02 k6/sleep- t -.md
+++ b/src/data/markdown/versioned-js-api/v0.33/javascript api/02 k6/sleep- t -.md
@@ -36,7 +36,7 @@ Using the [k6-utils](https://jslib.k6.io/k6-utils/) library to specify a range b
 ```javascript
 import { sleep } from 'k6';
 import http from 'k6/http';
-import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
+import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.2.0/index.js';
 
 export default function () {
   http.get('https://k6.io');

--- a/src/data/markdown/versioned-js-api/v0.34/javascript api/02 k6/sleep- t -.md
+++ b/src/data/markdown/versioned-js-api/v0.34/javascript api/02 k6/sleep- t -.md
@@ -36,7 +36,7 @@ Using the [k6-utils](https://jslib.k6.io/k6-utils/) library to specify a range b
 ```javascript
 import { sleep } from 'k6';
 import http from 'k6/http';
-import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
+import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.2.0/index.js';
 
 export default function () {
   http.get('https://k6.io');

--- a/src/data/markdown/versioned-js-api/v0.35/javascript api/02 k6/sleep- t -.md
+++ b/src/data/markdown/versioned-js-api/v0.35/javascript api/02 k6/sleep- t -.md
@@ -36,7 +36,7 @@ Using the [k6-utils](https://jslib.k6.io/k6-utils/) library to specify a range b
 ```javascript
 import { sleep } from 'k6';
 import http from 'k6/http';
-import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
+import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.2.0/index.js';
 
 export default function () {
   http.get('https://k6.io');

--- a/src/data/markdown/versioned-js-api/v0.36/javascript api/02 k6/sleep- t -.md
+++ b/src/data/markdown/versioned-js-api/v0.36/javascript api/02 k6/sleep- t -.md
@@ -36,7 +36,7 @@ Using the [k6-utils](https://jslib.k6.io/k6-utils/) library to specify a range b
 ```javascript
 import { sleep } from 'k6';
 import http from 'k6/http';
-import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
+import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.2.0/index.js';
 
 export default function () {
   http.get('https://k6.io');


### PR DESCRIPTION
### reference
Today's Slack thread to enhance the existing randomString() function to support a conversion from JMeter's own ${__RandomString()} function. I have enhanced the documentation to describe the changes. Additionally, Tom mentioned that an inevitable version change to ks-jslib-utils to 1.2.0 would require additional edits to the documentation. Those changes were made in [PR #5 on ks-jslib-utils](https://github.com/grafana/k6-jslib-utils/pull/5).

### technical explanation
Enhance the existing randomString() function to accept a second string parameter to provide customized charset. Refactor the internal charset to be wrapped in a conditional if statement, for backwards compatibility where a charset was not provided.
Provide a new randomString.js set of tests; leveraging suggestions from Tom and others. 

### other comments
This is my first PR as a contributor to any open source project. Please forgive any mistakes or missed steps in this process. Thank you.