### PR TITLE
Add k6 extension xk6-oauth-pkce

### DIFF
--- a/src/data/doc-extensions/extensions.json
+++ b/src/data/doc-extensions/extensions.json
@@ -638,6 +638,18 @@
       },
       "official": false,
       "categories": ["Reporting"]
+    },
+    {
+      "name": "xk6-oauth-pkce",
+      "description": "Generate OAuth PKCE code verifier and code challenge",
+      "url": "https://github.com/frankhefeng/xk6-oauth-pkce",
+      "logo": "",
+      "author": {
+        "name": "Feng He",
+        "url": "https://github.com/frankhefeng"
+      },
+      "official": false,
+      "categories": ["Authentication"]
     }
   ]
 }


### PR DESCRIPTION
`xk6-oauth-pkce` provides the capability to generate [OAuth PKCE](https://datatracker.ietf.org/doc/html/rfc7636) code verifier and code challenge.