### PR TITLE
Bump dockerfile node version to 14-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # base image
-FROM node:12-slim
+FROM node:14-slim
 
 EXPOSE 8000
 


### PR DESCRIPTION
When running the `README.md` steps, I noticed the `docker-compose` stack was not working anymore. Gatsby was complaining about the node version being too low.

![Screenshot from 2022-04-11 10-43-07](https://user-images.githubusercontent.com/690867/162701510-054267c0-2651-4024-bc52-ac3f75d67d7e.png)

Here's a PR bumping the `Dockerfile` node image to `14-slim`.
