### PR TITLE
Address broken links in jslib-aws's docs and update to v0.4.0

### DIFF
--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/01 S3Client.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/01 S3Client.md
@@ -37,7 +37,7 @@ import { check } from 'k6';
 import exec from 'k6/execution';
 import http from 'k6/http';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.3.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.4.0/s3.js';
 
 const awsConfig = new AWSConfig(
   __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/01 S3Client.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/01 S3Client.md
@@ -11,13 +11,13 @@ S3Client is included in both the dedicated jslib `s3.js` bundle, and the `aws.js
 
 ### Methods
 
-| Function                                                                                                                  | Description                                           |
-| :------------------------------------------------------------------------------------------------------------------------ | :---------------------------------------------------- |
-| [listBuckets()](/javascript-api/jslib/aws/s3client/s3client-listbuckets)                                                  | List the buckets the authenticated user has access to |
-| [listObjects(bucketName, [prefix])](/javascript-api/jslib/aws/s3client/s3client-listobjects-bucketname-prefix)            | List the objects contained in a bucket                |
-| [getObject(bucketName, objectKey)](/javascript-api/jslib/aws/s3client/s3client-getobject-bucketname-objectkey)            | Download an object from a bucket                      |
-| [putObject(bucketName, objectKey, data)](/javascript-api/jslib/aws/s3client/s3client-putobject-bucketname-objectkey-data) | Upload an object to a bucket                          |
-| [deleteObject(bucketName, objectKey)](/javascript-api/jslib/aws/s3client/s3client-deleteobject-bucketname-objectkey)      | Delete an object from a bucket                        |
+| Function                                                                                         | Description                                           |
+| :----------------------------------------------------------------------------------------------- | :---------------------------------------------------- |
+| [listBuckets()](/javascript-api/jslib/aws/s3client/s3client-listbuckets)                         | List the buckets the authenticated user has access to |
+| [listObjects(bucketName, [prefix])](/javascript-api/jslib/aws/s3client/s3client-listobjects/)    | List the objects contained in a bucket                |
+| [getObject(bucketName, objectKey)](/javascript-api/jslib/aws/s3client/s3client-getobject/)       | Download an object from a bucket                      |
+| [putObject(bucketName, objectKey, data)](/javascript-api/jslib/aws/s3client/s3client-putobject/) | Upload an object to a bucket                          |
+| [deleteObject(bucketName, objectKey)](/javascript-api/jslib/aws/s3client/s3client-deleteobject/) | Delete an object from a bucket                        |
 
 ### Throws
 

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/02 SecretsManagerClient.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/02 SecretsManagerClient.md
@@ -35,7 +35,7 @@ S3 Client methods will throw errors in case of failure.
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.3.0/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.4.0/secrets-manager.js';
 
 const awsConfig = new AWSConfig(
   __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/02 SecretsManagerClient.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/02 SecretsManagerClient.md
@@ -11,13 +11,13 @@ SecretsManagerClient is included in both the dedicated jslib `secrets-manager.js
 
 ### Methods
 
-| Function                                                                                                                                                                                              | Description                                  |
-| :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------- |
-| [listSecrets()](/javascript-api/jslib/aws/secretsmanagerclient/secretsmanagerclient-listsecrets/)                                                                                                     | List secrets owned by the authenticated user |
-| [getSecret(secretID)](/javascript-api/jslib/aws/secretsmanagerclient/secretsmanagerclient-getsecret-secretid)                                                                                         | Download a secret                            |
-| [createSecret(name, secretString, description, [versionID], [tags])](/javascript-api/jslib/aws/secretsmanagerclient/secretsmanagerclient-createsecret-name-secretstring-description-versionid-tags)   | Create a new secret                          |
-| [putSecretValue(secretID, secretString, [versionID])](/javascript-api/jslib/aws/secretsmanagerclient/secretsmanagerclient-putsecret-secretid-secretstring-versionid-tags)                             | Update a secret                              |
-| [deleteSecret(secretID, { recoveryWindow: 30, noRecovery: false}})](/javascript-api/jslib/aws/secretsmanagerclient/secretsmanagerclient-deletesecret-secretid-{-recoverywindow-30-norecovery-false}}) | Delete a secret                              |
+| Function                                                                                                                                                | Description                                  |
+| :------------------------------------------------------------------------------------------------------------------------------------------------------ | :------------------------------------------- |
+| [listSecrets()](/javascript-api/jslib/aws/secretsmanagerclient/secretsmanagerclient-listsecrets/)                                                       | List secrets owned by the authenticated user |
+| [getSecret(secretID)](/javascript-api/jslib/aws/secretsmanagerclient/secretsmanagerclient-getsecret/)                                                   | Download a secret                            |
+| [createSecret(name, secretString, description, [versionID], [tags])](/javascript-api/jslib/aws/secretsmanagerclient/secretsmanagerclient-createsecret/) | Create a new secret                          |
+| [putSecretValue(secretID, secretString, [versionID])](/javascript-api/jslib/aws/secretsmanagerclient/secretsmanagerclient-putsecretvalue/)              | Update a secret                              |
+| [deleteSecret(secretID, { recoveryWindow: 30, noRecovery: false}})](/javascript-api/jslib/aws/secretsmanagerclient/secretsmanagerclient-deletesecret/)  | Delete a secret                              |
 
 ### Throws
 

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/03 AwsConfig.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/03 AwsConfig.md
@@ -5,15 +5,15 @@ description: 'AWSConfig is used to configure an AWS service client instances'
 excerpt: 'AWSConfig is used to configure an AWS service client instances'
 ---
 
-AWSConfig is used to configure an AWS service client instance, such as [S3Client](/javascript-api/jslib/aws/s3client) or [SecretsManagerClient](/javascript-api/jslib/aws/s3client). It effectively allows the user to select a [region](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html) they wish to interact with, and the AWS credentials they wish to use to authenticate.
+AWSConfig is used to configure an AWS service client instance, such as [S3Client](/javascript-api/jslib/aws/s3client) or [SecretsManagerClient](/javascript-api/jslib/aws/secretsmanagerclient). It effectively allows the user to select a [region](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html) they wish to interact with, and the AWS credentials they wish to use to authenticate.
 
 AWSConfig is included in the `aws.js` bundle, which includes all the content of the library. It is also included in the various services clients dedicated bundles such as `s3.js` and `secrets-manager.js`.
 
-| Parameter                  | Type   | Description                                                                                                             |
-| :------------------------- | :----- | :---------------------------------------------------------------------------------------------------------------------- |
-| region                     | string | the AWS region to connect to. As described by Amazon AWS docs: https://docs.aws.amazon.com/general/latest/gr/rande.html |
-| accessKeyID                | string | The AWS access key ID credential to use for authentication.                                                             |
-| secretAccessKey (optional) | string | The AWS secret access credential to use for authentication.                                                             |
+| Parameter                  | Type   | Description                                                                                                               |
+| :------------------------- | :----- | :------------------------------------------------------------------------------------------------------------------------ |
+| region                     | string | the AWS region to connect to. As described by [Amazon AWS docs](https://docs.aws.amazon.com/general/latest/gr/rande.html) |
+| accessKeyID                | string | The AWS access key ID credential to use for authentication.                                                               |
+| secretAccessKey (optional) | string | The AWS secret access credential to use for authentication.                                                               |
 
 ### Throws
 

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/03 AwsConfig.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/03 AwsConfig.md
@@ -32,7 +32,7 @@ import exec from 'k6/execution';
 
 // Note that you AWSConfig is also included in the dedicated service
 // client bundles such as `s3.js` and `secrets-manager.js`
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.3.0/aws.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.4.0/aws.js';
 
 const awsConfig = new AWSConfig(
   __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/S3Client/01 listBuckets().md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/S3Client/01 listBuckets().md
@@ -19,7 +19,7 @@ excerpt: 'S3Client.listBuckets lists the buckets the authenticated user has acce
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.3.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.4.0/s3.js';
 
 const awsConfig = new AWSConfig(
   __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/S3Client/02 listObjects(bucketName, [prefix]).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/S3Client/02 listObjects(bucketName, [prefix]).md
@@ -24,7 +24,7 @@ excerpt: 'S3Client.listObjects lists the objects contained in a bucket'
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.3.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.4.0/s3.js';
 
 const awsConfig = new AWSConfig(
   __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/S3Client/03 getObject(bucketName, objectKey).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/S3Client/03 getObject(bucketName, objectKey).md
@@ -24,7 +24,7 @@ excerpt: 'S3Client.getObject downloads an object from a bucket'
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.3.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.4.0/s3.js';
 
 const awsConfig = new AWSConfig(
   __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/S3Client/04 putObject(bucketName, objectKey, data).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/S3Client/04 putObject(bucketName, objectKey, data).md
@@ -17,7 +17,7 @@ excerpt: 'S3Client.putObject uploads an object to a bucket'
 <CodeGroup labels={[]}>
 
 ```javascript
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.3.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.4.0/s3.js';
 
 const awsConfig = new AWSConfig(
   __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/S3Client/05 deleteObject(bucketName, objectKey).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/S3Client/05 deleteObject(bucketName, objectKey).md
@@ -18,7 +18,7 @@ excerpt: 'S3Client.deleteObject deletes an object from a bucket'
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.3.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.4.0/s3.js';
 
 const awsConfig = new AWSConfig(
   __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/S3Client/98 Object.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/S3Client/98 Object.md
@@ -26,7 +26,7 @@ import {
   // listBuckets,
   AWSConfig,
   S3Client,
-} from 'https://jslib.k6.io/aws/0.3.0/s3.js';
+} from 'https://jslib.k6.io/aws/0.4.0/s3.js';
 
 const awsConfig = new AWSConfig(
   __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/S3Client/99 Bucket.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/S3Client/99 Bucket.md
@@ -16,7 +16,7 @@ Bucket is returned by the S3Client.* methods that query S3 buckets. Namely, `lis
 <CodeGroup labels={[]}>
 
 ```javascript
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.3.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.4.0/s3.js';
 
 const awsConfig = new AWSConfig(
   __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/01 listSecrets().md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/01 listSecrets().md
@@ -19,7 +19,7 @@ excerpt: 'SecretsManagerClient.listSecrets lists the secrets the authenticated u
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.3.0/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.4.0/secrets-manager.js';
 
 const awsConfig = new AWSConfig(
   __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/02 getSecret(secretID).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/02 getSecret(secretID).md
@@ -23,7 +23,7 @@ excerpt: 'SecretsManagerClient.getSecret(secretID) downloads a secret from AWS s
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.3.0/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.4.0/secrets-manager.js';
 
 const awsConfig = new AWSConfig(
   __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/03 createSecret(name, secretString, description, [versionID], [tags]).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/03 createSecret(name, secretString, description, [versionID], [tags]).md
@@ -19,7 +19,7 @@ excerpt: 'SecretsManagerClient.createSecret creates a new secret'
 <CodeGroup labels={[]}>
 
 ```javascript
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.3.0/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.4.0/secrets-manager.js';
 
 const awsConfig = new AWSConfig(
   __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/04 deleteSecret(secretID, { recoveryWindow: 30, noRecovery: false}}).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/04 deleteSecret(secretID, { recoveryWindow: 30, noRecovery: false}}).md
@@ -16,7 +16,7 @@ excerpt: 'SecretsManagerClient.deleteSecret deletes a secret'
 <CodeGroup labels={[]}>
 
 ```javascript
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.3.0/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.4.0/secrets-manager.js';
 
 const awsConfig = new AWSConfig(
   __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/05 putSecretValue(secretID, secretString, [versionID]).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/05 putSecretValue(secretID, secretString, [versionID]).md
@@ -20,7 +20,7 @@ excerpt: "SecretsManagerClient.putSecretValue updates an existing secret's value
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.3.0/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.4.0/secrets-manager.js';
 
 const awsConfig = new AWSConfig(
   __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/99 Secret.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/99 Secret.md
@@ -22,7 +22,7 @@ Secret is returned by the SecretsManagerClient.* methods that query secrets. Nam
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.3.0/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.4.0/secrets-manager.js';
 
 const awsConfig = new AWSConfig(
   __ENV.AWS_REGION,


### PR DESCRIPTION
This PR fixes jslib-aws links, which are broken in the current version of the docs. It also modifies most jslib-aws documentation examples to use the latest version of the library (`v0.4.0`) instead. 

Review: could you please open the jslib/aws section and click on every link to verify I didn't miss any? 🙇🏻 