### PR TITLE
fix: fix ID generation for TOC

### DIFF
--- a/src/components/shared/heading/heading.module.scss
+++ b/src/components/shared/heading/heading.module.scss
@@ -31,7 +31,7 @@
 .mark-heading {
   position: relative;
   margin-bottom: 15px;
-  a {
+  .anchor-icon {
     position: absolute;
     left: -20px;
     visibility: hidden;

--- a/src/components/shared/heading/heading.module.scss
+++ b/src/components/shared/heading/heading.module.scss
@@ -31,7 +31,7 @@
 .mark-heading {
   position: relative;
   margin-bottom: 15px;
-  .anchor-icon {
+  a:first-child {
     position: absolute;
     left: -20px;
     visibility: hidden;
@@ -44,7 +44,7 @@
     }
   }
   &:hover {
-    a {
+    a:first-child {
       visibility: visible;
     }
   }

--- a/src/hooks/use-landmark.js
+++ b/src/hooks/use-landmark.js
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { anchorify } from 'utils';
 
 const useLandmark = ({ containerRef, markSelector }, deps = []) => {
   const [links, setLinks] = useState([]);
@@ -9,7 +10,7 @@ const useLandmark = ({ containerRef, markSelector }, deps = []) => {
       setLinks(
         Array.from(allMarks).map(({ id, innerText, tagName }) => ({
           title: innerText,
-          anchor: `#${id}`,
+          anchor: `#${id || anchorify(innerText)}`,
           tagName,
         })),
       );


### PR DESCRIPTION
This PR returns back condition `id || anchorify(innerText)` when generating links for TOC because sometimes TOC renders before headings get IDs assigned

Also, this PR brings a small fix for anchor selector in headings