### PR TITLE
Update example for Page in docs

### DIFF
--- a/src/data/markdown/docs/30 xk6-browser/01 xk6-browser/09-page.md
+++ b/src/data/markdown/docs/30 xk6-browser/01 xk6-browser/09-page.md
@@ -121,7 +121,6 @@ import launcher from 'k6/x/browser';
 export default function () {
   const browser = launcher.launch('chromium', {
     headless: false,
-    slowMo: '500ms', // slow down by 500ms
   });
   const context = browser.newContext();
   const page = context.newPage();
@@ -140,7 +139,7 @@ export default function () {
   page.$('input[type="submit"]').click();
 
   // Wait for next page to load
-  page.waitForLoadState('networkdidle');
+  page.waitForNavigation();
 
   page.close();
   browser.close();

--- a/src/data/markdown/docs/30 xk6-browser/01 xk6-browser/09-page.md
+++ b/src/data/markdown/docs/30 xk6-browser/01 xk6-browser/09-page.md
@@ -131,6 +131,9 @@ export default function () {
   const elem = page.$('a[href="/my_messages.php"]');
   elem.click();
 
+  // Wait for login page to load
+  page.waitForLoadState();
+
   // Enter login credentials and login
   page.$('input[name="login"]').type('admin');
   page.$('input[name="password"]').type('123');


### PR DESCRIPTION
This PR updates the example mentioned in 'page' docs: https://k6.io/docs/javascript-api/xk6-browser/page/

In the example, the login credentials are set without waiting if login page is loaded or not.
The updated example waits till the login page loads and then tries to login with credentials.