### PR TITLE
docs/cloud; Add videos in a responsive iframe

### DIFF
--- a/src/styles/parts/global.scss
+++ b/src/styles/parts/global.scss
@@ -99,3 +99,18 @@ body .hide-md-down {
     display: initial;
   }
 }
+
+.iframe-container {
+  overflow: hidden;
+  padding-top: 56.25%;
+  position: relative;
+}
+
+.iframe-container iframe {
+  border: 0;
+  height: 100%;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+}

--- a/src/templates/docs/cloud.js
+++ b/src/templates/docs/cloud.js
@@ -44,23 +44,23 @@ export default function Cloud({ pageContext: { sidebarTree, navLinks } }) {
           <div ref={contentContainerRef} className={stickyContainerClasses}>
             <div className={'container'}>
               <div className={`${htmlStyles.wrapper}`}>
-                <h2>What is the k6 Cloud?</h2>
+                <h2>What is k6 Cloud?</h2>
                 <p>
-                  The k6 Cloud is a commercial SaaS product that we’ve designed
-                  to be the perfect companion to k6 OSS. It brings ease-of-use
-                  and convenience to your performance and load testing.
+                  The k6 Cloud is a commercial SaaS product designed to be the
+                  perfect companion to k6 OSS.
                 </p>
-                <p>
-                  This knowledge base will help you learn how to use the
-                  features and functionality of the k6 Cloud:
-                </p>
-                <ul>
-                  <li>Running cloud tests.</li>
-                  <li>Analyzing results.</li>
-                  <li>Managing projects, teams and users.</li>
-                  <li>Integrations.</li>
-                  <li>FAQ.</li>
-                </ul>
+                <div className="iframe-container">
+                  <iframe
+                    width="560"
+                    height="315"
+                    src="https://www.youtube.com/embed/ncxCIuo5tUU"
+                    title="YouTube video player"
+                    frameBorder="0"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowFullScreen
+                  />
+                </div>
+
                 <h2>How can it help me?</h2>
                 <p>
                   The k6 Cloud is a premium service to empower your team to

--- a/src/templates/docs/cloud.js
+++ b/src/templates/docs/cloud.js
@@ -53,7 +53,7 @@ export default function Cloud({ pageContext: { sidebarTree, navLinks } }) {
                   <iframe
                     width="560"
                     height="315"
-                    src="https://www.youtube.com/embed/ncxCIuo5tUU"
+                    src="https://www.youtube.com/embed/gwO7k5RTE54"
                     title="YouTube video player"
                     frameBorder="0"
                     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"


### PR DESCRIPTION
This is a visual and content change to the Overview page of the cloud docs. It replaces the out-of-date bullets that outline the doc structure with a video playlist.

@ppcano I've added a responsive Iframe, do you think this is enough? If not, I'd like to ask Kirill to give his opinion. Before merging, I also am going to try to get the thumbnail text changed so that it says k6 cloud.