### PR TITLE
Fix the default value for setup/teardown timeouts

### DIFF
--- a/src/data/markdown/translated-guides/en/02 Using k6/05 Options.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/05 Options.md
@@ -1116,7 +1116,7 @@ Specify how long the `setup()` function is allow to run before it's terminated a
 
 | Env                | CLI | Code / Config file | Default |
 | ------------------ | --- | ------------------ | ------- |
-| `K6_SETUP_TIMEOUT` | N/A | `setupTimeout`     | `"10s"` |
+| `K6_SETUP_TIMEOUT` | N/A | `setupTimeout`     | `"60s"` |
 
 <CodeGroup labels={[]} lineNumbers={[true]}>
 
@@ -1366,7 +1366,7 @@ fails.
 
 | Env                   | CLI | Code / Config file | Default |
 | --------------------- | --- | ------------------ | ------- |
-| `K6_TEARDOWN_TIMEOUT` | N/A | `teardownTimeout`  | `"10s"` |
+| `K6_TEARDOWN_TIMEOUT` | N/A | `teardownTimeout`  | `"60s"` |
 
 <CodeGroup labels={[]} lineNumbers={[true]}>
 

--- a/src/data/markdown/translated-guides/es/02 Using k6/05 Options.md
+++ b/src/data/markdown/translated-guides/es/02 Using k6/05 Options.md
@@ -970,7 +970,7 @@ Especifica el tiempo que se permite ejecutar la función `setup()` antes de que 
 
 | Env                | CLI | Code / Config file | Default |
 | ------------------ | --- | ------------------ | ------- |
-| `K6_SETUP_TIMEOUT` | N/A | `setupTimeout`     | `"10s"` |
+| `K6_SETUP_TIMEOUT` | N/A | `setupTimeout`     | `"60s"` |
 
 <CodeGroup labels={[]} lineNumbers={[true]}>
 
@@ -1165,7 +1165,7 @@ Especifica cuánto tiempo se permite que se ejecute la función `teardown()` ant
 
 | Env                   | CLI | Code / Config file | Default |
 | --------------------- | --- | ------------------ | ------- |
-| `K6_TEARDOWN_TIMEOUT` | N/A | `teardownTimeout`  | `"10s"` |
+| `K6_TEARDOWN_TIMEOUT` | N/A | `teardownTimeout`  | `"60s"` |
 
 <CodeGroup labels={[]} lineNumbers={[true]}>
 


### PR DESCRIPTION
I updated the setup/teardown timeouts' default values with the real value used in the code.

https://github.com/grafana/k6/blob/ff198a857003152e0dad2a834d88adb596427579/cmd/options.go#L126-L129