### PR TITLE
Update debian/ubuntu install instructions according to apt-key's deprecation

### DIFF
--- a/src/data/markdown/translated-guides/en/01 Getting started/02 Installation.md
+++ b/src/data/markdown/translated-guides/en/01 Getting started/02 Installation.md
@@ -10,8 +10,8 @@ k6 has packages for Linux, Mac, and Windows. As alternatives, you can also use a
 ### Debian/Ubuntu
 
 ```bash
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
-echo "deb https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
+sudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
+echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
 sudo apt-get update
 sudo apt-get install k6
 ```

--- a/src/data/markdown/translated-guides/en/01 Getting started/02 Installation/01 Troubleshooting.md
+++ b/src/data/markdown/translated-guides/en/01 Getting started/02 Installation/01 Troubleshooting.md
@@ -10,22 +10,49 @@ If you use such a distribution, you'll need to install them:
 
 ```bash
 sudo apt-get update && sudo apt-get install ca-certificates gnupg2 -y
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
-echo "deb https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
+sudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
+echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
 sudo apt-get update
 sudo apt-get install k6
 ```
 
+## apt-key is deprecated
+
+Some Ubuntu and Debian users might run into an `apt-key` deprecation warning while adding k6's repository key to their system's keyring: `Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8))`. In order to avoid it, and be future-proof, users should delete the existing `security@k6.io` repository key present on their system, and update their sources list accordingly.
+
+```bash
+# delete existing key
+sudo apt-key del k6
+
+# import key the updated way
+sudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
+
+# update /etc/apt-sources.list.d/k6.list
+echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
+```
+
+## Dirmng is missing or uninitialized
+
+Some users might encounter an error mentioning `No dirmng` as they try to download k6's GPG key from ubuntu's keyserver:
+```bash
+gpg: keybox '/usr/share/keyrings/k6-archive-keyring.gpg' created
+gpg: failed to create temporary file '/root/.gnupg/.#lk0x000055db689f2310.a86c4b090dc7.7': No such file or directory
+gpg: connecting dirmngr at '/root/.gnupg/S.dirmngr' failed: No such file or directory
+gpg: keyserver receive failed: No dirmngr
+```
+
+If this issue affects you, make sure `dirmngr` is installed on your system by running `apt-get install dirmngr` (or equivalent for your distribution),
+and run `dirmngr -q` to initialize it. 
 
 ## Behind a firewall or proxy
 
 Some users have reported that they can't download the key from Ubuntu's keyserver.
-When they run the `apt-key` command, their firewalls or proxies block their requests to download.
+When they run the `gpg` command, their firewalls or proxies block their requests to download.
 If this issue affects you, you can try this alternative:
 
 
 ```bash
-curl -s https://dl.k6.io/key.gpg | sudo apt-key add -
+curl -s https://dl.k6.io/key.gpg | gpg --dearmor | sudo tee /usr/share/keyrings/k6-archive-keyring.gpg
 ```
 
 Run `sudo apt-key list`, and confirm that the output shows the preceding key.

--- a/src/data/markdown/translated-guides/en/01 Getting started/02 Installation/01 Troubleshooting.md
+++ b/src/data/markdown/translated-guides/en/01 Getting started/02 Installation/01 Troubleshooting.md
@@ -18,7 +18,11 @@ sudo apt-get install k6
 
 ## apt-key is deprecated
 
-Some Ubuntu and Debian users might run into an `apt-key` deprecation warning while adding k6's repository key to their system's keyring: `Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8))`. In order to avoid it, and be future-proof, users should delete the existing `security@k6.io` repository key present on their system, and update their sources list accordingly.
+Some Ubuntu and Debian users might run into an `apt-key` deprecation warning while adding k6's repository key to their system's keyring:
+
+> `Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8))`
+
+To avoid this and be future-proof, users should delete the existing `security@k6.io` repository key on their system, and update their sources list accordingly.
 
 ```bash
 # delete existing key

--- a/src/data/markdown/translated-guides/es/01 Getting started/02 Installation.md
+++ b/src/data/markdown/translated-guides/es/01 Getting started/02 Installation.md
@@ -16,8 +16,8 @@ excerpt: 'Instrucciones para installar k6 en Linux, Mac, or Windows. Usa Docker 
 > ```
 
 ```bash
-$ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
-$ echo "deb https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
+$ sudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
+$ echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
 $ sudo apt-get update
 $ sudo apt-get install k6
 ```


### PR DESCRIPTION
This PR addresses #639 and updates both install and troubleshooting instructions for Debian/Ubuntu, considering `apt-key` command's deprecation in most recent versions of said OSes.

Following the [new recommended way](https://www.linuxuprising.com/2021/01/apt-key-is-deprecated-how-to-add.html) of installing repositories GPG keys, we now instruct to directly import k6's GPG key from Ubuntu's key server, and add the `signed-by` parameter to the sources list entry.

Here's a Dockerfile to verify that the new instructions work: 

```dockerfile
FROM ubuntu:latest

RUN apt-get update && apt-get install -y gpg ca-certificates dirmngr curl
RUN dirmngr
RUN gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
RUN echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" | tee /etc/apt/sources.list.d/k6.list
RUN apt-get update
RUN apt-get install k6
```

Please let me know if it works on your side, if you have further questions, or if I have missed something 👍🏻 

cc @christopwner