### PR TITLE
Gatsby; removes inserted slash from og:url

### DIFF
--- a/src/components/shared/seo/seo.view.js
+++ b/src/components/shared/seo/seo.view.js
@@ -44,8 +44,8 @@ export const SEO = ({
     // eslint-disable-next-line no-nested-ternary
     slug && slug !== '*'
       ? slug.startsWith('jslib/')
-        ? `${docs}/javascript-api/${slug}`
-        : `${docs}${slug}`
+        ? `${docs}/javascript-api${slug}`
+        : `${docs}${slug.startsWith('/') ? slug : `/${slug}`}`
       : docs;
 
   let versionedCanonicalUrl = currentUrl;

--- a/src/components/shared/seo/seo.view.js
+++ b/src/components/shared/seo/seo.view.js
@@ -45,7 +45,7 @@ export const SEO = ({
     slug && slug !== '*'
       ? slug.startsWith('jslib/')
         ? `${docs}/javascript-api/${slug}`
-        : `${docs}/${slug}`
+        : `${docs}${slug}`
       : docs;
 
   let versionedCanonicalUrl = currentUrl;


### PR DESCRIPTION
Fixes: https://github.com/grafana/k6-docs/issues/771

I tested locally, as far as I can tell it fixes the double slash issue:

```html
<meta property="og:url" content="http://localhost:8000/cloud/analyzing-results/checks/" data-react-helmet="true">
```

The only issue is that it now will create invalid URLs if the slug doesn't start with a slash. I guess we could fix this by blocking invalid slugs in the CI, but every author so far has independently decided to start slug values at the site root, so it doesn't seem like a big issue.