### PR TITLE
WIP: programmatically builds Glossary w/ JS script and JSON data

### DIFF
--- a/src/data/glossary/gloss.json
+++ b/src/data/glossary/gloss.json
@@ -1,0 +1,247 @@
+[
+  {
+    "term": "Concurrency",
+    "definition": "When multiple computations happen at the same time.\nIn the context of k6, virtual users can make concurrent requests as a test runs. In k6 cloud, you can also run multiple tests concurrently."
+  },
+  {
+    "term": "Correlation",
+    "definition": "The process of capturing dynamic data received from the system under test and reusing the data in subsequent requests. A common use case for correlation is retrieving and reusing a session id, or token, throughout the whole lifetime of a [virtual user](#virtual-user).",
+    "see_also": [
+      "[Correlation and dynamic data example](https://k6.io/docs/examples/correlation-and-dynamic-data/)",
+      "[Correlation in testing APIs](https://k6.io/docs/testing-guides/api-load-testing/#correlation-and-data-parameterization)"
+    ],
+    "dnt": false,
+    "en_US_note": "Avoid using \"correlation\" in the statistical sense, unless the usage is precise and necessary"
+  },
+  {
+    "term": "Checks",
+    "definition": "Conditions that validate the correctness of a service.\nIn k6, checks are an object in the API that validates a test condition.",
+    "see_also": [
+      "[/using-k6/checks]"
+    ],
+    "en_US_note": "Grafana also uses checks as a concept in their synthetic monitoring service."
+  },
+  {
+    "term": "Duration",
+    "definition": "The length of time that a test runs. When duration is set as an option, VU code runs for the length of time specified.",
+    "see_also": [
+      "[Duration option](https://k6.io/docs/using-k6/k6-options/reference/#duration)"
+    ]
+  },
+  {
+    "term": "Dynamic data",
+    "definition": "Data that might, or will, change between test runs. Common examples are order ids, session tokens or timestamps.",
+    "see_also": [
+      "[Correlation and dynamic data example](https://k6.io/docs/examples/correlation-and-dynamic-data/)"
+    ],
+    "dnt": false,
+    "en_US_note": null
+  },
+  {
+    "term": "Endurance testing",
+    "definition": "A synonym for [soak testing](#soak-test).",
+    "see_also": null,
+    "dnt": false,
+    "en_US_note": "Prefer Soak testing"
+  },
+  {
+    "term": "Executor",
+    "definition": "An attribute that configures VU behavior in a scenario."
+  },
+  {
+    "term": "Goja",
+    "definition": "A JavaScript runtime, purely written in go, that emphasizes standard compliance and performance. We use goja to allow for test scripting without having to compromise speed, efficiency or reliability, which would have been the case using NodeJS. For more details, see the [Goja repository on GitHub](https://github.com/dop251/goja).",
+    "see_also": null,
+    "dnt": true,
+    "en_US_note": null
+  },
+  {
+    "term": "Graceful stop",
+    "definition": "Some period of intentional ramping down at the end of a load test. Graceful stops prevent abrupt, unrealistic drops to zero VUs.",
+    "see_also": [
+      "The [Graceful stop reference](https://k6.io/docs/using-k6/scenarios/graceful-stop/)"
+    ]
+  },
+  {
+    "term": "Horizontal scalability",
+    "definition": "The degree to which one can improve the performance of a system by adding more nodes (servers or computers for instance).",
+    "see_also": null,
+    "dnt": false
+  },
+  {
+    "term": "HTTP archive (HAR file)",
+    "definition": "A file containing logs of a browser interactions with the system under test. All of the included transactions are stored as JSON-formatted text. These archives may then be used to generate test scripts using, for instance, the [har-to-k6 Converter](https://github.com/k6io/har-to-k6).\n\nFor more details, see the [HAR 1.2 Specification](http://www.softwareishard.com/blog/har-12-spec/).",
+    "see_also": [
+      "[Har converter](https://k6.io/docs/test-authoring/recording-a-session/har-converter/)"
+    ],
+    "dnt": false,
+    "en_US_note": null
+  },
+  {
+    "term": "Iteration",
+    "definition": "An iteration is an execution of the `default function`, or scenario `exec` function.\nYou can either calculate iterations across all [virtual users](#virtual-users) (as done by the [Shared iterations](/using-k6/scenarios/executors/shared-iterations) executor), or per virtual user (as the [Per-VU Iterations](/using-k6/scenarios/executors/per-vu-iterations)).",
+    "see_also": [
+      "The [test life cycle](https://k6.io/docs/using-k6/test-life-cycle/) document breaks down each stage of a k6 script, including iterations in VU code."
+    ],
+    "dnt": false,
+    "en_US_note": "Applies only to code in VU context."
+  },
+  {
+    "term": "k6 Cloud",
+    "definition": "**k6 Cloud** is the common name for the entire cloud product, which is composed of both k6 Cloud Execution and k6 Cloud Test Results.",
+    "see_also": [
+      "[k6 Cloud docs](https://k6.io/docs/cloud)"
+    ],
+    "dnt": true,
+    "en_US_note": null
+  },
+  {
+    "term": "k6 Options",
+    "definition": "Values that configure a k6 test run. Can be set with command-line flags, environment variables, and in the script.",
+    "see_also": [
+      "[k6 Options](/using-ky/k6-options)"
+    ],
+    "dnt": false
+  },
+  {
+    "term": "Load test",
+    "definition": "A test that assesses the performance of the system under test in terms of concurrent users or requests per second.",
+    "see_also": [
+      "[Load Testing](/test-types/load-testing)"
+    ],
+    "dnt": false,
+    "en_US_note": null
+  },
+  {
+    "term": "Metric",
+    "definition": "Anything measurable that a test emits. Users use metrics to assess the performance of the system under test in terms of concurrent users or requests per second.",
+    "see_also": [
+      "[Metrics](/using-k6/metrics)"
+    ],
+    "dnt": false
+  },
+  {
+    "term": "Metric sample",
+    "definition": "A metric's value (and, in time-series data, its timestamp)",
+    "dnt": false,
+    "en_US_note": null
+  },
+  {
+    "term": "Parameterization",
+    "definition": "The process of turning test values into reusable parameters, e.g. through variables and shared arrays.",
+    "see_also": [
+      "[Data parameterization examples](https://k6.io/docs/examples/data-parameterization/)"
+    ],
+    "dnt": false
+  },
+  {
+    "term": "Reliability",
+    "definition": "The degree to which a system can produce reliable results consecutively, even under pressure.",
+    "see_also": null,
+    "dnt": false
+  },
+  {
+    "term": "Requests per second",
+    "definition": "the rate at which requests are executed against the system under test.",
+    "see_also": null,
+    "dnt": false
+  },
+  {
+    "term": "Saturation",
+    "definition": "A condition when a system's reaches full resource utilization, and can handle no additional request.",
+    "see_also": null,
+    "dnt": false,
+    "en_US_note": null
+  },
+  {
+    "term": "Scalability",
+    "definition": "The degree to which system under test’s performance or capacity may be increased by adding additional resources. See [Vertical scalability](#vertical-scalability) and [Horizontal scalability](#horizontal-scalability).",
+    "see_also": null,
+    "dnt": false
+  },
+  {
+    "term": "Scenario",
+    "definition": "A special option that models plausible events that an application could experience. To model high traffic, a scenario might have virtual users making concurrent requests over multiple script iterations.",
+    "see_also": [
+      "[Scenarios reference](/using-k6/scenarios)"
+    ]
+  },
+  {
+    "term": "Service-level agreement",
+    "definition": "an agreement made between the one providing the service and someone, often a user of the service, promising that the availability of the service will meet a certain level during a certain period.",
+    "dnt": false
+  },
+  {
+    "term": "Service-level indicator (SLI)",
+    "definition": "the metric we use to measure whether a service meets the [service-level objective (SLO)](#service-level-objective). While doing performance monitoring this could, for instance, be the number of successful requests against the service during a specified period.",
+    "dnt": false
+  },
+  {
+    "term": "Service-level objective (SLO)",
+    "defintion": "An actual target, either internal or part of the [service-level agreement (SLA)](#service-level-agreement), for the availability of the service. This is often expressed as a percentage (99,2%, for instance). If the service meets or exceeds this target, it's deemed stable."
+  },
+  {
+    "term": "Smoke test",
+    "definition": "A type of test used to verify that the system under test can handle a minimal amount of load without any issues. It’s commonly used as a first step, to ensure that everything works as intended under optimal conditions, before advancing to any of the other performance test types.",
+    "see_also": [
+      "[Smoke Testing](/test-types/smoke-testing)"
+    ],
+    "dnt": false
+  },
+  {
+    "term": "Soak test",
+    "definition": "A type of test used to uncover performance and reliability issues stemming from a system being under pressure for an extended period.",
+    "see_also": "[Soak Testing](/test-types/soak-testing)",
+    "dnt": false
+  },
+  {
+    "Term": "Stability",
+    "definition": "A trait used to describe a system under test’s ability to withstand failures and erroneous behavior under normal usage.",
+    "dnt": false
+  },
+  {
+    "term": "Stress test",
+    "definition": "A type of test used to identify the limits of what the system under test is capable of handling in terms of load.",
+    "see_also": [
+      "[Stress Testing](/test-types/stress-testing)"
+    ]
+  },
+  {
+    "term": "System under test",
+    "definition": "The actual piece of software that we're currently testing. This could be an API, a website, infrastructure, or any combination of these.",
+    "dnt": false
+  },
+  {
+    "term": "Test run",
+    "definition": "An individual execution of a test script.",
+    "see_also": [
+      "[Running k6](/getting-started/running-k6)"
+    ],
+    "en_US_note": "Prefer *run* over *execution*."
+  },
+  {
+    "term": "Test script",
+    "definition": "The actual code you run as part of your test run, as well as any (or at least most) of the configuration needed to run the code. It defines how the test will behave as well as what requests will be made. See the [Single Request example](/examples/single-request).",
+    "see_also": null
+  },
+  {
+    "term": "Threshold",
+    "definition": "A minimum value that indicates something significant about a system.\nIn k6, thresholds are pass/fail criteria that specify the performance expectations of the system under test.",
+    "see_also": [
+      "[k6.io/docs/using-k6/thresholds](Thresholds are pass/fail criteria that specify the performance expectations of the system under test.)"
+    ],
+    "dnt": false,
+    "en_US_note": "Grafana also has thresholds, which mean something different from k6."
+  },
+  {
+    "term": "Vertical scalability",
+    "definition": "A trait describing to what degree a system under test’s performance or capacity may be increased by adding more hardware resources to a node (RAM, cores, bandwidth, etc.)."
+  },
+  {
+    "term": "Virtual users (VU)",
+    "definition": "The simulated users that perform separate and concurrent iterations of your test script.",
+    "see_also": [
+      "[Tutorial to calculate the number of Virtual Users with Google Analytics](https://k6.io/blog/monthly-visits-concurrent-users)."
+    ]
+  }
+]

--- a/src/data/glossary/vocab.js
+++ b/src/data/glossary/vocab.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const fs = require('fs');
+const rawdata = fs.readFileSync('gloss.json');
+const words = JSON.parse(rawdata);
+const frontmatter = `---
+title: Glossary
+excerpt: 'Find a list of terms commonly used within the k6 project and what we mean when we use them.'
+---\n`;
+let list = '';
+
+function makeDoc(words) {
+  for (let i = 0; i < words.length; i++) {
+    list += `<dt id="${words[i]['term']}"><b> ${words[i]['term']}</b></dt>
+    <dd> ${words[i]['definition']} </dd> \n`;
+  }
+  return `${frontmatter} <dl> ${list} </dl>`;
+}
+
+fs.writeFile("glossary.md", makeDoc(words), function(err) {
+  if(err) {
+    return console.log(err);
+  }
+  console.log("File saved at glossary.md");
+});

--- a/src/data/markdown/translated-guides/en/07 Misc/09 Glossary.md
+++ b/src/data/markdown/translated-guides/en/07 Misc/09 Glossary.md
@@ -3,187 +3,82 @@ title: Glossary
 excerpt: 'Find a list of terms commonly used within the k6 project and what we mean when we use them.'
 ---
 
-When discussing complex topics, it is usually a good idea to define a clear, shared terminology to ensure that we leave as little room as possible for misunderstandings. Below, you'll find a list of terms commonly used within the k6 project and what we mean when we use them.
-
-<Glossary>
-
-- [Correlation](#correlation)
-- [Dynamic Data](#dynamic-data)
-- [Endurance Testing](#endurance-testing)
-- [Goja](#goja)
-- [Horizontal Scalability](#horizontal-scalability)
-- [HTTP Archive](#http-archive)
-- [k6 Cloud](#k6-cloud)
-- [Load Test](#load-test)
-- [Metric](#metric)
-- [Parameterization](#parameterization)
-- [Performance Threshold](#performance-threshold)
-- [Reliability](#reliability)
-- [Requests per Second](#requests-per-second)
-- [Saturation](#saturation)
-- [Scalability](#scalability)
-- [Service-level Agreement](#service-level-agreement)
-- [Service-level Indicator](#service-level-indicator)
-- [Service-level Objective](#service-level-objective)
-- [Smoke test](#smoke-test)
-- [Soak test](#soak-test)
-- [Stability](#stability)
-- [Stress test](#stress-test)
-- [System under test](#system-under-test)
-- [Test configuration](#test-configuration)
-- [Test Run](#test-run)
-- [Test Script](#test-script)
-- [User Journey](#user-journey)
-- [User Scenario](#user-scenario)
-- [Vertical Scalability](#vertical-scalability)
-- [Virtual Users](#virtual-users)
-
-</Glossary>
-
-### Correlation
-
-**Correlation** is a term used for describing the process of capturing dynamic data, received from the system under test, for reuse in subsequent requests. A common use case for correlation is retrieving and reusing a session id, or token, throughout the whole lifetime of a [virtual user](#virtual-user).
-
-### Dynamic Data
-
-**Dynamic data** is data that might, or will, change between test runs. Common examples are order ids, session tokens or timestamps.
-
-### Endurance Testing
-
-**Endurance testing** is a synonym for [soak testing](#soak-test).
-
-### Goja
-
-**Goja** is a JavaScript runtime, purely written in go, that emphasizes standard compliance and performance. We use goja to allow for test scripting without having to compromise speed, efficiency or reliability, which would have been the case using NodeJS. For more details, see the [Goja repository on GitHub](https://github.com/dop251/goja).
-
-### Horizontal Scalability
-
-**Horizontal Scalability** is a trait describing to what degree a system under test’s performance and capacity may be increased by adding more nodes (servers or computers for instance).
-
-### HTTP Archive
-
-An **HTTP Archive**, or **HAR file**, is a file containing logs of a browser interactions with the system under test. All of the included transactions are stored as JSON-formatted text. These archives may then be used to generate test scripts using, for instance, the [har-to-k6 Converter](https://github.com/k6io/har-to-k6). For more details, see the [HAR 1.2 Specification](http://www.softwareishard.com/blog/har-12-spec/).
-
-### Iteration
-
-An iteration is an execution of the `default function`, or scenario `exec` function.
-
-You can either calculate iterations across all [virtual users](#virtual-users) (as done by the [Shared iterations](/using-k6/scenarios/executors/shared-iterations) executor), or per virtual user (as the [Per-VU Iterations](/using-k6/scenarios/executors/per-vu-iterations)).
-
-### k6 Cloud
-
-**k6 Cloud** is the common name for the entire cloud product, which is composed of both k6 Cloud Execution and k6 Cloud Test Results.
-
-### Load Test
-
-A **load test** is a type of test used to assess the performance of the system under test in terms of concurrent users or requests per second. See [Load Testing](/test-types/load-testing).
-
-### Metric
-
-A **metric** is a calculation that, using measurements, serves as an indicator of how the system under test performs under a given condition.
-
-### Parameterization
-
-**Parameterization** refers to the process of building a test in such a way that the values used throughout the test might be changed without having to change the actual test script.
-
-### Performance Threshold
-
-A **performance threshold** describes the limits of what is considered acceptable values for a metric produced by a performance test. In many ways, this is similar to an [SLO](#service-level-objective), although a performance threshold only concerns itself with a single metric.
-
-### Reliability
-
-**Reliability** is a trait used to describe a system under test’s ability to produce reliable results consecutively, even under pressure.
-
-### Requests per Second
-
-**Requests per Second**, or **RPS**, is the rate at which requests are executed against the system under test.
-
-### Saturation
-
-**Saturation** is reached when the system under test is fully utilized and hence, unable to handle any additional requests.
-
-### Scalability
-
-**Scalability** is a trait used to describe to what degree a system under test’s performance or capacity may be increased by adding additional resources. See [Vertical scalability](#vertical-scalability) and [Horizontal scalability](#horizontal-scalability).
-
-### Service-level Agreement
-
-A **service-level agreement**, or **SLA** is an agreement made between the one providing the service and someone, often a user of the service, promising that the availability of the service will meet a certain level during a certain period.
-
-If the service provider fails to deliver on that promise, some kind of penalty is usually applied, like a partial or full refund, or monetary compensation.
-
-### Service-level Indicator
-
-A **service-level indicator**, or **SLI** is the metric we use to measure whether a service meets the [service-level objective (SLO)](#service-level-objective). While doing performance monitoring this could, for instance, be the number of successful requests against the service during a specified period.
-
-### Service-level Objective
-
-A **service-level objective**, or **SLO** is an actual target, either internal or part of the [service-level agreement (SLA)](#service-level-agreement), for the availability of the service. This is often expressed as a percentage (99,2%, for instance). If the service meets or exceeds this target, it's deemed stable.
-
-### Smoke test
-
-A **smoke test** is a type of test used to verify that the system under test can handle a minimal amount of load without any issues. It’s commonly used as a first step, to ensure that everything works as intended under optimal conditions, before advancing to any of the other performance test types. See [Smoke Testing](/test-types/smoke-testing).
-
-### Soak test
-
-A **soak test** is a type of test used to uncover performance and reliability issues stemming from a system being under pressure for an extended period. See [Soak Testing](/test-types/soak-testing).
-
-### Stability
-
-**Stability** is a trait used to describe a system under test’s ability to withstand failures and erroneous behavior under normal usage.
-
-### Stress test
-
-A **stress test** is a type of test used to identify the limits of what the system under test is capable of handling in terms of load. See [Stress Testing](/test-types/stress-testing).
-
-### System under test
-
-**System under test** refers to the actual piece of software that we're currently testing. This could be an API, a website, infrastructure, or any combination of these.
-
-### Test Configuration
-
-The options object of a test script or configuration parameters passed via the CLI. See [Options](/using-k6/options).
-
-### Test Run
-
-An individual execution of a test script. See [Running k6](/getting-started/running-k6).
-
-### Test Script
-
-A **test script** is the actual code you run as part of your test run, as well as any (or at least most) of the configuration needed to run the code. It defines how the test will behave as well as what requests will be made. See the [Single Request example](/examples/single-request).
-
-### User Journey
-
-**User journey** is used to describe a sequence of actions taken by either a real or simulated user.
-
-### User Scenario
-
-**User Scenario** is a synonym for [user journey](#user-journey).
-
-### Vertical Scalability
-
-**Vertical scalability** is a trait describing to what degree a system under test’s performance or capacity may be increased by adding more hardware resources to a node (RAM, cores, bandwidth, etc.).
-
-### Virtual Users
-
-**Virtual Users**, or **VUs** are used to perform separate and concurrent executions of your test script. They can make HTTP(s) and WebSocket requests against a webpage or API.
-
-Virtual Users, although emulated by k6 itself, can be used to mimic the behavior of a real user.
-
-**Virtual Users in context of Web Apps/Websites**
-
-Virtual Users are designed to act and behave like real users/browsers would. That is, they are capable of making multiple network connections in parallel, just like a real user in a browser would. When using a [http.batch](/using-k6/options#batch) request, HTTP requests are sent in parallel. For further information, refer to the article about [load testing websites](/testing-guides/load-testing-websites).
-
-<CodeGroup labels={["Formula for calculating the number of VUs needed"]}>
-
-```plain
-VUs = (hourly sessions * average session duration in seconds)/3600
-```
-
-</CodeGroup>
-
-Read more about using this formula in the [tutorial to calculate the number of Virtual Users with Google Analytics](https://k6.io/blog/monthly-visits-concurrent-users).
-
-**Virtual Users in context of APIs**
-
-When testing individual API endpoints, you can take advantage of each VU making multiple requests each to produce requests per second(rps) a factor higher than your VU count. e.g. Your test may be stable with each VU making 10 rps each. If you wanted to reach 1000 RPS, you may only need 100 VUs in that case. For more information on testing APIs, please refer to our article [API Load Testing](/testing-guides/api-load-testing).
+ <dl> <dt id="Concurrency"><b> Concurrency</b></dt>
+    <dd> When multiple computations happen at the same time.
+In the context of k6, virtual users can make concurrent requests as a test runs. In k6 cloud, you can also run multiple tests concurrently. </dd> 
+<dt id="Correlation"><b> Correlation</b></dt>
+    <dd> The process of capturing dynamic data received from the system under test and reusing the data in subsequent requests. A common use case for correlation is retrieving and reusing a session id, or token, throughout the whole lifetime of a [virtual user](#virtual-user). </dd> 
+<dt id="Checks"><b> Checks</b></dt>
+    <dd> Conditions that validate the correctness of a service.
+In k6, checks are an object in the API that validates a test condition. </dd> 
+<dt id="Duration"><b> Duration</b></dt>
+    <dd> The length of time that a test runs. When duration is set as an option, VU code runs for the length of time specified. </dd> 
+<dt id="Dynamic data"><b> Dynamic data</b></dt>
+    <dd> Data that might, or will, change between test runs. Common examples are order ids, session tokens or timestamps. </dd> 
+<dt id="Endurance testing"><b> Endurance testing</b></dt>
+    <dd> A synonym for [soak testing](#soak-test). </dd> 
+<dt id="Executor"><b> Executor</b></dt>
+    <dd> An attribute that configures VU behavior in a scenario. </dd> 
+<dt id="Goja"><b> Goja</b></dt>
+    <dd> A JavaScript runtime, purely written in go, that emphasizes standard compliance and performance. We use goja to allow for test scripting without having to compromise speed, efficiency or reliability, which would have been the case using NodeJS. For more details, see the [Goja repository on GitHub](https://github.com/dop251/goja). </dd> 
+<dt id="Graceful stop"><b> Graceful stop</b></dt>
+    <dd> Some period of intentional ramping down at the end of a load test. Graceful stops prevent abrupt, unrealistic drops to zero VUs. </dd> 
+<dt id="Horizontal scalability"><b> Horizontal scalability</b></dt>
+    <dd> The degree to which one can improve the performance of a system by adding more nodes (servers or computers for instance). </dd> 
+<dt id="HTTP archive (HAR file)"><b> HTTP archive (HAR file)</b></dt>
+    <dd> A file containing logs of a browser interactions with the system under test. All of the included transactions are stored as JSON-formatted text. These archives may then be used to generate test scripts using, for instance, the [har-to-k6 Converter](https://github.com/k6io/har-to-k6).
+
+For more details, see the [HAR 1.2 Specification](http://www.softwareishard.com/blog/har-12-spec/). </dd> 
+<dt id="Iteration"><b> Iteration</b></dt>
+    <dd> An iteration is an execution of the `default function`, or scenario `exec` function.
+You can either calculate iterations across all [virtual users](#virtual-users) (as done by the [Shared iterations](/using-k6/scenarios/executors/shared-iterations) executor), or per virtual user (as the [Per-VU Iterations](/using-k6/scenarios/executors/per-vu-iterations)). </dd> 
+<dt id="k6 Cloud"><b> k6 Cloud</b></dt>
+    <dd> **k6 Cloud** is the common name for the entire cloud product, which is composed of both k6 Cloud Execution and k6 Cloud Test Results. </dd> 
+<dt id="k6 Options"><b> k6 Options</b></dt>
+    <dd> Values that configure a k6 test run. Can be set with command-line flags, environment variables, and in the script. </dd> 
+<dt id="Load test"><b> Load test</b></dt>
+    <dd> A test that assesses the performance of the system under test in terms of concurrent users or requests per second. </dd> 
+<dt id="Metric"><b> Metric</b></dt>
+    <dd> Anything measurable that a test emits. Users use metrics to assess the performance of the system under test in terms of concurrent users or requests per second. </dd> 
+<dt id="Metric sample"><b> Metric sample</b></dt>
+    <dd> A metric's value (and, in time-series data, its timestamp) </dd> 
+<dt id="Parameterization"><b> Parameterization</b></dt>
+    <dd> The process of turning test values into reusable parameters, e.g. through variables and shared arrays. </dd> 
+<dt id="Reliability"><b> Reliability</b></dt>
+    <dd> The degree to which a system can produce reliable results consecutively, even under pressure. </dd> 
+<dt id="Requests per second"><b> Requests per second</b></dt>
+    <dd> the rate at which requests are executed against the system under test. </dd> 
+<dt id="Saturation"><b> Saturation</b></dt>
+    <dd> A condition when a system's reaches full resource utilization, and can handle no additional request. </dd> 
+<dt id="Scalability"><b> Scalability</b></dt>
+    <dd> The degree to which system under test’s performance or capacity may be increased by adding additional resources. See [Vertical scalability](#vertical-scalability) and [Horizontal scalability](#horizontal-scalability). </dd> 
+<dt id="Scenario"><b> Scenario</b></dt>
+    <dd> A special option that models plausible events that an application could experience. To model high traffic, a scenario might have virtual users making concurrent requests over multiple script iterations. </dd> 
+<dt id="Service-level agreement"><b> Service-level agreement</b></dt>
+    <dd> an agreement made between the one providing the service and someone, often a user of the service, promising that the availability of the service will meet a certain level during a certain period. </dd> 
+<dt id="Service-level indicator (SLI)"><b> Service-level indicator (SLI)</b></dt>
+    <dd> the metric we use to measure whether a service meets the [service-level objective (SLO)](#service-level-objective). While doing performance monitoring this could, for instance, be the number of successful requests against the service during a specified period. </dd> 
+<dt id="Service-level objective (SLO)"><b> Service-level objective (SLO)</b></dt>
+    <dd> undefined </dd> 
+<dt id="Smoke test"><b> Smoke test</b></dt>
+    <dd> A type of test used to verify that the system under test can handle a minimal amount of load without any issues. It’s commonly used as a first step, to ensure that everything works as intended under optimal conditions, before advancing to any of the other performance test types. </dd> 
+<dt id="Soak test"><b> Soak test</b></dt>
+    <dd> A type of test used to uncover performance and reliability issues stemming from a system being under pressure for an extended period. </dd> 
+<dt id="undefined"><b> undefined</b></dt>
+    <dd> A trait used to describe a system under test’s ability to withstand failures and erroneous behavior under normal usage. </dd> 
+<dt id="Stress test"><b> Stress test</b></dt>
+    <dd> A type of test used to identify the limits of what the system under test is capable of handling in terms of load. </dd> 
+<dt id="System under test"><b> System under test</b></dt>
+    <dd> The actual piece of software that we're currently testing. This could be an API, a website, infrastructure, or any combination of these. </dd> 
+<dt id="Test run"><b> Test run</b></dt>
+    <dd> An individual execution of a test script. </dd> 
+<dt id="Test script"><b> Test script</b></dt>
+    <dd> The actual code you run as part of your test run, as well as any (or at least most) of the configuration needed to run the code. It defines how the test will behave as well as what requests will be made. See the [Single Request example](/examples/single-request). </dd> 
+<dt id="Threshold"><b> Threshold</b></dt>
+    <dd> A minimum value that indicates something significant about a system.
+In k6, thresholds are pass/fail criteria that specify the performance expectations of the system under test. </dd> 
+<dt id="Vertical scalability"><b> Vertical scalability</b></dt>
+    <dd> A trait describing to what degree a system under test’s performance or capacity may be increased by adding more hardware resources to a node (RAM, cores, bandwidth, etc.). </dd> 
+<dt id="Virtual users (VU)"><b> Virtual users (VU)</b></dt>
+    <dd> The simulated users that perform separate and concurrent iterations of your test script. </dd> 
+ </dl>


### PR DESCRIPTION
This is more of a proof of concept over anything else at this point.

Writing a glossary by hand in markdown has some problems:
- It's boring and repetitive to write
- So much repetition makes it easy to format improperly
- It doesn't let us use a description list, probably the ideal HTML element for a glossary
  - Writing a description list by hand is even more error-prone
- If we want to reuse the glossary in multiple places, we have to copy and paste
   - Possible areas for Reuse would be at the top of a reference (print the definition) or in a style guide (with notes on usage).

To solve these issues, this branch experiments with programmatically creating the glossary page:
- it writes definitions in `src/data/glossary/gloss.json`
- a script, vocab.json, parses the JSON file into definition list and writes the list to a file.

However, there are many, many issues to fix before this is a usable solution:

- [ ] The definitions themselves need to be proofread
- [ ] The definitions need to be vetted and approved by experts, and cross-referenced with Grafana's technical vocabulary
- [ ] I need to figure out how to add a "Read more" field only if the `see_also:` property in the JSON file is non-empty
- [ ] The code is likely really, really bad. I would be shocked if it wasn't. I would put on socks, rub them on a carpet, and touch a doorknob, just to reduce the shock.
- [ ] The markdown links in the definitions are broken in in-line HTML
  -  This is probably worth waiting for better extended-markdown support: https://github.com/grafana/k6-docs/issues/694
- [ ] There needs to be an introductory list, using the `<Glossary>` function.
- [ ] It would be better to use YAML instead of JSON, for increased writer comfort
- [ ] Reading the datafile needs to be incorporated into the build automation:
   - either with the CI
   - Or more likely, using [Gatsby's source from YAML feature](https://www.gatsbyjs.com/docs/how-to/sourcing-data/sourcing-from-json-or-yaml/)
