### PR TITLE
k6 installation and troubleshooting fixes, add Spanish translation

### DIFF
--- a/src/data/markdown/translated-guides/en/01 Getting started/02 Installation.md
+++ b/src/data/markdown/translated-guides/en/01 Getting started/02 Installation.md
@@ -1,9 +1,9 @@
 ---
 title: 'Installation'
-excerpt: 'k6 has packages for Linux, Mac, and Windows. As alternatives, you can also using a Docker container or a prebuilt binary.'
+excerpt: 'k6 has packages for Linux, Mac, and Windows. As alternatives, you can also using a Docker container or a standalone binary.'
 ---
 
-k6 has packages for Linux, Mac, and Windows. As alternatives, you can also use a Docker container or a prebuilt binary.
+k6 has packages for Linux, Mac, and Windows. Alternatively, you can use a Docker container or a standalone binary.
 
 ## Linux
 
@@ -25,7 +25,6 @@ Using `dnf` (or `yum` on older versions):
 sudo dnf install https://dl.k6.io/rpm/repo.rpm
 sudo dnf install k6
 ```
-
 
 
 ## MacOS
@@ -50,7 +49,7 @@ If you use the [Windows Package Manager](https://github.com/microsoft/winget-cli
 winget install k6
 ```
 
-You can also manually download and install the [latest official `.msi` package](https://dl.k6.io/msi/k6-latest-amd64.msi).
+Alternatively, you can download and run [the latest official installer](https://dl.k6.io/msi/k6-latest-amd64.msi).
 
 ## Docker
 
@@ -60,8 +59,7 @@ docker pull grafana/k6
 
 ## Download the k6 binary
 
-The [Releases page](https://github.com/grafana/k6/releases) has a prebuilt binary.
-After you download it, place it in your `PATH` to run `k6` from any location.
+Our [GitHub Releases page](https://github.com/grafana/k6/releases) has a standalone binary for all platforms. After downloading and extracting the archive for your platform, place the `k6` or `k6.exe` binary in your `PATH` to run `k6` from any location.
 
 ## Using k6 extensions
 
@@ -71,3 +69,4 @@ Head to the [bundle builder page](/extensions/bundle-builder/) to get started.
 ## Troubleshooting
 
 If installation fails, check the [list of common installation issues](/getting-started/installation/troubleshooting/).
+If your problem is not listed and persists, reach out via the channel `#community-discussion` on our [official Slack](https://k6io.slack.com/), or report it on our [community forum](https://community.k6.io/).

--- a/src/data/markdown/translated-guides/en/01 Getting started/02 Installation/01 Troubleshooting.md
+++ b/src/data/markdown/translated-guides/en/01 Getting started/02 Installation/01 Troubleshooting.md
@@ -46,7 +46,8 @@ gpg: connecting dirmngr at '/root/.gnupg/S.dirmngr' failed: No such file or dire
 gpg: keyserver receive failed: No dirmngr
 ```
 
-This happens if it's the first time `gpg` is run by that user, so the directory `/root/.gnupg/` doesn't exist yet. You can create it by running `sudo gpg -k` and trying to import the key again.
+This happens if it's the first time that the user runs `gpg` , so the directory `/root/.gnupg/` doesn't exist yet.
+To create the directory, run `sudo gpg -k` and try to import the key again.
 
 
 ## Behind a firewall or proxy

--- a/src/data/markdown/translated-guides/en/01 Getting started/02 Installation/01 Troubleshooting.md
+++ b/src/data/markdown/translated-guides/en/01 Getting started/02 Installation/01 Troubleshooting.md
@@ -55,8 +55,6 @@ If this issue affects you, you can try this alternative:
 curl -s https://dl.k6.io/key.gpg | gpg --dearmor | sudo tee /usr/share/keyrings/k6-archive-keyring.gpg
 ```
 
-Run `sudo apt-key list`, and confirm that the output shows the preceding key.
-
 
 ## CentOS versions older than 8
 

--- a/src/data/markdown/translated-guides/en/01 Getting started/02 Installation/01 Troubleshooting.md
+++ b/src/data/markdown/translated-guides/en/01 Getting started/02 Installation/01 Troubleshooting.md
@@ -61,24 +61,6 @@ curl -s https://dl.k6.io/key.gpg | gpg --dearmor | sudo tee /usr/share/keyrings/
 
 Run `sudo apt-key list`, and confirm that the output shows the preceding key.
 
-## Using the old Bintray repository
-
-The Bintray k6 repositories [stopped working May 1st, 2021](https://k6.io/blog/sunsetting-bintray/).
-You should use the preceding instructions to switch to our repositories.
-
-On Debian/Ubuntu, you can remove the Bintray repository with:
-```bash
-sudo sed -i '/dl\.bintray\.com\/loadimpact\/deb/d' /etc/apt/sources.list
-sudo apt-key del 379CE192D401AB61
-sudo apt-get update
-```
-
-And on Fedora/CentOS with:
-```bash
-sudo rm /etc/yum.repos.d/bintray-loadimpact-rpm.repo
-```
-
-
 
 ## CentOS versions older than 8
 

--- a/src/data/markdown/translated-guides/en/01 Getting started/02 Installation/01 Troubleshooting.md
+++ b/src/data/markdown/translated-guides/en/01 Getting started/02 Installation/01 Troubleshooting.md
@@ -9,11 +9,7 @@ Some Linux distributions don't come bundled with the `ca-certificates` and `gnup
 If you use such a distribution, you'll need to install them:
 
 ```bash
-sudo apt-get update && sudo apt-get install ca-certificates gnupg2 -y
-sudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
-echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
-sudo apt-get update
-sudo apt-get install k6
+sudo apt-get update && sudo apt-get install -y ca-certificates gnupg2
 ```
 
 ## apt-key is deprecated

--- a/src/data/markdown/translated-guides/en/01 Getting started/02 Installation/01 Troubleshooting.md
+++ b/src/data/markdown/translated-guides/en/01 Getting started/02 Installation/01 Troubleshooting.md
@@ -3,14 +3,17 @@ title: 'Troubleshooting'
 excerpt: 'Instructions to fix the most common installation issues.'
 ---
 
-## Distro lacks ca-certificates or gnupg2
+## System lacks ca-certificates or gnupg2
 
 Some Linux distributions don't come bundled with the `ca-certificates` and `gnupg2` packages.
-If you use such a distribution, you'll need to install them:
+If you use such a distribution, you'll need to install them with:
 
 ```bash
 sudo apt-get update && sudo apt-get install -y ca-certificates gnupg2
 ```
+
+This example is for Debian/Ubuntu and derivatives. Consult your distribution's documentation if you use another one.
+
 
 ## apt-key is deprecated
 
@@ -24,11 +27,12 @@ To avoid this and be future-proof, users should delete the existing `security@k6
 # delete existing key
 sudo apt-key del k6
 
-# import key the updated way
+# import the key the recommended way
 sudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
 
-# update /etc/apt-sources.list.d/k6.list
+# update the repository
 echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
+sudo apt-get update
 ```
 
 

--- a/src/data/markdown/translated-guides/en/01 Getting started/02 Installation/01 Troubleshooting.md
+++ b/src/data/markdown/translated-guides/en/01 Getting started/02 Installation/01 Troubleshooting.md
@@ -31,9 +31,10 @@ sudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.g
 echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
 ```
 
-## Dirmng is missing or uninitialized
 
-Some users might encounter an error mentioning `No dirmng` as they try to download k6's GPG key from ubuntu's keyserver:
+## Error importing k6's GPG key
+
+The `gpg` command to import k6's package signing key might fail with:
 ```bash
 gpg: keybox '/usr/share/keyrings/k6-archive-keyring.gpg' created
 gpg: failed to create temporary file '/root/.gnupg/.#lk0x000055db689f2310.a86c4b090dc7.7': No such file or directory
@@ -41,8 +42,8 @@ gpg: connecting dirmngr at '/root/.gnupg/S.dirmngr' failed: No such file or dire
 gpg: keyserver receive failed: No dirmngr
 ```
 
-If this issue affects you, make sure `dirmngr` is installed on your system by running `apt-get install dirmngr` (or equivalent for your distribution),
-and run `dirmngr -q` to initialize it. 
+This happens if it's the first time `gpg` is run by that user, so the directory `/root/.gnupg/` doesn't exist yet. You can create it by running `sudo gpg -k` and trying to import the key again.
+
 
 ## Behind a firewall or proxy
 

--- a/src/data/markdown/translated-guides/es/01 Getting started/02 Installation.md
+++ b/src/data/markdown/translated-guides/es/01 Getting started/02 Installation.md
@@ -3,17 +3,11 @@ title: 'Instalación'
 excerpt: 'Instrucciones para installar k6 en Linux, Mac, or Windows. Usa Docker o los binarios de k6.'
 ---
 
+k6 tiene paquetes para Linux, Mac, y Windows. Alternativamente, puede usar un contenedor Docker o un binario independiente.
+
 ## Linux
 
 ### Debian/Ubuntu
-
-> #### 🧠 Si usas una imagen que le falte  `ca-certificates` o `gnupg2`
-> 
-> Necesitas instalar primero esos paquetes con añadiendo el comando:
-> 
-> ```bash
-> $ sudo apt-get update && sudo apt-get install ca-certificates gnupg2 -y
-> ```
 
 ```bash
 $ sudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
@@ -22,13 +16,6 @@ $ sudo apt-get update
 $ sudo apt-get install k6
 ```
 
-> #### ⚠️ En caso de usar un firewall o un proxy
-> Usted debe tener en cuenta que algunos usuarios han reportado que no pueden descargar la clave del servidor de Ubuntu usando el comando `apt-key`, debido a que los firewalls o los proxies bloquean las solicitudes. Si usted está presentando este problema, puede intentar hacerlo de la siguiente manera:
->
-> ```bash
-> $ curl -s https://dl.k6.io/key.gpg | sudo apt-key add -
-> ```
-> Entonces confirme que la clave con el ID mencionado arriba se muestre al ejecutar `sudo apt-key list`.
 
 ### Fedora/CentOS
 
@@ -38,28 +25,6 @@ Usando `dnf` o `yum`:
 $ sudo dnf install https://dl.k6.io/rpm/repo.rpm
 $ sudo dnf install k6
 ```
-
-Versiones anteriores a CentOS 8 no soportan firmas PGP V4 que utilizamos, por lo que debe deshabilitar la verificación instalando k6 con:
-```bash
-$ sudo yum install --nogpgcheck k6
-```
-
-> #### ⚠️ Nota sobre Bintray
->
-> Los repositorios k6 de Bintray [dejarán de funcionar después del 1ro de mayo, 2021](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/)
-> y deberá cambiar a nuestros repositorios siguiendo las instrucciones mencionadas arriba.
->
-> En Debian/Ubuntu puede remover el repositorio de Bintray con:
-> ```bash
-> $ sudo sed -i '/dl\.bintray\.com\/loadimpact\/deb/d' /etc/apt/sources.list
-> $ sudo apt-key del 379CE192D401AB61
-> $ sudo apt-get update
-> ```
->
-> Y en Fedora/CentOS con:
-> ```bash
-> $ sudo rm /etc/yum.repos.d/bintray-loadimpact-rpm.repo
-> ```
 
 
 ## macOS
@@ -79,12 +44,7 @@ Si usa el [gestor de paquetes Chocolatey](https://chocolatey.org/) puede instala
 choco install k6
 ```
 
-Si no, puede descargar e instalar [el más reciente paquete oficial `.msi`](https://dl.k6.io/msi/k6-latest-amd64.msi).
-
-
-## Binarios
-
-Descarga un binario preconstruido de nuestra [página de releases](https://github.com/grafana/k6/releases), y colócalo en el `PATH` de tu sistema. De esta manera puede ejecutar `k6` desde cualquier lugar.
+Alternativamente, puede descargar y ejecutar [el instalador oficial más reciente](https://dl.k6.io/msi/k6-latest-amd64.msi).
 
 
 ## Docker
@@ -92,3 +52,18 @@ Descarga un binario preconstruido de nuestra [página de releases](https://githu
 ```bash
 $ docker pull grafana/k6
 ```
+
+## Binarios
+
+Nuestra [página de releases en GitHub](https://github.com/grafana/k6/releases) tiene binarios independientes para todas las plataformas. Descargue y extraiga el archivo para su plataforma, y coloque el binario `k6` o `k6.exe` en el `PATH` de su sistema. De esta manera puede ejecutar `k6` desde cualquier lugar.
+
+
+## Usando extensiones de k6
+
+Si utiliza una o más [extensiones de k6](/extensions), necesita un binario compilado con las extensiones deseadas. Visite la página [del creador de paquetes](/extensions/bundle-builder/) para empezar.
+
+
+## Solución de problemas
+
+Si tiene problemas con la instalación, visite [la lista de problemas y soluciones comúnes](/es/empezando/instalacion/solucion-de-problemas/) para ayuda.
+Si su problema no está listado y persiste, contacte el canal `#lang-spanish` en nuestro [Slack oficial](https://k6io.slack.com/), o repórtelo en nuestro [foro comunitario](https://community.k6.io/).

--- a/src/data/markdown/translated-guides/es/01 Getting started/02 Installation/01 Troubleshooting.md
+++ b/src/data/markdown/translated-guides/es/01 Getting started/02 Installation/01 Troubleshooting.md
@@ -17,7 +17,11 @@ Este ejemplo es para Debian/Ubuntu y derivados. Consulte la documentación de su
 
 ## apt-key es deprecado
 
-Algunos usuarios de Debian/Ubuntu y derivados podrían encontrar una advertencia utilizando `apt-key` para añadir la clave de firma del repositorio de k6: `Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8))`. Para evitar esto, y estar a prueba del futuro, se recomienda remover la clave existente de `security@k6.io`, y actualizar la lista de repositorios.
+Algunos usuarios de Debian/Ubuntu y derivados podrían encontrar una advertencia utilizando `apt-key` para añadir la clave de firma del repositorio de k6:
+
+> `Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8))`
+
+Para evitar esto, y estar a prueba del futuro, se recomienda remover la clave existente de `security@k6.io`, y actualizar la lista de repositorios.
 
 ```bash
 # borra la clave existente

--- a/src/data/markdown/translated-guides/es/01 Getting started/02 Installation/01 Troubleshooting.md
+++ b/src/data/markdown/translated-guides/es/01 Getting started/02 Installation/01 Troubleshooting.md
@@ -1,0 +1,62 @@
+---
+title: 'Solución de problemas'
+excerpt: 'Instrucciones para corregir problemas comunes de instalación.'
+---
+
+## Sistema no tiene ca-certificates or gnupg2
+
+Algunas distribuciones de Linux no vienen con los paquetes `ca-certificates` y `gnupg2` instalados.
+Si usa tal distribución, necesita instalarlos con:
+
+```bash
+sudo apt-get update && sudo apt-get install -y ca-certificates gnupg2
+```
+
+Este ejemplo es para Debian/Ubuntu y derivados. Consulte la documentación de su distribución si usa una diferente.
+
+
+## apt-key es deprecado
+
+Algunos usuarios de Debian/Ubuntu y derivados podrían encontrar una advertencia utilizando `apt-key` para añadir la clave de firma del repositorio de k6: `Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8))`. Para evitar esto, y estar a prueba del futuro, se recomienda remover la clave existente de `security@k6.io`, y actualizar la lista de repositorios.
+
+```bash
+# borra la clave existente
+sudo apt-key del k6
+
+# importa la clave de la forma recomendada
+sudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
+
+# actualiza el repositorio
+echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
+sudo apt-get update
+```
+
+
+## Error importando la clave GPG de k6
+
+El comando `gpg` para importar la clave de firma podría fallar con:
+```bash
+gpg: keybox '/usr/share/keyrings/k6-archive-keyring.gpg' created
+gpg: failed to create temporary file '/root/.gnupg/.#lk0x000055db689f2310.a86c4b090dc7.7': No such file or directory
+gpg: connecting dirmngr at '/root/.gnupg/S.dirmngr' failed: No such file or directory
+gpg: keyserver receive failed: No dirmngr
+```
+
+Esto pasaría si es la primera vez que ejecuta `gpg` para ese usuario, por lo que el directorio `/root/.gnupg/` no existe. Puede crearlo ejecutando `sudo gpg -k` e intentando importar la clave nuevamente.
+
+
+## En caso de usar un muro de fuego o proxy
+
+Algunos usuarios han reportado no poder importar la clave de firma de k6 desde el servidor de Ubuntu usando el comando `gpg`, debido a que la solicitud es bloqueada por un muro de fuego o proxy en su red. Si tiene este problema, puede intentar hacerlo de la siguiente manera:
+
+```bash
+curl -s https://dl.k6.io/key.gpg | gpg --dearmor | sudo tee /usr/share/keyrings/k6-archive-keyring.gpg
+```
+
+
+## Versiones anteriores a CentOS 8
+
+Versiones anteriores a CentOS 8 no soportan firmas PGP V4 que utilizamos, por lo que debe deshabilitar la verificación instalando k6 con:
+```bash
+$ sudo yum install --nogpgcheck k6
+```


### PR DESCRIPTION
This does some of my suggestions in #640, syncs the English and Spanish installation instructions, and adds the Spanish troubleshooting document.