### PR TITLE
Use httpbin.test.k6.io instead of httpbin.org in examples

### DIFF
--- a/src/data/markdown/docs/02 javascript api/02 k6/check- val- sets- -tags- -.md
+++ b/src/data/markdown/docs/02 javascript api/02 k6/check- val- sets- -tags- -.md
@@ -35,7 +35,7 @@ import http from 'k6/http';
 import { check } from 'k6';
 
 export default function () {
-  const res = http.get('http://httpbin.org');
+  const res = http.get('http://httpbin.test.k6.io');
   check(res, {
     'response code was 200': (res) => res.status == 200,
   });
@@ -53,7 +53,7 @@ import http from 'k6/http';
 import { check, fail } from 'k6';
 
 export default function () {
-  const res = http.get('http://httpbin.org');
+  const res = http.get('http://httpbin.test.k6.io');
   const checkOutput = check(
     res,
     {

--- a/src/data/markdown/docs/02 javascript api/08 k6-http/10-batch- requests -.md
+++ b/src/data/markdown/docs/02 javascript api/08 k6-http/10-batch- requests -.md
@@ -83,7 +83,7 @@ import { check } from 'k6';
 export default function () {
   const req1 = {
     method: 'GET',
-    url: 'https://httpbin.org/get',
+    url: 'https://httpbin.test.k6.io/get',
   };
   const req2 = {
     method: 'GET',
@@ -91,7 +91,7 @@ export default function () {
   };
   const req3 = {
     method: 'POST',
-    url: 'https://httpbin.org/post',
+    url: 'https://httpbin.test.k6.io/post',
     body: {
       hello: 'world!',
     },
@@ -100,7 +100,7 @@ export default function () {
     },
   };
   const responses = http.batch([req1, req2, req3]);
-  // httpbin.org should return our POST data in the response body, so
+  // httpbin.test.k6.io should return our POST data in the response body, so
   // we check the third response object to see that the POST worked.
   check(responses[2], {
     'form data OK': (res) => JSON.parse(res.body)['form']['hello'] == 'world!',

--- a/src/data/markdown/docs/02 javascript api/08 k6-http/60 CookieJar.md
+++ b/src/data/markdown/docs/02 javascript api/08 k6-http/60 CookieJar.md
@@ -21,9 +21,9 @@ import http from 'k6/http';
 import { check } from 'k6';
 
 export default function () {
-  const res = http.get('https://httpbin.org/cookies/set?my_cookie=hello%20world', { redirects: 0 });
+  const res = http.get('https://httpbin.test.k6.io/cookies/set?my_cookie=hello%20world', { redirects: 0 });
   const jar = http.cookieJar();
-  const cookies = jar.cookiesForURL('http://httpbin.org/');
+  const cookies = jar.cookiesForURL('http://httpbin.test.k6.io/');
   check(res, {
     "has cookie 'my_cookie'": (r) => cookies.my_cookie.length > 0,
     'cookie has correct value': (r) => cookies.my_cookie[0] === 'hello world',

--- a/src/data/markdown/docs/02 javascript api/08 k6-http/60 CookieJar/CookieJar-cookiesForUrl-url.md
+++ b/src/data/markdown/docs/02 javascript api/08 k6-http/60 CookieJar/CookieJar-cookiesForUrl-url.md
@@ -22,9 +22,9 @@ import http from 'k6/http';
 import { check } from 'k6';
 
 export default function () {
-  const res = http.get('https://httpbin.org/cookies/set?my_cookie=hello%20world', { redirects: 0 });
+  const res = http.get('https://httpbin.test.k6.io/cookies/set?my_cookie=hello%20world', { redirects: 0 });
   const jar = http.cookieJar();
-  const cookies = jar.cookiesForURL('http://httpbin.org/');
+  const cookies = jar.cookiesForURL('http://httpbin.test.k6.io/');
   check(res, {
     "has cookie 'my_cookie'": (r) => cookies.my_cookie.length > 0,
     'cookie has correct value': (r) => cookies.my_cookie[0] === 'hello world',

--- a/src/data/markdown/docs/02 javascript api/08 k6-http/60 CookieJar/CookieJar-set-url-name-value-options.md
+++ b/src/data/markdown/docs/02 javascript api/08 k6-http/60 CookieJar/CookieJar-set-url-name-value-options.md
@@ -22,13 +22,13 @@ import { check } from 'k6';
 
 export default function () {
   const jar = http.cookieJar();
-  jar.set('https://httpbin.org/cookies', 'my_cookie', 'hello world', {
-    domain: 'httpbin.org',
+  jar.set('https://httpbin.test.k6.io/cookies', 'my_cookie', 'hello world', {
+    domain: 'httpbin.test.k6.io',
     path: '/cookies',
     secure: true,
     max_age: 600,
   });
-  const res = http.get('https://httpbin.org/cookies');
+  const res = http.get('https://httpbin.test.k6.io/cookies');
   check(res, {
     'has status 200': (r) => r.status === 200,
     "has cookie 'my_cookie'": (r) => r.json().cookies.my_cookie !== null,

--- a/src/data/markdown/docs/02 javascript api/08 k6-http/60-Params.md
+++ b/src/data/markdown/docs/02 javascript api/08 k6-http/60-Params.md
@@ -51,7 +51,7 @@ Here is another example using [http.batch()](/javascript-api/k6-http/batch-reque
 import http from 'k6/http';
 
 const url1 = 'https://api.k6.io/v3/account/me';
-const url2 = 'http://httpbin.org/get';
+const url2 = 'http://httpbin.test.k6.io/get';
 const apiToken = 'f232831bda15dd233c53b9c548732c0197619a3d3c451134d9abded7eb5bb195';
 const requestHeaders = {
   'User-Agent': 'k6',
@@ -80,7 +80,7 @@ import { check } from 'k6';
 
 export default function () {
   // Passing username and password as part of URL plus the auth option will authenticate using HTTP Digest authentication
-  const res = http.get('http://user:passwd@httpbin.org/digest-auth/auth/user/passwd', {
+  const res = http.get('http://user:passwd@httpbin.test.k6.io/digest-auth/auth/user/passwd', {
     auth: 'digest',
   });
 
@@ -107,7 +107,7 @@ export default function () {}
 export function setup() {
   // Get 10 random bytes as an ArrayBuffer. Without the responseType the body
   // will be null.
-  const response = http.get('https://httpbin.org/bytes/10', {
+  const response = http.get('https://httpbin.test.k6.io/bytes/10', {
     responseType: 'binary',
   });
   // response.body is an ArrayBuffer, so wrap it in a typed array view to access

--- a/src/data/markdown/docs/02 javascript api/08 k6-http/61 Response/Response-clickLink- -params- -.md
+++ b/src/data/markdown/docs/02 javascript api/08 k6-http/61 Response/Response-clickLink- -params- -.md
@@ -27,7 +27,7 @@ import http from 'k6/http';
 
 export default function () {
   // Request page with links
-  let res = http.get('https://httpbin.org/links/10/0');
+  let res = http.get('https://httpbin.test.k6.io/links/10/0');
 
   // Now, click the 4th link on the page
   res = res.clickLink({ selector: 'a:nth-child(4)' });

--- a/src/data/markdown/docs/02 javascript api/08 k6-http/61 Response/Response-submitForm- -params- -.md
+++ b/src/data/markdown/docs/02 javascript api/08 k6-http/61 Response/Response-submitForm- -params- -.md
@@ -30,7 +30,7 @@ import { sleep } from 'k6';
 
 export default function () {
   // Request page containing a form
-  let res = http.get('https://httpbin.org/forms/post');
+  let res = http.get('https://httpbin.test.k6.io/forms/post');
 
   // Now, submit form setting/overriding some fields of the form
   res = res.submitForm({

--- a/src/data/markdown/docs/03 cloud/08 Cloud FAQ/06 What's the Difference Between k6 Cloud's Version 3.0 (Lua) and 4.0(JavaScript).md
+++ b/src/data/markdown/docs/03 cloud/08 Cloud FAQ/06 What's the Difference Between k6 Cloud's Version 3.0 (Lua) and 4.0(JavaScript).md
@@ -154,13 +154,13 @@ To make HTTP requests there are a number of different Lua APIs available. In the
 
 ```plain
 -- Send a single GET request
-http.get("https://httpbin.org/")
+http.get("https://httpbin.test.k6.io/")
 -- Send a single POST request
-http.post("https://httpbin.org", "key=val&key2=val")
+http.post("https://httpbin.test.k6.io", "key=val&key2=val")
 -- Send several requests in parallel
 http.request_batch({
-  { "GET", "https://httpbin.org/" },
-  { "POST", "https://httpbin.org/", "key=val&key2=val" }
+  { "GET", "https://httpbin.test.k6.io/" },
+  { "POST", "https://httpbin.test.k6.io/", "key=val&key2=val" }
 })
 ```
 
@@ -168,13 +168,13 @@ http.request_batch({
 import http from 'k6/http';
 export default function () {
   // Send a single GET request
-  http.get('https://httpbin.org/');
+  http.get('https://httpbin.test.k6.io/');
   // Send a single POST request
-  http.post('https://httpbin.org', 'key=val&key2=val');
+  http.post('https://httpbin.test.k6.io', 'key=val&key2=val');
   // Send several requests in parallel
   http.batch([
-    'https://httpbin.org/',
-    { method: 'POST', url: 'https://httpbin.org/', body: 'key=val&key2=val' },
+    'https://httpbin.test.k6.io/',
+    { method: 'POST', url: 'https://httpbin.test.k6.io/', body: 'key=val&key2=val' },
   ]);
 }
 ```
@@ -191,10 +191,10 @@ In the 3.0 product there's a concept of pages. Lua code in between calls to `htt
 
 ```plain
 http.page_start("My page")
-http.get("https://httpbin.org/")
+http.get("https://httpbin.test.k6.io/")
 http.request_batch({
-  { "GET", "https://httpbin.org/" },
-  { "GET", "https://httpbin.org/get" },
+  { "GET", "https://httpbin.test.k6.io/" },
+  { "GET", "https://httpbin.test.k6.io/get" },
 })
 http.page_end("My page")
 ```
@@ -205,8 +205,8 @@ import { group } from 'k6';
 
 export default function () {
   group('My page', function () {
-    http.get('https://httpbin.org/');
-    http.batch(['https://httpbin.org/', 'https://httpbin.org/get']);
+    http.get('https://httpbin.test.k6.io/');
+    http.batch(['https://httpbin.test.k6.io/', 'https://httpbin.test.k6.io/get']);
   });
 }
 ```
@@ -315,7 +315,7 @@ Beyond the standard metrics collected by the 3.0 product you can also collect cu
 
 ```plain
 -- Track the time-to-first-byte (TTFB)
-local res = http.get("https://httpbin.org/")
+local res = http.get("https://httpbin.test.k6.io/")
 result.custom_metric("time_to_first_byte", res.time_to_first_byte)
 ```
 
@@ -326,7 +326,7 @@ import { Trend } from 'k6/metrics';
 const ttfbMetric = new Trend('time_to_first_byte');
 export default function () {
   group('My page', function () {
-    const res = http.get('https://httpbin.org/');
+    const res = http.get('https://httpbin.test.k6.io/');
     ttfbMetric.add(res.timings.waiting);
   });
 }

--- a/src/data/markdown/docs/05 Examples/01 Examples/02 http-authentication.md
+++ b/src/data/markdown/docs/05 Examples/01 Examples/02 http-authentication.md
@@ -22,7 +22,7 @@ export default function () {
 
   // Passing username and password as part of the URL will
   // allow us to authenticate using HTTP Basic Auth.
-  const url = `http://${credentials}@httpbin.org/basic-auth/${username}/${password}`;
+  const url = `http://${credentials}@httpbin.test.k6.io/basic-auth/${username}/${password}`;
 
   let res = http.get(url);
 
@@ -42,9 +42,9 @@ export default function () {
     },
   };
 
-  res = http.get(`http://httpbin.org/basic-auth/${username}/${password}`, options);
+  res = http.get(`http://httpbin.test.k6.io/basic-auth/${username}/${password}`, options);
 
-  // Verify response (checking the echoed data from the httpbin.org
+  // Verify response (checking the echoed data from the httpbin.test.k6.io
   // basic auth test API endpoint)
   check(res, {
     'status is 200': (r) => r.status === 200,
@@ -72,11 +72,11 @@ export default function () {
   // authenticate using HTTP Digest authentication.
   const credentials = `${username}:${password}`;
   const res = http.get(
-    `http://${credentials}@httpbin.org/digest-auth/auth/${username}/${password}`,
+    `http://${credentials}@httpbin.test.k6.io/digest-auth/auth/${username}/${password}`,
     { auth: 'digest' }
   );
 
-  // Verify response (checking the echoed data from the httpbin.org digest auth
+  // Verify response (checking the echoed data from the httpbin.test.k6.io digest auth
   // test API endpoint)
   check(res, {
     'status is 200': (r) => r.status === 200,

--- a/src/data/markdown/docs/05 Examples/01 Examples/04 correlation-and-dynamic-data.md
+++ b/src/data/markdown/docs/05 Examples/01 Examples/04 correlation-and-dynamic-data.md
@@ -36,7 +36,7 @@ import { check } from 'k6';
 
 export default function () {
   // Make a request that returns some JSON data
-  const res = http.get('https://httpbin.org/json');
+  const res = http.get('https://httpbin.test.k6.io/json');
 
   // Extract data from that JSON data by first parsing it
   // using a call to "json()" and then accessing properties by

--- a/src/data/markdown/docs/05 Examples/01 Examples/07 html-forms.md
+++ b/src/data/markdown/docs/05 Examples/01 Examples/07 html-forms.md
@@ -15,7 +15,7 @@ import { sleep } from 'k6';
 
 export default function () {
   // Request page containing a form
-  let res = http.get('https://httpbin.org/forms/post');
+  let res = http.get('https://httpbin.test.k6.io/forms/post');
 
   // Now, submit form setting/overriding some fields of the form
   res = res.submitForm({

--- a/src/data/markdown/docs/05 Examples/01 Examples/08 cookies-example.md
+++ b/src/data/markdown/docs/05 Examples/01 Examples/08 cookies-example.md
@@ -22,7 +22,7 @@ import { check, group } from 'k6';
 
 export default function () {
   // Since this request redirects the `res.cookies` property won't contain the cookies
-  const res = http.get('http://httpbin.org/cookies/set?name1=value1&name2=value2');
+  const res = http.get('http://httpbin.test.k6.io/cookies/set?name1=value1&name2=value2');
   check(res, {
     'status is 200': (r) => r.status === 200,
   });
@@ -94,8 +94,8 @@ export default function () {
   // that a request must match (domain, path, HTTPS or not etc.)
   // to have the cookie attached to it when sent to the server.
   const jar = http.cookieJar();
-  jar.set('https://httpbin.org/cookies', 'my_cookie', 'hello world', {
-    domain: 'httpbin.org',
+  jar.set('https://httpbin.test.k6.io/cookies', 'my_cookie', 'hello world', {
+    domain: 'httpbin.test.k6.io',
     path: '/cookies',
     secure: true,
     max_age: 600,
@@ -104,7 +104,7 @@ export default function () {
   // As the following request is matching the above cookie in terms of domain,
   // path, HTTPS (secure) and will happen within the specified "age" limit, the
   // cookie will be attached to this request.
-  const res = http.get('https://httpbin.org/cookies');
+  const res = http.get('https://httpbin.test.k6.io/cookies');
   check(res, {
     'has status 200': (r) => r.status === 200,
     "has cookie 'my_cookie'": (r) => r.json().cookies.my_cookie !== null,

--- a/src/data/markdown/translated-guides/en/01 Getting started/03 Running k6.md
+++ b/src/data/markdown/translated-guides/en/01 Getting started/03 Running k6.md
@@ -188,7 +188,7 @@ export const options = {
 };
 
 export default function () {
-  const res = http.get('https://httpbin.org/');
+  const res = http.get('https://httpbin.test.k6.io/');
   check(res, { 'status was 200': (r) => r.status == 200 });
   sleep(1);
 }

--- a/src/data/markdown/translated-guides/en/02 Using k6/02 Metrics.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/02 Metrics.md
@@ -115,7 +115,7 @@ If you want to access the timing information from an individual HTTP request in 
 import http from 'k6/http';
 
 export default function () {
-  const res = http.get('http://httpbin.org');
+  const res = http.get('http://httpbin.test.k6.io');
   console.log('Response time was ' + String(res.timings.duration) + ' ms');
 }
 ```
@@ -148,7 +148,7 @@ import { Trend } from 'k6/metrics';
 const myTrend = new Trend('waiting_time');
 
 export default function () {
-  const r = http.get('https://httpbin.org');
+  const r = http.get('https://httpbin.test.k6.io');
   myTrend.add(r.timings.waiting);
   console.log(myTrend.name); // waiting_time
 }

--- a/src/data/markdown/translated-guides/en/02 Using k6/04 Thresholds.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/04 Thresholds.md
@@ -424,7 +424,7 @@ export const options = {
 };
 
 export default function () {
-  const res = http.get('http://httpbin.org');
+  const res = http.get('http://httpbin.test.k6.io');
 
   check(res, {
     'status is 500': (r) => r.status == 500,
@@ -457,12 +457,12 @@ export const options = {
 export default function () {
   let res;
 
-  res = http.get('http://httpbin.org');
+  res = http.get('http://httpbin.test.k6.io');
   check(res, {
     'status is 500': (r) => r.status == 500,
   });
 
-  res = http.get('http://httpbin.org');
+  res = http.get('http://httpbin.test.k6.io');
   check(
     res,
     {

--- a/src/data/markdown/translated-guides/en/02 Using k6/06 Test life cycle.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/06 Test life cycle.md
@@ -173,7 +173,7 @@ stages:
 import http from 'k6/http';
 
 export function setup() {
-  const res = http.get('https://httpbin.org/get');
+  const res = http.get('https://httpbin.test.k6.io/get');
   return { data: res.json() };
 }
 

--- a/src/data/markdown/translated-guides/en/02 Using k6/08 Tags and Groups.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/08 Tags and Groups.md
@@ -155,7 +155,7 @@ const myTrend = new Trend('my_trend');
 
 export default function () {
   // Add tag to request metric data
-  const res = http.get('http://httpbin.org/', {
+  const res = http.get('http://httpbin.test.k6.io/', {
     tags: {
       my_tag: "I'm a tag",
     },
@@ -203,7 +203,7 @@ export const options = {
       "group ": "::my group::json ",
       "method ": "GET ",
       "status ": "200 ",
-      "url ": "https://httpbin.org/get "
+      "url ": "https://httpbin.test.k6.io/get "
     }
   },
   "metric ": "http_req_duration "

--- a/src/data/markdown/translated-guides/en/02 Using k6/09 Cookies.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/09 Cookies.md
@@ -37,7 +37,7 @@ in a subsequent request to the server we include the cookie in the `cookies` req
 import http from 'k6/http';
 
 export default function () {
-  http.get('https://httpbin.org/cookies', {
+  http.get('https://httpbin.test.k6.io/cookies', {
     cookies: {
       my_cookie: 'hello world',
     },
@@ -58,8 +58,8 @@ import http from 'k6/http';
 
 export default function () {
   const jar = http.cookieJar();
-  jar.set('https://httpbin.org/cookies', 'my_cookie', 'hello world');
-  http.get('https://httpbin.org/cookies');
+  jar.set('https://httpbin.test.k6.io/cookies', 'my_cookie', 'hello world');
+  http.get('https://httpbin.test.k6.io/cookies');
 }
 ```
 
@@ -78,7 +78,7 @@ import { check } from 'k6';
 
 export default function () {
   const jar = http.cookieJar();
-  jar.set('https://httpbin.org/cookies', 'my_cookie', 'hello world');
+  jar.set('https://httpbin.test.k6.io/cookies', 'my_cookie', 'hello world');
 
   const cookies = {
     my_cookie: {
@@ -87,7 +87,7 @@ export default function () {
     },
   };
 
-  const res = http.get('https://httpbin.org/cookies', {
+  const res = http.get('https://httpbin.test.k6.io/cookies', {
     cookies,
   });
 
@@ -111,7 +111,7 @@ import http from 'k6/http';
 import { check } from 'k6';
 
 export default function () {
-  const res = http.get('https://httpbin.org/cookies/set?my_cookie=hello%20world', { redirects: 0 });
+  const res = http.get('https://httpbin.test.k6.io/cookies/set?my_cookie=hello%20world', { redirects: 0 });
   check(res, {
     "has cookie 'my_cookie'": (r) => r.cookies.my_cookie.length > 0,
     'cookie has correct value': (r) => r.cookies.my_cookie[0].value === 'hello world',
@@ -153,9 +153,9 @@ import http from 'k6/http';
 import { check } from 'k6';
 
 export default function () {
-  const res = http.get('https://httpbin.org/cookies/set?my_cookie=hello%20world', { redirects: 0 });
+  const res = http.get('https://httpbin.test.k6.io/cookies/set?my_cookie=hello%20world', { redirects: 0 });
   const jar = http.cookieJar();
-  const cookies = jar.cookiesForURL('http://httpbin.org/');
+  const cookies = jar.cookiesForURL('http://httpbin.test.k6.io/');
   check(res, {
     "has cookie 'my_cookie'": (r) => cookies.my_cookie.length > 0,
     'cookie has correct value': (r) => cookies.my_cookie[0] === 'hello world',
@@ -183,13 +183,13 @@ import { check } from 'k6';
 
 export default function () {
   const jar = http.cookieJar();
-  jar.set('https://httpbin.org/cookies', 'my_cookie', 'hello world', {
-    domain: 'httpbin.org',
+  jar.set('https://httpbin.test.k6.io/cookies', 'my_cookie', 'hello world', {
+    domain: 'httpbin.test.k6.io',
     path: '/cookies',
     secure: true,
     max_age: 600,
   });
-  const res = http.get('https://httpbin.org/cookies');
+  const res = http.get('https://httpbin.test.k6.io/cookies');
   check(res, {
     'has status 200': (r) => r.status === 200,
     "has cookie 'my_cookie'": (r) => r.cookies.my_cookie[0] !== null,
@@ -216,15 +216,15 @@ export default function () {
 
   // Add cookie to local jar
   const cookieOptions = {
-    domain: 'httpbin.org',
+    domain: 'httpbin.test.k6.io',
     path: '/cookies',
     secure: true,
     max_age: 600,
   };
-  jar.set('https://httpbin.org/cookies', 'my_cookie', 'hello world', cookieOptions);
+  jar.set('https://httpbin.test.k6.io/cookies', 'my_cookie', 'hello world', cookieOptions);
 
   // Override per-VU jar with local jar for the following request
-  const res = http.get('https://httpbin.org/cookies', { jar });
+  const res = http.get('https://httpbin.test.k6.io/cookies', { jar });
   check(res, {
     'has status 200': (r) => r.status === 200,
     "has cookie 'my_cookie'": (r) => r.cookies.my_cookie[0] !== null,

--- a/src/data/markdown/translated-guides/en/04 Results visualization/07 JSON.md
+++ b/src/data/markdown/translated-guides/en/04 Results visualization/07 JSON.md
@@ -52,7 +52,7 @@ The JSON file will contain lines like these:
 {"type":"Metric","data":{"type":"gauge","contains":"default","tainted":null,"thresholds":[],"submetrics":null},"metric":"vus"}
 {"type":"Point","data":{"time":"2017-05-09T14:34:45.625742514+02:00","value":5,"tags":null},"metric":"vus"}
 {"type":"Metric","data":{"type":"trend","contains":"time","tainted":null,"thresholds":["avg<1000"],"submetrics":null},"metric":"http_req_duration"}
-{"type":"Point","data":{"time":"2017-05-09T14:34:45.239531499+02:00","value":459.865729,"tags":{"group":"::my group::json","method":"GET","status":"200","url":"https://httpbin.org/get"}},"metric":"http_req_duration"}
+{"type":"Point","data":{"time":"2017-05-09T14:34:45.239531499+02:00","value":459.865729,"tags":{"group":"::my group::json","method":"GET","status":"200","url":"https://httpbin.test.k6.io/get"}},"metric":"http_req_duration"}
 ```
 
 </CodeGroup>

--- a/src/data/markdown/translated-guides/es/01 Getting started/03 Running k6.md
+++ b/src/data/markdown/translated-guides/es/01 Getting started/03 Running k6.md
@@ -158,7 +158,7 @@ export const options = {
 };
 
 export default function () {
-  const res = http.get('https://httpbin.org/');
+  const res = http.get('https://httpbin.test.k6.io/');
   check(res, { 'status was 200': (r) => r.status == 200 });
   sleep(1);
 }

--- a/src/data/markdown/translated-guides/es/02 Using k6/02 Metrics.md
+++ b/src/data/markdown/translated-guides/es/02 Using k6/02 Metrics.md
@@ -106,7 +106,7 @@ Si desea acceder a la información de tiempo de una solicitud HTTP individual en
 import http from 'k6/http';
 
 export default function () {
-  const res = http.get('http://httpbin.org');
+  const res = http.get('http://httpbin.test.k6.io');
   console.log('Response time was ' + String(res.timings.duration) + ' ms');
 }
 ```
@@ -136,7 +136,7 @@ import { Trend } from 'k6/metrics';
 const myTrend = new Trend('waiting_time');
 
 export default function () {
-  const r = http.get('https://httpbin.org');
+  const r = http.get('https://httpbin.test.k6.io');
   myTrend.add(r.timings.waiting);
   console.log(myTrend.name); // waiting_time
 }

--- a/src/data/markdown/translated-guides/es/02 Using k6/04 Thresholds.md
+++ b/src/data/markdown/translated-guides/es/02 Using k6/04 Thresholds.md
@@ -398,7 +398,7 @@ export const options = {
 };
 
 export default function () {
-  const res = http.get('http://httpbin.org');
+  const res = http.get('http://httpbin.test.k6.io');
 
   check(res, {
     'status is 500': (r) => r.status == 500,
@@ -432,12 +432,12 @@ export const options = {
 export default function () {
   let res;
 
-  res = http.get('http://httpbin.org');
+  res = http.get('http://httpbin.test.k6.io');
   check(res, {
     'status is 500': (r) => r.status == 500,
   });
 
-  res = http.get('http://httpbin.org');
+  res = http.get('http://httpbin.test.k6.io');
   check(
     res,
     {

--- a/src/data/markdown/translated-guides/es/02 Using k6/06 Test life cycle.md
+++ b/src/data/markdown/translated-guides/es/02 Using k6/06 Test life cycle.md
@@ -135,7 +135,7 @@ Una gran diferencia entre la etapa init y la de setup/teardown es que en esta ú
 import http from 'k6/http';
 
 export function setup() {
-  const res = http.get('https://httpbin.org/get');
+  const res = http.get('https://httpbin.test.k6.io/get');
   return { data: res.json() };
 }
 

--- a/src/data/markdown/translated-guides/es/02 Using k6/08 Tags and Groups.md
+++ b/src/data/markdown/translated-guides/es/02 Using k6/08 Tags and Groups.md
@@ -144,7 +144,7 @@ const myTrend = new Trend('my_trend');
 
 export default function () {
   // Add tag to request metric data
-  const res = http.get('http://httpbin.org/', {
+  const res = http.get('http://httpbin.test.k6.io/', {
     tags: {
       my_tag: "I'm a tag",
     },
@@ -191,7 +191,7 @@ export const options = {
       "group ": "::my group::json ",
       "method ": "GET ",
       "status ": "200 ",
-      "url ": "https://httpbin.org/get "
+      "url ": "https://httpbin.test.k6.io/get "
     }
   },
   "metric ": "http_req_duration "

--- a/src/data/markdown/translated-guides/es/02 Using k6/09 Cookies.md
+++ b/src/data/markdown/translated-guides/es/02 Using k6/09 Cookies.md
@@ -25,7 +25,7 @@ Para simular que una cookie ha sido previamente establecida por un navegador y a
 import http from 'k6/http';
 
 export default function () {
-  http.get('https://httpbin.org/cookies', {
+  http.get('https://httpbin.test.k6.io/cookies', {
     cookies: {
       my_cookie: 'hello world',
     },
@@ -44,8 +44,8 @@ import http from 'k6/http';
 
 export default function () {
   const jar = http.cookieJar();
-  jar.set('https://httpbin.org/cookies', 'my_cookie', 'hello world');
-  http.get('https://httpbin.org/cookies');
+  jar.set('https://httpbin.test.k6.io/cookies', 'my_cookie', 'hello world');
+  http.get('https://httpbin.test.k6.io/cookies');
 }
 ```
 
@@ -63,7 +63,7 @@ import { check } from 'k6';
 
 export default function () {
   const jar = http.cookieJar();
-  jar.set('https://httpbin.org/cookies', 'my_cookie', 'hello world');
+  jar.set('https://httpbin.test.k6.io/cookies', 'my_cookie', 'hello world');
 
   const cookies = {
     my_cookie: {
@@ -72,7 +72,7 @@ export default function () {
     },
   };
 
-  const res = http.get('https://httpbin.org/cookies', {
+  const res = http.get('https://httpbin.test.k6.io/cookies', {
     cookies,
   });
 
@@ -95,7 +95,7 @@ import http from 'k6/http';
 import { check } from 'k6';
 
 export default function () {
-  const res = http.get('https://httpbin.org/cookies/set?my_cookie=hello%20world', { redirects: 0 });
+  const res = http.get('https://httpbin.test.k6.io/cookies/set?my_cookie=hello%20world', { redirects: 0 });
   check(res, {
     "has cookie 'my_cookie'": (r) => r.cookies.my_cookie.length > 0,
     'cookie has correct value': (r) => r.cookies.my_cookie[0].value === 'hello world',
@@ -134,9 +134,9 @@ import http from 'k6/http';
 import { check } from 'k6';
 
 export default function () {
-  const res = http.get('https://httpbin.org/cookies/set?my_cookie=hello%20world', { redirects: 0 });
+  const res = http.get('https://httpbin.test.k6.io/cookies/set?my_cookie=hello%20world', { redirects: 0 });
   const jar = http.cookieJar();
-  const cookies = jar.cookiesForURL('http://httpbin.org/');
+  const cookies = jar.cookiesForURL('http://httpbin.test.k6.io/');
   check(res, {
     "has cookie 'my_cookie'": (r) => cookies.my_cookie.length > 0,
     'cookie has correct value': (r) => cookies.my_cookie[0] === 'hello world',
@@ -160,13 +160,13 @@ import { check } from 'k6';
 
 export default function () {
   const jar = http.cookieJar();
-  jar.set('https://httpbin.org/cookies', 'my_cookie', 'hello world', {
-    domain: 'httpbin.org',
+  jar.set('https://httpbin.test.k6.io/cookies', 'my_cookie', 'hello world', {
+    domain: 'httpbin.test.k6.io',
     path: '/cookies',
     secure: true,
     max_age: 600,
   });
-  const res = http.get('https://httpbin.org/cookies');
+  const res = http.get('https://httpbin.test.k6.io/cookies');
   check(res, {
     'has status 200': (r) => r.status === 200,
     "has cookie 'my_cookie'": (r) => r.cookies.my_cookie[0] !== null,
@@ -192,15 +192,15 @@ export default function () {
 
   // Add cookie to local jar
   const cookieOptions = {
-    domain: 'httpbin.org',
+    domain: 'httpbin.test.k6.io',
     path: '/cookies',
     secure: true,
     max_age: 600,
   };
-  jar.set('https://httpbin.org/cookies', 'my_cookie', 'hello world', cookieOptions);
+  jar.set('https://httpbin.test.k6.io/cookies', 'my_cookie', 'hello world', cookieOptions);
 
   // Override per-VU jar with local jar for the following request
-  const res = http.get('https://httpbin.org/cookies', { jar });
+  const res = http.get('https://httpbin.test.k6.io/cookies', { jar });
   check(res, {
     'has status 200': (r) => r.status === 200,
     "has cookie 'my_cookie'": (r) => r.cookies.my_cookie[0] !== null,

--- a/src/data/markdown/translated-guides/es/04 Results visualization/07 JSON.md
+++ b/src/data/markdown/translated-guides/es/04 Results visualization/07 JSON.md
@@ -52,7 +52,7 @@ El archivo JSON contendrá líneas como las que se describen a continuación:
 {"type":"Metric","data":{"type":"gauge","contains":"default","tainted":null,"thresholds":[],"submetrics":null},"metric":"vus"}
 {"type":"Point","data":{"time":"2017-05-09T14:34:45.625742514+02:00","value":5,"tags":null},"metric":"vus"}
 {"type":"Metric","data":{"type":"trend","contains":"time","tainted":null,"thresholds":["avg<1000"],"submetrics":null},"metric":"http_req_duration"}
-{"type":"Point","data":{"time":"2017-05-09T14:34:45.239531499+02:00","value":459.865729,"tags":{"group":"::my group::json","method":"GET","status":"200","url":"https://httpbin.org/get"}},"metric":"http_req_duration"}
+{"type":"Point","data":{"time":"2017-05-09T14:34:45.239531499+02:00","value":459.865729,"tags":{"group":"::my group::json","method":"GET","status":"200","url":"https://httpbin.test.k6.io/get"}},"metric":"http_req_duration"}
 ```
 
 </CodeGroup>

--- a/src/data/markdown/versioned-js-api/v0.32/javascript api/02 k6/check- val- sets- -tags- -.md
+++ b/src/data/markdown/versioned-js-api/v0.32/javascript api/02 k6/check- val- sets- -tags- -.md
@@ -35,7 +35,7 @@ import http from 'k6/http';
 import { check } from 'k6';
 
 export default function () {
-  const res = http.get('http://httpbin.org');
+  const res = http.get('http://httpbin.test.k6.io');
   check(res, {
     'response code was 200': (res) => res.status == 200,
     'body size was 1234 bytes': (res) => res.body.length == 1234,

--- a/src/data/markdown/versioned-js-api/v0.32/javascript api/07 k6-http/10-batch- requests -.md
+++ b/src/data/markdown/versioned-js-api/v0.32/javascript api/07 k6-http/10-batch- requests -.md
@@ -82,7 +82,7 @@ import { check } from 'k6';
 export default function () {
   const req1 = {
     method: 'GET',
-    url: 'https://httpbin.org/get',
+    url: 'https://httpbin.test.k6.io/get',
   };
   const req2 = {
     method: 'GET',
@@ -90,7 +90,7 @@ export default function () {
   };
   const req3 = {
     method: 'POST',
-    url: 'https://httpbin.org/post',
+    url: 'https://httpbin.test.k6.io/post',
     body: {
       hello: 'world!',
     },
@@ -99,7 +99,7 @@ export default function () {
     },
   };
   const responses = http.batch([req1, req2, req3]);
-  // httpbin.org should return our POST data in the response body, so
+  // httpbin.test.k6.io should return our POST data in the response body, so
   // we check the third response object to see that the POST worked.
   check(responses[2], {
     'form data OK': (res) => JSON.parse(res.body)['form']['hello'] == 'world!',

--- a/src/data/markdown/versioned-js-api/v0.32/javascript api/07 k6-http/60 CookieJar.md
+++ b/src/data/markdown/versioned-js-api/v0.32/javascript api/07 k6-http/60 CookieJar.md
@@ -21,9 +21,9 @@ import http from 'k6/http';
 import { check } from 'k6';
 
 export default function () {
-  const res = http.get('https://httpbin.org/cookies/set?my_cookie=hello%20world', { redirects: 0 });
+  const res = http.get('https://httpbin.test.k6.io/cookies/set?my_cookie=hello%20world', { redirects: 0 });
   const jar = http.cookieJar();
-  const cookies = jar.cookiesForURL('http://httpbin.org/');
+  const cookies = jar.cookiesForURL('http://httpbin.test.k6.io/');
   check(res, {
     "has cookie 'my_cookie'": (r) => cookies.my_cookie.length > 0,
     'cookie has correct value': (r) => cookies.my_cookie[0] === 'hello world',

--- a/src/data/markdown/versioned-js-api/v0.32/javascript api/07 k6-http/60 CookieJar/CookieJar-cookiesForUrl-url.md
+++ b/src/data/markdown/versioned-js-api/v0.32/javascript api/07 k6-http/60 CookieJar/CookieJar-cookiesForUrl-url.md
@@ -22,9 +22,9 @@ import http from 'k6/http';
 import { check } from 'k6';
 
 export default function () {
-  const res = http.get('https://httpbin.org/cookies/set?my_cookie=hello%20world', { redirects: 0 });
+  const res = http.get('https://httpbin.test.k6.io/cookies/set?my_cookie=hello%20world', { redirects: 0 });
   const jar = http.cookieJar();
-  const cookies = jar.cookiesForURL('http://httpbin.org/');
+  const cookies = jar.cookiesForURL('http://httpbin.test.k6.io/');
   check(res, {
     "has cookie 'my_cookie'": (r) => cookies.my_cookie.length > 0,
     'cookie has correct value': (r) => cookies.my_cookie[0] === 'hello world',

--- a/src/data/markdown/versioned-js-api/v0.32/javascript api/07 k6-http/60 CookieJar/CookieJar-set-url-name-value-options.md
+++ b/src/data/markdown/versioned-js-api/v0.32/javascript api/07 k6-http/60 CookieJar/CookieJar-set-url-name-value-options.md
@@ -22,13 +22,13 @@ import { check } from 'k6';
 
 export default function () {
   const jar = http.cookieJar();
-  jar.set('https://httpbin.org/cookies', 'my_cookie', 'hello world', {
-    domain: 'httpbin.org',
+  jar.set('https://httpbin.test.k6.io/cookies', 'my_cookie', 'hello world', {
+    domain: 'httpbin.test.k6.io',
     path: '/cookies',
     secure: true,
     max_age: 600,
   });
-  const res = http.get('https://httpbin.org/cookies');
+  const res = http.get('https://httpbin.test.k6.io/cookies');
   check(res, {
     'has status 200': (r) => r.status === 200,
     "has cookie 'my_cookie'": (r) => r.json().cookies.my_cookie !== null,

--- a/src/data/markdown/versioned-js-api/v0.32/javascript api/07 k6-http/60-Params.md
+++ b/src/data/markdown/versioned-js-api/v0.32/javascript api/07 k6-http/60-Params.md
@@ -51,7 +51,7 @@ Here is another example using [http.batch()](/javascript-api/k6-http/batch-reque
 import http from 'k6/http';
 
 const url1 = 'https://api.k6.io/v3/account/me';
-const url2 = 'http://httpbin.org/get';
+const url2 = 'http://httpbin.test.k6.io/get';
 const apiToken = 'f232831bda15dd233c53b9c548732c0197619a3d3c451134d9abded7eb5bb195';
 const requestHeaders = {
   'User-Agent': 'k6',
@@ -80,7 +80,7 @@ import { check } from 'k6';
 
 export default function () {
   // Passing username and password as part of URL plus the auth option will authenticate using HTTP Digest authentication
-  const res = http.get('http://user:passwd@httpbin.org/digest-auth/auth/user/passwd', {
+  const res = http.get('http://user:passwd@httpbin.test.k6.io/digest-auth/auth/user/passwd', {
     auth: 'digest',
   });
 
@@ -107,7 +107,7 @@ export default function () {}
 export function setup() {
   // Get 10 random bytes as an ArrayBuffer. Without the responseType the body
   // will be null.
-  const response = http.get('https://httpbin.org/bytes/10', {
+  const response = http.get('https://httpbin.test.k6.io/bytes/10', {
     responseType: 'binary',
   });
   // response.body is an ArrayBuffer, so wrap it in a typed array view to access

--- a/src/data/markdown/versioned-js-api/v0.32/javascript api/07 k6-http/61 Response/Response-clickLink- -params- -.md
+++ b/src/data/markdown/versioned-js-api/v0.32/javascript api/07 k6-http/61 Response/Response-clickLink- -params- -.md
@@ -27,7 +27,7 @@ import http from 'k6/http';
 
 export default function () {
   // Request page with links
-  let res = http.get('https://httpbin.org/links/10/0');
+  let res = http.get('https://httpbin.test.k6.io/links/10/0');
 
   // Now, click the 4th link on the page
   res = res.clickLink({ selector: 'a:nth-child(4)' });

--- a/src/data/markdown/versioned-js-api/v0.32/javascript api/07 k6-http/61 Response/Response-submitForm- -params- -.md
+++ b/src/data/markdown/versioned-js-api/v0.32/javascript api/07 k6-http/61 Response/Response-submitForm- -params- -.md
@@ -30,7 +30,7 @@ import { sleep } from 'k6';
 
 export default function () {
   // Request page containing a form
-  let res = http.get('https://httpbin.org/forms/post');
+  let res = http.get('https://httpbin.test.k6.io/forms/post');
 
   // Now, submit form setting/overriding some fields of the form
   res = res.submitForm({

--- a/src/data/markdown/versioned-js-api/v0.33/javascript api/02 k6/check- val- sets- -tags- -.md
+++ b/src/data/markdown/versioned-js-api/v0.33/javascript api/02 k6/check- val- sets- -tags- -.md
@@ -35,7 +35,7 @@ import http from 'k6/http';
 import { check } from 'k6';
 
 export default function () {
-  const res = http.get('http://httpbin.org');
+  const res = http.get('http://httpbin.test.k6.io');
   check(res, {
     'response code was 200': (res) => res.status == 200,
     'body size was 1234 bytes': (res) => res.body.length == 1234,

--- a/src/data/markdown/versioned-js-api/v0.33/javascript api/07 k6-http/10-batch- requests -.md
+++ b/src/data/markdown/versioned-js-api/v0.33/javascript api/07 k6-http/10-batch- requests -.md
@@ -82,7 +82,7 @@ import { check } from 'k6';
 export default function () {
   const req1 = {
     method: 'GET',
-    url: 'https://httpbin.org/get',
+    url: 'https://httpbin.test.k6.io/get',
   };
   const req2 = {
     method: 'GET',
@@ -90,7 +90,7 @@ export default function () {
   };
   const req3 = {
     method: 'POST',
-    url: 'https://httpbin.org/post',
+    url: 'https://httpbin.test.k6.io/post',
     body: {
       hello: 'world!',
     },
@@ -99,7 +99,7 @@ export default function () {
     },
   };
   const responses = http.batch([req1, req2, req3]);
-  // httpbin.org should return our POST data in the response body, so
+  // httpbin.test.k6.io should return our POST data in the response body, so
   // we check the third response object to see that the POST worked.
   check(responses[2], {
     'form data OK': (res) => JSON.parse(res.body)['form']['hello'] == 'world!',

--- a/src/data/markdown/versioned-js-api/v0.33/javascript api/07 k6-http/60 CookieJar.md
+++ b/src/data/markdown/versioned-js-api/v0.33/javascript api/07 k6-http/60 CookieJar.md
@@ -21,9 +21,9 @@ import http from 'k6/http';
 import { check } from 'k6';
 
 export default function () {
-  const res = http.get('https://httpbin.org/cookies/set?my_cookie=hello%20world', { redirects: 0 });
+  const res = http.get('https://httpbin.test.k6.io/cookies/set?my_cookie=hello%20world', { redirects: 0 });
   const jar = http.cookieJar();
-  const cookies = jar.cookiesForURL('http://httpbin.org/');
+  const cookies = jar.cookiesForURL('http://httpbin.test.k6.io/');
   check(res, {
     "has cookie 'my_cookie'": (r) => cookies.my_cookie.length > 0,
     'cookie has correct value': (r) => cookies.my_cookie[0] === 'hello world',

--- a/src/data/markdown/versioned-js-api/v0.33/javascript api/07 k6-http/60 CookieJar/CookieJar-cookiesForUrl-url.md
+++ b/src/data/markdown/versioned-js-api/v0.33/javascript api/07 k6-http/60 CookieJar/CookieJar-cookiesForUrl-url.md
@@ -22,9 +22,9 @@ import http from 'k6/http';
 import { check } from 'k6';
 
 export default function () {
-  const res = http.get('https://httpbin.org/cookies/set?my_cookie=hello%20world', { redirects: 0 });
+  const res = http.get('https://httpbin.test.k6.io/cookies/set?my_cookie=hello%20world', { redirects: 0 });
   const jar = http.cookieJar();
-  const cookies = jar.cookiesForURL('http://httpbin.org/');
+  const cookies = jar.cookiesForURL('http://httpbin.test.k6.io/');
   check(res, {
     "has cookie 'my_cookie'": (r) => cookies.my_cookie.length > 0,
     'cookie has correct value': (r) => cookies.my_cookie[0] === 'hello world',

--- a/src/data/markdown/versioned-js-api/v0.33/javascript api/07 k6-http/60 CookieJar/CookieJar-set-url-name-value-options.md
+++ b/src/data/markdown/versioned-js-api/v0.33/javascript api/07 k6-http/60 CookieJar/CookieJar-set-url-name-value-options.md
@@ -22,13 +22,13 @@ import { check } from 'k6';
 
 export default function () {
   const jar = http.cookieJar();
-  jar.set('https://httpbin.org/cookies', 'my_cookie', 'hello world', {
-    domain: 'httpbin.org',
+  jar.set('https://httpbin.test.k6.io/cookies', 'my_cookie', 'hello world', {
+    domain: 'httpbin.test.k6.io',
     path: '/cookies',
     secure: true,
     max_age: 600,
   });
-  const res = http.get('https://httpbin.org/cookies');
+  const res = http.get('https://httpbin.test.k6.io/cookies');
   check(res, {
     'has status 200': (r) => r.status === 200,
     "has cookie 'my_cookie'": (r) => r.json().cookies.my_cookie !== null,

--- a/src/data/markdown/versioned-js-api/v0.33/javascript api/07 k6-http/60-Params.md
+++ b/src/data/markdown/versioned-js-api/v0.33/javascript api/07 k6-http/60-Params.md
@@ -51,7 +51,7 @@ Here is another example using [http.batch()](/javascript-api/k6-http/batch-reque
 import http from 'k6/http';
 
 const url1 = 'https://api.k6.io/v3/account/me';
-const url2 = 'http://httpbin.org/get';
+const url2 = 'http://httpbin.test.k6.io/get';
 const apiToken = 'f232831bda15dd233c53b9c548732c0197619a3d3c451134d9abded7eb5bb195';
 const requestHeaders = {
   'User-Agent': 'k6',
@@ -80,7 +80,7 @@ import { check } from 'k6';
 
 export default function () {
   // Passing username and password as part of URL plus the auth option will authenticate using HTTP Digest authentication
-  const res = http.get('http://user:passwd@httpbin.org/digest-auth/auth/user/passwd', {
+  const res = http.get('http://user:passwd@httpbin.test.k6.io/digest-auth/auth/user/passwd', {
     auth: 'digest',
   });
 
@@ -107,7 +107,7 @@ export default function () {}
 export function setup() {
   // Get 10 random bytes as an ArrayBuffer. Without the responseType the body
   // will be null.
-  const response = http.get('https://httpbin.org/bytes/10', {
+  const response = http.get('https://httpbin.test.k6.io/bytes/10', {
     responseType: 'binary',
   });
   // response.body is an ArrayBuffer, so wrap it in a typed array view to access

--- a/src/data/markdown/versioned-js-api/v0.33/javascript api/07 k6-http/61 Response/Response-clickLink- -params- -.md
+++ b/src/data/markdown/versioned-js-api/v0.33/javascript api/07 k6-http/61 Response/Response-clickLink- -params- -.md
@@ -27,7 +27,7 @@ import http from 'k6/http';
 
 export default function () {
   // Request page with links
-  let res = http.get('https://httpbin.org/links/10/0');
+  let res = http.get('https://httpbin.test.k6.io/links/10/0');
 
   // Now, click the 4th link on the page
   res = res.clickLink({ selector: 'a:nth-child(4)' });

--- a/src/data/markdown/versioned-js-api/v0.33/javascript api/07 k6-http/61 Response/Response-submitForm- -params- -.md
+++ b/src/data/markdown/versioned-js-api/v0.33/javascript api/07 k6-http/61 Response/Response-submitForm- -params- -.md
@@ -30,7 +30,7 @@ import { sleep } from 'k6';
 
 export default function () {
   // Request page containing a form
-  let res = http.get('https://httpbin.org/forms/post');
+  let res = http.get('https://httpbin.test.k6.io/forms/post');
 
   // Now, submit form setting/overriding some fields of the form
   res = res.submitForm({

--- a/src/data/markdown/versioned-js-api/v0.34/javascript api/02 k6/check- val- sets- -tags- -.md
+++ b/src/data/markdown/versioned-js-api/v0.34/javascript api/02 k6/check- val- sets- -tags- -.md
@@ -35,7 +35,7 @@ import http from 'k6/http';
 import { check } from 'k6';
 
 export default function () {
-  const res = http.get('http://httpbin.org');
+  const res = http.get('http://httpbin.test.k6.io');
   check(res, {
     'response code was 200': (res) => res.status == 200,
   });
@@ -53,7 +53,7 @@ import http from 'k6/http';
 import { check, fail } from 'k6';
 
 export default function () {
-  const res = http.get('http://httpbin.org');
+  const res = http.get('http://httpbin.test.k6.io');
   const checkOutput = check(
     res,
     {

--- a/src/data/markdown/versioned-js-api/v0.34/javascript api/08 k6-http/10-batch- requests -.md
+++ b/src/data/markdown/versioned-js-api/v0.34/javascript api/08 k6-http/10-batch- requests -.md
@@ -83,7 +83,7 @@ import { check } from 'k6';
 export default function () {
   const req1 = {
     method: 'GET',
-    url: 'https://httpbin.org/get',
+    url: 'https://httpbin.test.k6.io/get',
   };
   const req2 = {
     method: 'GET',
@@ -91,7 +91,7 @@ export default function () {
   };
   const req3 = {
     method: 'POST',
-    url: 'https://httpbin.org/post',
+    url: 'https://httpbin.test.k6.io/post',
     body: {
       hello: 'world!',
     },
@@ -100,7 +100,7 @@ export default function () {
     },
   };
   const responses = http.batch([req1, req2, req3]);
-  // httpbin.org should return our POST data in the response body, so
+  // httpbin.test.k6.io should return our POST data in the response body, so
   // we check the third response object to see that the POST worked.
   check(responses[2], {
     'form data OK': (res) => JSON.parse(res.body)['form']['hello'] == 'world!',

--- a/src/data/markdown/versioned-js-api/v0.34/javascript api/08 k6-http/60 CookieJar.md
+++ b/src/data/markdown/versioned-js-api/v0.34/javascript api/08 k6-http/60 CookieJar.md
@@ -21,9 +21,9 @@ import http from 'k6/http';
 import { check } from 'k6';
 
 export default function () {
-  const res = http.get('https://httpbin.org/cookies/set?my_cookie=hello%20world', { redirects: 0 });
+  const res = http.get('https://httpbin.test.k6.io/cookies/set?my_cookie=hello%20world', { redirects: 0 });
   const jar = http.cookieJar();
-  const cookies = jar.cookiesForURL('http://httpbin.org/');
+  const cookies = jar.cookiesForURL('http://httpbin.test.k6.io/');
   check(res, {
     "has cookie 'my_cookie'": (r) => cookies.my_cookie.length > 0,
     'cookie has correct value': (r) => cookies.my_cookie[0] === 'hello world',

--- a/src/data/markdown/versioned-js-api/v0.34/javascript api/08 k6-http/60 CookieJar/CookieJar-cookiesForUrl-url.md
+++ b/src/data/markdown/versioned-js-api/v0.34/javascript api/08 k6-http/60 CookieJar/CookieJar-cookiesForUrl-url.md
@@ -22,9 +22,9 @@ import http from 'k6/http';
 import { check } from 'k6';
 
 export default function () {
-  const res = http.get('https://httpbin.org/cookies/set?my_cookie=hello%20world', { redirects: 0 });
+  const res = http.get('https://httpbin.test.k6.io/cookies/set?my_cookie=hello%20world', { redirects: 0 });
   const jar = http.cookieJar();
-  const cookies = jar.cookiesForURL('http://httpbin.org/');
+  const cookies = jar.cookiesForURL('http://httpbin.test.k6.io/');
   check(res, {
     "has cookie 'my_cookie'": (r) => cookies.my_cookie.length > 0,
     'cookie has correct value': (r) => cookies.my_cookie[0] === 'hello world',

--- a/src/data/markdown/versioned-js-api/v0.34/javascript api/08 k6-http/60 CookieJar/CookieJar-set-url-name-value-options.md
+++ b/src/data/markdown/versioned-js-api/v0.34/javascript api/08 k6-http/60 CookieJar/CookieJar-set-url-name-value-options.md
@@ -22,13 +22,13 @@ import { check } from 'k6';
 
 export default function () {
   const jar = http.cookieJar();
-  jar.set('https://httpbin.org/cookies', 'my_cookie', 'hello world', {
-    domain: 'httpbin.org',
+  jar.set('https://httpbin.test.k6.io/cookies', 'my_cookie', 'hello world', {
+    domain: 'httpbin.test.k6.io',
     path: '/cookies',
     secure: true,
     max_age: 600,
   });
-  const res = http.get('https://httpbin.org/cookies');
+  const res = http.get('https://httpbin.test.k6.io/cookies');
   check(res, {
     'has status 200': (r) => r.status === 200,
     "has cookie 'my_cookie'": (r) => r.json().cookies.my_cookie !== null,

--- a/src/data/markdown/versioned-js-api/v0.34/javascript api/08 k6-http/60-Params.md
+++ b/src/data/markdown/versioned-js-api/v0.34/javascript api/08 k6-http/60-Params.md
@@ -51,7 +51,7 @@ Here is another example using [http.batch()](/javascript-api/k6-http/batch-reque
 import http from 'k6/http';
 
 const url1 = 'https://api.k6.io/v3/account/me';
-const url2 = 'http://httpbin.org/get';
+const url2 = 'http://httpbin.test.k6.io/get';
 const apiToken = 'f232831bda15dd233c53b9c548732c0197619a3d3c451134d9abded7eb5bb195';
 const requestHeaders = {
   'User-Agent': 'k6',
@@ -80,7 +80,7 @@ import { check } from 'k6';
 
 export default function () {
   // Passing username and password as part of URL plus the auth option will authenticate using HTTP Digest authentication
-  const res = http.get('http://user:passwd@httpbin.org/digest-auth/auth/user/passwd', {
+  const res = http.get('http://user:passwd@httpbin.test.k6.io/digest-auth/auth/user/passwd', {
     auth: 'digest',
   });
 
@@ -107,7 +107,7 @@ export default function () {}
 export function setup() {
   // Get 10 random bytes as an ArrayBuffer. Without the responseType the body
   // will be null.
-  const response = http.get('https://httpbin.org/bytes/10', {
+  const response = http.get('https://httpbin.test.k6.io/bytes/10', {
     responseType: 'binary',
   });
   // response.body is an ArrayBuffer, so wrap it in a typed array view to access

--- a/src/data/markdown/versioned-js-api/v0.34/javascript api/08 k6-http/61 Response/Response-clickLink- -params- -.md
+++ b/src/data/markdown/versioned-js-api/v0.34/javascript api/08 k6-http/61 Response/Response-clickLink- -params- -.md
@@ -27,7 +27,7 @@ import http from 'k6/http';
 
 export default function () {
   // Request page with links
-  let res = http.get('https://httpbin.org/links/10/0');
+  let res = http.get('https://httpbin.test.k6.io/links/10/0');
 
   // Now, click the 4th link on the page
   res = res.clickLink({ selector: 'a:nth-child(4)' });

--- a/src/data/markdown/versioned-js-api/v0.34/javascript api/08 k6-http/61 Response/Response-submitForm- -params- -.md
+++ b/src/data/markdown/versioned-js-api/v0.34/javascript api/08 k6-http/61 Response/Response-submitForm- -params- -.md
@@ -30,7 +30,7 @@ import { sleep } from 'k6';
 
 export default function () {
   // Request page containing a form
-  let res = http.get('https://httpbin.org/forms/post');
+  let res = http.get('https://httpbin.test.k6.io/forms/post');
 
   // Now, submit form setting/overriding some fields of the form
   res = res.submitForm({

--- a/src/data/markdown/versioned-js-api/v0.35/javascript api/02 k6/check- val- sets- -tags- -.md
+++ b/src/data/markdown/versioned-js-api/v0.35/javascript api/02 k6/check- val- sets- -tags- -.md
@@ -35,7 +35,7 @@ import http from 'k6/http';
 import { check } from 'k6';
 
 export default function () {
-  const res = http.get('http://httpbin.org');
+  const res = http.get('http://httpbin.test.k6.io');
   check(res, {
     'response code was 200': (res) => res.status == 200,
   });
@@ -53,7 +53,7 @@ import http from 'k6/http';
 import { check, fail } from 'k6';
 
 export default function () {
-  const res = http.get('http://httpbin.org');
+  const res = http.get('http://httpbin.test.k6.io');
   const checkOutput = check(
     res,
     {

--- a/src/data/markdown/versioned-js-api/v0.35/javascript api/08 k6-http/10-batch- requests -.md
+++ b/src/data/markdown/versioned-js-api/v0.35/javascript api/08 k6-http/10-batch- requests -.md
@@ -83,7 +83,7 @@ import { check } from 'k6';
 export default function () {
   const req1 = {
     method: 'GET',
-    url: 'https://httpbin.org/get',
+    url: 'https://httpbin.test.k6.io/get',
   };
   const req2 = {
     method: 'GET',
@@ -91,7 +91,7 @@ export default function () {
   };
   const req3 = {
     method: 'POST',
-    url: 'https://httpbin.org/post',
+    url: 'https://httpbin.test.k6.io/post',
     body: {
       hello: 'world!',
     },
@@ -100,7 +100,7 @@ export default function () {
     },
   };
   const responses = http.batch([req1, req2, req3]);
-  // httpbin.org should return our POST data in the response body, so
+  // httpbin.test.k6.io should return our POST data in the response body, so
   // we check the third response object to see that the POST worked.
   check(responses[2], {
     'form data OK': (res) => JSON.parse(res.body)['form']['hello'] == 'world!',

--- a/src/data/markdown/versioned-js-api/v0.35/javascript api/08 k6-http/60 CookieJar.md
+++ b/src/data/markdown/versioned-js-api/v0.35/javascript api/08 k6-http/60 CookieJar.md
@@ -21,9 +21,9 @@ import http from 'k6/http';
 import { check } from 'k6';
 
 export default function () {
-  const res = http.get('https://httpbin.org/cookies/set?my_cookie=hello%20world', { redirects: 0 });
+  const res = http.get('https://httpbin.test.k6.io/cookies/set?my_cookie=hello%20world', { redirects: 0 });
   const jar = http.cookieJar();
-  const cookies = jar.cookiesForURL('http://httpbin.org/');
+  const cookies = jar.cookiesForURL('http://httpbin.test.k6.io/');
   check(res, {
     "has cookie 'my_cookie'": (r) => cookies.my_cookie.length > 0,
     'cookie has correct value': (r) => cookies.my_cookie[0] === 'hello world',

--- a/src/data/markdown/versioned-js-api/v0.35/javascript api/08 k6-http/60 CookieJar/CookieJar-cookiesForUrl-url.md
+++ b/src/data/markdown/versioned-js-api/v0.35/javascript api/08 k6-http/60 CookieJar/CookieJar-cookiesForUrl-url.md
@@ -22,9 +22,9 @@ import http from 'k6/http';
 import { check } from 'k6';
 
 export default function () {
-  const res = http.get('https://httpbin.org/cookies/set?my_cookie=hello%20world', { redirects: 0 });
+  const res = http.get('https://httpbin.test.k6.io/cookies/set?my_cookie=hello%20world', { redirects: 0 });
   const jar = http.cookieJar();
-  const cookies = jar.cookiesForURL('http://httpbin.org/');
+  const cookies = jar.cookiesForURL('http://httpbin.test.k6.io/');
   check(res, {
     "has cookie 'my_cookie'": (r) => cookies.my_cookie.length > 0,
     'cookie has correct value': (r) => cookies.my_cookie[0] === 'hello world',

--- a/src/data/markdown/versioned-js-api/v0.35/javascript api/08 k6-http/60 CookieJar/CookieJar-set-url-name-value-options.md
+++ b/src/data/markdown/versioned-js-api/v0.35/javascript api/08 k6-http/60 CookieJar/CookieJar-set-url-name-value-options.md
@@ -22,13 +22,13 @@ import { check } from 'k6';
 
 export default function () {
   const jar = http.cookieJar();
-  jar.set('https://httpbin.org/cookies', 'my_cookie', 'hello world', {
-    domain: 'httpbin.org',
+  jar.set('https://httpbin.test.k6.io/cookies', 'my_cookie', 'hello world', {
+    domain: 'httpbin.test.k6.io',
     path: '/cookies',
     secure: true,
     max_age: 600,
   });
-  const res = http.get('https://httpbin.org/cookies');
+  const res = http.get('https://httpbin.test.k6.io/cookies');
   check(res, {
     'has status 200': (r) => r.status === 200,
     "has cookie 'my_cookie'": (r) => r.json().cookies.my_cookie !== null,

--- a/src/data/markdown/versioned-js-api/v0.35/javascript api/08 k6-http/60-Params.md
+++ b/src/data/markdown/versioned-js-api/v0.35/javascript api/08 k6-http/60-Params.md
@@ -51,7 +51,7 @@ Here is another example using [http.batch()](/javascript-api/k6-http/batch-reque
 import http from 'k6/http';
 
 const url1 = 'https://api.k6.io/v3/account/me';
-const url2 = 'http://httpbin.org/get';
+const url2 = 'http://httpbin.test.k6.io/get';
 const apiToken = 'f232831bda15dd233c53b9c548732c0197619a3d3c451134d9abded7eb5bb195';
 const requestHeaders = {
   'User-Agent': 'k6',
@@ -80,7 +80,7 @@ import { check } from 'k6';
 
 export default function () {
   // Passing username and password as part of URL plus the auth option will authenticate using HTTP Digest authentication
-  const res = http.get('http://user:passwd@httpbin.org/digest-auth/auth/user/passwd', {
+  const res = http.get('http://user:passwd@httpbin.test.k6.io/digest-auth/auth/user/passwd', {
     auth: 'digest',
   });
 
@@ -107,7 +107,7 @@ export default function () {}
 export function setup() {
   // Get 10 random bytes as an ArrayBuffer. Without the responseType the body
   // will be null.
-  const response = http.get('https://httpbin.org/bytes/10', {
+  const response = http.get('https://httpbin.test.k6.io/bytes/10', {
     responseType: 'binary',
   });
   // response.body is an ArrayBuffer, so wrap it in a typed array view to access

--- a/src/data/markdown/versioned-js-api/v0.35/javascript api/08 k6-http/61 Response/Response-clickLink- -params- -.md
+++ b/src/data/markdown/versioned-js-api/v0.35/javascript api/08 k6-http/61 Response/Response-clickLink- -params- -.md
@@ -27,7 +27,7 @@ import http from 'k6/http';
 
 export default function () {
   // Request page with links
-  let res = http.get('https://httpbin.org/links/10/0');
+  let res = http.get('https://httpbin.test.k6.io/links/10/0');
 
   // Now, click the 4th link on the page
   res = res.clickLink({ selector: 'a:nth-child(4)' });

--- a/src/data/markdown/versioned-js-api/v0.35/javascript api/08 k6-http/61 Response/Response-submitForm- -params- -.md
+++ b/src/data/markdown/versioned-js-api/v0.35/javascript api/08 k6-http/61 Response/Response-submitForm- -params- -.md
@@ -30,7 +30,7 @@ import { sleep } from 'k6';
 
 export default function () {
   // Request page containing a form
-  let res = http.get('https://httpbin.org/forms/post');
+  let res = http.get('https://httpbin.test.k6.io/forms/post');
 
   // Now, submit form setting/overriding some fields of the form
   res = res.submitForm({

--- a/src/data/markdown/versioned-js-api/v0.36/javascript api/02 k6/check- val- sets- -tags- -.md
+++ b/src/data/markdown/versioned-js-api/v0.36/javascript api/02 k6/check- val- sets- -tags- -.md
@@ -35,7 +35,7 @@ import http from 'k6/http';
 import { check } from 'k6';
 
 export default function () {
-  const res = http.get('http://httpbin.org');
+  const res = http.get('http://httpbin.test.k6.io');
   check(res, {
     'response code was 200': (res) => res.status == 200,
   });
@@ -53,7 +53,7 @@ import http from 'k6/http';
 import { check, fail } from 'k6';
 
 export default function () {
-  const res = http.get('http://httpbin.org');
+  const res = http.get('http://httpbin.test.k6.io');
   const checkOutput = check(
     res,
     {

--- a/src/data/markdown/versioned-js-api/v0.36/javascript api/08 k6-http/10-batch- requests -.md
+++ b/src/data/markdown/versioned-js-api/v0.36/javascript api/08 k6-http/10-batch- requests -.md
@@ -83,7 +83,7 @@ import { check } from 'k6';
 export default function () {
   const req1 = {
     method: 'GET',
-    url: 'https://httpbin.org/get',
+    url: 'https://httpbin.test.k6.io/get',
   };
   const req2 = {
     method: 'GET',
@@ -91,7 +91,7 @@ export default function () {
   };
   const req3 = {
     method: 'POST',
-    url: 'https://httpbin.org/post',
+    url: 'https://httpbin.test.k6.io/post',
     body: {
       hello: 'world!',
     },
@@ -100,7 +100,7 @@ export default function () {
     },
   };
   const responses = http.batch([req1, req2, req3]);
-  // httpbin.org should return our POST data in the response body, so
+  // httpbin.test.k6.io should return our POST data in the response body, so
   // we check the third response object to see that the POST worked.
   check(responses[2], {
     'form data OK': (res) => JSON.parse(res.body)['form']['hello'] == 'world!',

--- a/src/data/markdown/versioned-js-api/v0.36/javascript api/08 k6-http/60 CookieJar.md
+++ b/src/data/markdown/versioned-js-api/v0.36/javascript api/08 k6-http/60 CookieJar.md
@@ -21,9 +21,9 @@ import http from 'k6/http';
 import { check } from 'k6';
 
 export default function () {
-  const res = http.get('https://httpbin.org/cookies/set?my_cookie=hello%20world', { redirects: 0 });
+  const res = http.get('https://httpbin.test.k6.io/cookies/set?my_cookie=hello%20world', { redirects: 0 });
   const jar = http.cookieJar();
-  const cookies = jar.cookiesForURL('http://httpbin.org/');
+  const cookies = jar.cookiesForURL('http://httpbin.test.k6.io/');
   check(res, {
     "has cookie 'my_cookie'": (r) => cookies.my_cookie.length > 0,
     'cookie has correct value': (r) => cookies.my_cookie[0] === 'hello world',

--- a/src/data/markdown/versioned-js-api/v0.36/javascript api/08 k6-http/60 CookieJar/CookieJar-cookiesForUrl-url.md
+++ b/src/data/markdown/versioned-js-api/v0.36/javascript api/08 k6-http/60 CookieJar/CookieJar-cookiesForUrl-url.md
@@ -22,9 +22,9 @@ import http from 'k6/http';
 import { check } from 'k6';
 
 export default function () {
-  const res = http.get('https://httpbin.org/cookies/set?my_cookie=hello%20world', { redirects: 0 });
+  const res = http.get('https://httpbin.test.k6.io/cookies/set?my_cookie=hello%20world', { redirects: 0 });
   const jar = http.cookieJar();
-  const cookies = jar.cookiesForURL('http://httpbin.org/');
+  const cookies = jar.cookiesForURL('http://httpbin.test.k6.io/');
   check(res, {
     "has cookie 'my_cookie'": (r) => cookies.my_cookie.length > 0,
     'cookie has correct value': (r) => cookies.my_cookie[0] === 'hello world',

--- a/src/data/markdown/versioned-js-api/v0.36/javascript api/08 k6-http/60 CookieJar/CookieJar-set-url-name-value-options.md
+++ b/src/data/markdown/versioned-js-api/v0.36/javascript api/08 k6-http/60 CookieJar/CookieJar-set-url-name-value-options.md
@@ -22,13 +22,13 @@ import { check } from 'k6';
 
 export default function () {
   const jar = http.cookieJar();
-  jar.set('https://httpbin.org/cookies', 'my_cookie', 'hello world', {
-    domain: 'httpbin.org',
+  jar.set('https://httpbin.test.k6.io/cookies', 'my_cookie', 'hello world', {
+    domain: 'httpbin.test.k6.io',
     path: '/cookies',
     secure: true,
     max_age: 600,
   });
-  const res = http.get('https://httpbin.org/cookies');
+  const res = http.get('https://httpbin.test.k6.io/cookies');
   check(res, {
     'has status 200': (r) => r.status === 200,
     "has cookie 'my_cookie'": (r) => r.json().cookies.my_cookie !== null,

--- a/src/data/markdown/versioned-js-api/v0.36/javascript api/08 k6-http/60-Params.md
+++ b/src/data/markdown/versioned-js-api/v0.36/javascript api/08 k6-http/60-Params.md
@@ -51,7 +51,7 @@ Here is another example using [http.batch()](/javascript-api/k6-http/batch-reque
 import http from 'k6/http';
 
 const url1 = 'https://api.k6.io/v3/account/me';
-const url2 = 'http://httpbin.org/get';
+const url2 = 'http://httpbin.test.k6.io/get';
 const apiToken = 'f232831bda15dd233c53b9c548732c0197619a3d3c451134d9abded7eb5bb195';
 const requestHeaders = {
   'User-Agent': 'k6',
@@ -80,7 +80,7 @@ import { check } from 'k6';
 
 export default function () {
   // Passing username and password as part of URL plus the auth option will authenticate using HTTP Digest authentication
-  const res = http.get('http://user:passwd@httpbin.org/digest-auth/auth/user/passwd', {
+  const res = http.get('http://user:passwd@httpbin.test.k6.io/digest-auth/auth/user/passwd', {
     auth: 'digest',
   });
 
@@ -107,7 +107,7 @@ export default function () {}
 export function setup() {
   // Get 10 random bytes as an ArrayBuffer. Without the responseType the body
   // will be null.
-  const response = http.get('https://httpbin.org/bytes/10', {
+  const response = http.get('https://httpbin.test.k6.io/bytes/10', {
     responseType: 'binary',
   });
   // response.body is an ArrayBuffer, so wrap it in a typed array view to access

--- a/src/data/markdown/versioned-js-api/v0.36/javascript api/08 k6-http/61 Response/Response-clickLink- -params- -.md
+++ b/src/data/markdown/versioned-js-api/v0.36/javascript api/08 k6-http/61 Response/Response-clickLink- -params- -.md
@@ -27,7 +27,7 @@ import http from 'k6/http';
 
 export default function () {
   // Request page with links
-  let res = http.get('https://httpbin.org/links/10/0');
+  let res = http.get('https://httpbin.test.k6.io/links/10/0');
 
   // Now, click the 4th link on the page
   res = res.clickLink({ selector: 'a:nth-child(4)' });

--- a/src/data/markdown/versioned-js-api/v0.36/javascript api/08 k6-http/61 Response/Response-submitForm- -params- -.md
+++ b/src/data/markdown/versioned-js-api/v0.36/javascript api/08 k6-http/61 Response/Response-submitForm- -params- -.md
@@ -30,7 +30,7 @@ import { sleep } from 'k6';
 
 export default function () {
   // Request page containing a form
-  let res = http.get('https://httpbin.org/forms/post');
+  let res = http.get('https://httpbin.test.k6.io/forms/post');
 
   // Now, submit form setting/overriding some fields of the form
   res = res.submitForm({


### PR DESCRIPTION
We should use our own httpbin app in examples.

This was a mass replace done with:
`rg 'httpbin\.org' -0 --files-with-matches | xargs -0 sed -i 's:httpbin\.org:httpbin.test.k6.io:g'`