### PR TITLE
fix: fix ToC element with special characters

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -51,7 +51,7 @@ const slugify = (path) =>
 // anchor strings sane
 const anchorify = (str) =>
   slugify(str)
-    .replace(/[=/]/g, '-')
+    .replace(/[^\w]/g, '-')
     .replace(/^\d+/g, '')
     .replace(/^-*/g, '')
     .replace(/-*$/g, '');


### PR DESCRIPTION
This PR brings an update to the existing `anchorify` function that extends a list of special characters to replace with `-`