### PR TITLE
Add Outdated k6 Release Used to Performance Insights

### DIFF
--- a/src/data/markdown/docs/03 cloud/02 Analyzing Results/02 Performance Insights.md
+++ b/src/data/markdown/docs/03 cloud/02 Analyzing Results/02 Performance Insights.md
@@ -222,8 +222,8 @@ for (let id = 1; id <= 1000; id++) {
 - **Happens when**:
   you use a legacy version of k6 that is significantly older than the latest stable version.
 - **Recommendations**:
-  - Download and install the latest release of k6 [here](/getting-started/installation) or upgrade your packages if relevant.
-  - Update the k6 binary that your CI/CD pipeline uses for running tests.
+  - [Install the latest release of k6](/getting-started/installation), or upgrade your existing packages.
+  - Update the k6 binary that your CI/CD pipeline uses to run tests.
   - If you're part of an organization or team, collectively decide on a version of k6 to use going forward for consistency and ease of comparison.
 
 ## Health alerts

--- a/src/data/markdown/docs/03 cloud/02 Analyzing Results/02 Performance Insights.md
+++ b/src/data/markdown/docs/03 cloud/02 Analyzing Results/02 Performance Insights.md
@@ -22,6 +22,7 @@ k6 categorizes performance insights into three sets:
 - [Too many URLs](#too-many-urls)
 - [Too many groups](#too-many-groups)
 - [Too many metrics](#too-many-metrics)
+- [Outdated k6 Release Used](#outdated-k6-release-used)
 - [High load generator CPU usage](#high-load-generator-cpu-usage)
 - [High load generator memory usage](#high-load-generator-memory-usage)
 
@@ -215,6 +216,17 @@ for (let id = 1; id <= 1000; id++) {
 
 </CodeGroup>
 
+### Outdated k6 release used
+
+*Identifier*: `best_practice_outdated_k6_release_used`
+- **Happens when**:
+  you use a legacy version of k6 that is significantly older than the latest stable version.
+- **Recommendations**:
+  - Download and install the latest release of k6 [here](/getting-started/installation) or upgrade your packages if relevant.
+  - Update the k6 binary that your CI/CD pipeline uses for running tests.
+  - If you're part of an organization or team, collectively decide on a version of k6 to use going forward for consistency and ease of comparison.
+  - If you have questions about which version of k6 to use, please contact our [Support team](mailto:support@k6.io).
+
 ## Health alerts
 
 Health alerts happen when the load generator has high resource utilization.
@@ -330,6 +342,7 @@ For all insights and their identifiers, refer to the table below:
 | Too Many URLs                    | `best_practice_too_many_urls`            | `best_practice` |
 | Too Many Groups                  | `best_practice_too_many_groups`          | `best_practice` |
 | Too Many Metrics                 | `best_practice_too_many_metrics`         | `best_practice` |
+| Outdated k6 Release Used         | `best_practice_outdated_k6_release_used` | `best_practice` |
 | High Load Generator CPU Usage    | `health_high_loadgen_cpu_usage`          | `health`        |
 | High Load Generator Memory Usage | `health_high_loadgen_mem_usage`          | `health`        |
 

--- a/src/data/markdown/docs/03 cloud/02 Analyzing Results/02 Performance Insights.md
+++ b/src/data/markdown/docs/03 cloud/02 Analyzing Results/02 Performance Insights.md
@@ -225,7 +225,6 @@ for (let id = 1; id <= 1000; id++) {
   - Download and install the latest release of k6 [here](/getting-started/installation) or upgrade your packages if relevant.
   - Update the k6 binary that your CI/CD pipeline uses for running tests.
   - If you're part of an organization or team, collectively decide on a version of k6 to use going forward for consistency and ease of comparison.
-  - If you have questions about which version of k6 to use, please contact our [Support team](mailto:support@k6.io).
 
 ## Health alerts
 


### PR DESCRIPTION
Documentation for the new performance insight `Outdated k6 Release Used`. The recommendations are exactly the same as the one we display in the app and are curtesy of @nicolevanderhoeven
