### PR TITLE
Change docs to use chromium instead of launcher

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1447,8 +1447,6 @@ const createRedirects = ({ actions }) => {
       '/javascript-api/xk6-browser/response/',
     '/javascript-api/k6-x-browser/touchscreen/':
       '/javascript-api/xk6-browser/touchscreen/',
-    '/javascript-api/k6-x-browser/launcher/':
-      '/javascript-api/xk6-browser/launcher/',
     ...newJavascriptURLsRedirects,
   };
 

--- a/src/data/markdown/docs/30 xk6-browser/01 xk6-browser/01 Browser.md
+++ b/src/data/markdown/docs/30 xk6-browser/01 xk6-browser/01 Browser.md
@@ -7,7 +7,7 @@ The `Browser` class is the entry point for all your tests, and it is what intera
 - [BrowserContext](/javascript-api/xk6-browser/browsercontext/)s which is where you can set a variety of attributes to control the behavior of pages;
 - and [Page](/javascript-api/xk6-browser/page/)s which is where your rendered site is displayed.
 
-A new Browser instance (hence a new browser process) can be created using the `launch()` function of the `'k6/x/browser'` module.
+A new Browser instance (hence a new browser process) can be created using the `launch()` method of the `chromium` module from `'k6/x/browser'`.
 
 | Method                                                                                    | Description                                                                                                                                           |
 |-------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -22,10 +22,10 @@ A new Browser instance (hence a new browser process) can be created using the `l
 An example of using a Browser to create a [Page](/javascript-api/xk6-browser/page):
 
 ```javascript
-import launcher from 'k6/x/browser';
+import { chromium } from 'k6/x/browser';
 
 export default function () {
-  const browser = launcher.launch('chromium');
+  const browser = chromium.launch();
   const context = browser.newContext();
   const page = context.newPage();
   const res = page.goto('https://test.k6.io/');

--- a/src/data/markdown/docs/30 xk6-browser/01 xk6-browser/01 Browser/contexts.md
+++ b/src/data/markdown/docs/30 xk6-browser/01 xk6-browser/01 Browser/contexts.md
@@ -17,7 +17,7 @@ Allows you to access all open [BrowserContext](/javascript-api/xk6-browser/brows
 <!-- eslint-skip -->
 
 ```javascript
-const browser = launcher.launch('chromium');
+const browser = chromium.launch();
 console.log(browser.contexts().length); // prints `0`
 
 const context = browser.newContext();

--- a/src/data/markdown/docs/30 xk6-browser/01 xk6-browser/01 Browser/newcontext--options--.md
+++ b/src/data/markdown/docs/30 xk6-browser/01 xk6-browser/01 Browser/newcontext--options--.md
@@ -50,10 +50,10 @@ Creates and returns a new [BrowserContext](/javascript-api/xk6-browser/browserco
 ### deviceScaleFactor example
 
 ```javascript
-import k6b from 'k6/x/browser';
+import { chromium } from 'k6/x/browser';
 
 export default function () {
-  const browser = k6b.launch('chromium', {
+  const browser = chromium.launch({
     headless: false,
   });
 

--- a/src/data/markdown/docs/30 xk6-browser/01 xk6-browser/01 Browser/newpage--options--.md
+++ b/src/data/markdown/docs/30 xk6-browser/01 xk6-browser/01 Browser/newpage--options--.md
@@ -49,10 +49,10 @@ Creates a new [Page](/javascript-api/xk6-browser/page/) in a new [BrowserContext
 ### deviceScaleFactor example
 
 ```javascript
-import k6b from 'k6/x/browser';
+import { chromium } from 'k6/x/browser';
 
 export default function () {
-  const browser = k6b.launch('chromium', {
+  const browser = chromium.launch({
     headless: false,
   });
 

--- a/src/data/markdown/docs/30 xk6-browser/01 xk6-browser/01 Browser/on--event--.md
+++ b/src/data/markdown/docs/30 xk6-browser/01 xk6-browser/01 Browser/on--event--.md
@@ -25,11 +25,11 @@ The returned promise will be resolved when the Browser disconnects from the brow
 <!-- eslint-skip -->
 
 ```javascript
-import launcher from 'k6/x/browser';
+import { chromium } from 'k6/x/browser';
 import { check, sleep } from 'k6';
 
 export default function() {
-  const browser = launcher.launch('chromium');
+  const browser = chromium.launch();
 
   check(browser, {
     'should be connected after launch': browser.isConnected(),

--- a/src/data/markdown/docs/30 xk6-browser/01 xk6-browser/02 BrowserContext/browser.md
+++ b/src/data/markdown/docs/30 xk6-browser/01 xk6-browser/02 BrowserContext/browser.md
@@ -18,10 +18,10 @@ Returns the [browser](/javascript-api/xk6-browser/browser) instance that this `B
 <CodeGroup labels={[]}>
 
 ```javascript
-import launcher from 'k6/x/browser';
+import { chromium } from 'k6/x/browser';
 
 export default function () {
-  const browser = launcher.launch('chromium');
+  const browser = chromium.launch();
   const context = browser.newContext();
   const b2 = context.browser();
   b2.close();

--- a/src/data/markdown/docs/30 xk6-browser/01 xk6-browser/03-element-handle.md
+++ b/src/data/markdown/docs/30 xk6-browser/01 xk6-browser/03-element-handle.md
@@ -49,10 +49,10 @@ excerpt: "xk6-browser: ElementHandle Class"
 <CodeGroup labels={["Fill out a form"]} >
 
 ```javascript
-import launcher from 'k6/x/browser';
+import { chromium } from 'k6/x/browser';
 
 export default function () {
-  const browser = launcher.launch('chromium', {
+  const browser = chromium.launch({
     headless: false,
     slowMo: '500ms', // slow down by 500ms
   });
@@ -82,11 +82,11 @@ export default function () {
 <CodeGroup labels={["Check element state"]} >
 
 ```javascript
-import launcher from 'k6/x/browser';
+import { chromium } from 'k6/x/browser';
 import { check } from 'k6';
 
 export default function () {
-  const browser = launcher.launch('chromium', {
+  const browser = chromium.launch({
     headless: false,
   });
   const context = browser.newContext();

--- a/src/data/markdown/docs/30 xk6-browser/01 xk6-browser/07 Locator.md
+++ b/src/data/markdown/docs/30 xk6-browser/01 xk6-browser/07 Locator.md
@@ -46,10 +46,10 @@ Locator can be created with the [page.locator(selector[, options])](/javascript-
 <!-- eslint-skip -->
 
 ```javascript
-import launcher from "k6/x/browser";
+import { chromium } from 'k6/x/browser';
 
 export default function () {
-  const browser = launcher.launch('chromium', {
+  const browser = chromium.launch({
     headless: false,
   });
   const context = browser.newContext();

--- a/src/data/markdown/docs/30 xk6-browser/01 xk6-browser/09-page.md
+++ b/src/data/markdown/docs/30 xk6-browser/01 xk6-browser/09-page.md
@@ -72,10 +72,10 @@ excerpt: "xk6-browser: Page Class"
 ## Examples
 
 ```javascript
-import launcher from 'k6/x/browser';
+import { chromium } from 'k6/x/browser';
 
 export default function () {
-  const browser = launcher.launch('chromium', {
+  const browser = chromium.launch({
     headless: false,
   });
   const context = browser.newContext();

--- a/src/data/markdown/docs/30 xk6-browser/30 xk6-browser.md
+++ b/src/data/markdown/docs/30 xk6-browser/30 xk6-browser.md
@@ -19,13 +19,14 @@ If you're more adventurous or want to get the latest changes of the xk6-browser 
 
 <InstallationInstructions extensionUrl="github.com/grafana/xk6-browser"/>
 
-## Launch
+## Launch Chromium
 
-The first step is to launch a [Browser](/javascript-api/xk6-browser/browser). After the browser starts, you can interact with it using the [browser-level APIs](#browser-level-apis). The only accepted browser type is currently `chromium`.
+The first step is to launch a `chromium` [Browser](/javascript-api/xk6-browser/browser) (which is currently the only available browser type). After the browser starts, you can interact with it using the [browser-level APIs](#browser-level-apis).
 
-| Method                         | Description                                                                                                                                                                                                         |
-|--------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| launch(browserName, [options]) | The first parameter is required, and the only accepted `browserName` is currently `chromium`. The `options` parameter is optional. You can see a list of all possible `options` in [the options heading](#options). |
+| Method                     | Description                                                                      |
+|----------------------------|----------------------------------------------------------------------------------|
+| chromium                   | Import module from `'k6/x/browser'`                                              |
+| chromium.launch([options]) | You can see a list of all possible `options` in [the options heading](#options). |
 
 ### Options
 
@@ -49,10 +50,10 @@ The first step is to launch a [Browser](/javascript-api/xk6-browser/browser). Af
 <!-- eslint-skip -->
 
 ```javascript
-import launcher from 'k6/x/browser';
+import { chromium } from 'k6/x/browser';
 
 export default function () {
-  const browser = launcher.launch('chromium', {
+  const browser = chromium.launch({
     args: ['show-property-changed-rects'],
     debug: true,
     devtools: true,


### PR DESCRIPTION
Closes: https://github.com/grafana/xk6-browser/issues/465

The latest version of `xk6-browser` now exports a `chromium` type when it comes to launching and testing against browser. This is still the only supported browser. This api also matches PW. This PR changes the examples and docs to match the new way of launching the browser.

## Previous

```javascript
import launcher from 'k6/x/browser';

export default function () {
  const browser = launcher.launch('chromium', {
```

## New

```javascript
import { chromium } from 'k6/x/browser';

export default function () {
  const browser = chromium.launch({
```