### PR TITLE
Rename cloud environment variables

### DIFF
--- a/src/data/markdown/docs/03 cloud/01 Creating and running a test/02 Cloud tests from the CLI.md
+++ b/src/data/markdown/docs/03 cloud/01 Creating and running a test/02 Cloud tests from the CLI.md
@@ -329,10 +329,12 @@ export default function () {
 
 </CodeGroup>
 
-#### ⚠️ Warning
+<Blockquote mod="Attention" title="The LI_ prefix is deprecated">
 
-Previously, these cloud environment variables had prefixed `LI_` (like `LI_LOAD_ZONE`). These names are deprecated and will be removed in future versions of the k6 cloud.
+Previously, cloud environment variables were prefixed with `LI_` (for example, `LI_LOAD_ZONE`).
+These names are deprecated and will be removed in future versions of k6 Cloud.
 
+</Blockquote>
 ## Differences between local and cloud execution
 
 While the cloud and local execution modes are almost completely compatible, they differ in a few particularities.

--- a/src/data/markdown/docs/03 cloud/01 Creating and running a test/02 Cloud tests from the CLI.md
+++ b/src/data/markdown/docs/03 cloud/01 Creating and running a test/02 Cloud tests from the CLI.md
@@ -332,7 +332,7 @@ export default function () {
 <Blockquote mod="Attention" title="The LI_ prefix is deprecated">
 
 Previously, cloud environment variables were prefixed with `LI_` (for example, `LI_LOAD_ZONE`).
-These names are deprecated and will be removed in future versions of k6 Cloud.
+These names are deprecated and may be removed in future versions of k6 Cloud.
 
 </Blockquote>
 

--- a/src/data/markdown/docs/03 cloud/01 Creating and running a test/02 Cloud tests from the CLI.md
+++ b/src/data/markdown/docs/03 cloud/01 Creating and running a test/02 Cloud tests from the CLI.md
@@ -335,6 +335,8 @@ Previously, cloud environment variables were prefixed with `LI_` (for example, `
 These names are deprecated and will be removed in future versions of k6 Cloud.
 
 </Blockquote>
+
+
 ## Differences between local and cloud execution
 
 While the cloud and local execution modes are almost completely compatible, they differ in a few particularities.

--- a/src/data/markdown/docs/03 cloud/01 Creating and running a test/02 Cloud tests from the CLI.md
+++ b/src/data/markdown/docs/03 cloud/01 Creating and running a test/02 Cloud tests from the CLI.md
@@ -297,9 +297,9 @@ When you run tests in k6 Cloud, you can use three additional environment variabl
 
 | Name              | Value  | Description                                                                                                                                              |
 | ----------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `LI_LOAD_ZONE`    | string | The load zone from where the metric was collected. Values will be of the form: amazon:us :ashburn (see list above).                                      |
-| `LI_INSTANCE_ID`  | number | A sequential number representing the unique ID of a load generator server taking part in the test, starts at 0.                                          |
-| `LI_DISTRIBUTION` | string | The value of the "distribution label" that you used in `ext.loadimpact.distribution` corresponding to the load zone the script is currently executed in. |
+| `K6_CLOUDRUN_LOAD_ZONE`    | string | The load zone from where the metric was collected. Values will be of the form: amazon:us :ashburn (see list above).                                      |
+| `K6_CLOUDRUN_INSTANCE_ID`  | number | A sequential number representing the unique ID of a load generator server taking part in the test, starts at 0.                                          |
+| `K6_CLOUDRUN_DISTRIBUTION` | string | The value of the "distribution label" that you used in `ext.loadimpact.distribution` corresponding to the load zone the script is currently executed in. |
 
 You can read the values of these variables in your k6 script as usual.
 
@@ -319,15 +319,19 @@ export const options = {
   },
 };
 export default function () {
-  if (__ENV.LI_DISTRIBUTION === 'ashburnDistribution') {
+  if (__ENV.K6_CLOUDRUN_DISTRIBUTION === 'ashburnDistribution') {
     // do something
-  } else if (__ENV.LI_DISTRIBUTION == 'dublinDistribution') {
+  } else if (__ENV.K6_CLOUDRUN_DISTRIBUTION == 'dublinDistribution') {
     // do something
   }
 }
 ```
 
 </CodeGroup>
+
+#### ⚠️ Warning
+
+Previously, these cloud environment variables had prefixed `LI_` (like `LI_LOAD_ZONE`). These names are deprecated and will be removed in future versions of the k6 cloud.
 
 ## Differences between local and cloud execution
 


### PR DESCRIPTION
# What?

Update names of the cloud environment variables and warn that old (`LI_`) will be deprecated in future versions of the k6 cloud.

# Why?

`LI_` is an old abbreviation and it's, not consistent with most of the current abbreviations.