### PR TITLE
Document changes in the AWS jslib v0.5.0

### DIFF
--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws.md
@@ -7,10 +7,10 @@ description: "aws is a library implementing APIs for accessing a selection of AW
 The `aws` module is a JavaScript library that wraps around some Amazon AWS services API. 
 
 The library exposes a couple of configuration and client classes allowing to interact with a subset of AWS services in the context of k6 load test scripts:
-- The [S3Client](/javascript-api/jslib/aws/s3client) to list S3 buckets and the objects they contain, as well as uploading, downloading and deleting objects from them.
-- The [SecretsManagerClient](/javascript-api/jslib/aws/secretsmanagerclient) class allows listing, getting, creating, updating, and deleting secrets from the AWS secrets manager service.
-- The [KMSClient](/javascript-api/jslib/aws/kmsclient) class can list and generate keys from the AWS Key Management Service.
-- The [AWSConfig](/javascript-api/jslib/aws/awsconfig/) class is used by each client classes to provide them access to AWS credentials as well as configuration.
+- [S3Client](/javascript-api/jslib/aws/s3client): a class to list S3 buckets and the objects they contain, as well as uploading, downloading and deleting objects from them.
+- [SecretsManagerClient](/javascript-api/jslib/aws/secretsmanagerclient): a class allows listing, getting, creating, updating, and deleting secrets from the AWS secrets manager service.
+- [KMSClient](/javascript-api/jslib/aws/kmsclient): a class to list and generate keys from the AWS Key Management Service.
+- [AWSConfig](/javascript-api/jslib/aws/awsconfig/): a class is used by each client classes to provide them access to AWS credentials as well as configuration.
 
 > ⭐️ Source code available on [GitHub](https://github.com/grafana/k6-jslib-aws). 
 > Please request features and report bugs through [GitHub issues](https://github.com/grafana/k6-jslib-aws/issues).
@@ -28,11 +28,11 @@ This documentation is for the last version only. If you discover that some code 
 
 ### Classes
 
-| Library                                                          | Description                                                                   |
-| :--------------------------------------------------------------- | :---------------------------------------------------------------------------- |
-| [S3Client](/javascript-api/jslib/aws/s3client)                   | Client class allowing to interact with AWS S3 buckets and objects.            |
-| [SecretsManager](/javascript-api/jslib/aws/secretsmanagerclient) | Client class allowing to interact with AWS secrets stored in Secrets Manager. |
-| [KMSClient](/javascript-api/jslib/aws/kmsclient)                 | Client class allowing to interact with AWS Key Management Service.            |                                  |
-| [AWSConfig](/javascript-api/jslib/aws/awsconfig)                 | Class allowing to configure AWS client classes                                |
+| Library                                                          | Description                                                          |
+| :--------------------------------------------------------------- | :------------------------------------------------------------------- |
+| [S3Client](/javascript-api/jslib/aws/s3client)                   | Client class to interact with AWS S3 buckets and objects.            |
+| [SecretsManager](/javascript-api/jslib/aws/secretsmanagerclient) | Client class to interact with AWS secrets stored in Secrets Manager. |
+| [KMSClient](/javascript-api/jslib/aws/kmsclient)                 | Client class to interact with AWS Key Management Service.            |                                  
+| [AWSConfig](/javascript-api/jslib/aws/awsconfig)                 | Class to configure AWS client classes.                               |
 
 

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws.md
@@ -9,7 +9,7 @@ The `aws` module is a JavaScript library that wraps around some Amazon AWS servi
 The library exposes a couple of configuration and client classes allowing to interact with a subset of AWS services in the context of k6 load test scripts:
 - The [S3Client](/javascript-api/jslib/aws/s3client) to list S3 buckets and the objects they contain, as well as uploading, downloading and deleting objects from them.
 - The [SecretsManagerClient](/javascript-api/jslib/aws/secretsmanagerclient) class allows listing, getting, creating, updating, and deleting secrets from the AWS secrets manager service.
-- The [KMSClient](/javascript-api/jslib/aws/kmsclient) class allows listing keys, and generating data keys from the AWS Key Management Service.
+- The [KMSClient](/javascript-api/jslib/aws/kmsclient) class can list and generate keys from the AWS Key Management Service.
 - The [AWSConfig](/javascript-api/jslib/aws/awsconfig/) class is used by each client classes to provide them access to AWS credentials as well as configuration.
 
 > ⭐️ Source code available on [GitHub](https://github.com/grafana/k6-jslib-aws). 

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws.md
@@ -4,11 +4,12 @@ excerpt: "aws is a library implementing APIs for accessing a selection of AWS se
 description: "aws is a library implementing APIs for accessing a selection of AWS servicese"
 ---
 
-The `aws` module is a JavaScript library that wraps around some Amazon AWS service APIs. 
+The `aws` module is a JavaScript library that wraps around some Amazon AWS services API. 
 
 The library exposes a couple of configuration and client classes allowing to interact with a subset of AWS services in the context of k6 load test scripts:
 - The [S3Client](/javascript-api/jslib/aws/s3client) to list S3 buckets and the objects they contain, as well as uploading, downloading and deleting objects from them.
 - The [SecretsManagerClient](/javascript-api/jslib/aws/secretsmanagerclient) class allows listing, getting, creating, updating, and deleting secrets from the AWS secrets manager service.
+- The [KMSClient](/javascript-api/jslib/aws/kmsclient) class allows listing keys, and generating data keys from the AWS Key Management Service.
 - The [AWSConfig](/javascript-api/jslib/aws/awsconfig/) class is used by each client classes to provide them access to AWS credentials as well as configuration.
 
 > ⭐️ Source code available on [GitHub](https://github.com/grafana/k6-jslib-aws). 
@@ -31,6 +32,7 @@ This documentation is for the last version only. If you discover that some code 
 | :--------------------------------------------------------------- | :---------------------------------------------------------------------------- |
 | [S3Client](/javascript-api/jslib/aws/s3client)                   | Client class allowing to interact with AWS S3 buckets and objects.            |
 | [SecretsManager](/javascript-api/jslib/aws/secretsmanagerclient) | Client class allowing to interact with AWS secrets stored in Secrets Manager. |
+| [KMSClient](/javascript-api/jslib/aws/kmsclient)                 | Client class allowing to interact with AWS Key Management Service.            |                                  |
 | [AWSConfig](/javascript-api/jslib/aws/awsconfig)                 | Class allowing to configure AWS client classes                                |
 
 

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws.md
@@ -8,7 +8,7 @@ The `aws` module is a JavaScript library that wraps around some Amazon AWS servi
 
 The library exposes a couple of configuration and client classes allowing to interact with a subset of AWS services in the context of k6 load test scripts:
 - [S3Client](/javascript-api/jslib/aws/s3client): a class to list S3 buckets and the objects they contain, as well as uploading, downloading and deleting objects from them.
-- [SecretsManagerClient](/javascript-api/jslib/aws/secretsmanagerclient): a class allows listing, getting, creating, updating, and deleting secrets from the AWS secrets manager service.
+- [SecretsManagerClient](/javascript-api/jslib/aws/secretsmanagerclient): a class to list, get, create, update, and delete secrets from the AWS secrets manager service.
 - [KMSClient](/javascript-api/jslib/aws/kmsclient): a class to list and generate keys from the AWS Key Management Service.
 - [AWSConfig](/javascript-api/jslib/aws/awsconfig/): a class is used by each client classes to provide them access to AWS credentials as well as configuration.
 

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/01 S3Client.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/01 S3Client.md
@@ -37,13 +37,13 @@ import { check } from 'k6';
 import exec from 'k6/execution';
 import http from 'k6/http';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.4.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.5.0/s3.js';
 
-const awsConfig = new AWSConfig(
-  __ENV.AWS_REGION,
-  __ENV.AWS_ACCESS_KEY_ID,
-  __ENV.AWS_SECRET_ACCESS_KEY
-);
+const awsConfig = new AWSConfig({
+  region: __ENV.AWS_REGION,
+  accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+  secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+});
 
 const s3 = new S3Client(awsConfig);
 const testBucketName = 'test-jslib-aws';

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/02 SecretsManagerClient.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/02 SecretsManagerClient.md
@@ -35,13 +35,13 @@ S3 Client methods will throw errors in case of failure.
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.4.0/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.5.0/secrets-manager.js';
 
-const awsConfig = new AWSConfig(
-  __ENV.AWS_REGION,
-  __ENV.AWS_ACCESS_KEY_ID,
-  __ENV.AWS_SECRET_ACCESS_KEY
-);
+const awsConfig = new AWSConfig({
+  region: __ENV.AWS_REGION,
+  accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+  secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+});
 
 const secretsManager = new SecretsManagerClient(awsConfig);
 const testSecretName = 'jslib-test-secret';

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/03 AwsConfig.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/03 AwsConfig.md
@@ -32,13 +32,13 @@ import exec from 'k6/execution';
 
 // Note that you AWSConfig is also included in the dedicated service
 // client bundles such as `s3.js` and `secrets-manager.js`
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.4.0/aws.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.5.0/aws.js';
 
-const awsConfig = new AWSConfig(
-  __ENV.AWS_REGION,
-  __ENV.AWS_ACCESS_KEY_ID,
-  __ENV.AWS_SECRET_ACCESS_KEY
-);
+const awsConfig = new AWSConfig({
+  region: __ENV.AWS_REGION,
+  accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+  secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+});
 
 const secretsManager = new SecretsManagerClient(awsConfig);
 

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/03 KMSClient.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/03 KMSClient.md
@@ -8,7 +8,7 @@ excerpt: 'KMSClient allows interacting with the AWS Key Management Service'
 `KMSClient` interacts with the AWS Key Management Service.
 With it, the user can list all the Key Management Service keys in the caller's AWS account and region. They can also generate symmetric data keys to use outside of AWS Key Management Service. `KMSClient` operations are blocking. k6 recommends reserving their use to the [`setup`](/using-k6/test-life-cycle/) and [`teardown`](/using-k6/test-life-cycle/) stages as much as possible.
 
-The dedicated `kms.js` jslib bundle, and the all-encompassing `aws.js` one, include the `KMSClient`. 
+Both the dedicated `kms.js` jslib bundle and the all-encompassing `aws.js` bundle include the `KMSClient`. 
 
 ### Methods
 

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/03 KMSClient.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/03 KMSClient.md
@@ -1,0 +1,65 @@
+---
+title: 'KMSClient'
+head_title: 'KMSClient'
+description: 'KMSClient allows interacting with the AWS Key Management Service'
+excerpt: 'KMSClient allows interacting with the AWS Key Management Service'
+---
+
+`KMSClient` allows interactions with the AWS Key Management Service. Using it, the user can list all the Key Management Service keys in the caller's AWS account and region. They can also generate symmetric data keys for use outside of AWS Key Management Service. `KMSClient` operations are blocking, and we recommend reserving their usage to the [`setup`](/using-k6/test-life-cycle/) and [`teardown`](/using-k6/test-life-cycle/) functions as much as possible.
+
+The dedicated `kms.js` jslib bundle, and the all-encompassing `aws.js` one, include the `KMSClient`. 
+
+### Methods
+
+| Function                                                                          | Description                                                                          |
+| :-------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------- |
+| [listKeys](/javascript-api/jslib/aws/kmsclient/kmsclient-listkeys/)               | List the all the Key Management Service keys in the caller's AWS account and region. |
+| [generateDataKey](/javascript-api/jslib/aws/kmsclient/kmsclient-generatedatakey/) | Generate a symmetric data key for use outside of the AWS Key Management Service.     |
+
+### Throws
+
+`KMSClient` methods throw errors in case of failure.
+
+| Error                 | Condition                                                  |
+| :-------------------- | :--------------------------------------------------------- |
+| `InvalidSignatureError` | when using invalid credentials                    |
+| `KMSServiceError`        | when AWS replied to the requested operation with an error |
+
+### Example
+
+<CodeGroup labels={[]}>
+
+```javascript
+import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.1/index.js';
+
+import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.5.0/kms.js';
+
+const awsConfig = new AWSConfig({
+  region: __ENV.AWS_REGION,
+  accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+  secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+});
+
+const kms = new KMSClient(awsConfig);
+const keyAlias = 'alias/k6-key';
+
+export function setup() {
+  // Create a symmetric data key
+  return {
+    dataKey: kms.generateDataKey(keyAlias, 32),
+  };
+}
+
+export default function (data) {
+  // Use the data key to encrypt data
+}
+
+export function handleSummary(data) {
+  return {
+    'stdout': textSummary(data, { indent: ' ', enableColors: true }),
+    './test-run.key': data.dataKey,
+  };
+}
+```
+
+</CodeGroup>

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/03 KMSClient.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/03 KMSClient.md
@@ -5,7 +5,8 @@ description: 'KMSClient allows interacting with the AWS Key Management Service'
 excerpt: 'KMSClient allows interacting with the AWS Key Management Service'
 ---
 
-`KMSClient` allows interactions with the AWS Key Management Service. Using it, the user can list all the Key Management Service keys in the caller's AWS account and region. They can also generate symmetric data keys for use outside of AWS Key Management Service. `KMSClient` operations are blocking, and we recommend reserving their usage to the [`setup`](/using-k6/test-life-cycle/) and [`teardown`](/using-k6/test-life-cycle/) functions as much as possible.
+`KMSClient` interacts with the AWS Key Management Service.
+With it, the user can list all the Key Management Service keys in the caller's AWS account and region. They can also generate symmetric data keys to use outside of AWS Key Management Service. `KMSClient` operations are blocking. k6 recommends reserving their use to the [`setup`](/using-k6/test-life-cycle/) and [`teardown`](/using-k6/test-life-cycle/) stages as much as possible.
 
 The dedicated `kms.js` jslib bundle, and the all-encompassing `aws.js` one, include the `KMSClient`. 
 

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/04 AwsConfig.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/04 AwsConfig.md
@@ -9,11 +9,14 @@ AWSConfig is used to configure an AWS service client instance, such as [S3Client
 
 AWSConfig is included in the `aws.js` bundle, which includes all the content of the library. It is also included in the various services clients dedicated bundles such as `s3.js` and `secrets-manager.js`.
 
-| Parameter                  | Type   | Description                                                                                                               |
+It takes an options object as its single parameter, with the following properties:
+
+| Property                   | Type   | Description                                                                                                               |
 | :------------------------- | :----- | :------------------------------------------------------------------------------------------------------------------------ |
 | region                     | string | the AWS region to connect to. As described by [Amazon AWS docs](https://docs.aws.amazon.com/general/latest/gr/rande.html) |
 | accessKeyID                | string | The AWS access key ID credential to use for authentication.                                                               |
-| secretAccessKey (optional) | string | The AWS secret access credential to use for authentication.                                                               |
+| secretAccessKey            | string | The AWS secret access credential to use for authentication.                                                               |
+| sessionToken (optional)    | string | The AWS secret access token to use for authentication.                                                               |
 
 ### Throws
 

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/KMSClient/01 listKeys.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/KMSClient/01 listKeys.md
@@ -1,0 +1,49 @@
+---
+title: 'KMSClient.listKeys()'
+description: "KMSClient.listKeys lists all the KMS keys in the caller's AWS account and region"
+excerpt: "KMSClient.listKeys lists all the KMS keys in the caller's AWS account and region"
+---
+
+`KMSClient.listKeys()` lists all the Key Management Service keys in the caller's AWS account and region.
+
+### Returns
+
+| Type                                                        | Description                                                               |
+| :---------------------------------------------------------- | :------------------------------------------------------------------------ |
+| [`KMSKey[]`](/javascript-api/jslib/aws/kmsclient/kmskey) | An array of [`KMSKey`](/javascript-api/jslib/aws/kmsclient/kmskey) objects. |
+
+### Example
+
+<CodeGroup labels={[]}>
+
+```javascript
+import exec from 'k6/execution';
+
+import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.5.0/kms.js';
+
+const awsConfig = new AWSConfig({
+  region: __ENV.AWS_REGION,
+  accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+  secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+});
+
+const kms = new KMSClient(awsConfig);
+const testKeyId = 'e67f95-4c047567-4-a0b7-62f7ce8ec8f48';
+
+export default function () {
+  // List the KMS keys the AWS authentication configuration
+  // gives us access to.
+  const keys = kms.listKeys();
+
+  // If our test key does not exist, abort the execution.
+  if (keys.filter((b) => b.keyId === testKeyId).length == 0) {
+    exec.test.abort();
+  }
+}
+```
+
+_A k6 script querying the user's Key Management Service keys and verifying their test key exists_
+
+</CodeGroup>
+
+

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/KMSClient/02 generateDataKey.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/KMSClient/02 generateDataKey.md
@@ -1,0 +1,59 @@
+---
+title: 'KMSClient.generateDataKey'
+description: 'KMSClient.generateDataKey generates a symmetric data key for use outside of the AWS Key Management Service'
+excerpt: 'KMSClient.generateDataKey generates a symmetric data key for use outside of the AWS Key Management Service'
+---
+
+`KMSClient.generateDataKey` generates a symmetric data key for use outside of the AWS Key Management Service.
+
+### Parameters
+
+| Name | Type   | Description                                                                                                                                                                  |
+| :--- | :----- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`   | string | The identifier of the key. This can be either the key ID or the Amazon Resource Name (ARN) of the key.                                                                       |
+| `size` | number | The length of the data key. For example, use the value 64 to generate a 512-bit data key (64 bytes is 512 bits). For 256-bit (32-byte) data keys, use the value 32, instead. |
+
+### Returns
+
+| Type                                                         | Description                                                        |
+| :----------------------------------------------------------- | :----------------------------------------------------------------- |
+| [`KMSDataKey`](/javascript-api/jslib/aws/kmsclient/kmsdatakey) | A [KMSDataKey](/javascript-api/jslib/aws/kmsclient/kmskey) object. |
+
+### Example
+
+<CodeGroup labels={[]}>
+
+```javascript
+import exec from 'k6/execution';
+
+import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.5.0/kms.js';
+
+const awsConfig = new AWSConfig({
+  region: __ENV.AWS_REGION,
+  accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+  secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+});
+
+const kms = new KMSClient(awsConfig);
+const testKeyId = 'e67f95-4c047567-4-a0b7-62f7ce8ec8f48';
+
+export default function () {
+  // List the KMS keys the AWS authentication configuration
+  // gives us access to.
+  const keys = kms.listKeys();
+
+  // If our test key does not exist, abort the execution.
+  if (keys.filter((b) => b.keyId === testKeyId).length == 0) {
+    exec.test.abort();
+  }
+
+  // Generate a data key from the KMS key.
+  const key = kms.generateDataKey(testKeyId, 32);
+}
+```
+
+_A k6 script that generating a data key from an AWS Key Management Service key_
+
+</CodeGroup>
+
+

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/KMSClient/98 KMSDataKey.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/KMSClient/98 KMSDataKey.md
@@ -4,7 +4,7 @@ description: 'KMSDataKey is returned by the KMSClient.*DataKey methods that quer
 excerpt: 'KMSDataKey is returned by the KMSClient.*DataKey methods that query KMS data keys'
 ---
 
-KMSClient.*DataKey methods, querying Key Management Service data keys, return some KMSDataKey instances. The KMSDataKey object describes an Amazon Key Management Service data key. For instance, the [`generateDataKey`](/javascript-api/jslib/aws/kmsclient/kmsclient-generate-data-key/) returns the generated KMSDataKey object.   
+`KMSClient.*DataKey` methods, querying Key Management Service data keys, return some KMSDataKey instances. The KMSDataKey object describes an Amazon Key Management Service data key. For instance, the [`generateDataKey`](/javascript-api/jslib/aws/kmsclient/kmsclient-generate-data-key/) returns the generated KMSDataKey object.   
 
 | Name                        | Type   | Description                                                                                                                     |
 | :-------------------------- | :----- | :------------------------------------------------------------------------------------------------------------------------------ |

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/KMSClient/98 KMSDataKey.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/KMSClient/98 KMSDataKey.md
@@ -1,0 +1,50 @@
+---
+title: 'KMSDataKey'
+description: 'KMSDataKey is returned by the KMSClient.*DataKey methods that query KMS data keys'
+excerpt: 'KMSDataKey is returned by the KMSClient.*DataKey methods that query KMS data keys'
+---
+
+KMSClient.*DataKey methods, querying Key Management Service data keys, return some KMSDataKey instances. The KMSDataKey object describes an Amazon Key Management Service data key. For instance, the [`generateDataKey`](/javascript-api/jslib/aws/kmsclient/kmsclient-generate-data-key/) returns the generated KMSDataKey object.   
+
+| Name                        | Type   | Description                                                                                                                     |
+| :-------------------------- | :----- | :------------------------------------------------------------------------------------------------------------------------------ |
+| `KMSDataKey.id`             | string | The identifier of the Key Management Service key that encrypted the data key.                                                                      |
+| `KMSDataKey.ciphertextBlob` | string | The base64-encoded encrypted copy of the data key.                                                                              |
+| `KMSDataKey.plaintext`      | string | The plain text data key. Use this data key to encrypt your data outside of Key Management Service. Then, remove it from memory as soon as possible. |
+
+### Example
+
+<CodeGroup labels={[]}>
+
+```javascript
+import exec from 'k6/execution';
+
+import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.5.0/kms.js';
+
+const awsConfig = new AWSConfig({
+  region: __ENV.AWS_REGION,
+  accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+  secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+});
+
+const kms = new KMSClient(awsConfig);
+const testKeyId = 'e67f95-4c047567-4-a0b7-62f7ce8ec8f48';
+
+export default function () {
+  // List the KMS keys the AWS authentication configuration
+  // gives us access to.
+  const keys = kms.listKeys();
+
+  // If our test key does not exist, abort the execution.
+  if (keys.filter((b) => b.keyId === testKeyId).length == 0) {
+    exec.test.abort();
+  }
+
+  // Generate a data key from the KMS key.
+  const key = kms.generateDataKey(testKeyId, 32);
+}
+```
+
+_A k6 script that generating a data key from an AWS Key Management Service key_
+
+</CodeGroup>

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/KMSClient/99 KMSKey.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/KMSClient/99 KMSKey.md
@@ -1,0 +1,46 @@
+---
+title: 'KMSKey'
+description: 'KMSKey is returned by the KMSClient.* methods that query KMS keys'
+excerpt: 'KMSKey is returned by the KMSClient.* methods that query KMS keys'
+---
+
+`KMSClient.*` methods querying Key Management Service keys return some `KMSKey` instances. Namely, `listKeys()` returns an array of `KMSKey` objects. The `KMSKey` object describes an Amazon Key Management Service key.  
+
+| Name            | Type   | Description                  |
+| :-------------- | :----- | :--------------------------- |
+| `KMSKey.keyId`  | string | Unique identifier of the key |
+| `KMSKey.keyArn` | string | ARN of the key               |
+
+### Example
+
+<CodeGroup labels={[]}>
+
+```javascript
+import exec from 'k6/execution';
+
+import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.5.0/kms.js';
+
+const awsConfig = new AWSConfig({
+  region: __ENV.AWS_REGION,
+  accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+  secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+});
+
+const kms = new KMSClient(awsConfig);
+const testKeyId = 'e67f95-4c047567-4-a0b7-62f7ce8ec8f48';
+
+export default function () {
+  // List the KMS keys the AWS authentication configuration
+  // gives us access to.
+  const keys = kms.listKeys();
+
+  // If our test key does not exist, abort the execution.
+  if (keys.filter((b) => b.keyId === testKeyId).length == 0) {
+    exec.test.abort();
+  }
+}
+```
+
+_A k6 script querying the user's Key Management Service keys and verifying their test key exists_
+
+</CodeGroup>

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/S3Client/01 listBuckets().md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/S3Client/01 listBuckets().md
@@ -19,13 +19,13 @@ excerpt: 'S3Client.listBuckets lists the buckets the authenticated user has acce
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.4.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.5.0/s3.js';
 
-const awsConfig = new AWSConfig(
-  __ENV.AWS_REGION,
-  __ENV.AWS_ACCESS_KEY_ID,
-  __ENV.AWS_SECRET_ACCESS_KEY
-);
+const awsConfig = new AWSConfig({
+  region: __ENV.AWS_REGION,
+  accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+  secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+});
 
 const s3 = new S3Client(awsConfig);
 const testBucketName = 'test-jslib-aws';

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/S3Client/02 listObjects(bucketName, [prefix]).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/S3Client/02 listObjects(bucketName, [prefix]).md
@@ -24,13 +24,13 @@ excerpt: 'S3Client.listObjects lists the objects contained in a bucket'
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.4.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.5.0/s3.js';
 
-const awsConfig = new AWSConfig(
-  __ENV.AWS_REGION,
-  __ENV.AWS_ACCESS_KEY_ID,
-  __ENV.AWS_SECRET_ACCESS_KEY
-);
+const awsConfig = new AWSConfig({
+  region: __ENV.AWS_REGION,
+  accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+  secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+});
 
 const s3 = new S3Client(awsConfig);
 const testBucketName = 'test-jslib-aws';

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/S3Client/03 getObject(bucketName, objectKey).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/S3Client/03 getObject(bucketName, objectKey).md
@@ -24,13 +24,13 @@ excerpt: 'S3Client.getObject downloads an object from a bucket'
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.4.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.5.0/s3.js';
 
-const awsConfig = new AWSConfig(
-  __ENV.AWS_REGION,
-  __ENV.AWS_ACCESS_KEY_ID,
-  __ENV.AWS_SECRET_ACCESS_KEY
-);
+const awsConfig = new AWSConfig({
+  region: __ENV.AWS_REGION,
+  accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+  secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+});
 
 const s3 = new S3Client(awsConfig);
 const testBucketName = 'test-jslib-aws';

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/S3Client/04 putObject(bucketName, objectKey, data).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/S3Client/04 putObject(bucketName, objectKey, data).md
@@ -17,13 +17,13 @@ excerpt: 'S3Client.putObject uploads an object to a bucket'
 <CodeGroup labels={[]}>
 
 ```javascript
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.4.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.5.0/s3.js';
 
-const awsConfig = new AWSConfig(
-  __ENV.AWS_REGION,
-  __ENV.AWS_ACCESS_KEY_ID,
-  __ENV.AWS_SECRET_ACCESS_KEY
-);
+const awsConfig = new AWSConfig({
+  region: __ENV.AWS_REGION,
+  accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+  secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+});
 
 const s3 = new S3Client(awsConfig);
 const testBucketName = 'test-jslib-aws';

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/S3Client/05 deleteObject(bucketName, objectKey).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/S3Client/05 deleteObject(bucketName, objectKey).md
@@ -18,13 +18,13 @@ excerpt: 'S3Client.deleteObject deletes an object from a bucket'
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.4.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.5.0/s3.js';
 
-const awsConfig = new AWSConfig(
-  __ENV.AWS_REGION,
-  __ENV.AWS_ACCESS_KEY_ID,
-  __ENV.AWS_SECRET_ACCESS_KEY
-);
+const awsConfig = new AWSConfig({
+  region: __ENV.AWS_REGION,
+  accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+  secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+});
 
 const s3 = new S3Client(awsConfig);
 const testBucketName = 'test-jslib-aws';

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/S3Client/98 Object.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/S3Client/98 Object.md
@@ -26,13 +26,13 @@ import {
   // listBuckets,
   AWSConfig,
   S3Client,
-} from 'https://jslib.k6.io/aws/0.4.0/s3.js';
+} from 'https://jslib.k6.io/aws/0.5.0/s3.js';
 
-const awsConfig = new AWSConfig(
-  __ENV.AWS_REGION,
-  __ENV.AWS_ACCESS_KEY_ID,
-  __ENV.AWS_SECRET_ACCESS_KEY
-);
+const awsConfig = new AWSConfig({
+  region: __ENV.AWS_REGION,
+  accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+  secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+});
 
 const s3 = new S3Client(awsConfig);
 const testBucketName = 'test-jslib-aws';

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/S3Client/99 Bucket.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/S3Client/99 Bucket.md
@@ -16,13 +16,13 @@ Bucket is returned by the S3Client.* methods that query S3 buckets. Namely, `lis
 <CodeGroup labels={[]}>
 
 ```javascript
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.4.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.5.0/s3.js';
 
-const awsConfig = new AWSConfig(
-  __ENV.AWS_REGION,
-  __ENV.AWS_ACCESS_KEY_ID,
-  __ENV.AWS_SECRET_ACCESS_KEY
-);
+const awsConfig = new AWSConfig({
+  region: __ENV.AWS_REGION,
+  accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+  secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+});
 
 const s3 = new S3Client(awsConfig);
 

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/01 listSecrets().md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/01 listSecrets().md
@@ -19,13 +19,13 @@ excerpt: 'SecretsManagerClient.listSecrets lists the secrets the authenticated u
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.4.0/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.5.0/secrets-manager.js';
 
-const awsConfig = new AWSConfig(
-  __ENV.AWS_REGION,
-  __ENV.AWS_ACCESS_KEY_ID,
-  __ENV.AWS_SECRET_ACCESS_KEY
-);
+const awsConfig = new AWSConfig({
+  region: __ENV.AWS_REGION,
+  accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+  secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+});
 
 const secretsManager = new SecretsManagerClient(awsConfig);
 const testSecretName = 'jslib-test-secret';

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/02 getSecret(secretID).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/02 getSecret(secretID).md
@@ -23,13 +23,13 @@ excerpt: 'SecretsManagerClient.getSecret(secretID) downloads a secret from AWS s
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.4.0/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.5.0/secrets-manager.js';
 
-const awsConfig = new AWSConfig(
-  __ENV.AWS_REGION,
-  __ENV.AWS_ACCESS_KEY_ID,
-  __ENV.AWS_SECRET_ACCESS_KEY
-);
+const awsConfig = new AWSConfig({
+  region: __ENV.AWS_REGION,
+  accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+  secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+});
 
 const secretsManager = new SecretsManagerClient(awsConfig);
 const testSecretName = 'jslib-test-secret';

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/03 createSecret(name, secretString, description, [versionID], [tags]).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/03 createSecret(name, secretString, description, [versionID], [tags]).md
@@ -19,13 +19,13 @@ excerpt: 'SecretsManagerClient.createSecret creates a new secret'
 <CodeGroup labels={[]}>
 
 ```javascript
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.4.0/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.5.0/secrets-manager.js';
 
-const awsConfig = new AWSConfig(
-  __ENV.AWS_REGION,
-  __ENV.AWS_ACCESS_KEY_ID,
-  __ENV.AWS_SECRET_ACCESS_KEY
-);
+const awsConfig = new AWSConfig({
+  region: __ENV.AWS_REGION,
+  accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+  secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+});
 
 const secretsManager = new SecretsManagerClient(awsConfig);
 const testSecretName = 'jslib-test-secret';

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/04 deleteSecret(secretID, { recoveryWindow: 30, noRecovery: false}}).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/04 deleteSecret(secretID, { recoveryWindow: 30, noRecovery: false}}).md
@@ -16,13 +16,13 @@ excerpt: 'SecretsManagerClient.deleteSecret deletes a secret'
 <CodeGroup labels={[]}>
 
 ```javascript
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.4.0/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.5.0/secrets-manager.js';
 
-const awsConfig = new AWSConfig(
-  __ENV.AWS_REGION,
-  __ENV.AWS_ACCESS_KEY_ID,
-  __ENV.AWS_SECRET_ACCESS_KEY
-);
+const awsConfig = new AWSConfig({
+  region: __ENV.AWS_REGION,
+  accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+  secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+});
 
 const secretsManager = new SecretsManagerClient(awsConfig);
 const testSecretName = 'jslib-test-secret';

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/05 putSecretValue(secretID, secretString, [versionID]).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/05 putSecretValue(secretID, secretString, [versionID]).md
@@ -20,13 +20,13 @@ excerpt: "SecretsManagerClient.putSecretValue updates an existing secret's value
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.4.0/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.5.0/secrets-manager.js';
 
-const awsConfig = new AWSConfig(
-  __ENV.AWS_REGION,
-  __ENV.AWS_ACCESS_KEY_ID,
-  __ENV.AWS_SECRET_ACCESS_KEY
-);
+const awsConfig = new AWSConfig({
+  region: __ENV.AWS_REGION,
+  accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+  secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+});
 
 const secretsManager = new SecretsManagerClient(awsConfig);
 const testSecretName = 'jslib-test-secret';

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/99 Secret.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/99 Secret.md
@@ -22,13 +22,13 @@ Secret is returned by the SecretsManagerClient.* methods that query secrets. Nam
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.4.0/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.5.0/secrets-manager.js';
 
-const awsConfig = new AWSConfig(
-  __ENV.AWS_REGION,
-  __ENV.AWS_ACCESS_KEY_ID,
-  __ENV.AWS_SECRET_ACCESS_KEY
-);
+const awsConfig = new AWSConfig({
+  region: __ENV.AWS_REGION,
+  accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+  secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+});
 
 const secretsManager = new SecretsManagerClient(awsConfig);
 const testSecretName = 'jslib-test-secret';


### PR DESCRIPTION
This PR documents the changes brought in the AWS jslib with version v0.5.0.

Namely, the introduction of the KMS service, support AWS session tokens authentication, changes in how options are passed to `AWSConfig`, and some bug fixes for the S3 integration.

Merging this PR should happen once and only once the [jslib PR](https://github.com/grafana/jslib.k6.io/pull/59) is effectively merged.