### PR TITLE
Fix gRPC Params object to account for headers deprecation in v0.37.0

### DIFF
--- a/src/data/markdown/docs/02 javascript api/10 k6-net-grpc/20-Params.md
+++ b/src/data/markdown/docs/02 javascript api/10 k6-net-grpc/20-Params.md
@@ -8,7 +8,8 @@ excerpt: 'Params is an object used by the gRPC methods that generate RPC request
 
 | Name | Type | Description |
 |------|------|-------------|
-| `Params.headers` | object | Object with key-value pairs representing custom headers the user would like to add to the request. |
+| `Params.headers` | object | Deprecated, use metadata instead. |
+| `Params.metadata` | object | Object with key-value pairs representing custom metadata the user would like to add to the request. |
 | `Params.tags` | object | Key-value pairs where the keys are names of tags and the values are tag values. Response time metrics generated as a result of the request will have these tags added to them, allowing the user to filter out those results specifically, when looking at results data. |
 | `Params.timeout` | string / number | Request timeout to use. Default timeout is 60 seconds (`"60s"`). <br/> The type can also be a number, in which case k6 interprets it as milliseconds, e.g., `60000` is equivalent to `"60s"`. |
 
@@ -29,7 +30,7 @@ export default function () {
     longitude: -747127767,
   };
   const params = {
-    headers: { 'x-my-header': 'k6test' },
+    metadata: { 'x-my-header': 'k6test' },
     tags: { k6test: 'yes' },
   };
   const response = client.invoke('main.RouteGuide/GetFeature', req, params);

--- a/src/data/markdown/versioned-js-api/v0.37/javascript api/10 k6-net-grpc/20-Params.md
+++ b/src/data/markdown/versioned-js-api/v0.37/javascript api/10 k6-net-grpc/20-Params.md
@@ -8,7 +8,8 @@ excerpt: 'Params is an object used by the gRPC methods that generate RPC request
 
 | Name | Type | Description |
 |------|------|-------------|
-| `Params.headers` | object | Object with key-value pairs representing custom headers the user would like to add to the request. |
+| `Params.headers` | object | Deprecated, use metadata instead. |
+| `Params.metadata` | object | Object with key-value pairs representing custom metadata the user would like to add to the request. |
 | `Params.tags` | object | Key-value pairs where the keys are names of tags and the values are tag values. Response time metrics generated as a result of the request will have these tags added to them, allowing the user to filter out those results specifically, when looking at results data. |
 | `Params.timeout` | string / number | Request timeout to use. Default timeout is 60 seconds (`"60s"`). <br/> The type can also be a number, in which case k6 interprets it as milliseconds, e.g., `60000` is equivalent to `"60s"`. |
 
@@ -29,7 +30,7 @@ export default function () {
     longitude: -747127767,
   };
   const params = {
-    headers: { 'x-my-header': 'k6test' },
+    metadata: { 'x-my-header': 'k6test' },
     tags: { k6test: 'yes' },
   };
   const response = client.invoke('main.RouteGuide/GetFeature', req, params);

--- a/src/data/markdown/versioned-js-api/v0.38/javascript api/10 k6-net-grpc/20-Params.md
+++ b/src/data/markdown/versioned-js-api/v0.38/javascript api/10 k6-net-grpc/20-Params.md
@@ -8,7 +8,8 @@ excerpt: 'Params is an object used by the gRPC methods that generate RPC request
 
 | Name | Type | Description |
 |------|------|-------------|
-| `Params.headers` | object | Object with key-value pairs representing custom headers the user would like to add to the request. |
+| `Params.headers` | object | Deprecated, use metadata instead. |
+| `Params.metadata` | object | Object with key-value pairs representing custom metadata the user would like to add to the request. |
 | `Params.tags` | object | Key-value pairs where the keys are names of tags and the values are tag values. Response time metrics generated as a result of the request will have these tags added to them, allowing the user to filter out those results specifically, when looking at results data. |
 | `Params.timeout` | string / number | Request timeout to use. Default timeout is 60 seconds (`"60s"`). <br/> The type can also be a number, in which case k6 interprets it as milliseconds, e.g., `60000` is equivalent to `"60s"`. |
 
@@ -29,7 +30,7 @@ export default function () {
     longitude: -747127767,
   };
   const params = {
-    headers: { 'x-my-header': 'k6test' },
+    metadata: { 'x-my-header': 'k6test' },
     tags: { k6test: 'yes' },
   };
   const response = client.invoke('main.RouteGuide/GetFeature', req, params);


### PR DESCRIPTION
`Params.headers` was deprecated in v0.37.0 and replaced by `Params.metadata` (see grafana/k6#2370).