### PR TITLE
feat: switch from react-sticky to native CSS position sticky property for TOC

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,6 @@
         "react-dom": "^17.0.2",
         "react-helmet": "^6.1.0",
         "react-instantsearch-dom": "^6.16.0",
-        "react-sticky": "^6.0.3",
         "runes": "^0.4.3",
         "sass": "^1.34.0"
       },
@@ -22404,7 +22403,8 @@
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "optional": true
     },
     "node_modules/phin": {
       "version": "2.9.3",
@@ -23131,14 +23131,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/raf": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
-      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "dependencies": {
-        "performance-now": "^2.1.0"
-      }
-    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -23650,19 +23642,6 @@
       "integrity": "sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ==",
       "peerDependencies": {
         "react": "^16.3.0 || ^17.0.0"
-      }
-    },
-    "node_modules/react-sticky": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/react-sticky/-/react-sticky-6.0.3.tgz",
-      "integrity": "sha512-LNH4UJlRatOqo29/VHxDZOf6fwbgfgcHO4mkEFvrie5FuaZCSTGtug5R8NGqJ0kSnX8gHw8qZN37FcvnFBJpTQ==",
-      "dependencies": {
-        "prop-types": "^15.5.8",
-        "raf": "^3.3.0"
-      },
-      "peerDependencies": {
-        "react": ">=15",
-        "react-dom": ">=15"
       }
     },
     "node_modules/read": {
@@ -47060,7 +47039,8 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "optional": true
     },
     "phin": {
       "version": "2.9.3",
@@ -47603,14 +47583,6 @@
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
     },
-    "raf": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
-      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "requires": {
-        "performance-now": "^2.1.0"
-      }
-    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -48002,15 +47974,6 @@
       "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.1.tgz",
       "integrity": "sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ==",
       "requires": {}
-    },
-    "react-sticky": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/react-sticky/-/react-sticky-6.0.3.tgz",
-      "integrity": "sha512-LNH4UJlRatOqo29/VHxDZOf6fwbgfgcHO4mkEFvrie5FuaZCSTGtug5R8NGqJ0kSnX8gHw8qZN37FcvnFBJpTQ==",
-      "requires": {
-        "prop-types": "^15.5.8",
-        "raf": "^3.3.0"
-      }
     },
     "read": {
       "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "react-dom": "^17.0.2",
     "react-helmet": "^6.1.0",
     "react-instantsearch-dom": "^6.16.0",
-    "react-sticky": "^6.0.3",
     "runes": "^0.4.3",
     "sass": "^1.34.0"
   },

--- a/src/components/pages/doc-page/table-of-contents/table-of-contents.js
+++ b/src/components/pages/doc-page/table-of-contents/table-of-contents.js
@@ -13,7 +13,12 @@ const components = {
 
 const TableOfContents = forwardRef(
   (
-    { style, label, contentContainerRef, shouldMakeReplacement = false },
+    {
+      label,
+      contentContainerRef,
+      shouldMakeReplacement = false,
+      withTopOffset,
+    },
     ref,
   ) => {
     useElementsReplacement({
@@ -47,10 +52,9 @@ const TableOfContents = forwardRef(
 
     return (
       <div
-        style={style}
         className={`${styles.anchorBarWrapper} ${
           !links.length && styles.hidden
-        }`}
+        } ${withTopOffset && styles.withTopOffset}`}
         ref={ref}
       >
         <nav className={`${styles.anchorBar} ${label ?? ''}`}>

--- a/src/components/pages/doc-page/table-of-contents/table-of-contents.module.scss
+++ b/src/components/pages/doc-page/table-of-contents/table-of-contents.module.scss
@@ -1,15 +1,9 @@
 .anchor-bar-wrapper {
   position: absolute;
   right: 0;
-  top: -15px;
-  display: flex;
-  justify-content: flex-end;
-  padding-top: 15px;
-
+  top: 0;
+  height: 100%;
   margin-right: -30px;
-
-  overflow-x: hidden;
-  overflow-y: auto;
 
   @include lg-down {
     display: none;
@@ -17,9 +11,20 @@
   &.hidden {
     visibility: hidden;
   }
+  &.with-top-offset {
+    top: 40px;
+  }
 }
 
 .anchor-bar {
+  position: sticky;
+  top: 35px;
+  bottom: 35px;
+  right: 0;
+  // Height of the screen, minus values of top and bottom properties
+  max-height: calc(100vh - 35px - 35px);
+  overflow-x: hidden;
+  overflow-y: auto;
   width: 275px;
 }
 

--- a/src/components/templates/doc-page/doc-page-content/doc-page-content.view.js
+++ b/src/components/templates/doc-page/doc-page-content/doc-page-content.view.js
@@ -3,18 +3,17 @@ import { HtmlContent } from 'components/blocks/html-content';
 import Glossary from 'components/pages/doc-page/glossary';
 import TableOfContents from 'components/pages/doc-page/table-of-contents';
 import Blockquote from 'components/shared/blockquote';
+import BrowserClassList from 'components/shared/browser-class-list';
+import BrowserCompatibility from 'components/shared/browser-compatibility';
+import BrowserWIP from 'components/shared/browser-wip';
 import { Code, CodeInline, CodeGroup } from 'components/shared/code';
 import Collapsible from 'components/shared/collapsible';
 import { HeadingLandmark } from 'components/shared/heading';
-import BrowserCompatibility from 'components/shared/browser-compatibility';
-import BrowserClassList from 'components/shared/browser-class-list';
-import BrowserWIP from 'components/shared/browser-wip';
 import InstallationInstructions from 'components/shared/installation-instructions';
 import LdScript from 'components/shared/ld-script';
 import { Link } from 'components/shared/link';
 import TableWrapper from 'components/shared/table-wrapper';
 import React, { useRef } from 'react';
-import { StickyContainer, Sticky } from 'react-sticky';
 
 import styles from './doc-page-content.module.scss';
 
@@ -53,45 +52,29 @@ export const DocPageContent = ({
       })}
     >
       <div className={`${styles.inner}`}>
-        <StickyContainer>
-          <div
-            ref={contentContainerRef}
-            className={classNames(styles.mainDocContent, {
-              [styles.beliefs]: mod === 'beliefs',
-            })}
-          >
-            <HtmlContent
-              content={content}
-              componentsForNativeReplacement={{
-                ...componentsForNativeReplacement,
-                a: Link(version),
-              }}
-              className={classNames(
-                styles.contentWrapper,
-                { [styles.beliefs]: mod === 'beliefs' },
-                label,
-              )}
-            />
-          </div>
-
-          <Sticky
-            topOffset={!hasGithubLink ? -15 : 25}
-            bottomOffset={0}
-            disableCompensation
-          >
-            {({ style }) => (
-              <TableOfContents
-                style={{
-                  ...style,
-                  left: 350,
-                  top: !hasGithubLink ? -15 : 25,
-                  maxHeight: '100vh',
-                }}
-                contentContainerRef={contentContainerRef}
-              />
+        <div
+          ref={contentContainerRef}
+          className={classNames(styles.mainDocContent, {
+            [styles.beliefs]: mod === 'beliefs',
+          })}
+        >
+          <HtmlContent
+            content={content}
+            componentsForNativeReplacement={{
+              ...componentsForNativeReplacement,
+              a: Link(version),
+            }}
+            className={classNames(
+              styles.contentWrapper,
+              { [styles.beliefs]: mod === 'beliefs' },
+              label,
             )}
-          </Sticky>
-        </StickyContainer>
+          />
+        </div>
+        <TableOfContents
+          contentContainerRef={contentContainerRef}
+          withTopOffset={hasGithubLink}
+        />
       </div>
     </div>
   );

--- a/src/templates/docs/cloud.js
+++ b/src/templates/docs/cloud.js
@@ -11,7 +11,6 @@ import { Link } from 'gatsby';
 import { useScrollToAnchor } from 'hooks';
 import { DocLayout } from 'layouts/doc-layout';
 import React, { useRef, useState, useEffect } from 'react';
-import { StickyContainer, Sticky } from 'react-sticky';
 import { isInIFrame } from 'utils';
 import SeoMetadata from 'utils/seo-metadata';
 import { app } from 'utils/urls';
@@ -42,216 +41,199 @@ export default function Cloud({ pageContext: { sidebarTree, navLinks } }) {
       >
         <PageInfo title={'k6 Cloud documentation'} />
         <div className={`${docPageContent.inner}`}>
-          <StickyContainer>
-            <div ref={contentContainerRef} className={stickyContainerClasses}>
-              <div className={'container'}>
-                <div className={`${htmlStyles.wrapper}`}>
-                  <h2>What is the k6 Cloud?</h2>
-                  <p>
-                    The k6 Cloud is a commercial SaaS product that we’ve
-                    designed to be the perfect companion to k6 OSS. It brings
-                    ease-of-use and convenience to your performance and load
-                    testing.
-                  </p>
-                  <p>
-                    This knowledge base will help you learn how to use the
-                    features and functionality of the k6 Cloud:
-                  </p>
-                  <ul>
-                    <li>Running cloud tests.</li>
-                    <li>Analyzing results.</li>
-                    <li>Managing projects, teams and users.</li>
-                    <li>Integrations.</li>
-                    <li>FAQ.</li>
-                  </ul>
-                  <h2>How can it help me?</h2>
-                  <p>
-                    The k6 Cloud is a premium service to empower your team to
-                    manage your load testing efforts:
-                  </p>
-                  <ul>
-                    <li>Scaling your load tests.</li>
-                    <li>Storing and visualizing your test results.</li>
-                    <li>Detecting performance issues.</li>
-                    <li>Correlating results between different tests.</li>
-                    <li>Organizing testing in a central location.</li>
-                  </ul>
-                  <blockquote>
-                    We want you to spend time building and maintaining
-                    well-performing applications. Don’t saddle your team with
-                    the{' '}
-                    <a href="https://k6.io/what-to-consider-when-building-or-buying-a-load-testing-solution/">
-                      additional maintenance burden
-                    </a>{' '}
-                    of your load testing infrastructure.
-                  </blockquote>
-                  <h2>Cloud Features</h2>
-                  <div className={'row'}>
-                    <div className={'col-lg-6 traits'}>
-                      <Trait>
-                        Scale tests from{' '}
-                        <Link
-                          to={
-                            '/cloud/creating-and-running-a-test/cloud-tests-from-the-cli/#list-of-supported-load-zones'
-                          }
-                        >
-                          multiple locations
-                        </Link>
-                        .
-                      </Trait>
-                      <Trait>
-                        <Link to={'/test-authoring/test-builder/'}>
-                          Test Builder
-                        </Link>{' '}
-                        and{' '}
-                        <Link
-                          to={
-                            '/cloud/creating-and-running-a-test/script-editor/'
-                          }
-                        >
-                          Script Editor
-                        </Link>
-                        .
-                      </Trait>
-                      <Trait>
-                        <Link
-                          to={
-                            '/cloud/creating-and-running-a-test/cloud-tests-from-the-cli/'
-                          }
-                        >
-                          CLI
-                        </Link>{' '}
-                        and{' '}
-                        <Link
-                          to={
-                            '/test-authoring/recording-a-session/browser-recorder/'
-                          }
-                        >
-                          Browser Recorder
-                        </Link>
-                        .
-                      </Trait>
-                      <Trait>
-                        <Link to={'/cloud/manage/scheduled-tests/'}>
-                          Scheduling
-                        </Link>{' '}
-                        and{' '}
-                        <Link to={'/cloud/manage/notifications/'}>
-                          Notifications
-                        </Link>
-                        .
-                      </Trait>
-                      <Trait>
-                        <Link
-                          to={'/cloud/project-and-team-management/members/'}
-                        >
-                          Members
-                        </Link>{' '}
-                        and{' '}
-                        <Link
-                          to={'/cloud/project-and-team-management/projects/'}
-                        >
-                          Projects
-                        </Link>
-                        .
-                      </Trait>
-                      <Trait>
-                        See team and testing activity with{' '}
-                        <Link to={'/cloud/manage/usage-reports/'}>
-                          Usage reports
-                        </Link>
-                        .
-                      </Trait>
-                    </div>
+          <div ref={contentContainerRef} className={stickyContainerClasses}>
+            <div className={'container'}>
+              <div className={`${htmlStyles.wrapper}`}>
+                <h2>What is the k6 Cloud?</h2>
+                <p>
+                  The k6 Cloud is a commercial SaaS product that we’ve designed
+                  to be the perfect companion to k6 OSS. It brings ease-of-use
+                  and convenience to your performance and load testing.
+                </p>
+                <p>
+                  This knowledge base will help you learn how to use the
+                  features and functionality of the k6 Cloud:
+                </p>
+                <ul>
+                  <li>Running cloud tests.</li>
+                  <li>Analyzing results.</li>
+                  <li>Managing projects, teams and users.</li>
+                  <li>Integrations.</li>
+                  <li>FAQ.</li>
+                </ul>
+                <h2>How can it help me?</h2>
+                <p>
+                  The k6 Cloud is a premium service to empower your team to
+                  manage your load testing efforts:
+                </p>
+                <ul>
+                  <li>Scaling your load tests.</li>
+                  <li>Storing and visualizing your test results.</li>
+                  <li>Detecting performance issues.</li>
+                  <li>Correlating results between different tests.</li>
+                  <li>Organizing testing in a central location.</li>
+                </ul>
+                <blockquote>
+                  We want you to spend time building and maintaining
+                  well-performing applications. Don’t saddle your team with the{' '}
+                  <a href="https://k6.io/what-to-consider-when-building-or-buying-a-load-testing-solution/">
+                    additional maintenance burden
+                  </a>{' '}
+                  of your load testing infrastructure.
+                </blockquote>
+                <h2>Cloud Features</h2>
+                <div className={'row'}>
+                  <div className={'col-lg-6 traits'}>
+                    <Trait>
+                      Scale tests from{' '}
+                      <Link
+                        to={
+                          '/cloud/creating-and-running-a-test/cloud-tests-from-the-cli/#list-of-supported-load-zones'
+                        }
+                      >
+                        multiple locations
+                      </Link>
+                      .
+                    </Trait>
+                    <Trait>
+                      <Link to={'/test-authoring/test-builder/'}>
+                        Test Builder
+                      </Link>{' '}
+                      and{' '}
+                      <Link
+                        to={'/cloud/creating-and-running-a-test/script-editor/'}
+                      >
+                        Script Editor
+                      </Link>
+                      .
+                    </Trait>
+                    <Trait>
+                      <Link
+                        to={
+                          '/cloud/creating-and-running-a-test/cloud-tests-from-the-cli/'
+                        }
+                      >
+                        CLI
+                      </Link>{' '}
+                      and{' '}
+                      <Link
+                        to={
+                          '/test-authoring/recording-a-session/browser-recorder/'
+                        }
+                      >
+                        Browser Recorder
+                      </Link>
+                      .
+                    </Trait>
+                    <Trait>
+                      <Link to={'/cloud/manage/scheduled-tests/'}>
+                        Scheduling
+                      </Link>{' '}
+                      and{' '}
+                      <Link to={'/cloud/manage/notifications/'}>
+                        Notifications
+                      </Link>
+                      .
+                    </Trait>
+                    <Trait>
+                      <Link to={'/cloud/project-and-team-management/members/'}>
+                        Members
+                      </Link>{' '}
+                      and{' '}
+                      <Link to={'/cloud/project-and-team-management/projects/'}>
+                        Projects
+                      </Link>
+                      .
+                    </Trait>
+                    <Trait>
+                      See team and testing activity with{' '}
+                      <Link to={'/cloud/manage/usage-reports/'}>
+                        Usage reports
+                      </Link>
+                      .
+                    </Trait>
+                  </div>
 
-                    <div className={'col-lg-6 traits'}>
-                      <Trait>
-                        <Link to={'/cloud/analyzing-results/overview/'}>
-                          Premium test result visualization
-                        </Link>
-                        .
-                      </Trait>
-                      <Trait>
-                        Get actionable{' '}
-                        <Link
-                          to={'/cloud/analyzing-results/performance-insights/'}
-                        >
-                          Performance Insights
-                        </Link>{' '}
-                        .
-                      </Trait>
-                      <Trait>
-                        <Link to={'/cloud/analyzing-results/test-comparison/'}>
-                          Compare tests{' '}
-                        </Link>{' '}
-                        and{' '}
-                        <Link
-                          to={'/cloud/analyzing-results/performance-trending/'}
-                        >
-                          performance trends
-                        </Link>
-                        .
-                      </Trait>
-                      <Trait>
-                        Integrate results with{' '}
-                        <Link to={'/cloud/integrations/cloud-apm/'}>
-                          APM platforms
-                        </Link>{' '}
-                        and{' '}
-                        <Link to={'/cloud/integrations/grafana-plugin/'}>
-                          Grafana
-                        </Link>
-                        .
-                      </Trait>
-                      <Trait>
-                        Export results to{' '}
-                        <Link to={'/cloud/analyzing-results/result-export/'}>
-                          CSV
-                        </Link>{' '}
-                        and generate{' '}
-                        <Link to={'/cloud/analyzing-results/result-export/'}>
-                          PDF reports
-                        </Link>
-                        .
-                      </Trait>
-                      <Trait>
-                        <Link
-                          to={'/cloud/analyzing-results/test-results-menu/'}
-                        >
-                          Create notes and share results
-                        </Link>
-                        .
-                      </Trait>
-                    </div>
+                  <div className={'col-lg-6 traits'}>
+                    <Trait>
+                      <Link to={'/cloud/analyzing-results/overview/'}>
+                        Premium test result visualization
+                      </Link>
+                      .
+                    </Trait>
+                    <Trait>
+                      Get actionable{' '}
+                      <Link
+                        to={'/cloud/analyzing-results/performance-insights/'}
+                      >
+                        Performance Insights
+                      </Link>{' '}
+                      .
+                    </Trait>
+                    <Trait>
+                      <Link to={'/cloud/analyzing-results/test-comparison/'}>
+                        Compare tests{' '}
+                      </Link>{' '}
+                      and{' '}
+                      <Link
+                        to={'/cloud/analyzing-results/performance-trending/'}
+                      >
+                        performance trends
+                      </Link>
+                      .
+                    </Trait>
+                    <Trait>
+                      Integrate results with{' '}
+                      <Link to={'/cloud/integrations/cloud-apm/'}>
+                        APM platforms
+                      </Link>{' '}
+                      and{' '}
+                      <Link to={'/cloud/integrations/grafana-plugin/'}>
+                        Grafana
+                      </Link>
+                      .
+                    </Trait>
+                    <Trait>
+                      Export results to{' '}
+                      <Link to={'/cloud/analyzing-results/result-export/'}>
+                        CSV
+                      </Link>{' '}
+                      and generate{' '}
+                      <Link to={'/cloud/analyzing-results/result-export/'}>
+                        PDF reports
+                      </Link>
+                      .
+                    </Trait>
+                    <Trait>
+                      <Link to={'/cloud/analyzing-results/test-results-menu/'}>
+                        Create notes and share results
+                      </Link>
+                      .
+                    </Trait>
                   </div>
                 </div>
-                <p />
               </div>
-              {showFooter && (
-                <CtaDoc
-                  btnLink={`${app}/account/register`}
-                  title={'Free Trial'}
-                  btnText={'Try now'}
-                  description={'Sign up to run 50 cloud tests for Free.'}
-                  isExternal
-                />
-              )}
+              <p />
             </div>
-            <DocPageNavigation
-              prev={null}
-              next={flatSidebar[0]}
-              variant="top-level"
-            />
-            <Sticky topOffset={-15} bottomOffset={0} disableCompensation>
-              {({ style }) => (
-                <TableOfContents
-                  style={{ ...style, left: 350 }}
-                  contentContainerRef={contentContainerRef}
-                  shouldMakeReplacement
-                />
-              )}
-            </Sticky>
-          </StickyContainer>
+            {showFooter && (
+              <CtaDoc
+                btnLink={`${app}/account/register`}
+                title={'Free Trial'}
+                btnText={'Try now'}
+                description={'Sign up to run 50 cloud tests for Free.'}
+                isExternal
+              />
+            )}
+          </div>
+          <DocPageNavigation
+            prev={null}
+            next={flatSidebar[0]}
+            variant="top-level"
+          />
+          <TableOfContents
+            contentContainerRef={contentContainerRef}
+            shouldMakeReplacement
+          />
         </div>
       </DocLayout>
     </LocaleProvider>

--- a/src/templates/docs/examples.js
+++ b/src/templates/docs/examples.js
@@ -8,7 +8,6 @@ import { graphql, useStaticQuery } from 'gatsby';
 import { useScrollToAnchor } from 'hooks';
 import { DocLayout } from 'layouts/doc-layout';
 import React, { useRef } from 'react';
-import { StickyContainer, Sticky } from 'react-sticky';
 import SeoMetadata from 'utils/seo-metadata';
 
 export default function Examples({ pageContext: { sidebarTree, navLinks } }) {
@@ -55,25 +54,18 @@ export default function Examples({ pageContext: { sidebarTree, navLinks } }) {
           }
         />
         <div className={`${docPageContent.inner} `}>
-          <StickyContainer>
-            <div ref={contentContainerRef} className={stickyContainerClasses}>
-              <DocLinksBlock title={'Examples'} links={examplesBlockLinks} />
-              <DocLinksBlock
-                title={'Tutorials'}
-                links={tutorialsBlockLinks}
-                last
-              />
-            </div>
-            <Sticky topOffset={-15} bottomOffset={0} disableCompensation>
-              {({ style }) => (
-                <TableOfContents
-                  style={{ ...style, left: 350 }}
-                  contentContainerRef={contentContainerRef}
-                  shouldMakeReplacement
-                />
-              )}
-            </Sticky>
-          </StickyContainer>
+          <div ref={contentContainerRef} className={stickyContainerClasses}>
+            <DocLinksBlock title={'Examples'} links={examplesBlockLinks} />
+            <DocLinksBlock
+              title={'Tutorials'}
+              links={tutorialsBlockLinks}
+              last
+            />
+          </div>
+          <TableOfContents
+            contentContainerRef={contentContainerRef}
+            shouldMakeReplacement
+          />
         </div>
       </DocLayout>
     </LocaleProvider>

--- a/src/templates/docs/guides.js
+++ b/src/templates/docs/guides.js
@@ -17,7 +17,6 @@ import LocaleProvider from 'contexts/locale-provider';
 import { useScrollToAnchor } from 'hooks';
 import { DocLayout } from 'layouts/doc-layout';
 import React, { useRef } from 'react';
-import { Sticky, StickyContainer } from 'react-sticky';
 import SeoMetadata from 'utils/seo-metadata';
 import { docs } from 'utils/urls';
 import { flattenSidebarTree } from 'utils/utils';
@@ -79,43 +78,35 @@ function GuidesContent({
     >
       <PageInfo {...pageInfo[locale]} />
       <div className={classNames(docPageContent.inner)}>
-        <StickyContainer>
-          <div ref={contentContainerRef} className={stickyContainerClasses}>
-            <Quickstart />
-            <WhatIs />
-            <Features />
-            <UseCases />
-            <Manifesto />
-            <K6DoesNot />
-            {locale === 'en' && (
-              <Cloud
-                title={'Looking for k6 Cloud?'}
-                btnLink={`${docs}/cloud`}
-                isExternal
-                btnTarget={'_self'}
-                btnText={'Cloud docs'}
-                description={
-                  'A tailored SaaS service to bring your team together into load testing.'
-                }
-              />
-            )}
-          </div>
-          <DocPageNavigation
-            prev={null}
-            next={flatSidebar[1]}
-            variant="top-level"
-          />
-
-          <Sticky topOffset={-15} bottomOffset={10} disableCompensation>
-            {({ style }) => (
-              <TableOfContents
-                style={{ ...style, left: 350 }}
-                contentContainerRef={contentContainerRef}
-                shouldMakeReplacement
-              />
-            )}
-          </Sticky>
-        </StickyContainer>
+        <div ref={contentContainerRef} className={stickyContainerClasses}>
+          <Quickstart />
+          <WhatIs />
+          <Features />
+          <UseCases />
+          <Manifesto />
+          <K6DoesNot />
+          {locale === 'en' && (
+            <Cloud
+              title={'Looking for k6 Cloud?'}
+              btnLink={`${docs}/cloud`}
+              isExternal
+              btnTarget={'_self'}
+              btnText={'Cloud docs'}
+              description={
+                'A tailored SaaS service to bring your team together into load testing.'
+              }
+            />
+          )}
+        </div>
+        <DocPageNavigation
+          prev={null}
+          next={flatSidebar[1]}
+          variant="top-level"
+        />
+        <TableOfContents
+          contentContainerRef={contentContainerRef}
+          shouldMakeReplacement
+        />
       </div>
     </DocLayout>
   );

--- a/src/templates/docs/integrations.js
+++ b/src/templates/docs/integrations.js
@@ -1,11 +1,11 @@
 import classNames from 'classnames';
 // components
+import { ItemCardsRow } from 'components/blocks/item-cards-row';
 import { DocIconsRow } from 'components/pages/doc-integrations/doc-icons-row';
 import { ExternalLinksDashboard } from 'components/pages/doc-integrations/external-links-dashboard';
 import TableOfContents from 'components/pages/doc-page/table-of-contents';
 import CustomContentContainer from 'components/shared/custom-content-container';
 import { PageInfo } from 'components/shared/page-info';
-import { ItemCardsRow } from 'components/blocks/item-cards-row';
 // styles
 import docPageContent from 'components/templates/doc-page/doc-page-content/doc-page-content.module.scss';
 import LocaleProvider from 'contexts/locale-provider';
@@ -14,7 +14,6 @@ import { useStaticQuery, graphql } from 'gatsby';
 import { useScrollToAnchor } from 'hooks';
 import { DocLayout } from 'layouts/doc-layout';
 import React, { useRef } from 'react';
-import { StickyContainer, Sticky } from 'react-sticky';
 // icons
 import CloudWatch from 'svg/amazon-cloudwatch.inline.svg';
 import Kafka from 'svg/apache-kafka.inline.svg';
@@ -37,9 +36,9 @@ import K6 from 'svg/logo.inline.svg';
 import Netdata from 'svg/netdata.inline.svg';
 import NewRelic from 'svg/new-relic.inline.svg';
 import Prometheus from 'svg/prometheus.inline.svg';
-import TimescaleDB from 'svg/timescaledb.inline.svg';
 import StatsD from 'svg/statsd.inline.svg';
 import TeamCity from 'svg/teamcity.inline.svg';
+import TimescaleDB from 'svg/timescaledb.inline.svg';
 import SeoMetadata from 'utils/seo-metadata';
 import { blog, main } from 'utils/urls';
 
@@ -359,186 +358,179 @@ export default function Integrations({
       >
         <PageInfo title={'Integrations & Tools'} description={''} />
         <div className={`${docPageContent.inner} `}>
-          <StickyContainer>
-            <div ref={contentContainerRef} className={stickyContainerClasses}>
-              <ExternalLinksDashboard
-                dashboardTitle={'Test authoring'}
-                subtitle={'Codeless tools to speed up the test creation.'}
-                linksData={[
-                  {
-                    image: testBuilderImg,
-                    title: 'Test Builder',
-                    description:
-                      'Inspired in Postman API Builder. Codeless UI tool to generate a k6 test quickly.',
-                    url: 'https://k6.io/docs/test-authoring/test-builder/',
-                  },
-                  {
-                    image: browserRecorderImg,
-                    title: 'Browser Recorder',
-                    description: 'Record a user journey to base your k6 test.',
-                    url: 'https://k6.io/docs/test-authoring/recording-a-session/browser-recorder/',
-                  },
-                ]}
-              />
-              <ExternalLinksDashboard
-                dashboardTitle={'IDE extensions'}
-                subtitle={
-                  'Code k6 scripts in your IDE of choice. Empower your development workflow with IDE extensions.'
-                }
-                linksData={[
-                  {
-                    image: vscodeImg,
-                    title: 'Visual Studio Code Extension',
-                    description: 'Run k6 tests from VS Code.',
-                    url: 'https://marketplace.visualstudio.com/items?itemName=k6.k6',
-                  },
-                  {
-                    image: intellijImg,
-                    title: 'IntelliJ IDEA',
-                    description: 'Run k6 tests from IntelliJ IDEs.',
-                    url: 'https://plugins.jetbrains.com/plugin/16141-k6',
-                  },
-                  {
-                    image: javascriptImg,
-                    title: 'IntelliSense',
-                    description:
-                      'Get code autocompletion and in-context documentation.',
-                    url: 'https://k6.io/docs/misc/intellisense/',
-                  },
-                ]}
-              />
-              <ExternalLinksDashboard
-                dashboardTitle={'Converters'}
-                subtitle={'Generate a k6 script quickly from an existing file.'}
-                linksData={[
-                  {
-                    image: harImg,
-                    title: 'HAR-to-k6',
-                    description: 'Convert a HAR file to k6 script.',
-                    url: 'https://github.com/k6io/har-to-k6',
-                  },
-                  {
-                    image: postmanImg,
-                    title: 'Postman-to-k6',
-                    description: 'Convert a Postman collection to k6 script.',
-                    url: 'https://github.com/apideck-libraries/postman-to-k6',
-                  },
-                  {
-                    image: swaggerImg,
-                    title: 'OpenAPI generator',
-                    description:
-                      'Convert Swagger/OpenAPI specification to k6 script.',
-                    url: 'https://k6.io/blog/load-testing-your-api-with-swagger-openapi-and-k6',
-                  },
-                ]}
-              />
-              <DocIconsRow
-                title={'Result store and visualization'}
-                subtitle={
-                  'k6 can output test results in various formats and backends.'
-                }
-                iconsData={iconsDataSet1}
-              />
-              <DocIconsRow
-                title={'Continuous Integration and Continuous Delivery'}
-                subtitle={
-                  // eslint-disable-next-line max-len
-                  'By automating load testing with your CI / CD tools, you can quickly see when a code change has introduced a performance regression.'
-                }
-                iconsData={iconsDataSet2}
-              />
-              <ExternalLinksDashboard
-                dashboardTitle={'Chaos engineering'}
-                linksData={[
-                  {
-                    image: steadybitImg,
-                    title: 'Steadybit',
-                    description: 'Using k6 and Steadybit for chaos engineering',
-                    url: 'https://k6.io/blog/chaos-engineering-with-k6-and-steadybit',
-                  },
-                  {
-                    image: k6Img,
-                    title: 'xk6-chaos',
-                    description: 'A k6 extension to test k8s failures',
-                    url: 'https://github.com/grafana/xk6-chaos',
-                  },
-                  {
-                    image: chaostoolkitImg,
-                    title: 'ChaosToolkit',
-                    description: 'A collection of k6 actions and probes',
-                    url: 'http://chaostoolkit.org/drivers/k6/',
-                  },
-                ]}
-              />
-              <ExternalLinksDashboard
-                dashboardTitle={'Test management'}
-                linksData={[
-                  {
-                    image: azureTestImg,
-                    title: 'Azure Test Plan',
-                    description: 'Load Testing with Azure DevOps and k6',
-                    url: 'https://medium.com/microsoftazure/load-testing-with-azure-devops-and-k6-839be039b68a',
-                  },
-                  {
-                    image: testRailImg,
-                    title: 'TestRail',
-                    description: 'Introducing TestRail in your k6 tests',
-                    url: 'https://dev.to/kwidera/introducing-testrail-in-you-k6-tests-eck',
-                  },
-                  {
-                    image: xrayImg,
-                    title: 'Xray',
-                    description:
-                      'Integrating with Xray. Validate test results in JIRA.',
-                    url: 'https://docs.getxray.app/display/XRAYCLOUD/Performance+and+load+testing+with+k6',
-                  },
-                ]}
-              />
-              <ItemCardsRow
-                blockTitle="k6 Extensions"
-                subtitle={`Use k6 extensions to further extend the possible use cases of k6. 
+          <div ref={contentContainerRef} className={stickyContainerClasses}>
+            <ExternalLinksDashboard
+              dashboardTitle={'Test authoring'}
+              subtitle={'Codeless tools to speed up the test creation.'}
+              linksData={[
+                {
+                  image: testBuilderImg,
+                  title: 'Test Builder',
+                  description:
+                    'Inspired in Postman API Builder. Codeless UI tool to generate a k6 test quickly.',
+                  url: 'https://k6.io/docs/test-authoring/test-builder/',
+                },
+                {
+                  image: browserRecorderImg,
+                  title: 'Browser Recorder',
+                  description: 'Record a user journey to base your k6 test.',
+                  url: 'https://k6.io/docs/test-authoring/recording-a-session/browser-recorder/',
+                },
+              ]}
+            />
+            <ExternalLinksDashboard
+              dashboardTitle={'IDE extensions'}
+              subtitle={
+                'Code k6 scripts in your IDE of choice. Empower your development workflow with IDE extensions.'
+              }
+              linksData={[
+                {
+                  image: vscodeImg,
+                  title: 'Visual Studio Code Extension',
+                  description: 'Run k6 tests from VS Code.',
+                  url: 'https://marketplace.visualstudio.com/items?itemName=k6.k6',
+                },
+                {
+                  image: intellijImg,
+                  title: 'IntelliJ IDEA',
+                  description: 'Run k6 tests from IntelliJ IDEs.',
+                  url: 'https://plugins.jetbrains.com/plugin/16141-k6',
+                },
+                {
+                  image: javascriptImg,
+                  title: 'IntelliSense',
+                  description:
+                    'Get code autocompletion and in-context documentation.',
+                  url: 'https://k6.io/docs/misc/intellisense/',
+                },
+              ]}
+            />
+            <ExternalLinksDashboard
+              dashboardTitle={'Converters'}
+              subtitle={'Generate a k6 script quickly from an existing file.'}
+              linksData={[
+                {
+                  image: harImg,
+                  title: 'HAR-to-k6',
+                  description: 'Convert a HAR file to k6 script.',
+                  url: 'https://github.com/k6io/har-to-k6',
+                },
+                {
+                  image: postmanImg,
+                  title: 'Postman-to-k6',
+                  description: 'Convert a Postman collection to k6 script.',
+                  url: 'https://github.com/apideck-libraries/postman-to-k6',
+                },
+                {
+                  image: swaggerImg,
+                  title: 'OpenAPI generator',
+                  description:
+                    'Convert Swagger/OpenAPI specification to k6 script.',
+                  url: 'https://k6.io/blog/load-testing-your-api-with-swagger-openapi-and-k6',
+                },
+              ]}
+            />
+            <DocIconsRow
+              title={'Result store and visualization'}
+              subtitle={
+                'k6 can output test results in various formats and backends.'
+              }
+              iconsData={iconsDataSet1}
+            />
+            <DocIconsRow
+              title={'Continuous Integration and Continuous Delivery'}
+              subtitle={
+                // eslint-disable-next-line max-len
+                'By automating load testing with your CI / CD tools, you can quickly see when a code change has introduced a performance regression.'
+              }
+              iconsData={iconsDataSet2}
+            />
+            <ExternalLinksDashboard
+              dashboardTitle={'Chaos engineering'}
+              linksData={[
+                {
+                  image: steadybitImg,
+                  title: 'Steadybit',
+                  description: 'Using k6 and Steadybit for chaos engineering',
+                  url: 'https://k6.io/blog/chaos-engineering-with-k6-and-steadybit',
+                },
+                {
+                  image: k6Img,
+                  title: 'xk6-chaos',
+                  description: 'A k6 extension to test k8s failures',
+                  url: 'https://github.com/grafana/xk6-chaos',
+                },
+                {
+                  image: chaostoolkitImg,
+                  title: 'ChaosToolkit',
+                  description: 'A collection of k6 actions and probes',
+                  url: 'http://chaostoolkit.org/drivers/k6/',
+                },
+              ]}
+            />
+            <ExternalLinksDashboard
+              dashboardTitle={'Test management'}
+              linksData={[
+                {
+                  image: azureTestImg,
+                  title: 'Azure Test Plan',
+                  description: 'Load Testing with Azure DevOps and k6',
+                  url: 'https://medium.com/microsoftazure/load-testing-with-azure-devops-and-k6-839be039b68a',
+                },
+                {
+                  image: testRailImg,
+                  title: 'TestRail',
+                  description: 'Introducing TestRail in your k6 tests',
+                  url: 'https://dev.to/kwidera/introducing-testrail-in-you-k6-tests-eck',
+                },
+                {
+                  image: xrayImg,
+                  title: 'Xray',
+                  description:
+                    'Integrating with Xray. Validate test results in JIRA.',
+                  url: 'https://docs.getxray.app/display/XRAYCLOUD/Performance+and+load+testing+with+k6',
+                },
+              ]}
+            />
+            <ItemCardsRow
+              blockTitle="k6 Extensions"
+              subtitle={`Use k6 extensions to further extend the possible use cases of k6. 
                 Extensions are written in go and then made available as JavaScript modules
                 for you to utilise in your test scripts.`}
-                linkText="Read more"
-                cardsData={[
-                  {
-                    as: 'a',
-                    title: '🔎 Explore the k6 extensions ecosystem',
-                    href: 'https://k6.io/docs/extensions/',
-                  },
-                  {
-                    as: 'a',
-                    title: '📖 Learn more about k6 extensions',
-                    href: 'https://k6.io/docs/extensions/guides/what-are-k6-extensions/',
-                  },
-                  {
-                    as: 'a',
-                    title: '🏗️ How to create your first k6 extension',
-                    href: 'https://k6.io/docs/extensions/guides/create-an-extension/',
-                  },
-                ]}
-              />
-              <CustomContentContainer>
-                <p>
-                  Please get in touch with us on{' '}
-                  <a href={`${main}/slack`} className={'link'}>
-                    Slack
-                  </a>{' '}
-                  if you have a tool or add-on that works well with k6, and we
-                  will list it here!
-                </p>
-              </CustomContentContainer>
-            </div>
-            <Sticky topOffset={-15} bottomOffset={0} disableCompensation>
-              {({ style }) => (
-                <TableOfContents
-                  style={{ ...style, left: 350 }}
-                  contentContainerRef={contentContainerRef}
-                  shouldMakeReplacement
-                />
-              )}
-            </Sticky>
-          </StickyContainer>
+              linkText="Read more"
+              cardsData={[
+                {
+                  as: 'a',
+                  title: '🔎 Explore the k6 extensions ecosystem',
+                  href: 'https://k6.io/docs/extensions/',
+                },
+                {
+                  as: 'a',
+                  title: '📖 Learn more about k6 extensions',
+                  href: 'https://k6.io/docs/extensions/guides/what-are-k6-extensions/',
+                },
+                {
+                  as: 'a',
+                  title: '🏗️ How to create your first k6 extension',
+                  href: 'https://k6.io/docs/extensions/guides/create-an-extension/',
+                },
+              ]}
+            />
+            <CustomContentContainer>
+              <p>
+                Please get in touch with us on{' '}
+                <a href={`${main}/slack`} className={'link'}>
+                  Slack
+                </a>{' '}
+                if you have a tool or add-on that works well with k6, and we
+                will list it here!
+              </p>
+            </CustomContentContainer>
+          </div>
+          <TableOfContents
+            contentContainerRef={contentContainerRef}
+            shouldMakeReplacement
+          />
         </div>
       </DocLayout>
     </LocaleProvider>

--- a/src/templates/docs/javascript-api.js
+++ b/src/templates/docs/javascript-api.js
@@ -19,7 +19,6 @@ import { graphql } from 'gatsby';
 import { useScrollToAnchor } from 'hooks';
 import { DocLayout } from 'layouts/doc-layout';
 import React, { useRef } from 'react';
-import { Sticky, StickyContainer } from 'react-sticky';
 import SeoMetadata from 'utils/seo-metadata';
 import { LATEST_VERSION, SUPPORTED_VERSIONS } from 'utils/utils.node';
 
@@ -125,24 +124,17 @@ export default function JavascriptAPI({
           className={classNames(version !== LATEST_VERSION && jsApiStyles.info)}
         />
         <div className={docPageContent.inner}>
-          <StickyContainer>
-            <div ref={contentContainerRef} className={stickyContainerClasses}>
-              <div className={`${htmlStyles.wrapper}`}>
-                <CustomContentContainer label={jsApiStyles.jsApiWrapper}>
-                  {content}
-                </CustomContentContainer>
-              </div>
+          <div ref={contentContainerRef} className={stickyContainerClasses}>
+            <div className={`${htmlStyles.wrapper}`}>
+              <CustomContentContainer label={jsApiStyles.jsApiWrapper}>
+                {content}
+              </CustomContentContainer>
             </div>
-            <Sticky topOffset={-15} bottomOffset={10} disableCompensation>
-              {({ style }) => (
-                <TableOfContents
-                  style={{ ...style, left: 350 }}
-                  contentContainerRef={contentContainerRef}
-                  shouldMakeReplacement
-                />
-              )}
-            </Sticky>
-          </StickyContainer>
+          </div>
+          <TableOfContents
+            contentContainerRef={contentContainerRef}
+            shouldMakeReplacement
+          />
         </div>
       </DocLayout>
     </LocaleProvider>

--- a/src/templates/docs/versioned-javascript-api.js
+++ b/src/templates/docs/versioned-javascript-api.js
@@ -20,7 +20,6 @@ import { graphql } from 'gatsby';
 import { useScrollToAnchor } from 'hooks';
 import { DocLayout } from 'layouts/doc-layout';
 import React, { useRef } from 'react';
-import { Sticky, StickyContainer } from 'react-sticky';
 import SeoMetadata from 'utils/seo-metadata';
 import { LATEST_VERSION, SUPPORTED_VERSIONS } from 'utils/utils.node';
 
@@ -130,24 +129,17 @@ export default function VersionedJavascriptAPI({
           className={classNames(version !== LATEST_VERSION && jsApiStyles.info)}
         />
         <div className={docPageContent.inner}>
-          <StickyContainer>
-            <div ref={contentContainerRef} className={stickyContainerClasses}>
-              <div className={`${htmlStyles.wrapper}`}>
-                <CustomContentContainer label={jsApiStyles.jsApiWrapper}>
-                  {content}
-                </CustomContentContainer>
-              </div>
+          <div ref={contentContainerRef} className={stickyContainerClasses}>
+            <div className={`${htmlStyles.wrapper}`}>
+              <CustomContentContainer label={jsApiStyles.jsApiWrapper}>
+                {content}
+              </CustomContentContainer>
             </div>
-            <Sticky topOffset={-15} bottomOffset={10} disableCompensation>
-              {({ style }) => (
-                <TableOfContents
-                  style={{ ...style, left: 350 }}
-                  contentContainerRef={contentContainerRef}
-                  shouldMakeReplacement
-                />
-              )}
-            </Sticky>
-          </StickyContainer>
+          </div>
+          <TableOfContents
+            contentContainerRef={contentContainerRef}
+            shouldMakeReplacement
+          />
         </div>
       </DocLayout>
     </LocaleProvider>


### PR DESCRIPTION
This PR migrates TOC from [react-sticky](https://www.npmjs.com/package/react-sticky) to the [native CSS position sticky property](https://developer.mozilla.org/en-US/docs/Web/CSS/position#sticky)