### PR TITLE
Fix per-VU cookie jar example

### DIFF
--- a/src/data/markdown/translated-guides/en/02 Using k6/09 Cookies.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/09 Cookies.md
@@ -91,8 +91,8 @@ export default function () {
     cookies,
   });
 
-  check(res, {
-    'cookie has correct value': (r) => r.cookies.my_cookie[0].value === 'hello world 2',
+  check(res.json(), {
+    'cookie has correct value': (b) => b.cookies.my_cookie == 'hello world 2',
   });
 }
 ```

--- a/src/data/markdown/translated-guides/es/02 Using k6/09 Cookies.md
+++ b/src/data/markdown/translated-guides/es/02 Using k6/09 Cookies.md
@@ -76,8 +76,8 @@ export default function () {
     cookies,
   });
 
-  check(res, {
-    'cookie has correct value': (r) => r.cookies.my_cookie[0].value === 'hello world 2',
+  check(res.json(), {
+    'cookie has correct value': (b) => b.cookies.my_cookie == 'hello world 2',
   });
 }
 ```


### PR DESCRIPTION
The cookie is set and overriden on the `/cookies` endpoint, and it's sent in the GET request, but not returned in the response headers, so it's not available in the `Response.cookies` property. Instead it's returned in the body as JSON, which is an httpbin feature.

Previously this example would fail with:

```
ERRO[0001] TypeError: Cannot read property '0' of undefined
running at cookie has correct value (file:///tmp/test-cookies2.js:43:39(5))
default at go.k6.io/k6/js/modules/k6.(*K6).Check-fm (native)
        at file:///tmp/test-cookies2.js:42:13(39)
        at native  executor=per-vu-iterations scenario=default source=stacktrace
```