### PR TITLE
fix anchors position on mobile screens

### DIFF
--- a/src/components/shared/description-list/description-list.module.scss
+++ b/src/components/shared/description-list/description-list.module.scss
@@ -7,8 +7,7 @@
     font-size: $font-size-lg;
     font-weight: 500;
     .anchor-icon {
-      position: absolute !important;
-      left: -20px;
+      margin-left: 7px;
       visibility: hidden;
       transition: all 0.3s ease;
       text-decoration: none !important;

--- a/src/components/shared/description-list/description-list.module.scss
+++ b/src/components/shared/description-list/description-list.module.scss
@@ -7,7 +7,8 @@
     font-size: $font-size-lg;
     font-weight: 500;
     .anchor-icon {
-      margin-left: 7px;
+      position: absolute !important;
+      left: -20px;
       visibility: hidden;
       transition: all 0.3s ease;
       text-decoration: none !important;
@@ -15,6 +16,10 @@
       &:hover {
         text-decoration: none !important;
         border: none !important;
+      }
+      @include sm-down {
+        position: static !important;
+        margin-left: 5px;
       }
     }
     &:hover {

--- a/src/components/shared/description-list/description-list.view.js
+++ b/src/components/shared/description-list/description-list.view.js
@@ -90,12 +90,12 @@ const DescriptionList = ({ children }) => {
               const anchorMold = slugify(termTextContent);
               return (
                 <dt id={!termIdx ? anchorMold : termIdx}>
+                  {term}
                   {!termIdx && (
                     <a className={cx('anchor-icon')} href={`#${anchorMold}`}>
                       <AnchorIcon />
                     </a>
                   )}
-                  {term}
                 </dt>
               );
             })}

--- a/src/components/shared/heading/heading.module.scss
+++ b/src/components/shared/heading/heading.module.scss
@@ -42,6 +42,10 @@
       text-decoration: none;
       border: none;
     }
+    @include xs-down {
+      position: static;
+      margin-left: 5px;
+    }
   }
   &:hover {
     a:first-child {

--- a/src/components/shared/heading/heading.view.js
+++ b/src/components/shared/heading/heading.view.js
@@ -61,10 +61,10 @@ export const HeadingLandmark =
     const anchor = `${anchorify(anchorMold)}`;
     return (
       <Tag className={styles.markHeading} id={anchor}>
+        {renderContent}
         <a className={'anchor-icon'} href={`#${anchor}`}>
           <AnchorIcon />
         </a>
-        {renderContent}
       </Tag>
     );
   };


### PR DESCRIPTION
**Describe what changes this pull request brings**
This pull request adds new position of the anchor in content's header & in `DescriptionList` (from 575px - `xs-down`).

**Screenshot**
<img width="1048" alt="Screenshot 2022-08-18 at 11 21 22" src="https://user-images.githubusercontent.com/75138180/185309093-594a46b7-a449-4134-b3b2-9cf3f21676ea.png">
