### PR TITLE
Use only the hyphenated log-format option

### DIFF
--- a/src/data/markdown/translated-guides/en/02 Using k6/05 Options.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/05 Options.md
@@ -804,12 +804,12 @@ A value specifying the log format. By default, k6 includes extra debug informati
 
 | Env            | CLI                 | Code / Config file | Default |
 | -------------- | ------------------- | ------------------ | ------- |
-| `K6_LOGFORMAT` | `--logformat`, `-f` | N/A                |         |
+| `K6_LOG_FORMAT` | `--log-format`, `-f` | N/A                |         |
 
 <CodeGroup labels={[]} lineNumbers={[true]}>
 
 ```bash
-$ k6 run --logformat raw test.js
+$ k6 run --log-format raw test.js
 ```
 
 </CodeGroup>

--- a/src/data/markdown/translated-guides/es/02 Using k6/05 Options.md
+++ b/src/data/markdown/translated-guides/es/02 Using k6/05 Options.md
@@ -656,12 +656,12 @@ Un valor que especifica el formato del registro. Por defecto, k6 incluye informa
 
 | Env            | CLI                 | Code / Config file | Default |
 | -------------- | ------------------- | ------------------ | ------- |
-| `K6_LOGFORMAT` | `--logformat`, `-f` | N/A                |         |
+| `K6_LOG_FORMAT` | `--log-format`, `-f` | N/A                |         |
 
 <CodeGroup labels={[]} lineNumbers={[true]}>
 
 ```bash
-$ k6 run --logformat raw test.js
+$ k6 run --log-format raw test.js
 ```
 
 </CodeGroup>


### PR DESCRIPTION
This now supported since v0.38.0, and is more consistent. The old option still works, there is just no need to document both of them.