### PR TITLE
Correction for integrating K6 to Datadog

### DIFF
--- a/src/data/markdown/docs/03 cloud/04 Integrations/05 Cloud APM/03 DataDog.md
+++ b/src/data/markdown/docs/03 cloud/04 Integrations/05 Cloud APM/03 DataDog.md
@@ -39,7 +39,7 @@ Currently, there are two options to set up the Cloud APM settings in the test:
 
 First, configure the Datadog integration for an organization.
 
-1. From the Main navigation, go to **Manage > Cloud APM** and select **Azure Monitor**.
+1. From the Main navigation, go to **Manage > Cloud APM** and select **Datadog**.
 
   ![Cloud APM - Datadog Form UI](images/datadog-cloud-app-form.png)
 


### PR DESCRIPTION
In cloud APM, we should select Datadog instead of Azure monitor as that's the service we are trying to integrate it with