### PR TITLE
Add jslib/aws documentation

### DIFF
--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws.md
@@ -1,0 +1,36 @@
+---
+title: "aws"
+excerpt: "aws is a library implementing APIs for accessing a selection of AWS services"
+description: "aws is a library implementing APIs for accessing a selection of AWS servicese"
+---
+
+The `aws` module is a JavaScript library that wraps around some Amazon AWS service APIs. 
+
+The library exposes a couple of configuration and client classes allowing to interact with a subset of AWS services in the context of k6 load test scripts:
+- The [S3Client](/javascript-api/jslib/aws/s3client) to list S3 buckets and the objects they contain, as well as uploading, downloading and deleting objects from them.
+- The [SecretsManagerClient](/javascript-api/jslib/aws/secretsmanagerclient) class allows listing, getting, creating, updating, and deleting secrets from the AWS secrets manager service.
+- The [AWSConfig](/javascript-api/jslib/aws/awsconfig/) class is used by each client classes to provide them access to AWS credentials as well as configuration.
+
+> ⭐️ Source code available on [GitHub](https://github.com/grafana/k6-jslib-aws). . 
+> Please request features and report bugs through [GitHub issues](https://github.com/grafana/k6-jslib-aws/issues).
+
+
+<Blockquote mod='info'>
+
+#### This library is in active development
+
+This library is stable enough to be useful, but pay attention to the new versions released on [jslib.k6.io](https://jslib.k6.io). 
+
+This documentation is for the last version only. If you discover that some code below does not work, it most likely means that you are using an older version.
+
+</Blockquote>
+
+### Classes
+
+| Library                                                          | Description                                                                   |
+| :--------------------------------------------------------------- | :---------------------------------------------------------------------------- |
+| [S3Client](/javascript-api/jslib/aws/s3client)                   | Client class allowing to interact with AWS S3 buckets and objects.            |
+| [SecretsManager](/javascript-api/jslib/aws/secretsmanagerclient) | Client class allowing to interact with AWS secrets stored in Secrets Manager. |
+| [AWSConfig](/javascript-api/jslib/aws/awsconfig)                 | Class allowing to configure AWS client classes                                |
+
+

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws.md
@@ -11,7 +11,7 @@ The library exposes a couple of configuration and client classes allowing to int
 - The [SecretsManagerClient](/javascript-api/jslib/aws/secretsmanagerclient) class allows listing, getting, creating, updating, and deleting secrets from the AWS secrets manager service.
 - The [AWSConfig](/javascript-api/jslib/aws/awsconfig/) class is used by each client classes to provide them access to AWS credentials as well as configuration.
 
-> ⭐️ Source code available on [GitHub](https://github.com/grafana/k6-jslib-aws). . 
+> ⭐️ Source code available on [GitHub](https://github.com/grafana/k6-jslib-aws). 
 > Please request features and report bugs through [GitHub issues](https://github.com/grafana/k6-jslib-aws/issues).
 
 

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws.md
@@ -19,7 +19,7 @@ The library exposes a couple of configuration and client classes allowing to int
 
 #### This library is in active development
 
-This library is stable enough to be useful, but pay attention to the new versions released on [jslib.k6.io](https://jslib.k6.io). 
+This library is stable enough to be useful, but pay attention to the new versions released on [jslib.k6.io](https://jslib.k6.io) and [k6-jslib-aws/releases](https://github.com/grafana/k6-jslib-aws/releases).   
 
 This documentation is for the last version only. If you discover that some code below does not work, it most likely means that you are using an older version.
 

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/01 S3Client.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/01 S3Client.md
@@ -1,0 +1,92 @@
+---
+title: 'S3Client'
+head_title: 'S3Client'
+description: 'S3Client allows interacting with AWS S3 buckets and objects'
+excerpt: 'S3Client class allows interacting with AWS S3 buckets and objects'
+---
+
+S3Client allows interacting with AWS S3's buckets and objects. Namely, it allows the user to list buckets and the objects they contain, as well as download, uploading, and deleting objects. The S3Client operations are blocking, and we recommend reserving their usage to the [`setup`](/using-k6/test-life-cycle/) and [`teardown`](/using-k6/test-life-cycle/) functions as much as possible.
+
+S3Client is included in both the dedicated jslib `s3.js` bundle, and the `aws.js` one, containing all the services clients.
+
+### Methods
+
+| Function                                                                                                                  | Description                                           |
+| :------------------------------------------------------------------------------------------------------------------------ | :---------------------------------------------------- |
+| [listBuckets()](/javascript-api/jslib/aws/s3client/s3client-listbuckets)                                                  | List the buckets the authenticated user has access to |
+| [listObjects(bucketName, [prefix])](/javascript-api/jslib/aws/s3client/s3client-listobjects-bucketname-prefix)            | List the objects contained in a bucket                |
+| [getObject(bucketName, objectKey)](/javascript-api/jslib/aws/s3client/s3client-getobject-bucketname-objectkey)            | Download an object from a bucket                      |
+| [putObject(bucketName, objectKey, data)](/javascript-api/jslib/aws/s3client/s3client-putobject-bucketname-objectkey-data) | Upload an object to a bucket                          |
+| [deleteObject(bucketName, objectKey)](/javascript-api/jslib/aws/s3client/s3client-deleteobject-bucketname-objectkey)      | Delete an object from a bucket                        |
+
+### Throws
+
+S3 Client methods will throw errors in case of failure.
+
+| Error                 | Condition                                                  |
+| :-------------------- | :--------------------------------------------------------- |
+| InvalidSignatureError | when invalid credentials were provided.                    |
+| S3ServiceError        | when AWS replied to the requested operation with an error. |
+
+### Example
+
+<CodeGroup labels={[]}>
+
+```javascript
+import { check } from 'k6';
+import exec from 'k6/execution';
+import http from 'k6/http';
+
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.3.0/s3.js';
+
+const awsConfig = new AWSConfig(
+  __ENV.AWS_REGION,
+  __ENV.AWS_ACCESS_KEY_ID,
+  __ENV.AWS_SECRET_ACCESS_KEY
+);
+
+const s3 = new S3Client(awsConfig);
+const testBucketName = 'test-jslib-aws';
+const testInputFileKey = 'productIDs.json';
+const testOutputFileKey = `results-${Date.now()}.json`;
+
+export function setup() {
+  // If our test bucket does not exist, abort the execution.
+  const buckets = s3.listBuckets();
+  if (buckets.filter((b) => b.name === testBucketName).length == 0) {
+    exec.test.abort();
+  }
+
+  // If our test object does not exist, abort the execution.
+  const objects = s3.listObjects(testBucketName);
+  if (objects.filter((o) => o.key === testInputFileKey).length == 0) {
+    exec.test.abort();
+  }
+
+  // Download the S3 object containing our test data
+  const inputObject = s3.getObject(testBucketName, testInputFileKey);
+
+  // Let's return the downloaded S3 object's data from the
+  // setup function to allow the default function to use it.
+  return {
+    productIDs: JSON.parse(inputObject.data),
+  };
+}
+
+export default function (data) {
+  // Pick a random product ID from our test data
+  const randomProductID = data.productIDs[Math.floor(Math.random() * data.productIDs.length)];
+
+  // Query our ecommerce website's product page using the ID
+  const res = http.get(`http://your.website.com/product/${randomProductID}/`);
+  check(res, { 'is status 200': res.status === 200 });
+}
+
+export function handleSummary(data) {
+  // Once the load test is over, let's upload the results to our
+  // S3 bucket. This is executed after teardown.
+  s3.putObject(testBucketName, testOutputFileKey, JSON.stringify(data));
+}
+```
+
+</CodeGroup>

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/02 SecretsManagerClient.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/02 SecretsManagerClient.md
@@ -1,0 +1,88 @@
+---
+title: 'SecretsManagerClient'
+head_title: 'SecretsManagerClient'
+description: 'SecretsManagerClient allows interacting with AWS secrets stored in Secrets Manager'
+excerpt: 'SecretsManagerClient allows interacting with AWS secrets stored in Secrets Manager'
+---
+
+SecretsManagerClient allows interacting with secrets stored in AWS's Secrets Manager. Namely, it allows the user to list, download, create, modify and delete secrets. Note that the SecretsManagerClient operations are blocking, and we recommend reserving their usage to the [`setup`](/using-k6/test-life-cycle/) and [`teardown`](/using-k6/test-life-cycle/) functions as much as possible.
+
+SecretsManagerClient is included in both the dedicated jslib `secrets-manager.js` bundle, and the `aws.js` one, containing all the services clients.
+
+### Methods
+
+| Function                                                                                                                                                                                              | Description                                  |
+| :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------- |
+| [listSecrets()](/javascript-api/jslib/aws/secretsmanagerclient/secretsmanagerclient-listsecrets/)                                                                                                     | List secrets owned by the authenticated user |
+| [getSecret(secretID)](/javascript-api/jslib/aws/secretsmanagerclient/secretsmanagerclient-getsecret-secretid)                                                                                         | Download a secret                            |
+| [createSecret(name, secretString, description, [versionID], [tags])](/javascript-api/jslib/aws/secretsmanagerclient/secretsmanagerclient-createsecret-name-secretstring-description-versionid-tags)   | Create a new secret                          |
+| [putSecretValue(secretID, secretString, [versionID])](/javascript-api/jslib/aws/secretsmanagerclient/secretsmanagerclient-putsecret-secretid-secretstring-versionid-tags)                             | Update a secret                              |
+| [deleteSecret(secretID, { recoveryWindow: 30, noRecovery: false}})](/javascript-api/jslib/aws/secretsmanagerclient/secretsmanagerclient-deletesecret-secretid-{-recoverywindow-30-norecovery-false}}) | Delete a secret                              |
+
+### Throws
+
+S3 Client methods will throw errors in case of failure.
+
+| Error                      | Condition                                                  |
+| :------------------------- | :--------------------------------------------------------- |
+| InvalidSignatureError      | when invalid credentials were provided.                    |
+| SecretsManagerServiceError | when AWS replied to the requested operation with an error. |
+
+### Example
+
+<CodeGroup labels={[]}>
+
+```javascript
+import exec from 'k6/execution';
+
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.3.0/secrets-manager.js';
+
+const awsConfig = new AWSConfig(
+  __ENV.AWS_REGION,
+  __ENV.AWS_ACCESS_KEY_ID,
+  __ENV.AWS_SECRET_ACCESS_KEY
+);
+
+const secretsManager = new SecretsManagerClient(awsConfig);
+const testSecretName = 'jslib-test-secret';
+const testSecretValue = 'jslib-test-value';
+
+export function setup() {
+  // Let's make sure our test secret is created
+  const testSecret = secretsManager.createSecret(
+    testSecretName,
+    testSecretValue,
+    'this is a test secret, delete me.'
+  );
+
+  // List the secrets the AWS authentication configuration
+  // gives us access to, and verify the creation was successful.
+  const secrets = secretsManager.listSecrets();
+  if (!secrets.filter((s) => s.name === testSecret.name).length == 0) {
+    exec.test.abort('test secret not found');
+  }
+}
+
+export default function () {
+  // Knnowing that we know the secret exist, let's update its value
+  const newTestSecretValue = 'new-test-value';
+  secretsManager.putSecretValue(testSecretName, newTestSecretValue);
+
+  // Let's get its value and verify it was indeed updated
+  const updatedSecret = secretsManager.getSecret(testSecretName);
+  if (updatedSecret.secret !== newTestSecretValue) {
+    exec.test.abort('unable to update test secret');
+  }
+
+  // Let's now use our secret in the context of our load test...
+}
+
+export function teardown() {
+  // Finally, let's clean after ourselves and delete our test secret
+  secretsManager.deleteSecret(testSecretName, { noRecovery: true });
+}
+```
+
+</CodeGroup>
+
+

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/03 AwsConfig.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/03 AwsConfig.md
@@ -1,0 +1,54 @@
+---
+title: 'AWSConfig'
+head_title: 'AWSConfig'
+description: 'AWSConfig is used to configure an AWS service client instances'
+excerpt: 'AWSConfig is used to configure an AWS service client instances'
+---
+
+AWSConfig is used to configure an AWS service client instance, such as [S3Client](/javascript-api/jslib/aws/s3client) or [SecretsManagerClient](/javascript-api/jslib/aws/s3client). It effectively allows the user to select a [region](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html) they wish to interact with, and the AWS credentials they wish to use to authenticate.
+
+AWSConfig is included in the `aws.js` bundle, which includes all the content of the library. It is also included in the various services clients dedicated bundles such as `s3.js` and `secrets-manager.js`.
+
+| Parameter                  | Type   | Description                                                                                                             |
+| :------------------------- | :----- | :---------------------------------------------------------------------------------------------------------------------- |
+| region                     | string | the AWS region to connect to. As described by Amazon AWS docs: https://docs.aws.amazon.com/general/latest/gr/rande.html |
+| accessKeyID                | string | The AWS access key ID credential to use for authentication.                                                             |
+| secretAccessKey (optional) | string | The AWS secret access credential to use for authentication.                                                             |
+
+### Throws
+
+S3 Client methods will throw errors in case of failure.
+
+| Error                      | Condition                                                  |
+| :------------------------- | :--------------------------------------------------------- |
+| InvalidArgumentException   | when an invalid region name or credentials were used.      |
+
+### Example
+
+<CodeGroup labels={[]}>
+
+```javascript
+import exec from 'k6/execution';
+
+// Note that you AWSConfig is also included in the dedicated service
+// client bundles such as `s3.js` and `secrets-manager.js`
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.3.0/aws.js';
+
+const awsConfig = new AWSConfig(
+  __ENV.AWS_REGION,
+  __ENV.AWS_ACCESS_KEY_ID,
+  __ENV.AWS_SECRET_ACCESS_KEY
+);
+
+const secretsManager = new SecretsManagerClient(awsConfig);
+
+export default function () {
+  // ...
+}
+```
+
+_k6 will instantiate an `AWSConfig` object and use it to configure a `SecretsManagerClient` instance_
+
+</CodeGroup>
+
+

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/S3Client/01 listBuckets().md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/S3Client/01 listBuckets().md
@@ -1,0 +1,49 @@
+---
+title: 'S3Client.listBuckets()'
+description: 'S3Client.listBuckets lists the buckets the authenticated user has access to'
+excerpt: 'S3Client.listBuckets lists the buckets the authenticated user has access to'
+---
+
+`S3Client.listBuckets()` lists the buckets the authenticated user has access to in the region set by the `S3Client` instance's configuration.
+
+### Returns
+
+| Type            | Description                                                              |
+| :-------------- | :----------------------------------------------------------------------- |
+| Array<[Bucket](/javascript-api/jslib/aws/s3client/bucket)> | An array of [Bucket](/javascript-api/jslib/aws/s3client/bucket) objects. |
+
+### Example
+
+<CodeGroup labels={[]}>
+
+```javascript
+import exec from 'k6/execution';
+
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.3.0/s3.js';
+
+const awsConfig = new AWSConfig(
+  __ENV.AWS_REGION,
+  __ENV.AWS_ACCESS_KEY_ID,
+  __ENV.AWS_SECRET_ACCESS_KEY
+);
+
+const s3 = new S3Client(awsConfig);
+const testBucketName = 'test-jslib-aws';
+
+export default function () {
+  // List the buckets the AWS authentication configuration
+  // gives us access to.
+  const buckets = s3.listBuckets();
+
+  // If our test bucket does not exist, abort the execution.
+  if (buckets.filter((b) => b.name === testBucketName).length == 0) {
+    exec.test.abort();
+  }
+
+  // ... work with the bucket's content
+}
+```
+
+</CodeGroup>
+
+

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/S3Client/02 listObjects(bucketName, [prefix]).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/S3Client/02 listObjects(bucketName, [prefix]).md
@@ -1,0 +1,53 @@
+---
+title: 'S3Client.listObjects(bucketName, [prefix])'
+description: 'S3Client.listObjects lists the objects contained in a bucket'
+excerpt: 'S3Client.listObjects lists the objects contained in a bucket'
+---
+
+`S3Client.listObjects()` lists the objects contained in a bucket.
+
+| Parameter         | Type   | Description                                                       |
+| :---------------- | :----- | :---------------------------------------------------------------- |
+| bucketName        | string | Name of the bucket to fetch the object from.                      |
+| prefix (optional) | string | Limits the response to keys that begin with the specified prefix. |
+
+### Returns
+
+| Type                                                       | Description                                                              |
+| :--------------------------------------------------------- | :----------------------------------------------------------------------- |
+| Array<[Object](/javascript-api/jslib/aws/s3client/object)> | An array of [Object](/javascript-api/jslib/aws/s3client/object) objects. |
+
+### Example
+
+<CodeGroup labels={[]}>
+
+```javascript
+import exec from 'k6/execution';
+
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.3.0/s3.js';
+
+const awsConfig = new AWSConfig(
+  __ENV.AWS_REGION,
+  __ENV.AWS_ACCESS_KEY_ID,
+  __ENV.AWS_SECRET_ACCESS_KEY
+);
+
+const s3 = new S3Client(awsConfig);
+const testBucketName = 'test-jslib-aws';
+const testFileKey = 'bonjour.txt';
+
+export default function () {
+  // List our bucket's objects
+  const objects = s3.listObjects(testBucketName);
+
+  // If our test object does not exist, abort the execution.
+  if (objects.filter((o) => o.key === testFileKey).length == 0) {
+    exec.test.abort();
+  }
+
+  // ... work with the bucket's objects
+  console.log(JSON.stringify(objects));
+}
+```
+
+</CodeGroup>

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/S3Client/03 getObject(bucketName, objectKey).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/S3Client/03 getObject(bucketName, objectKey).md
@@ -1,0 +1,55 @@
+---
+title: 'S3Client.getObject(bucketName, objectKey)'
+description: 'S3Client.getObject downloads an object from a bucket'
+excerpt: 'S3Client.getObject downloads an object from a bucket'
+---
+
+`S3Client.getObject` downloads an object from a bucket.
+
+| Parameter  | Type   | Description                                  |
+| :--------- | :----- | :------------------------------------------- |
+| bucketName | string | Name of the bucket to fetch the object from. |
+| objectKey  | string | Name of the object to download.              |
+
+### Returns
+
+| Type                                                | Description                                                                                           |
+| :-------------------------------------------------- | :---------------------------------------------------------------------------------------------------- |
+| [Object](/javascript-api/jslib/aws/s3client/object) | An [Object](/javascript-api/jslib/aws/s3client/object) describing and holding the downloaded content. |
+
+### Example
+
+<CodeGroup labels={[]}>
+
+```javascript
+import exec from 'k6/execution';
+
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.3.0/s3.js';
+
+const awsConfig = new AWSConfig(
+  __ENV.AWS_REGION,
+  __ENV.AWS_ACCESS_KEY_ID,
+  __ENV.AWS_SECRET_ACCESS_KEY
+);
+
+const s3 = new S3Client(awsConfig);
+const testBucketName = 'test-jslib-aws';
+const testFileKey = 'bonjour.txt';
+
+export default function () {
+  const objects = s3.listObjects(testBucketName);
+
+  // If our test object does not exist, abort the execution.
+  if (objects.filter((o) => o.key === testFileKey).length == 0) {
+    exec.test.abort();
+  }
+
+  // Let's download our test object and print its content
+  const object = s3.getObject(testBucketName, testFileKey);
+  console.log(JSON.stringify(object));
+}
+```
+
+_A k6 script that will download an object from a bucket_
+
+</CodeGroup>

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/S3Client/04 putObject(bucketName, objectKey, data).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/S3Client/04 putObject(bucketName, objectKey, data).md
@@ -1,0 +1,45 @@
+---
+title: 'S3Client.putObject(bucketName, objectKey, data)'
+description: 'S3Client.putObject uploads an object to a bucket'
+excerpt: 'S3Client.putObject uploads an object to a bucket'
+---
+
+`S3Client.putObject` uploads an object to a bucket.
+
+| Parameter  | Type                  | Description                                  |
+| :--------- | :-------------------- | :------------------------------------------- |
+| bucketName | string                | Name of the bucket to upload the object to.  |
+| objectKey  | string                | Name of the uploaded object.                 |
+| data       | string \| ArrayBuffer | Content of the object to upload.             |
+
+### Example
+
+<CodeGroup labels={[]}>
+
+```javascript
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.3.0/s3.js';
+
+const awsConfig = new AWSConfig(
+  __ENV.AWS_REGION,
+  __ENV.AWS_ACCESS_KEY_ID,
+  __ENV.AWS_SECRET_ACCESS_KEY
+);
+
+const s3 = new S3Client(awsConfig);
+const testBucketName = 'test-jslib-aws';
+const testFileKey = 'bonjour.txt';
+const testFile = open('./bonjour.txt', 'r');
+
+export default function () {
+  // Let's upload our test file to the bucket
+  s3.putObject(testBucketName, testFileKey, testFile);
+
+  // And let's redownload it to verify it's correct
+  const obj = s3.getObject(testBucketName, testFileKey);
+  console.log(JSON.stringify(obj));
+}
+```
+
+_A k6 script that will upload an object to a S3 bucket_
+
+</CodeGroup>

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/S3Client/05 deleteObject(bucketName, objectKey).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/S3Client/05 deleteObject(bucketName, objectKey).md
@@ -1,0 +1,47 @@
+---
+title: 'S3Client.deleteObject(bucketName, objectKey)'
+description: 'S3Client.deleteObject deletes an object from a bucket'
+excerpt: 'S3Client.deleteObject deletes an object from a bucket'
+---
+
+`S3Client.deleteObject` deletes an object from a bucket.
+
+| Parameter  | Type                  | Description                                  |
+| :--------- | :-------------------- | :------------------------------------------- |
+| bucketName | string                | Name of the bucket to delete the object from.|
+| objectKey  | string                | Name of the object to delete.                |
+
+### Example
+
+<CodeGroup labels={[]}>
+
+```javascript
+import exec from 'k6/execution';
+
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.3.0/s3.js';
+
+const awsConfig = new AWSConfig(
+  __ENV.AWS_REGION,
+  __ENV.AWS_ACCESS_KEY_ID,
+  __ENV.AWS_SECRET_ACCESS_KEY
+);
+
+const s3 = new S3Client(awsConfig);
+const testBucketName = 'test-jslib-aws';
+const testFileKey = 'bonjour.txt';
+
+export default function () {
+  // Let's delete our test object
+  s3.deleteObject(testBucketName, testFileKey);
+
+  // And make sure it was indeed deleted
+  const objects = s3.listObjects();
+  if (objects.filter((o) => o.name === testBucketName).length != 0) {
+    exec.test.abort();
+  }
+}
+```
+
+_A k6 script that will delete an object from a S3 bucket_
+
+</CodeGroup>

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/S3Client/98 Object.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/S3Client/98 Object.md
@@ -1,0 +1,58 @@
+---
+title: 'Object'
+description: "Object is returned by the S3Client.* methods who query S3 buckets' objects."
+excerpt: "Object is returned by the S3Client.* methods who query S3 buckets' objects."
+---
+
+Object is returned by the S3Client.\* methods that query S3 buckets' objects. Namely, [`listObjects`](/javascript-api/jslib/aws/s3client/listObjects), [`getObject`](/javascript-api/jslib/aws/s3client/getObject), [`putObject`](/javascript-api/jslib/aws/s3client/putObject), and [`deleteObject`](/javascript-api/jslib/aws/s3client/deleteObject). The Object construct describes an Amazon S3 object.
+
+| Name                  | Type                                                                                                                                      | Description                                                                                                                                                                               |
+| :-------------------- | :---------------------------------------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Object.key`          | string                                                                                                                                    | The S3 object's name.                                                                                                                                                                     |
+| `Object.lastModified` | number                                                                                                                                    | The S3 object's last modification date.                                                                                                                                                   |
+| `Object.etag`         | string                                                                                                                                      | The S3 object's `etag` is a hash of the object. The ETag reflects changes only to the contents of an object, not its metadata. The ETag may or may not be an MD5 digest of the object data. |
+| `Object.size`         | size                                                                                                                                      | The S3 object's size in bytes.                                                                                                                                                            |
+| `Object.storageClass` | `STANDARD` \| `REDUCED_REDUNDANCY` \| `GLACIER` \| `STANDARD_IA` \| `INTELLIGENT_TIERING` \| `DEEP_ARCHIVE` \| `OUTPOSTS` \| `GLACIER_IR` | The S3 object's class of storage used to store it.                                                                                                                                        |
+| `Object.data`         | `string` or `bytes` or `null`                                                                                                             | The S3 object's content.                                                                                                                                                                  |
+
+### Example
+
+<CodeGroup labels={[]}>
+
+```javascript
+import exec from 'k6/execution';
+
+import {
+  // listBuckets,
+  AWSConfig,
+  S3Client,
+} from 'https://jslib.k6.io/aws/0.3.0/s3.js';
+
+const awsConfig = new AWSConfig(
+  __ENV.AWS_REGION,
+  __ENV.AWS_ACCESS_KEY_ID,
+  __ENV.AWS_SECRET_ACCESS_KEY
+);
+
+const s3 = new S3Client(awsConfig);
+const testBucketName = 'test-jslib-aws';
+const testFileKey = 'bonjour.txt';
+
+export default function () {
+  const objects = s3.listObjects(testBucketName);
+
+  // If our test object does not exist, abort the execution.
+  if (objects.filter((o) => o.key === testFileKey).length == 0) {
+    exec.test.abort();
+  }
+
+  // Let's download our test object and print its content
+  const object = s3.getObject(testBucketName, testFileKey);
+  console.log(JSON.stringify(object));
+}
+```
+
+_A k6 script that will query a S3 bucket's objects and print its content and metadata_
+
+</CodeGroup>
+

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/S3Client/99 Bucket.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/S3Client/99 Bucket.md
@@ -1,0 +1,39 @@
+---
+title: 'Bucket'
+description: 'Bucket is returned by the S3Client.* methods who query S3 buckets.'
+excerpt: 'Bucket is returned by the S3Client.* methods who query S3 buckets.'
+---
+
+Bucket is returned by the S3Client.* methods that query S3 buckets. Namely, `listBuckets()` returns an array of Bucket objects. The Bucket object describes an Amazon S3 bucket.  
+
+| Name                  | Type   | Description                  |
+| :-------------------- | :----- | :--------------------------- |
+| `Bucket.name`         | string | The S3 bucket's name         |
+| `Bucket.creationDate` | Date   | The S3 bucket's creationDate |
+
+### Example
+
+<CodeGroup labels={[]}>
+
+```javascript
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.3.0/s3.js';
+
+const awsConfig = new AWSConfig(
+  __ENV.AWS_REGION,
+  __ENV.AWS_ACCESS_KEY_ID,
+  __ENV.AWS_SECRET_ACCESS_KEY
+);
+
+const s3 = new S3Client(awsConfig);
+
+export default function () {
+  // List the buckets the AWS authentication configuration
+  // gives us access to.
+  const buckets = s3.listBuckets();
+  console.log(JSON.stringify(buckets));
+}
+```
+
+_A k6 script that will query the user's S3 buckets and print all of their metadata_
+
+</CodeGroup>

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/01 listSecrets().md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/01 listSecrets().md
@@ -1,0 +1,47 @@
+---
+title: 'SecretsManagerClient.listSecrets()'
+description: 'SecretsManagerClient.listSecrets lists the secrets the authenticated user has access to'
+excerpt: 'SecretsManagerClient.listSecrets lists the secrets the authenticated user has access to'
+---
+
+`S3Client.listSecrets` lists the secrets the authenticated user has access to in the region set by the `SecretsManagerClient` instance's configuration.
+
+### Returns
+
+| Type                                                                   | Description                                                                          |
+| :--------------------------------------------------------------------- | :----------------------------------------------------------------------------------- |
+| Array<[Secret](/javascript-api/jslib/aws/secretsmanagerclient/secret)> | An array of [Secret](/javascript-api/jslib/aws/secretsmanagerclient/secret) objects. |
+
+### Example
+
+<CodeGroup labels={[]}>
+
+```javascript
+import exec from 'k6/execution';
+
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.3.0/secrets-manager.js';
+
+const awsConfig = new AWSConfig(
+  __ENV.AWS_REGION,
+  __ENV.AWS_ACCESS_KEY_ID,
+  __ENV.AWS_SECRET_ACCESS_KEY
+);
+
+const secretsManager = new SecretsManagerClient(awsConfig);
+const testSecretName = 'jslib-test-secret';
+
+export default function () {
+  // List the secrets the AWS authentication configuration
+  // gives us access to, and verify the test secret exists.
+  const secrets = secretsManager.listSecrets();
+  if (!secrets.filter((s) => s.name === testSecretName).length == 0) {
+    exec.test.abort('test secret not found');
+  }
+
+  console.log(JSON.stringify(secrets));
+}
+```
+
+_A k6 script that will list a user's secrets from AWS secrets manager_
+
+</CodeGroup>

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/02 getSecret(secretID).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/02 getSecret(secretID).md
@@ -1,0 +1,54 @@
+---
+title: 'SecretsManagerClient.getSecret(secretID)'
+description: 'SecretsManagerClient.getSecret(secretID) downloads a secret from AWS secrets manager'
+excerpt: 'SecretsManagerClient.getSecret(secretID) downloads a secret from AWS secrets manager'
+---
+
+`SecretsManagerClient.getSecret` downloads a secret from AWS secrets manager.
+
+| Parameter  | Type   | Description                                  |
+| :--------- | :----- | :------------------------------------------- |
+| secretID   | string | The ARN or name of the secret to retrieve.   |
+
+### Returns
+
+| Type                                                            | Description                                                                                                      |
+| :-------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------- |
+| [Secret](/javascript-api/jslib/aws/secretsmanagerclient/secret) | A [Secret](/javascript-api/jslib/aws/secretsmanagerclient/secrett) describing and holding the downloaded secret. |
+
+### Example
+
+<CodeGroup labels={[]}>
+
+```javascript
+import exec from 'k6/execution';
+
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.3.0/secrets-manager.js';
+
+const awsConfig = new AWSConfig(
+  __ENV.AWS_REGION,
+  __ENV.AWS_ACCESS_KEY_ID,
+  __ENV.AWS_SECRET_ACCESS_KEY
+);
+
+const secretsManager = new SecretsManagerClient(awsConfig);
+const testSecretName = 'jslib-test-secret';
+
+export default function () {
+  // List the secrets the AWS authentication configuration
+  // gives us access to.
+  const secrets = secretsManager.listSecrets();
+  if (!secrets.filter((s) => s.name === testSecretName).length == 0) {
+    exec.test.abort('test secret not found');
+  }
+
+  // Let's get our test secret's value and print it.
+  const secret = secretsManager.getSecret(testSecretName);
+  console.log(JSON.stringify(secret));
+}
+```
+
+_A k6 script that will download a user's secret from AWS secrets manager_
+
+</CodeGroup>
+

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/03 createSecret(name, secretString, description, [versionID], [tags]).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/03 createSecret(name, secretString, description, [versionID], [tags]).md
@@ -1,0 +1,50 @@
+---
+title: 'SecretsManagerClient.createSecret(name, secretString, description, [versionID], [tags])'
+description: 'SecretsManagerClient.createSecret creates a new secret'
+excerpt: 'SecretsManagerClient.createSecret creates a new secret'
+---
+
+`SecretsManagerClient.createSecret` creates a secret in AWS' secrets manager.
+
+| Parameter            | Type                     | Description                                                                                                                                           |
+| :------------------- | :----------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| name                 | string                   | The friendly name of the secret. You can use forward slashes in the name to represent a path hierarchy.                                               |
+| secretString         | string                   | The text data to encrypt and store in this new version of the secret. We recommend you use a JSON structure of key/value pairs for your secret value. |
+| description          | string                   | The description of the secret.                                                                                                                        |
+| versionID (optional) | string                   | Optional unique version identifier for the created secret. If no versionID is provided, an auto-generated UUID will be used instead.                   |
+| tags (optional)      | Array<{"key": "value"},> | A list of tags to attach to the secret. Each tag is a key and value pair of strings in a JSON text string                                             |
+
+### Example
+
+<CodeGroup labels={[]}>
+
+```javascript
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.3.0/secrets-manager.js';
+
+const awsConfig = new AWSConfig(
+  __ENV.AWS_REGION,
+  __ENV.AWS_ACCESS_KEY_ID,
+  __ENV.AWS_SECRET_ACCESS_KEY
+);
+
+const secretsManager = new SecretsManagerClient(awsConfig);
+const testSecretName = 'jslib-test-secret';
+const testSecretValue = 'jslib-test-value';
+
+export default function () {
+  // Let's create our test secret.
+  const testSecret = secretsManager.createSecret(
+    testSecretName,
+    testSecretValue,
+    'this is a test secret, delete me.'
+  );
+
+  // Let's get its value and verify it was indeed created.
+  const createdSecret = secretsManager.getSecret(testSecretName);
+  console.log(JSON.stringify(createdSecret));
+}
+```
+
+_A k6 script that will create a secret in AWS secrets manager_
+
+</CodeGroup>

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/04 deleteSecret(secretID, { recoveryWindow: 30, noRecovery: false}}).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/04 deleteSecret(secretID, { recoveryWindow: 30, noRecovery: false}}).md
@@ -1,0 +1,47 @@
+---
+title: 'SecretsManagerClient.deleteSecret(secretID, { recoveryWindow: 30, noRecovery: false}})'
+description: 'SecretsManagerClient.deleteSecret deletes a secret'
+excerpt: 'SecretsManagerClient.deleteSecret deletes a secret'
+---
+
+`SecretsManagerClient.deleteSecret` deletes a secret from AWS' secrets manager.
+
+| Parameter | Type                                      | Description                              |
+| :-------- | :---------------------------------------- | :--------------------------------------- |
+| secretID  | string                                    | The ARN or name of the secret to update. |
+| options   | { recoveryWindow: 30, noRecovery: false } | options allow you to control the deletion behavior. recoveryWindow defines how long a secret will remain “soft-deleted”, in days, before being hard-deleted. noRecovery set to true would hard-delete the secret immediately. Note that both options are exclusive. |
+
+### Example
+
+<CodeGroup labels={[]}>
+
+```javascript
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.3.0/secrets-manager.js';
+
+const awsConfig = new AWSConfig(
+  __ENV.AWS_REGION,
+  __ENV.AWS_ACCESS_KEY_ID,
+  __ENV.AWS_SECRET_ACCESS_KEY
+);
+
+const secretsManager = new SecretsManagerClient(awsConfig);
+const testSecretName = 'jslib-test-secret';
+const testSecretValue = 'jslib-test-value';
+
+export default function () {
+  // Let's make sure our test secret is created
+  const testSecret = secretsManager.createSecret(
+    testSecretName,
+    testSecretValue,
+    'this is a test secret, delete me.'
+  );
+
+  // Let's hard delete our test secret and verify it worked
+  secretsManager.deleteSecret(testSecretName, { noRecovery: true });
+}
+```
+
+_A k6 script that will delete a secret in AWS secrets manager_
+
+</CodeGroup>
+

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/05 putSecretValue(secretID, secretString, [versionID]).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/05 putSecretValue(secretID, secretString, [versionID]).md
@@ -1,0 +1,57 @@
+---
+title: 'SecretsManagerClient.putSecretValue(secretID, secretString, [versionID], [tags])'
+description: "SecretsManagerClient.putSecretValue updates an existing secret's value"
+excerpt: "SecretsManagerClient.putSecretValue updates an existing secret's value"
+---
+
+`SecretsManagerClient.putSecretValue` updates a secret's value in AWS' secrets manager.
+
+| Parameter            | Type                     | Description                                                                                                                                           |
+| :------------------- | :----------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| secretID             | string                   | The ARN or name of the secret to update.                                                                                                              |
+| secretString         | string                   | The text data to encrypt and store in this new version of the secret. We recommend you use a JSON structure of key/value pairs for your secret value. |
+| versionID (optional) | string                   | Optional unique version identifier for the updated version of the secret. If no versionID is provided, an auto-generated UUID will be used instead.    |
+| tags (optional)      | Array<{"key": "value"},> | A list of tags to attach to the secret. Each tag is a key and value pair of strings in a JSON text string                                             |
+
+### Example
+
+<CodeGroup labels={[]}>
+
+```javascript
+import exec from 'k6/execution';
+
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.3.0/secrets-manager.js';
+
+const awsConfig = new AWSConfig(
+  __ENV.AWS_REGION,
+  __ENV.AWS_ACCESS_KEY_ID,
+  __ENV.AWS_SECRET_ACCESS_KEY
+);
+
+const secretsManager = new SecretsManagerClient(awsConfig);
+const testSecretName = 'jslib-test-secret';
+const testSecretValue = 'jslib-test-value';
+
+export default function () {
+  // Let's make sure our test secret is created
+  const testSecret = secretsManager.createSecret(
+    testSecretName,
+    testSecretValue,
+    'this is a test secret, delete me.'
+  );
+
+  // Now that we know the secret exist, let's update its value
+  const newTestSecretValue = 'new-test-value';
+  const u = secretsManager.putSecretValue(testSecretName, newTestSecretValue);
+
+  // Let's get its value back and verify it was indeed updated
+  const updatedSecret = secretsManager.getSecret(testSecretName);
+  if (updatedSecret.secret !== newTestSecretValue) {
+    exec.test.abort('unable to update test secret');
+  }
+}
+```
+
+_A k6 script that will update a secret's value in AWS secrets manager_
+
+</CodeGroup>

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/99 Secret.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/99 Secret.md
@@ -1,0 +1,55 @@
+---
+title: 'Secret'
+description: 'Secret is returned by the SecretsManagerClient.* methods who query secrets from AWS secrets manager.'
+excerpt: 'Secret is returned by the SecretsManagerClient.* methods who query secrets from AWS secrets manager.'
+---
+
+Secret is returned by the SecretsManagerClient.* methods that query secrets. Namely, [listSecrets](/javascript-api/jslib/aws/secretsmanagerclient/secretsmanagerclient-listsecrets/), [getSecret](/javascript-api/jslib/aws/secretsmanagerclient/secretsmanagerclient-getsecret-secretid), [createSecret](/javascript-api/jslib/aws/secretsmanagerclient/secretsmanagerclient-createsecret-name-secretstring-description-versionid-tags), and [putSecretValue](/javascript-api/jslib/aws/secretsmanagerclient/secretsmanagerclient-putsecret-secretid-secretstring-versionid-tags) returns either an instance or array of Secret objects. The Secret object describes an Amazon Secrets Manager secret.  
+
+| Name                     | Type                    | Description                                                                                                                                   |
+| :----------------------- | :---------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Secret.name`            | string                  | The friendly name of the secret. You can use forward slashes in the name to represent a path hierarchy.                                       |
+| `Secret.arn`             | string                  | The Amazon Resource Name (ARN) of the secret.                                                                                                 |
+| `Secret.createdAt`       | number                  | The date and time (timestamp) when a secret was created.                                                                                      |
+| `Secret.lastAccessDate`  | number                  | The last date that this secret was accessed. This value is truncated to midnight of the date and therefore shows only the date, not the time. |
+| `Secret.lastChangedDate` | number                  | The last date and time that this secret was modified in any way.                                                                              |
+| `Secret.tags`            | Array<{"key": "value"}> | The list of user-defined tags associated with the secret.                                                                                     |
+
+### Example
+
+<CodeGroup labels={[]}>
+
+```javascript
+import exec from 'k6/execution';
+
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.3.0/secrets-manager.js';
+
+const awsConfig = new AWSConfig(
+  __ENV.AWS_REGION,
+  __ENV.AWS_ACCESS_KEY_ID,
+  __ENV.AWS_SECRET_ACCESS_KEY
+);
+
+const secretsManager = new SecretsManagerClient(awsConfig);
+const testSecretName = 'jslib-test-secret';
+
+export default function () {
+  // List the secrets the AWS authentication configuration
+  // gives us access to.
+  const secrets = secretsManager.listSecrets();
+
+  // If our test secret does not exist, abort the execution.
+  if (!secrets.filter((s) => s.name === testSecretName).length == 0) {
+    exec.test.abort('test secret not found');
+  }
+
+  // Let's get it and print its content
+  const downloadedSecret = secretsManager.getSecret(testSecretName);
+  console.log(downloadedSecret.secret);
+}
+```
+
+_A k6 script that will query the user's secrets and print a test secret's value_
+
+</CodeGroup>
+

--- a/src/data/markdown/docs/20 jslib/20 jslib.md
+++ b/src/data/markdown/docs/20 jslib/20 jslib.md
@@ -12,4 +12,6 @@ The [jslib.k6.io](https://jslib.k6.io/) is a collection of external JavaScript l
 | [httpx](/javascript-api/jslib/httpx)  | Wrapper around [k6/http](https://k6.io/docs/javascript-api/#k6-http) to simplify session handling |
 | [k6chaijs](/javascript-api/jslib/k6chaijs)  | BDD and TDD assertion style |
 | [utils](/javascript-api/jslib/utils)  | Small utility functions useful in every day load testing |
+| [aws](/javascript-api/jslib/aws)  | Library allowing to interact with Amazon AWS services |
+| -  | Documentation for other libraries will be added shortly. |
 


### PR DESCRIPTION
With k6 v0.38.0 we introduce the AWS JSlib library. The library allows
to interact with a restricted number of Amazon AWS services directly
from your k6 load test scripts.

This PR adds dedicated documentation, detailing the packages exposed
by this library, the constructs they introduce, and examples of how to
use them.