### PR TITLE
Update 10-batch- requests -.md

### DIFF
--- a/src/data/markdown/docs/02 javascript api/08 k6-http/10-batch- requests -.md
+++ b/src/data/markdown/docs/02 javascript api/08 k6-http/10-batch- requests -.md
@@ -5,6 +5,7 @@ excerpt: 'Issue multiple HTTP requests in parallel (like e.g. browsers tend to d
 ---
 
 Batch multiple HTTP requests together, to issue them in parallel over multiple TCP connections.
+Note that the batch size can be set as an option [HTTP URL](/using-k6/k6-options/reference/#batch-per-host).
 
 | Parameter | Type            | Description                                                      |
 | --------- | --------------- | ---------------------------------------------------------------- |


### PR DESCRIPTION
It took me a while to realise that batch request size was adjustable from reading the documentation. I'd like to add a reference to the fact that batch request size is adjustable in the documentation about the batch method.