### PR TITLE
feat: add categories & type for Extension card

### DIFF
--- a/src/components/pages/doc-extensions/extensions-title-group/extensions-title-group.module.scss
+++ b/src/components/pages/doc-extensions/extensions-title-group/extensions-title-group.module.scss
@@ -23,7 +23,7 @@
   align-items: center;
 
   &.low {
-    top: 150px;
+    top: 160px;
   }
 
   svg {
@@ -35,19 +35,24 @@
     }
   }
 
+  @include xl-down {
+    &.low {
+      top: 200px;
+    }
+  }
   @include lg-down {
     position: static;
     top: unset;
     right: unset;
-    margin-bottom: 30px;
+    margin-bottom: 10px;
     transform: unset;
 
     &.low {
-      top: unset;
+      top: 130px;
     }
   }
 
-  @include sm-down {
+  @include xs-down {
     margin-left: 20px;
   }
 

--- a/src/components/shared/extension-card/extension-card.module.scss
+++ b/src/components/shared/extension-card/extension-card.module.scss
@@ -73,11 +73,55 @@
 }
 
 .name {
-  padding-right: 30px;
+  margin-top: 6px;
+  padding-right: 8px;
   font-size: $font-size-lg;
   line-height: $line-height-lg;
   font-weight: 700;
   transition: color 0.3s;
+}
+
+.category-wrapper {
+  display: flex;
+  list-style-type: none;
+  padding: 0;
+  margin-top: 0;
+  margin-bottom: 6px;
+
+  :nth-child(n + 2) {
+    margin-right: 8px;
+    margin-left: 8px;
+
+    &::before {
+      content: '';
+      position: absolute;
+      width: 1px;
+      height: 13px;
+      background-color: $color-additional-2;
+      top: 4px;
+      bottom: 0%;
+      left: -8px;
+    }
+  }
+}
+.category {
+  font-size: $font-size-xs;
+  line-height: 20px;
+  color: $color-secondary;
+  text-transform: uppercase;
+  font-weight: 400;
+  position: relative;
+  margin-right: 8px;
+}
+
+.type {
+  background-color: rgba(125, 100, 255, 0.1);
+  padding: 2px 4px;
+  text-align: center;
+  color: $color-accent-primary;
+  text-transform: uppercase;
+  font-weight: 500;
+  font-size: $font-size-xs;
 }
 
 .author {

--- a/src/components/shared/extension-card/extension-card.module.scss
+++ b/src/components/shared/extension-card/extension-card.module.scss
@@ -72,24 +72,16 @@
   align-items: flex-start;
 }
 
-.name {
-  margin-top: 6px;
-  padding-right: 8px;
-  font-size: $font-size-lg;
-  line-height: $line-height-lg;
-  font-weight: 700;
-  transition: color 0.3s;
-}
-
 .category-wrapper {
   display: flex;
+  flex-wrap: wrap;
+
   list-style-type: none;
   padding: 0;
   margin-top: 0;
-  margin-bottom: 6px;
+  margin-bottom: 0px;
 
-  :nth-child(n + 2) {
-    margin-right: 8px;
+  li + li {
     margin-left: 8px;
 
     &::before {
@@ -104,6 +96,7 @@
     }
   }
 }
+
 .category {
   font-size: $font-size-xs;
   line-height: 20px;
@@ -114,7 +107,19 @@
   margin-right: 8px;
 }
 
+.name-wrapper {
+  margin-top: 6px;
+}
+
+.name {
+  font-size: $font-size-lg;
+  line-height: $line-height-lg;
+  font-weight: 700;
+  transition: color 0.3s;
+}
+
 .type {
+  margin-left: 8px;
   background-color: rgba(125, 100, 255, 0.1);
   padding: 2px 4px;
   text-align: center;

--- a/src/components/shared/extension-card/extension-card.view.js
+++ b/src/components/shared/extension-card/extension-card.view.js
@@ -53,14 +53,16 @@ export const ExtensionCard = ({
         </div>
       )}
       <div className={styles.content}>
-        <ul className={styles.categoryWrapper}>
-          {extension.categories.map((category, index) => (
-            <li className={styles.category} key={index}>
-              {category}
-            </li>
-          ))}
-        </ul>
-        <div>
+        {extension.categories && (
+          <ul className={styles.categoryWrapper}>
+            {extension.categories.map((category, index) => (
+              <li className={styles.category} key={index}>
+                {category}
+              </li>
+            ))}
+          </ul>
+        )}
+        <div className={styles.nameWrapper}>
           <span className={styles.name}>{extension.name}</span>
           {extension.type && (
             <span className={styles.type}>{extension.type}</span>

--- a/src/components/shared/extension-card/extension-card.view.js
+++ b/src/components/shared/extension-card/extension-card.view.js
@@ -53,7 +53,19 @@ export const ExtensionCard = ({
         </div>
       )}
       <div className={styles.content}>
-        <span className={styles.name}>{extension.name}</span>
+        <ul className={styles.categoryWrapper}>
+          {extension.categories.map((category, index) => (
+            <li className={styles.category} key={index}>
+              {category}
+            </li>
+          ))}
+        </ul>
+        <div>
+          <span className={styles.name}>{extension.name}</span>
+          {extension.type && (
+            <span className={styles.type}>{extension.type}</span>
+          )}
+        </div>
         <span className={styles.description}>{extension.description}</span>
       </div>
     </Wrapper>

--- a/src/components/shared/page-info/page-info.module.scss
+++ b/src/components/shared/page-info/page-info.module.scss
@@ -1,9 +1,15 @@
 .container {
-  margin-bottom: 47.5px;
+  margin-bottom: 20px;
   margin-top: 115px;
+
   @include xl-down {
     margin-top: 160px;
   }
+
+  @include lg-down {
+    margin-bottom: 20px;
+  }
+
   @include sm-down {
     margin-top: 230px;
   }
@@ -27,6 +33,7 @@
 
 .title {
   max-width: calc(100% - 325px); // preserving the spacing and width in adaptive
+
   @include lg-down {
     max-width: 100%;
   }

--- a/src/data/doc-extensions/extensions.json
+++ b/src/data/doc-extensions/extensions.json
@@ -180,7 +180,7 @@
       },
       "official": false,
       "categories": ["Protocol"],
-      "type": "JS"
+      "type": false
     },
     {
       "name": "xk6-mqtt",
@@ -192,8 +192,7 @@
         "url": "https://github.com/pmalhaire"
       },
       "official": false,
-      "categories": ["Messaging"],
-      "type": "Out"
+      "categories": ["Messaging"]
     },
     {
       "name": "xk6-kv",
@@ -205,8 +204,7 @@
         "url": "https://github.com/dgzlopes"
       },
       "official": false,
-      "categories": ["Data"],
-      "type": "JS"
+      "categories": ["Data"]
     },
     {
       "name": "xk6-url",
@@ -218,8 +216,7 @@
         "url": "https://github.com/dgzlopes"
       },
       "official": false,
-      "categories": ["Misc"],
-      "type": "Out"
+      "categories": ["Misc"]
     },
     {
       "name": "xk6-kubernetes",

--- a/src/data/doc-extensions/extensions.json
+++ b/src/data/doc-extensions/extensions.json
@@ -34,9 +34,7 @@
         "url": ""
       },
       "official": false,
-      "categories": [
-        "WebSockets"
-      ]
+      "categories": ["WebSockets"]
     },
     {
       "name": "xk6-kafka",
@@ -181,7 +179,8 @@
         "url": "https://github.com/vvarp"
       },
       "official": false,
-      "categories": ["Protocol"]
+      "categories": ["Protocol"],
+      "type": "JS"
     },
     {
       "name": "xk6-mqtt",
@@ -193,7 +192,8 @@
         "url": "https://github.com/pmalhaire"
       },
       "official": false,
-      "categories": ["Messaging"]
+      "categories": ["Messaging"],
+      "type": "Out"
     },
     {
       "name": "xk6-kv",
@@ -205,7 +205,8 @@
         "url": "https://github.com/dgzlopes"
       },
       "official": false,
-      "categories": ["Data"]
+      "categories": ["Data"],
+      "type": "JS"
     },
     {
       "name": "xk6-url",
@@ -217,7 +218,8 @@
         "url": "https://github.com/dgzlopes"
       },
       "official": false,
-      "categories": ["Misc"]
+      "categories": ["Misc"],
+      "type": "Out"
     },
     {
       "name": "xk6-kubernetes",

--- a/src/templates/docs/bundle-builder.js
+++ b/src/templates/docs/bundle-builder.js
@@ -42,6 +42,7 @@ export default function BundleBuilderPage({
           logo
           official
           categories
+          type
           author {
             name
             url

--- a/src/templates/docs/explore-extensions.js
+++ b/src/templates/docs/explore-extensions.js
@@ -46,6 +46,7 @@ export default function ExploreExtensionsPage({
           logo
           official
           categories
+          type
           author {
             name
             url


### PR DESCRIPTION
**Describe** what changes this pull request brings:
This pull request adds categories & type for Extension card for Docs.

**Steps to test**
1. Open the [page](https://mdr-ci.staging.k6.io/docs/refs/pull/802/merge/extensions/getting-started/explore/)
2. Confirm that everything looks and works as expected

<details>
<summary>Screenshots</summary>

<img width="2045" alt="Screenshot 2022-09-12 at 12 06 30" src="https://user-images.githubusercontent.com/75138180/189593089-83c8893d-6cd7-42ae-a751-2825457d7ca3.png">


</details>

TODO: please remove test types in `extensions.json`

**References**
[Design](https://www.figma.com/file/qOPbJuR5wWjOablZeFCQtu/K6-Website-Design?node-id=10348%3A31996)

Closes: #303 