### PR TITLE
fix: fix report link on Not-found page

### DIFF
--- a/src/components/pages/404/not-found/not-found.view.js
+++ b/src/components/pages/404/not-found/not-found.view.js
@@ -22,7 +22,7 @@ export const NotFound = () => (
             </p>
             <Button
               className={styles.button}
-              href={'https://github.com/k6io/docs'}
+              href={'https://github.com/grafana/k6-docs'}
               tag={'a'}
               cursor
             >


### PR DESCRIPTION
This PR brings the following fixes:
- fix report link on Not found page from `https://github.com/k6io/docs` to `https://github.com/grafana/k6-docs`;