### PR TITLE
restructures performance insights doc

### DIFF
--- a/src/data/markdown/docs/03 cloud/02 Analyzing Results/02 Performance Insights.md
+++ b/src/data/markdown/docs/03 cloud/02 Analyzing Results/02 Performance Insights.md
@@ -1,136 +1,193 @@
 ---
 title: 'Performance Insights'
-excerpt: 'Performance Insights are automated algorithms designed to help highlight performance issues automatically'
+excerpt: 'Performance Insights are automated algorithms designed to help highlight and diagnose performance issues.'
 ---
 
-## Background
+Whenever you run a test in k6 Cloud, *Performance Insights* algorithms automatically process the raw metrics and data.
 
-k6 Cloud's Performance Insights are algorithms built into k6 Cloud Test Results. Our algorithms are automatically executed as part of test result processing. This happens when you run a cloud test `k6 cloud myScript.js` or when you stream a local execution to the cloud `k6 run myScript.js -o cloud`.
+If k6 finds an issue, it will notify you at the end of the test and recommend ways to mitigate the issue.
 
-> ### Using Performance Insights
+k6 categorizes performance insights into three sets:
+- *HTTP load* insights help diagnose issues with your system under test.
+- *Best practices* insights help diagnose issues with your test script.
+- *Health alert* insights help discover issues with your load generator.
+
+<Glossary>
+
+- [Throughput limit](#throughput-limit)
+- [Increased HTTP failure rate](#increased-http-failure-rate)
+- [Not enough training data](#not-enough-training-data)
+- [Duration too short](#duration-too-short)
+- [Third-party content](#third-party-content)
+- [Too many URLs](#too-many-urls)
+- [Too many groups](#too-many-groups)
+- [Too many metrics](#too-many-metrics)
+- [High load generator CPU usage](#high-load-generator-cpu-usage)
+- [High load generator memory usage](#high-load-generator-memory-usage)
+
+</Glossary>
+
+You can [disable Performance Insights](#disabling-performance-insights) alerts, either for an individual insight or a set of insights.
+
+## HTTP load alerts
+
+HTTP load alerts happen when your test results have a high number of active requests or HTTP errors.
+
+### Throughput limit
+
+*Identifier*: `http_load_throughput_limit`
+- **Happens when**:
+  k6 detects a throughput limit.
+  The number of active in-flight requests continues to grow as the number of Virtual Users increases, while the request rate (finished requests) flatlines.
+- **What it might indicate**:
+  The system under test is overloaded, thus resulting in higher response times.
+- **Recommendations**:
+  Correlate the performance bottleneck with data from an APM or server monitoring tool.
+  After you make your changes, rerun your tests at the same VU level so you can verify whether your changes have improved performance.
+
+### Increased HTTP failure rate
+
+*Identifier*: `http_load_increased_http_failure_rate`
+- **Happens when**:
+   k6 detects a period of elevated HTTP errors(10% higher than the beginning of the test).
+- **What it might indicate**:
+   - Web server configuration issues (timeouts, rate limiting, etc.)
+   - Internal errors caused by saturation of a resource (CPU, memory, disk I/O or database connections).
+     Saturation typically means the target system is close to its performance limit.
+
+> **ⓘ Failed responses are often returned much faster than successful responses.**
 >
-> To use Performance Insights, just run your test. The algorithms automatically analyze
-> the raw metrics and data. If we find something, we will let you know in the Performance Overview section at the top of your test
+> Consequently, an increased HTTP failure rate may produce misleading metrics for request rates and response times.
 
-## Throughput Limit
+### High HTTP failure rate
 
-This alert is raised when a throughput limit has been detected. The number of active in-flight requests continue to grow as the number of Virtual Users are increasing, while the request rate (finished requests) has flatlined. This is indicative that the system under test is overloaded, thus resulting in higher response times. We recommend that you correlate the performance bottleneck with data from an APM and/or server monitoring tool. After making changes, you should run your tests again at the same Virtual User level, to verify if your changes have improved performance on the system under test.
-
-## Increased HTTP failure rate
-
-This alert is raised when a period of elevated HTTP errors has been detected (10% higher than in the beginning of the test). There could be a number of reasons for this, e.g. web server configuration (timeouts, rate limiting etc.) or internal errors caused by saturation of a resource (CPU, memory, disk I/O or database connections). It typically means the target system is close to its performance limit.
-
-**Note:** Failed responses are often returned much faster than successful responses. Consequently, an increased HTTP error rate may produce misleading request rate and response time metrics.
-
-## High HTTP failure rate
-
-The total number of HTTP(s) errors is higher than 15% during the first 100 completed script iterations.
-
-Errors that occur early on are typically not considered to be performance related. Our algorithms also have not detected an increase in the error rate as load has increased.
-With that in mind, there are a number of non-performance related reasons for errors, including, but not limited to:
-
-- You're making invalid requests:
-  - Invalid URLs, e.g. with a typo in it or a hostname that is not in the public DNS system
-  - Missing required headers, e.g. authentication/authorization headers or user-agent
+*Identifier*: `http_load_high_http_failure_rate`
+- **Happens when**:
+  The total number of HTTP(s) errors is higher than 15% during the first 100 completed script iterations.
+- **What it might indicate**
+  Errors that occur early in a test are often not performance-related.
+  Instead, your script might be making invalid requests:
+  - Invalid URLs, e.g. with typos or hostnames outside the public DNS system
+  - Missing required headers, e.g., for authentication, authorization, or user-agents
   - Sending the wrong body data
-- You're trying to test a system that's behind a firewall
-- You're hitting a rate limit
 
-**Note:** Failed responses are often returned much faster than successful responses.
+  The system under test also might be intentionally limiting requests.:
+  - It may be behind a firewall.
+  - It may have a rate limit that your test is reaching.
+- **Recommendations**: Check that your script is valid and that it properly access the system.
+  - Run a single iteration of the script locally to troubleshoot the failing requests running a load test.
+  - In the script, verify that the failing requests are formulated correctly and return the expected response.
+  - Verify that any user accounts have sufficient permissions to access the application.
+  - Verify that the application is publicly accessible.
 
-## Not Enough Training Data
+> **ⓘ Failed responses are often returned much faster than successful responses.**
+>
+> Consequently, a high HTTP failure rate may produce misleading metrics for request rates and response times.
 
-This alert is raised because our Smart Results algorithms need at least 100 complete VU iterations of training data plus an additional 15 seconds to produce meaningful output. Your test did not complete the 100 VU iterations necessary for the training data. We recommend increasing the test duration to get the full benefits of Performance Insights.
+### Not enough training data
 
-## Duration Too Short
+*Identifier*: `best_practice_not_enough_training_data`
+- **Happens when**:
+  Your test did not complete the 100 VU iterations necessary for the training data.
+  To be meaningful, Performance Insights need at least 100 complete VU iterations of training data plus an additional 15 seconds.
+- **Recommendations**:
+  Increase the test duration or number of iterations.
 
-Similar `Not Enough Training Data`, this alert is raised because our system does not have enough training data to produce meaningful results. More than 100 complete VU iterations were detected but duration needs to be extended in to analyze data.
+### Duration too short
 
-## Test Health and Informational Performance Insights
+*Identifier*: `best_practice_duration_too_short`
+- **Happens when**:
+More than 100 complete VU iterations were detected, but the duration needs to be extended to properly analyze data.
+Similar to `Not Enough Training Data`, this alert is raised because our system does not have enough training data to produce meaningful results.
+- **Recommendations**:
+  Increase the test duration or number of iterations.
 
-Test Health Performance Insights are alerts that intend to highlight test or script related issues. These issues, if not addressed, can either skew your results or make result analysis harder to parse through. These alerts are often quickly solved through changes in the test script or test configuration.
 
-**Important**: The `Third Party Content` and `Too Many URLs` alerts are more informational alerts. Depending on what you are testing, it may be appropriate to disregard these alerts. High CPU or Memory usage **should never** be ignored.
+## Best practice alerts
 
-## Third Party Content
+Best practices alerts happen when your test script generates either too much or too little data to be useful.
 
-**This is a best practice alert, we strongly recommend you remove third party requests from your test**
+These issues can either skew your results or make results harder to analyze and parse.
+These alerts are often quickly solved with changes in the test script or test configuration.
 
-This alert is raised when we detect many different domains in a test. This is typically caused by your test script containing requests to 3rd party resources such as CDNs, social media scripts, analytics tools, etc. It's recommended to remove third party requests as it may violate the terms of service of that third party, that third party may throttle your requests skewing the percentiles of your results, or you may have no ability to impact performance of that third party.
+### Third-party content
 
-_Special Notes:_
+*Identifier*: `best_practice_third_party_content`
+- **Happens when**:
+  We detect many different domains in a test.
+- **What it might indicate**:
+  Your test script contains requests to 3rd party resources such as CDNs, social media scripts, analytics tools, etc.
+- **Recommendations**.
+  Remove third-party requests:
+  - The requests may violate the third party's ToS.
+  - The third party may throttle your requests, skewing the percentiles of your results.
+  - You may have no ability to affect the performance of that third party.
 
-- You may have a valid reason to test your CDN. Most CDNs charge based on usage so your tests could result in additional costs from your CDN.
-- Your system under test may utilize multiple domains, in which case you can ignore this alert.
+> **ⓘ You may have valid reasons to ignore this alert**
+>
+> - Your system under test may use multiple domains, in which case you can ignore this alert.
+> - You also may have a valid reason to test your CDN. However, most CDNs charge based on usage, so your tests could generate additional costs from your CDN.
 
-## Too Many URLs
+### Too many URLs
 
-**This is a best practice alert, we strongly recommend you aggregate dynamic URLs as it will make analysis easier**
+*Identifier*: `best_practice_too_many_urls`
+- **Happens when:**
+  k6 detects more than 500 unique URLs in your test results.
+  This is commonly caused by a URL that contains a query parameter or other ID that is unique per iteration. e.g., tokens, session IDs, etc.
+  In the following example, our query parameter would produce a large number of URL metrics:
 
-This alert is raised when we detect more than 500 unique URLs in your test results. This is commonly caused by a URL that contains a query parameter or other ID that is unique per iteration. e.g. tokens, session IDs, etc.
+  <CodeGroup labels={["Using a name tag to aggregate URLs"]}>
 
-In the following example, our query parameter would produce large number of URL metrics:
+  ```javascript
+  import http from 'k6/http';
 
-<CodeGroup labels={["Using a name tag to aggregate URLs"]}>
+  for (let id = 1; id <= 600; id++) {
+    http.get(`http://test.k6.io/?ts=${id}`);
+  }
+  // But you can group all these URL metrics together
+  // in our result analysis using the name tag,
+  // making it easier for you to interpret the data.
+  // Note that you must use the name tag for grouping.
 
-```javascript
-import http from 'k6/http';
-
-for (let id = 1; id <= 600; id++) {
-  http.get(`http://test.k6.io/?ts=${id}`);
-}
-// But you can group all these URL metrics together
-// in our result analysis using the name tag,
-// making it easier for you to interpret the data.
-// Note that you must use the name tag for grouping.
-
-for (let id = 1; id <= 600; id++) {
-  http.get(`http://test.k6.io/?ts=${id}`, {
-    tags: { name: 'test.k6.io?ts' },
-  });
-}
-```
-
-</CodeGroup>
-
-_Note:_ In some cases, the unique URL may be generated by a third party resource. As mentioned in the <a href="#third-party-content">Third Party Content alert</a>, it is a best practice to not include third party resources in your test scripts.
-
-More on [URL Grouping](/using-k6/http-requests#url-grouping)
-
-## Too Many Groups
-
-**This is a best practice alert, we recommend reviewing how you use the [Group name](/javascript-api/k6/group) in your test script.**
-
-This alert is raised when we <b>detect a high number of groups</b> in your test script. The most common reason for this alert is an incorrect usage of the [Group name](/javascript-api/k6/group) using it for aggregating different HTTP requests, or within a loop statement. When aggregating URLs, please use the name tag.
-
-Groups are meant to organize and provide an overview of your result tests allowing you a BDD-style of testing. By allowing this organization, you can quickly find specific parts of your test. For example, the point where users are on a certain page or taking specific actions.
-
-<CodeGroup labels={["Using groups to organize your test"]}>
-
-```javascript
-import { group } from 'k6';
-
-export default function () {
-  group('user flow: returning user', function () {
-    group('visit homepage', function () {
-      // load homepage resources
+  for (let id = 1; id <= 600; id++) {
+    http.get(`http://test.k6.io/?ts=${id}`, {
+      tags: { name: 'test.k6.io?ts' },
     });
-    group('login', function () {
-      // perform login
-    });
-  });
-}
-```
+  }
+  ```
 
-</CodeGroup>
+  </CodeGroup>
 
-If you want to group multiple HTTP requests, we suggest you use the [URL grouping](/using-k6/http-requests#url-grouping) feature of k6 to aggregate data into a single URL metric.
+- **Recommendations**:
+  Aggregate dynamic URLs as it will make analysis easier.
+  To see how, refer to [URL Grouping](/using-k6/http-requests#url-grouping).
 
-## Too Many Metrics
+> **ⓘ In some cases, the unique URL may be generated by a third party**.
+>
+> As mentioned in the [Third Party Content](#third-party-content) alert, best practices recommend excluding third-party resources in your test scripts.
 
-**This is a best practice alert, we strongly recommend reviewing how you specify and use [metrics](/using-k6/metrics/).**
 
-This alert is raised when we <b>detect a high number of metrics</b> in your test script. Considering k6 can generate two types of metrics (built-in and custom), you should check if your script contains too many unique URL or generates custom metrics in a loop.
+### Too many groups
+
+*Identifier*: `best_practice_too_many_groups`
+- **Happens when**:
+  k6 detects a high number of groups in your test script.
+- **What it might indicate**:
+  Most commonly, this alert happens when a test uses a [Group name](/javascript-api/k6/group) to aggregate different HTTP requests or puts the group name in a loop statement.
+- **Recommendations**:
+  - When aggregating URLs, please use the `name` tag.
+  - Add [Group names](/javascript-api/k6/group) in your test script.
+  - If you want to group multiple HTTP requests, use [URL grouping](/using-k6/http-requests#url-grouping) to aggregate data in a single URL metric.
+
+### Too many metrics
+
+*Identifier*: `best_practice_too_many_metrics`
+- **Happens when**:
+  k6 detects a high number of metrics in your test script.
+- **Recommendations**
+  Considering k6 can generate two types of metrics (built-in and custom), there are two things to check:
+  - Whether your script contains too many unique URLs.
+  - Whether it generates custom metrics in a loop.
 
 Having too many metrics in a single test is considered an anti-pattern because it makes result analysis difficult.
 
@@ -157,43 +214,48 @@ for (let id = 1; id <= 1000; id++) {
 
 </CodeGroup>
 
+## Health alerts
 
-## High Load Generator CPU Usage
+Health alerts happen when the load generator has high resource utilization.
 
-**This is a Test Health Alert. You should address this to ensure accurate results**
+You **should not ignore** these alerts, and they can skew test data.
 
-This alert is raised when we detect high utilization of the load generator CPU during a test. Over utilization of the load generator can skew your test results producing data that varies from test to test and unpredictably. Virtual Users will naturally try to execute as quickly as possible. The exact cause of over utilization can vary, but is likely due to one of the following reasons:
+### High load generator CPU usage
 
-- Lack of sleep times in your scripts
-  - Sleep times help with pacing and emulating real user behaviour
-- High RPS per VU
-  - When testing API endpoints you may configure your test to aggressively request an endpoint
-- Large number of requests in a single request batch
-  - Requests made in a request batch will be made in parallel up to the default or defined limits
-- Large amounts of data are returned in responses resulting in high memory utilization
-  - When the memory of the load generator reaches near total consumption, the garbage collection efforts of the Load Generator can cause increase CPU utilization
-- A JavaScript exception is being thrown early in VU execution. This results in an endless restart loop until all CPU cycles are consumed
+*Identifier*: `health_high_loadgen_cpu_usage`
+- **Happens when**:
+  This alert is raised when we detect high utilization of the load generator CPU during a test.
+  Overutilization of the load generator can skew your test results, producing data that varies unpredictably from test to test.
+  Virtual Users will naturally try to execute as quickly as possible.
+- **What it might indicate**:
+  The exact cause of overutilization varies, but the following reasons are most likely:
+  - Lack of sleep times in your scripts. Sleep times help pace and emulate real user behavior.
+  - High RPS per VU. When testing API endpoints, you may configure your test to aggressively request an endpoint.
+  - Large numbers of requests in a single request batch. Requests made in a request batch are parallelized up to the default or defined limits.
+  - Large amounts of data are returned in responses, resulting in high memory utilization.
+  - When the memory of the load generator reaches near total consumption, the garbage-collection efforts of the load generator can increase CPU utilization.
+  - A JavaScript exception is being thrown early in VU execution. This results in an endless restart loop until all CPU cycles are consumed.
+- **Recommendations**.
+  - Increase sleep times where appropriate.
+  - Increase the number of VUs to produce less RPS per VU (thus the same total load)-
+  - Use multiple load zones to spread VUs across multiple regions.
 
-Possible fixes:
 
-- Increase sleep times where appropriate
-- Increase the number of VUs to produce less RPS per VU (thus the same total load)
-- Utilize multiple load zones to spread VUs out across multiple regions
+### High load generator memory usage
 
-## High Load Generator Memory Usage
+*Identifier*: `health_high_loadgen_mem_usage`
+- **Happens when**:
+  k6 detects high utilization of load-generator memory during a test.
+  When memory is highly utilized, the results may display some unexpected behavior or failures.
+  High memory utilization may also cause high CPU utilization as garbage-collection efforts consume more and more CPU cycles.
+- **Recommendations**:
+  - Use the test option `discardResponseBodies` to throw away the response body by default
+  - Use `responseType:` to capture the response bodies you may require
 
-**This is a Test Health Alert. You should address this to ensure accurate results**
+## Disabling performance insights
 
-This alert is raised when we detect high utilization of load generator memory during a test. When memory is highly utilized in a test, it can result in some unexpected behaviour or failures. It may also cause high CPU utilization as garage collection efforts consume more and more of the CPU cycles.
-
-Possible fixes:
-
-- Utilize the test option `discardResponseBodies` to throw away the response body by Default
-  - Use `responseType:` to capture the responseBodies you may require
-  
-## Disabling Specific Performance Insights
-
-It is possible to prevent one or more insights from showing up when executing load tests. This can be done by using `ext.loadimpct.insights` object in the `options`:
+You can disable one or more insights from showing up when executing load tests.
+This can be done by using `ext.loadimpct.insights` object in the `options`:
 
 
 ```javascript
@@ -208,7 +270,7 @@ export const options = {
 };
 ```
 
-When `disabled` array is provided, all insights in it will be skipped when displaying result analysis. In contrast, you can provide a list of **enabled** insights which excludes all other insights from analysis.
+When the `disabled` array is provided, k6 omits all results from the result analysis. In contrast, you can provide a list of **enabled** insights,  excluding all other insights from analysis.
 
 ```javascript
 export const options = {
@@ -222,9 +284,9 @@ export const options = {
 };
 ```
 
-In the above example only one insight will potentially be shown (given the script executes with a high HTTP failure rate).
+In the preceding example, only one insight will be shown (given that the script executes with a high HTTP failure rate).
 
-It is also possible to enable/disable multiple insights by their category (also called "set"). To achieve this, specify the `enabledSets`/`disabledSets` array in the `insights` object.
+You can also enable or disable multiple insights by their category (also called "set"). To achieve this, specify the `enabledSets` or `disabledSets` array in the `insights` object.
 
 ```javascript
 export const options = {
@@ -252,7 +314,7 @@ export const options = {
 };
 ```
 
-For all insights and their identifiers see the table below:
+For all insights and their identifiers, refer to the table below:
 
 | Name                             | Identifier                               | Set Identifier  |
 |----------------------------------|------------------------------------------|-----------------|
@@ -266,4 +328,5 @@ For all insights and their identifiers see the table below:
 | Too Many Groups                  | `best_practice_too_many_groups`          | `best_practice` |
 | Too Many Metrics                 | `best_practice_too_many_metrics`         | `best_practice` |
 | High Load Generator CPU Usage    | `health_high_loadgen_cpu_usage`          | `health`        |
-| High Load Generator Memory Usage | `health_high_loadgen_mem_usage`          | `health`        |
+| High Load Generator Memory Usage | `health_high_loadgen_mem_usage`          | `health`        geto boys we can't be stopped full album|
+


### PR DESCRIPTION
- Gives information repeatable structure
- Uses bullets to create two alignments: one for Insight and one for terms
- Uses h2 to categorize Insight sets
- Uses glossary to compensate for now-h3-level insights getting removed from floating TOC