### PR TITLE
Updated the threshold key in the example

### DIFF
--- a/src/data/markdown/docs/05 Examples/01 Examples/01 single-request.md
+++ b/src/data/markdown/docs/05 Examples/01 Examples/01 single-request.md
@@ -25,7 +25,7 @@ export const options = {
     { target: 0, duration: '1m' },
   ],
   thresholds: {
-    requests: ['count < 100'],
+    http_reqs: ['count < 100'],
   },
 };
 


### PR DESCRIPTION
Update the threshold key to be in line with the name of the counter.

Using the current example produces the error:

ERRO[0000] invalid threshold defined on requests; reason: no metric name "requests" found