### PR TITLE
Rewrite result-output getting started doc

### DIFF
--- a/src/data/markdown/translated-guides/en/01 Getting started/04 Results Output.md
+++ b/src/data/markdown/translated-guides/en/01 Getting started/04 Results Output.md
@@ -83,7 +83,7 @@ For both cases, you can use the `--out` flag.
 $ k6 run --out statsd script.js
 ```
 
-The available built-in outputs are:
+The available built-in outputs include:
 
 <Glossary>
 

--- a/src/data/markdown/translated-guides/en/01 Getting started/04 Results Output.md
+++ b/src/data/markdown/translated-guides/en/01 Getting started/04 Results Output.md
@@ -64,15 +64,14 @@ With a single iteration and VU, the min, max, median, average, and p values woul
 
 </Blockquote>
 
-<DescriptionList>
 
-Custom reports with `handleSummary()`
-: At the end of the test, k6 automatically creates an object with all aggregated statistics.
+### Custom reports with `handleSummary()`
+
+At the end of the test, k6 automatically creates an object with all aggregated statistics.
+
 To completely customize the end-of-test summary,
-you can use the `handleSummary()` function to process this object into any text format.
-: For example, the community project [k6 reporter](https://github.com/benc-uk/k6-reporter) uses `handleSummary()` to make an HTML report from your k6 summary metrics.
+you can use the `handleSummary()` function to process this object into any text format.For example, the community project [k6 reporter](https://github.com/benc-uk/k6-reporter) uses `handleSummary()` to make an HTML report from your k6 summary metrics.
 
-</DescriptionList>
 
 ## Time series and external outputs
 
@@ -111,8 +110,8 @@ The available built-in outputs are:
 
 ### Multiple outputs
 
-You can also send metrics simultaneously to several outputs.
-To do so, set separate arguments for multiple CLI `--out` flags.
+You can also send metrics simultaneously to several outputs
+by using multiple CLI `--out` flags:
 
 
 ```bash

--- a/src/data/markdown/translated-guides/en/01 Getting started/04 Results Output.md
+++ b/src/data/markdown/translated-guides/en/01 Getting started/04 Results Output.md
@@ -55,7 +55,7 @@ You can do further operations on metrics to build your analysis and test logic.
 For example, you can derive [custom metrics](/using-k6/metrics/#custom-metrics) from any default metric type, be it a trend, rate, count, or gauge (that is, a maximum value).
 
 Another useful application of metrics is in combination with [_thresholds_](/using-k6/thresholds).
-With thresholds, you can use metrics to set performance goals, and abort the test when performance degrades beyond the threshold point.
+With thresholds, you can use metrics to set performance goals and abort the test when performance degrades beyond the threshold point.
 For example, this threshold aborts a test once the p99 duration value crosses 3000 milliseconds.
 
 <CodeGroup labels={["latency-exceeds-3000.js"]} lineNumbers={[]} showCopyButton={[true]}>

--- a/src/data/markdown/translated-guides/en/01 Getting started/04 Results Output.md
+++ b/src/data/markdown/translated-guides/en/01 Getting started/04 Results Output.md
@@ -6,7 +6,7 @@ excerpt: 'For basic tests, the top-level summary that k6 provides might be enoug
 As a test runs, k6 starts generating _metrics_.
 These metrics provide quantitative data to help you interpret test results.
 
-k6 generates many metrics about the load that your test generates and about how the system under test (SUT) responds to this load.
+k6 generates many metrics about the load that your test generates and how the system under test (SUT) responds to this load.
 Broadly, you can analyze metrics in two ways:
 - As summary statistics, in an _end-of-test-summary_ report.
 - As _time-series data_, in granular, point-by-point detail
@@ -15,14 +15,14 @@ Broadly, you can analyze metrics in two ways:
 
 You can customize almost every aspect of k6 result output:
 - You can create your custom metrics
-- You can configure new summary statistics, and print them to not only `stdout` but also as HTML, JSON, or any text format.
+- You can configure new summary statistics and print them not only to `stdout` but also as HTML, JSON, or any text format.
 - You can stream the results to one or multiple of the services of your choice.
 
 ## Built-in and custom metrics
 
 **Documentation:** [Using metrics](/using-k6/metrics)
 
-k6 comes with a built-in set of metrics about the load generated and about the system response.
+k6 comes with a built-in set of metrics about the load generated and the system response.
 Key metrics include:
 - `iterations`, the total number of iterations
 - `http_req_failed`, the total number of failed requests
@@ -60,27 +60,35 @@ k6 run --iterations=100 --vus=10 \
 
 <Blockquote mod="note" title="">
 
-The preceding example uses multiple iterations and VUs so that the trend metrics have different values.
 With a single iteration and VU, the min, max, median, average, and p values would all be the same.
-For example, the community project [k6 reporter](https://github.com/benc-uk/k6-reporter) uses `handleSummary()` to make an HTML report from your k6 summary metrics.
 
-## External outputs
+</Blockquote>
 
-The condensed [end-of-test summary](/results-visualization/end-of-test-summary) is good for a top-level view of the test.
+<DescriptionList>
+
+Custom reports with `handleSummary()`
+: At the end of the test, k6 automatically creates an object with all aggregated statistics.
+To completely customize the end-of-test summary,
+you can use the `handleSummary()` function to process this object into any text format.
+: For example, the community project [k6 reporter](https://github.com/benc-uk/k6-reporter) uses `handleSummary()` to make an HTML report from your k6 summary metrics.
+
+</DescriptionList>
+
+## Time series and external outputs
+
+The condensed end-of-test summary provides a top-level view of the test.
 For deeper analysis, you need to look at granular time-series data.
 
 You can integrate and visualize k6 metrics on other platforms.
-You can also write every metric to a file, and analyze them in the program of your choice.
+You can also write every metric to a file and analyze them in the program of your choice.
 
 To send granular results data to an external output, use the `--out` flag.
 
-<CodeGroup labels={[]}>
 
-```bash
+```sh
 $ k6 run --out statsd script.js
 ```
 
-</CodeGroup>
 
 The available built-in outputs are:
 
@@ -106,7 +114,6 @@ The available built-in outputs are:
 You can also send metrics simultaneously to several outputs.
 To do so, set separate arguments for multiple CLI `--out` flags.
 
-<CodeGroup labels={[]}>
 
 ```bash
 $ k6 run \
@@ -114,4 +121,3 @@ $ k6 run \
 --out influxdb=http://localhost:8086/k6
 ```
 
-</CodeGroup>

--- a/src/data/markdown/translated-guides/en/01 Getting started/04 Results Output.md
+++ b/src/data/markdown/translated-guides/en/01 Getting started/04 Results Output.md
@@ -3,7 +3,7 @@ title: 'Results output'
 excerpt: 'For basic tests, the top-level summary that k6 provides might be enough. For detailed analysis, you can stream all data your test outputs to an external source.'
 ---
 
-As k6 starts generating load, it also starts generating _metrics_.
+As a test runs, k6 starts generating _metrics_.
 These metrics provide quantitative data to help you interpret test results.
 
 k6 generates many metrics about the load that your test generates and about how the system under test (SUT) responds to this load.
@@ -12,25 +12,6 @@ Broadly, you can analyze metrics in two ways:
 - As _time-series data_, in granular, point-by-point detail
 
 ![A diagram of the two broad ways to handle results: aggregated and granular](./images/k6-results-diagram.png)
-
-These are the essential elements of k6 test results: metrics, summary output, and granular time series. 
-
-<DescriptionList>
-
-Metrics
-: Measurements that k6 generates throughout the test.
-: For example, you can use the `http_req_duration` metric to measure end-to-end latency.
-
-End-of-test-summary report
-: The default report that k6 prints to `stdout` at the end of the test, with aggregated statistics for each metric.
-: For example, the report shows the 95th percentile of all `http_req_duration` values.
-
-Time-series data
-: The granular metrics generated throughout the test (often for each request).
-: You can stream these metrics to an external service, write them to a file, or both.
-: For example, you could look at the `http_req_duration` for any request in the entire test in a JSON file or on a Grafana dashboard.
-
-</DescriptionList>
 
 You can customize almost every aspect of k6 result output:
 - You can create your custom metrics
@@ -48,32 +29,6 @@ Key metrics include:
 - `http_req_duration`, the end-to-end time of all requests (that is, the total latency)
    - `expected_response:true`, the end-to-end time of successful requests (failed requests often have faster responses)
 
-You can also use [_checks_](/using-k6/checks) to make metrics from any boolean expression.
-For example, you can check that a response body has a certain text string.
-
-### Applications of metrics
-
-You can do further operations on metrics to build your analysis and test logic.
-For example, you can derive [custom metrics](/using-k6/metrics/#custom-metrics) from any default metric type, be it a trend, rate, count, or gauge (that is, a maximum value).
-
-Another useful application of metrics is in combination with [_thresholds_](/using-k6/thresholds).
-With thresholds, you can use metrics to set performance goals and abort the test when performance degrades beyond the threshold point.
-For example, this threshold aborts a test once the p99 duration value crosses 3000 milliseconds.
-
-<CodeGroup labels={["latency-exceeds-3000.js"]} lineNumbers={[]} showCopyButton={[true]}>
-
-```javascript
-import http from 'k6/http';
-
-export const options = {
-  thresholds: {
-    http_req_duration: ['p(99)<200'], // 99% of requests should be below 200ms
-  },
-};
-```
-
-</CodeGroup>
-
 ## End-of-test-summary report
 
 **Documentation**: [End-of-test-summary report](results-visualization/end-of-test-summary/)
@@ -90,120 +45,23 @@ The end-of-test-summary shows aggregated statistical values for your result metr
 - Minimum and maximum values
 - p90, p95, and p99 values
 
-If this default report is unsuitable,
-you can change the time units, display different aggregated statistics, or make an entirely new report in any format that you want.
+If this default report is unsuitable, you can change the trend stats with
+the [`--summary-trend-stats`](https://k6.io/docs/using-k6/k6-options/reference#summary-trend-stats) option.
+You can also change the time unit with 
+the [`--summary-time-unit`](/using-k6/k6-options/reference#summary-time-unit) option.
 
-### Change time units and summary stats
-
-To configure the aggregated metrics in an end-of-test summary, use the [`--summary-trend-stats`](https://k6.io/docs/using-k6/k6-options/reference#summary-trend-stats) option.
-For example, you might need more precise p-values.
-This command limits the stats to only p99 and p99.9 values.
-
-```sh
-k6 run --summary-trend-stats="med,p(95),p(99.9)" ./script.js
-```
-
-To change the unit of time, use the [`--summary-time-unit`](/using-k6/k6-options/reference#summary-time-unit) option.
-For example, this command displays the end-of-test values in milliseconds instead of seconds:
-
-```sh
-k6 run --summary-time-unit="ms" ./script.js
-```
-
-Putting these options together, this command creates a more compact summary, with more precise p-values and time units.
-Use the tab to compare the configured output with the default output.
+For example, this command displays only the median, p95, and p99.9 values,
+and it presents the statistics in milliseconds instead of seconds.
 
 ```sh
 k6 run --iterations=100 --vus=10 \
 --summary-trend-stats="med,p(95),p(99.9)" --summary-time-unit="ms" script.js
 ```
 
-<CodeGroup labels={["Configured summary", "default summary"]} lineNumbers={[]} showCopyButton={[true]}>
-
-```txt
-default ✓ [======================================] 10 VUs  00m14.1s/10m0s  100/100 shared iters
-
-     data_received..................: 1.2 MB 86 kB/s
-     data_sent......................: 13 kB  939 B/s
-     http_req_blocked...............: med=0.01ms    p(95)=571.30ms  p(99.9)=571.68ms
-     http_req_connecting............: med=0.00ms    p(95)=269.12ms  p(99.9)=269.99ms
-     http_req_duration..............: med=228.87ms  p(95)=482.99ms  p(99.9)=551.53ms
-       { expected_response:true }...: med=228.87ms  p(95)=482.99ms  p(99.9)=551.53ms
-     http_req_failed................: 0.00%  ✓ 0        ✗ 100
-     http_req_receiving.............: med=0.16ms    p(95)=215.87ms  p(99.9)=236.51ms
-     http_req_sending...............: med=0.04ms    p(95)=0.07ms    p(99.9)=0.09ms
-     http_req_tls_handshaking.......: med=0.00ms    p(95)=234.77ms  p(99.9)=235.20ms
-     http_req_waiting...............: med=227.52ms  p(95)=296.55ms  p(99.9)=548.41ms
-     http_reqs......................: 100    7.115226/s
-     iteration_duration.............: med=1229.85ms p(95)=1856.70ms p(99.9)=1857.05ms
-     iterations.....................: 100    7.115226/s
-     vus............................: 1      min=1      max=10
-     vus_max........................: 10     min=10     max=10
-```
-
-```sh
-default ✓ [======================================] 10 VUs  00m13.3s/10m0s  100/100 shared iters
-
-     data_received..................: 1.2 MB 90 kB/s
-     data_sent......................: 13 kB  990 B/s
-     http_req_blocked...............: avg=58.96ms  min=2.58µs   med=11.36µs  max=590.12ms p(90)=58.97ms  p(95)=589.38ms
-     http_req_connecting............: avg=25.51ms  min=0s       med=0s       max=255.49ms p(90)=25.48ms  p(95)=255.1ms
-     http_req_duration..............: avg=248.25ms min=181.43ms med=229.2ms  max=448.18ms p(90)=272.74ms p(95)=427.82ms
-       { expected_response:true }...: avg=248.25ms min=181.43ms med=229.2ms  max=448.18ms p(90)=272.74ms p(95)=427.82ms
-     http_req_failed................: 0.00%  ✓ 0        ✗ 100
-     http_req_receiving.............: avg=16.3ms   min=28.85µs  med=182.57µs max=230.11ms p(90)=373.79µs p(95)=197.37ms
-     http_req_sending...............: avg=47.81µs  min=9µs      med=48.16µs  max=119.64µs p(90)=59.36µs  p(95)=71.44µs
-     http_req_tls_handshaking.......: avg=24.9ms   min=0s       med=0s       max=249.63ms p(90)=24.82ms  p(95)=249.02ms
-     http_req_waiting...............: avg=231.9ms  min=181.2ms  med=228.85ms max=429.25ms p(90)=268.52ms p(95)=271.77ms
-     http_reqs......................: 100    7.497907/s
-     iteration_duration.............: avg=1.3s     min=1.18s    med=1.23s    max=1.86s    p(90)=1.48s    p(95)=1.86s
-     iterations.....................: 100    7.497907/s
-     vus............................: 5      min=5      max=10
-     vus_max........................: 10     min=10     max=10
-
-```
-
-</CodeGroup>
-
 <Blockquote mod="note" title="">
 
 The preceding example uses multiple iterations and VUs so that the trend metrics have different values.
 With a single iteration and VU, the min, max, median, average, and p values would all be the same.
-
-</Blockquote>
-
-### Customize reports with `handleSummary()` function
-
-If you want to make your own report, use the `handleSummary()` function.
-
-The `handleSummary()` function takes a single argument.
-When the test finishes, k6 runs `handleSummary()`, passing the summary-metrics object as the function argument.
-
-You can send data to `stdout`, `stderr`, or any file.
-
-To try `handleSummary()`, paste this function at the end of your script:
-
-<CodeGroup labels={["trivial-summary.js"]} lineNumbers={[]} showCopyButton={[true]}>
-
-```javascript
-export function handleSummary(data) {
-  const med_latency = data.metrics.iteration_duration.values.med;
-
-  return {
-    'stdout': med_latency.toString(),
-    'summary.json': JSON.stringify(data), // and a JSON with all the details...
-  };
-}
-```
-
-</CodeGroup>
-
-This is just an example, and its behavior is quite trivial:
-- It prints only the median value of the test `iteration_duration` metric.
-- It prints all summary statistics to a file at `summary.json`
-
-Admittedly, printing a single value isn't very useful, so open up `summary.json` to see the summary data.
-You can manipulate this summary data object into any report you want, then write it to a file.
 For example, the community project [k6 reporter](https://github.com/benc-uk/k6-reporter) uses `handleSummary()` to make an HTML report from your k6 summary metrics.
 
 ## External outputs

--- a/src/data/markdown/translated-guides/en/01 Getting started/04 Results Output.md
+++ b/src/data/markdown/translated-guides/en/01 Getting started/04 Results Output.md
@@ -68,26 +68,26 @@ With a single iteration and VU, the min, max, median, average, and p values woul
 ### Custom reports with `handleSummary()`
 
 At the end of the test, k6 automatically creates an object with all aggregated statistics.
-
 To completely customize the end-of-test summary,
-you can use the `handleSummary()` function to process this object into any text format. For example, the community project [k6 reporter](https://github.com/benc-uk/k6-reporter) uses `handleSummary()` to make an HTML report from your k6 summary metrics.
+you can use the `handleSummary()` function to process this object into any text format.
 
+For example, the community project [k6 reporter](https://github.com/benc-uk/k6-reporter) uses `handleSummary()` to make an HTML report from your k6 summary metrics.
 
 ## Time series and external outputs
 
 The condensed end-of-test summary provides a top-level view of the test.
 For deeper analysis, you need to look at granular time-series data.
+This data has metrics and timestamps for every point of the test.
 
-You can integrate and visualize k6 metrics on other platforms.
-You can also write every metric to a file and analyze them in the program of your choice.
+You can access time-series metrics in two ways:
+- Write them to a JSON or CSV file.
+- Stream them to an external service.
 
-To send granular results data to an external output, use the `--out` flag.
-
+For both cases, you can use the `--out` flag.
 
 ```sh
 $ k6 run --out statsd script.js
 ```
-
 
 The available built-in outputs are:
 

--- a/src/data/markdown/translated-guides/en/01 Getting started/04 Results Output.md
+++ b/src/data/markdown/translated-guides/en/01 Getting started/04 Results Output.md
@@ -45,10 +45,11 @@ The end-of-test-summary shows aggregated statistical values for your result metr
 - Minimum and maximum values
 - p90, p95, and p99 values
 
-If this default report is unsuitable, you can change the trend stats with
+If this default report is unsuitable, you can use
 the [`--summary-trend-stats`](https://k6.io/docs/using-k6/k6-options/reference#summary-trend-stats) option
-or change the time unit with
-the [`--summary-time-unit`](/using-k6/k6-options/reference#summary-time-unit) option.
+to configure the reported statistics, or the
+[`--summary-time-unit`](/using-k6/k6-options/reference#summary-time-unit) option
+to change the metric-value unit of time.
 
 For example, this command displays only the median, p95, and p99.9 values,
 and it presents the statistics in milliseconds instead of seconds.

--- a/src/data/markdown/translated-guides/en/01 Getting started/04 Results Output.md
+++ b/src/data/markdown/translated-guides/en/01 Getting started/04 Results Output.md
@@ -11,6 +11,8 @@ Broadly, you can analyze metrics in two ways:
 - As summary statistics, in an _end-of-test-summary_ report.
 - In granular, point-by-point detail. That is, as _time-series data_.
 
+![A diagram of the two broad ways to handle results: aggregated and granular](./images/k6-results-diagram.png)
+
 These are the essential elements of k6 test results: metrics, summary output, and granular time series. 
 
 <DescriptionList>
@@ -44,7 +46,7 @@ Key metrics include:
 - `iterations`, the total number of iterations
 - `http_req_failed`, the total number of failed requests
 - `http_req_duration`, the end-to-end time of all requests (that is, the total latency)
-     - `expected_response:true`, the end-to-end time of successful requests (failed requests often have faster responses)
+   - `expected_response:true`, the end-to-end time of successful requests (failed requests often have faster responses)
 
 You can also use [_checks_](/using-k6/checks) to make metrics from any boolean expression.
 For example, you can check that a response body has a certain text string.
@@ -93,23 +95,22 @@ you can change the time units, display different aggregated statistics, or make 
 
 ### Change time units and summary stats
 
-To configure the aggregated metrics in and end-of-test summary, use the [`--summary-trend-stats`](https://k6.io/docs/using-k6/k6-options/reference#summary-trend-stats) option.
-For example, you might need preciser p-values.
+To configure the aggregated metrics in an end-of-test summary, use the [`--summary-trend-stats`](https://k6.io/docs/using-k6/k6-options/reference#summary-trend-stats) option.
+For example, you might need more precise p-values.
 This command limits the stats to only p99 and p99.9 values.
 
 ```sh
 k6 run --summary-trend-stats="med,p(95),p(99.9)" ./script.js
 ```
 
-To change the unit of time that the test results show, use the [`--summary-time-unit`](/using-k6/k6-options/reference#summary-time-unit) option.
-For example, you might need preciser units of time.
-This command displays the end-of-test values in milliseconds:
+To change the unit of time, use the [`--summary-time-unit`](/using-k6/k6-options/reference#summary-time-unit) option.
+For example, this command displays the end-of-test values in milliseconds instead of seconds:
 
 ```sh
 k6 run --summary-time-unit="ms" ./script.js
 ```
 
-Putting these options together, this command creates a more compact summary, with preciser p-values and time units.
+Putting these options together, this command creates a more compact summary, with more precise p-values and time units.
 Use the tab to compare the configured output with the default output.
 
 ```sh
@@ -173,14 +174,14 @@ With a single iteration and VU, the min, max, median, average, and p values woul
 
 ### Customize reports with `handleSummary()` function
 
-If you want to make your own report, use the `handleSummary()` function to derive any report from the summary metrics that k6 creates.
+If you want to make your own report, use the `handleSummary()` function.
 
-Your `handleSummary()` can take a single argument.
-As the test finishes, k6 passes the calculated metrics as the argument `data` to the `handleSummary()` function, then runs the `handleSummary()` function.
+The `handleSummary()` function takes a single argument.
+When the test finishes, k6 runs `handleSummary()`, passing the summary-metrics object as the function argument.
 
 You can send data to `stdout`, `stderr`, or any file.
 
-To try `handleSummary()`, stick this function at the end of your script:
+To try `handleSummary()`, paste this function at the end of your script:
 
 <CodeGroup labels={["trivial-summary.js"]} lineNumbers={[]} showCopyButton={[true]}>
 
@@ -203,7 +204,6 @@ This is just an example, and its behavior is quite trivial:
 
 Admittedly, printing a single value isn't very useful, so open up `summary.json` to see the summary data.
 You can manipulate this summary data object into any report you want, then write it to a file.
-
 For example, the community project [k6 reporter](https://github.com/benc-uk/k6-reporter) uses `handleSummary()` to make an HTML report from your k6 summary metrics.
 
 ## External outputs

--- a/src/data/markdown/translated-guides/en/01 Getting started/04 Results Output.md
+++ b/src/data/markdown/translated-guides/en/01 Getting started/04 Results Output.md
@@ -3,8 +3,8 @@ title: 'Results output'
 excerpt: 'For basic tests, the top-level summary that k6 provides might be enough. For detailed analysis, you can stream all data your test outputs to an external source.'
 ---
 
-As a test runs, k6 starts generating _metrics_.
-You can use these metrics to interpret test results.
+As k6 generates load for your test, it also takes measurements of the performance of the system.
+You can use these measurements, called _metrics_, to interpret test results.
 
 k6 generates many metrics about the load that your test generates and how the system under test (SUT) responds to this load.
 Broadly, you can analyze metrics in two ways:

--- a/src/data/markdown/translated-guides/en/01 Getting started/04 Results Output.md
+++ b/src/data/markdown/translated-guides/en/01 Getting started/04 Results Output.md
@@ -3,13 +3,20 @@ title: 'Results output'
 excerpt: 'For basic tests, the top-level summary that k6 provides might be enough. For detailed analysis, you can stream all data your test outputs to an external source.'
 ---
 
-Modeling and generating load is just half the story:
-a useful load test also needs to generate useful results that you can interpret and act upon.
-A k6 test generates a rich amount of metrics, which you can analyze as summary statistics, or in granular, point-by-point detail:
+As k6 starts generating load according to your script logic,
+it also starts generating _metrics_.
+These metrics provide quantitative data to help you interpret test results.
+
+k6 generates many metrics about the load that your test generates and about how the system under test (SUT) responds to this load.
+Broadly, you can analyze metrics in two ways:
+- As summary statistics
+- In granular, point-by-point detail
 
 ![A diagram of the two broad ways to handle results: aggregated and granular](./images/k6-results-diagram.png)
 
-k6 results output centers around the concepts of _metrics_, _end-of-test-summary reports_, and _time-series data_.
+## Result-output essentials
+
+k6 turns metrics into two central outputs _end-of-test-summary reports_ and granular _time-series data_.
 
 <DescriptionList>
 
@@ -18,46 +25,199 @@ Metrics
 : For example, you can use the `http_req_duration` metric to measure end-to-end latency.
 
 End-of-test-summary report
-: The default report that k6 prints to `stdout` at the end of test, with aggregated statistics for each metric.
-: For example, the statistics show the value for the 95th percentile of all `http_req_duration` values.
+: The default report that k6 prints to `stdout` at the end of the test, with aggregated statistics for each metric.
+: For example, the report shows the 95th percentile of all `http_req_duration` values.
 
 Time-series data
 : The granular metrics generated throughout the test (often for each request).
-: You can stream these metrics to an external service, or write them to a file. or both.
-: For example, in your fine-grained analysis, you could look at the `http_req_duration` for any request in the entire test in your Grafana workspace or JSON file.
-  
+: You can stream these metrics to an external service, write them to a file, or both.
+: For example, you could look at the `http_req_duration` for any request in the entire test in a JSON file or on a Grafana dashboard.
+
 </DescriptionList>
-  
-Everything is customizable: you can create your own metrics; you can create your own summary statistics, and you can stream the results to one or multiple of the services of your choice. 
+
+You can customize almost every aspect of k6 result output:
+- You can create your custom metrics
+- You can configure new summary statistics, and print them to not only `stdout` but also as HTML, JSON, or any text format.
+- You can stream the results to one or multiple of the services of your choice.
 
 ## Built-in and custom metrics
 
-k6 comes with a built-in set of metrics about the load-generated and about the HTTP request times.
-You can also derive a custom metric from any trend, counter, gauge, or rate metric that k6 generates.
+**Documentation:** [Using metrics](/using-k6/metrics)
 
-[Using metrics](/using-k6/metrics/)
+k6 comes with a built-in set of metrics about the load generated and about the system response.
+Key metrics include:
+- `iterations`, the total number of iterations
+- `http_req_failed`, the total number of failed requests
+- `http_req_duration`, the end-to-end time of all requests (that is, the total latency)
+     - `expected_response:true`, the end-to-end time of successful requests (failed requests often have faster responses)
 
-## End-of-test summary report
+You can also use [_checks_](/using-k6/checks) to make metrics from any boolean expression.
+For example, you can check that a response body has a certain text string.
 
-![k6 results - console/stdout output](./images/k6-results-stdout.
+### Applications of metrics
 
-When k6 sends the results to [`stdout`](https://en.wikipedia.org/wiki/Standard_streams#Standard_output_(stdout)), it shows the k6 logo and the following test information:
+You can do further operations on metrics to build your analysis and test logic.
+For example, you can derive [custom metrics](/using-k6/metrics/#custom-metrics) from any default metric type, be it a trend, rate, count, or gauge (that is, a maximum value).
 
-- Test details: general test information and load options.
-- Progress bar: test status and how much time has passed.
-- [Test summary](/results-visualization/end-of-test-summary): the test results (after test completion).
+Another useful application of metrics is in combination with [_thresholds_](/using-k6/thresholds).
+With thresholds, you can use metrics to set performance goals, and abort the test when performance degrades beyond the threshold point.
+For example, this threshold aborts a test once the p99 duration value crosses 3000 milliseconds.
 
-### The summary report is customizable
+<CodeGroup labels={["latency-exceeds-3000.js"]} lineNumbers={[]} showCopyButton={[true]}>
 
-If the default report is not what you need, you have many ways to customize it:
-- To change the values (e.g p99 instead of p99.5), use the --end-of-test-summary
-- To change the units,
-- To customize everything, build your own report with handleSummary()
+```javascript
+import http from 'k6/http';
 
+export const options = {
+  thresholds: {
+    http_req_duration: ['p(99)<200'], // 99% of requests should be below 200ms
+  },
+};
+```
+
+</CodeGroup>
+
+## End-of-test-summary report
+
+**Documentation**: [End-of-test-summary report](results-visualization/end-of-test-summary/)
+
+By default, k6 prints summarized results to `stdout`.
+
+When you run a test, k6 outputs a plain-text logo, your test progress, and some test details.
+After the test finishes, k6 prints the full details and summary statistics of the test metrics.
+
+![k6 results - console/stdout output](./images/k6-results-stdout.png)
+
+The end-of-test-summary shows aggregated statistical values for your result metrics, including:
+- Median and average values
+- Minimum and maximum values
+- p90, p95, and p99 values
+
+If this default report is unsuitable,
+you can change the time units, display different aggregated statistics, or make an entirely new report in any format that you want.
+
+### Change time units and summary stats
+
+To configure the aggregated metrics in and end-of-test summary, use the [`--summary-trend-stats`](https://k6.io/docs/using-k6/k6-options/reference#summary-trend-stats) option.
+For example, you might need preciser p-values.
+This command limits the stats to only p99 and p99.9 values.
+
+```sh
+k6 run --summary-trend-stats="med,p(95),p(99.9)" ./script.js
+```
+
+To change the unit of time that the test results show, use the [`--summary-time-unit`](/using-k6/k6-options/reference#summary-time-unit) option.
+For example, you might need preciser units of time.
+This command displays the end-of-test values in milliseconds:
+
+```sh
+k6 run --summary-time-unit="ms" ./script.js
+```
+
+Putting these options together, this command creates a more compact summary, with preciser p-values and time units.
+Use the tab to compare the configured output with the default output.
+
+```sh
+k6 run --iterations=100 --vus=10 \
+--summary-trend-stats="med,p(95),p(99.9)" --summary-time-unit="ms" script.js
+```
+
+<CodeGroup labels={["Configured summary", "default summary"]} lineNumbers={[]} showCopyButton={[true]}>
+
+```txt
+default ✓ [======================================] 10 VUs  00m14.1s/10m0s  100/100 shared iters
+
+     data_received..................: 1.2 MB 86 kB/s
+     data_sent......................: 13 kB  939 B/s
+     http_req_blocked...............: med=0.01ms    p(95)=571.30ms  p(99.9)=571.68ms
+     http_req_connecting............: med=0.00ms    p(95)=269.12ms  p(99.9)=269.99ms
+     http_req_duration..............: med=228.87ms  p(95)=482.99ms  p(99.9)=551.53ms
+       { expected_response:true }...: med=228.87ms  p(95)=482.99ms  p(99.9)=551.53ms
+     http_req_failed................: 0.00%  ✓ 0        ✗ 100
+     http_req_receiving.............: med=0.16ms    p(95)=215.87ms  p(99.9)=236.51ms
+     http_req_sending...............: med=0.04ms    p(95)=0.07ms    p(99.9)=0.09ms
+     http_req_tls_handshaking.......: med=0.00ms    p(95)=234.77ms  p(99.9)=235.20ms
+     http_req_waiting...............: med=227.52ms  p(95)=296.55ms  p(99.9)=548.41ms
+     http_reqs......................: 100    7.115226/s
+     iteration_duration.............: med=1229.85ms p(95)=1856.70ms p(99.9)=1857.05ms
+     iterations.....................: 100    7.115226/s
+     vus............................: 1      min=1      max=10
+     vus_max........................: 10     min=10     max=10
+```
+
+```sh
+default ✓ [======================================] 10 VUs  00m13.3s/10m0s  100/100 shared iters
+
+     data_received..................: 1.2 MB 90 kB/s
+     data_sent......................: 13 kB  990 B/s
+     http_req_blocked...............: avg=58.96ms  min=2.58µs   med=11.36µs  max=590.12ms p(90)=58.97ms  p(95)=589.38ms
+     http_req_connecting............: avg=25.51ms  min=0s       med=0s       max=255.49ms p(90)=25.48ms  p(95)=255.1ms
+     http_req_duration..............: avg=248.25ms min=181.43ms med=229.2ms  max=448.18ms p(90)=272.74ms p(95)=427.82ms
+       { expected_response:true }...: avg=248.25ms min=181.43ms med=229.2ms  max=448.18ms p(90)=272.74ms p(95)=427.82ms
+     http_req_failed................: 0.00%  ✓ 0        ✗ 100
+     http_req_receiving.............: avg=16.3ms   min=28.85µs  med=182.57µs max=230.11ms p(90)=373.79µs p(95)=197.37ms
+     http_req_sending...............: avg=47.81µs  min=9µs      med=48.16µs  max=119.64µs p(90)=59.36µs  p(95)=71.44µs
+     http_req_tls_handshaking.......: avg=24.9ms   min=0s       med=0s       max=249.63ms p(90)=24.82ms  p(95)=249.02ms
+     http_req_waiting...............: avg=231.9ms  min=181.2ms  med=228.85ms max=429.25ms p(90)=268.52ms p(95)=271.77ms
+     http_reqs......................: 100    7.497907/s
+     iteration_duration.............: avg=1.3s     min=1.18s    med=1.23s    max=1.86s    p(90)=1.48s    p(95)=1.86s
+     iterations.....................: 100    7.497907/s
+     vus............................: 5      min=5      max=10
+     vus_max........................: 10     min=10     max=10
+
+```
+
+</CodeGroup>
+
+<Blockquote mod="note" title="">
+
+The preceding example uses multiple iterations and VUs so that the trend metrics have different values.
+With a single iteration and VU, the min, max, median, average, and p values would all be the same.
+
+</Blockquote>
+
+### Customize reports with `handleSummary()` function
+
+If you want to make your own report, use the `handleSummary()` function to derive any report from the summary metrics that k6 creates.
+
+Your `handleSummary()` can take a single argument.
+As the test finishes, k6 passes the calculated metrics as the argument `data` to the `handleSummary()` function, then runs the `handleSummary()` function.
+
+You can send data to `stdout`, `stderr`, or any file.
+
+To try `handleSummary()`, stick this function at the end of your script:
+
+<CodeGroup labels={["trivial-summary.js"]} lineNumbers={[]} showCopyButton={[true]}>
+
+```javascript
+export function handleSummary(data) {
+  const med_latency = data.metrics.iteration_duration.values.med;
+
+  return {
+    'stdout': med_latency.toString(),
+    'summary.json': JSON.stringify(data), // and a JSON with all the details...
+  };
+}
+```
+
+</CodeGroup>
+
+This is just an example, and its behavior is quite trivial:
+- It prints only the median value of the test `iteration_duration` metric.
+- It prints all summary statistics to a file at `summary.json`
+
+Admittedly, printing a single value isn't very useful, so open up `summary.json` to see the summary data.
+You can manipulate this summary data object into any report you want, then write it to a file.
+
+For example, the community project [k6 reporter](https://github.com/benc-uk/k6-reporter) uses `handleSummary()` to make an HTML report from your k6 summary metrics.
 
 ## External outputs
 
-If you need more data than what is condensed in the [end-of-test summary](/results-visualization/end-of-test-summary), you can integrate and visualize k6 metrics on other platforms.
+The condensed [end-of-test summary](/results-visualization/end-of-test-summary) is good for a top-level view of the test.
+For deeper analysis, you need to look at granular time-series data.
+
+You can integrate and visualize k6 metrics on other platforms.
+You can also write every metric to a file, and analyze them in the program of your choice.
 
 To send granular results data to an external output, use the `--out` flag.
 
@@ -91,7 +251,7 @@ The available built-in outputs are:
 ### Multiple outputs
 
 You can also send metrics simultaneously to several outputs.
-To do so, use the CLI `--out` flag multiple times.
+To do so, set separate arguments for multiple CLI `--out` flags.
 
 <CodeGroup labels={[]}>
 
@@ -100,5 +260,5 @@ $ k6 run \
 --out json=test.json \
 --out influxdb=http://localhost:8086/k6
 ```
-</CodeGroup>
 
+</CodeGroup>

--- a/src/data/markdown/translated-guides/en/01 Getting started/04 Results Output.md
+++ b/src/data/markdown/translated-guides/en/01 Getting started/04 Results Output.md
@@ -4,7 +4,7 @@ excerpt: 'For basic tests, the top-level summary that k6 provides might be enoug
 ---
 
 As a test runs, k6 starts generating _metrics_.
-These metrics provide quantitative data to help you interpret test results.
+You can use these metrics to interpret test results.
 
 k6 generates many metrics about the load that your test generates and how the system under test (SUT) responds to this load.
 Broadly, you can analyze metrics in two ways:

--- a/src/data/markdown/translated-guides/en/01 Getting started/04 Results Output.md
+++ b/src/data/markdown/translated-guides/en/01 Getting started/04 Results Output.md
@@ -9,7 +9,7 @@ You can use these measurements, called _metrics_, to interpret test results.
 k6 generates many metrics about the load that your test generates and how the system under test (SUT) responds to this load.
 Broadly, you can analyze metrics in two ways:
 - As summary statistics, in an _end-of-test-summary_ report.
-- As _time-series data_, in granular, point-by-point detail
+- As _time-series data_, in granular, point-by-point detail, which you can export to file formats, like CSV, or stream to external services, like Prometheus or InfluxDB.
 
 ![A diagram of the two broad ways to handle results: aggregated and granular](./images/k6-results-diagram.png)
 
@@ -18,7 +18,7 @@ You can customize almost every aspect of k6 result output:
 - You can configure new summary statistics and print them not only to `stdout` but also as HTML, JSON, or any text format.
 - You can stream the results to one or multiple of the services of your choice.
 
-## Built-in and custom metrics
+## Metrics
 
 **Documentation:** [Using metrics](/using-k6/metrics)
 
@@ -46,8 +46,8 @@ The end-of-test-summary shows aggregated statistical values for your result metr
 - p90, p95, and p99 values
 
 If this default report is unsuitable, you can change the trend stats with
-the [`--summary-trend-stats`](https://k6.io/docs/using-k6/k6-options/reference#summary-trend-stats) option.
-You can also change the time unit with 
+the [`--summary-trend-stats`](https://k6.io/docs/using-k6/k6-options/reference#summary-trend-stats) option
+or change the time unit with
 the [`--summary-time-unit`](/using-k6/k6-options/reference#summary-time-unit) option.
 
 For example, this command displays only the median, p95, and p99.9 values,
@@ -62,8 +62,8 @@ k6 run --iterations=100 --vus=10 \
 
 At the end of the test, k6 automatically creates an object with all aggregated statistics.
 To completely customize the end-of-test summary,
-you can use the `handleSummary()` function to process this object into any text format.
-
+you can use the `handleSummary()` function to process this object into any text format:
+HTML, JSON, XML, et cetera.
 For example, the community project [k6 reporter](https://github.com/benc-uk/k6-reporter) uses `handleSummary()` to make an HTML report from your k6 summary metrics.
 
 ## Time series and external outputs
@@ -101,10 +101,10 @@ The available built-in outputs are:
 
 </Glossary>
 
-### Multiple outputs
+<Blockquote mod="note" title="You can also send metrics simultaneously to several outputs">
 
-You can also send metrics simultaneously to several outputs
-by using multiple CLI `--out` flags:
+
+To export to multiple outputs, use multiple CLI `--out` flags:
 
 
 ```bash
@@ -112,4 +112,7 @@ $ k6 run \
 --out json=test.json \
 --out influxdb=http://localhost:8086/k6
 ```
+
+</Blockquote>
+
 

--- a/src/data/markdown/translated-guides/en/01 Getting started/04 Results Output.md
+++ b/src/data/markdown/translated-guides/en/01 Getting started/04 Results Output.md
@@ -9,7 +9,7 @@ These metrics provide quantitative data to help you interpret test results.
 k6 generates many metrics about the load that your test generates and about how the system under test (SUT) responds to this load.
 Broadly, you can analyze metrics in two ways:
 - As summary statistics, in an _end-of-test-summary_ report.
-- In granular, point-by-point detail. That is, as _time-series data_.
+- As _time-series data_, in granular, point-by-point detail
 
 ![A diagram of the two broad ways to handle results: aggregated and granular](./images/k6-results-diagram.png)
 

--- a/src/data/markdown/translated-guides/en/01 Getting started/04 Results Output.md
+++ b/src/data/markdown/translated-guides/en/01 Getting started/04 Results Output.md
@@ -70,7 +70,7 @@ With a single iteration and VU, the min, max, median, average, and p values woul
 At the end of the test, k6 automatically creates an object with all aggregated statistics.
 
 To completely customize the end-of-test summary,
-you can use the `handleSummary()` function to process this object into any text format.For example, the community project [k6 reporter](https://github.com/benc-uk/k6-reporter) uses `handleSummary()` to make an HTML report from your k6 summary metrics.
+you can use the `handleSummary()` function to process this object into any text format. For example, the community project [k6 reporter](https://github.com/benc-uk/k6-reporter) uses `handleSummary()` to make an HTML report from your k6 summary metrics.
 
 
 ## Time series and external outputs

--- a/src/data/markdown/translated-guides/en/01 Getting started/04 Results Output.md
+++ b/src/data/markdown/translated-guides/en/01 Getting started/04 Results Output.md
@@ -3,20 +3,15 @@ title: 'Results output'
 excerpt: 'For basic tests, the top-level summary that k6 provides might be enough. For detailed analysis, you can stream all data your test outputs to an external source.'
 ---
 
-As k6 starts generating load according to your script logic,
-it also starts generating _metrics_.
+As k6 starts generating load, it also starts generating _metrics_.
 These metrics provide quantitative data to help you interpret test results.
 
 k6 generates many metrics about the load that your test generates and about how the system under test (SUT) responds to this load.
 Broadly, you can analyze metrics in two ways:
-- As summary statistics
-- In granular, point-by-point detail
+- As summary statistics, in an _end-of-test-summary_ report.
+- In granular, point-by-point detail. That is, as _time-series data_.
 
-![A diagram of the two broad ways to handle results: aggregated and granular](./images/k6-results-diagram.png)
-
-## Result-output essentials
-
-k6 turns metrics into two central outputs _end-of-test-summary reports_ and granular _time-series data_.
+These are the essential elements of k6 test results: metrics, summary output, and granular time series. 
 
 <DescriptionList>
 

--- a/src/data/markdown/translated-guides/en/01 Getting started/04 Results Output.md
+++ b/src/data/markdown/translated-guides/en/01 Getting started/04 Results Output.md
@@ -64,7 +64,7 @@ k6 run --iterations=100 --vus=10 \
 At the end of the test, k6 automatically creates an object with all aggregated statistics.
 To completely customize the end-of-test summary,
 you can use the `handleSummary()` function to process this object into any text format:
-HTML, JSON, XML, et cetera.
+HTML, JSON, XML, what have you.
 For example, the community project [k6 reporter](https://github.com/benc-uk/k6-reporter) uses `handleSummary()` to make an HTML report from your k6 summary metrics.
 
 ## Time series and external outputs

--- a/src/data/markdown/translated-guides/en/01 Getting started/04 Results Output.md
+++ b/src/data/markdown/translated-guides/en/01 Getting started/04 Results Output.md
@@ -9,20 +9,20 @@ You can use these measurements, called _metrics_, to interpret test results.
 k6 generates many metrics about the load that your test generates and how the system under test (SUT) responds to this load.
 Broadly, you can analyze metrics in two ways:
 - As summary statistics, in an _end-of-test-summary_ report.
-- As _time-series data_, in granular, point-by-point detail, which you can export to file formats, like CSV, or stream to external services, like Prometheus or InfluxDB.
+- As _time-series data_, which you can write to a file, or stream to external services such as Prometheus or InfluxDB.
 
 ![A diagram of the two broad ways to handle results: aggregated and granular](./images/k6-results-diagram.png)
 
-You can customize almost every aspect of k6 result output:
-- You can create your custom metrics
-- You can configure new summary statistics and print them not only to `stdout` but also as HTML, JSON, or any text format.
-- You can stream the results to one or multiple of the services of your choice.
+You can customize almost every aspect of result output:
+- Create your custom metrics
+- Configure new summary statistics and print them not only to `stdout` but also as HTML, JSON, or any text format.
+- Stream the results to one or multiple services of your choice.
 
 ## Metrics
 
 **Documentation:** [Using metrics](/using-k6/metrics)
 
-k6 comes with a built-in set of metrics about the load generated and the system response.
+k6 comes with built-in metrics about the load generated and the system response.
 Key metrics include:
 - `iterations`, the total number of iterations
 - `http_req_failed`, the total number of failed requests
@@ -47,37 +47,33 @@ The end-of-test-summary shows aggregated statistical values for your result metr
 
 If this default report is unsuitable, you can use
 the [`--summary-trend-stats`](https://k6.io/docs/using-k6/k6-options/reference#summary-trend-stats) option
-to configure the reported statistics, or the
-[`--summary-time-unit`](/using-k6/k6-options/reference#summary-time-unit) option
-to change the metric-value unit of time.
-
-For example, this command displays only the median, p95, and p99.9 values,
-and it presents the statistics in milliseconds instead of seconds.
+to configure the reported statistics.
+For example, this command displays only median, p95, and p99.9 values.
 
 ```sh
 k6 run --iterations=100 --vus=10 \
---summary-trend-stats="med,p(95),p(99.9)" --summary-time-unit="ms" script.js
+--summary-trend-stats="med,p(95),p(99.9)" script.js
 ```
 
 ### Custom reports with `handleSummary()`
 
 At the end of the test, k6 automatically creates an object with all aggregated statistics.
 To completely customize the end-of-test summary,
-you can use the `handleSummary()` function to process this object into any text format:
+use the `handleSummary()` function to process this object into any text format:
 HTML, JSON, XML, what have you.
 For example, the community project [k6 reporter](https://github.com/benc-uk/k6-reporter) uses `handleSummary()` to make an HTML report from your k6 summary metrics.
 
 ## Time series and external outputs
 
 The condensed end-of-test summary provides a top-level view of the test.
-For deeper analysis, you need to look at granular time-series data.
-This data has metrics and timestamps for every point of the test.
+For deeper analysis, you need to look at granular time-series data,
+which has metrics and timestamps for every point of the test.
 
 You can access time-series metrics in two ways:
 - Write them to a JSON or CSV file.
 - Stream them to an external service.
 
-For both cases, you can use the `--out` flag.
+In both cases, you can use the `--out` flag.
 
 ```sh
 $ k6 run --out statsd script.js
@@ -104,9 +100,7 @@ The available built-in outputs include:
 
 <Blockquote mod="note" title="You can also send metrics simultaneously to several outputs">
 
-
 To export to multiple outputs, use multiple CLI `--out` flags:
-
 
 ```bash
 $ k6 run \

--- a/src/data/markdown/translated-guides/en/01 Getting started/04 Results Output.md
+++ b/src/data/markdown/translated-guides/en/01 Getting started/04 Results Output.md
@@ -3,30 +3,43 @@ title: 'Results output'
 excerpt: 'For basic tests, the top-level summary that k6 provides might be enough. For detailed analysis, you can stream all data your test outputs to an external source.'
 ---
 
-k6 provides two ways to look at test results:
-* After the test runs, k6 sends a small summary to `stdout`.
-* For granular analysis and time-series data, you can also stream live test data to an external output.
-
+Modeling and generating load is just half the story:
+a useful load test also needs to generate useful results that you can interpret and act upon.
+A k6 test generates a rich amount of metrics, which you can analyze as summary statistics, or in granular, point-by-point detail:
 
 ![A diagram of the two broad ways to handle results: aggregated and granular](./images/k6-results-diagram.png)
 
-By default, when a test finishes, k6 provides an [_end-of-test summary report_](#end-of-test-summary-report).
-This report aggregates the test results, with information about all [groups](/using-k6/tags-and-groups#groups), [checks](/using-k6/checks), and [thresholds](/using-k6/thresholds) in the load test.
-It also gives basic, summary statistics about each metric (e.g. mean, median, p95, etc).
+k6 results output centers around the concepts of _metrics_, _end-of-test-summary reports_, and _time-series data_.
 
-For fine-grained analysis, you can stream all the data that your test generates (e.g. all HTTP requests) to an _external output_.
-This output might be a structured file format, like CSV or JSON.
-But you could also stream to another program, like Datadog or Prometheus, or pipe results to our managed [k6 cloud](/results-visualization/cloud) service.
-The "External outputs" section lists [all supported built-in outputs](/getting-started/results-output#external-outputs).
+<DescriptionList>
 
-You have much room to handle the data in the way that best fits your use case.
-You can [customize the summary report](/results-visualization/end-of-test-summary#handlesummary-callback).
-In addition to the [built-in](/using-k6/metrics#built-in-metrics), you can also make [custom metrics](/using-k6/metrics#custom-metrics).
+Metrics
+: Measurements that k6 generates throughout the test.
+: For example, you can use the `http_req_duration` metric to measure end-to-end latency.
 
+End-of-test-summary report
+: The default report that k6 prints to `stdout` at the end of test, with aggregated statistics for each metric.
+: For example, the statistics show the value for the 95th percentile of all `http_req_duration` values.
 
-## Standard output
+Time-series data
+: The granular metrics generated throughout the test (often for each request).
+: You can stream these metrics to an external service, or write them to a file. or both.
+: For example, in your fine-grained analysis, you could look at the `http_req_duration` for any request in the entire test in your Grafana workspace or JSON file.
+  
+</DescriptionList>
+  
+Everything is customizable: you can create your own metrics; you can create your own summary statistics, and you can stream the results to one or multiple of the services of your choice. 
 
-![k6 results - console/stdout output](./images/k6-results-stdout.png)
+## Built-in and custom metrics
+
+k6 comes with a built-in set of metrics about the load-generated and about the HTTP request times.
+You can also derive a custom metric from any trend, counter, gauge, or rate metric that k6 generates.
+
+[Using metrics](/using-k6/metrics/)
+
+## End-of-test summary report
+
+![k6 results - console/stdout output](./images/k6-results-stdout.
 
 When k6 sends the results to [`stdout`](https://en.wikipedia.org/wiki/Standard_streams#Standard_output_(stdout)), it shows the k6 logo and the following test information:
 
@@ -34,104 +47,13 @@ When k6 sends the results to [`stdout`](https://en.wikipedia.org/wiki/Standard_s
 - Progress bar: test status and how much time has passed.
 - [Test summary](/results-visualization/end-of-test-summary): the test results (after test completion).
 
-You can completely customize the output and redirect it to a file.
-You can also save arbitrary files with machine-readable versions of the summary, like JSON, XML (e.g. JUnit, XUnit, etc.), or even nicely-formatted HTML reports meant for humans!
-For more details, see the [`handleSummary()` docs](/results-visualization/end-of-test-summary#handlesummary-callback).
+### The summary report is customizable
 
-### Test details
+If the default report is not what you need, you have many ways to customize it:
+- To change the values (e.g p99 instead of p99.5), use the --end-of-test-summary
+- To change the units,
+- To customize everything, build your own report with handleSummary()
 
-<CodeGroup labels={[]}>
-
-```bash
-execution: local
-  script: path/to/script.js
-  output: -
-
-scenarios: (100.00%) 1 scenario, 50 max VUs, 5m30s max duration (incl. graceful stop):
-        * default: Up to 50 looping VUs for 5m0s over 3 stages (gracefulRampDown: 30s, gracefulStop: 30s)
-```
-
-</CodeGroup>
-
-- `execution: local` shows the k6 execution mode (local or cloud).
-- `output: -` is the [output](/getting-started/results-output#external-outputs) of the granular test results. By default, no output is used, only the aggregated [end-of-test summary](/results-visualization/end-of-test-summary) is shown.
-- `script: path/to/script.js` shows the name of the script file that is being executed.
-- `scenarios: ...` is a summary of the [scenarios](/using-k6/scenarios) that will be executed this test run and some overview information:
-- `(100.00%)` is the used [execution segment](/using-k6/options#execution-segment)
-- `50 max VUs` tells us up to how many [VUs (virtual users)](/misc/glossary#virtual-users) will be used across all scenarios.
-- `5m30s max duration` is the maximum time the script will take to run, including any [graceful stop](/using-k6/scenarios/graceful-stop) times.
-- `* default: ...` describes the only scenario for this test run. In this case it's a scenario with a [ramping VUs executor](/using-k6/scenarios/executors/ramping-vus), specified via the [`stages` shortcut option](/using-k6/options#stages) instead of using the [`scenarios` long-form option](/using-k6/options#scenarios).
-
-### End-of-test summary report
-
-The [test summary](/results-visualization/end-of-test-summary) provides a general overview of test results.
-By default, the summary prints the following statuses to `stdout`:
-
-- Aggregated values for the [built-in metrics](/using-k6/metrics#built-in-metrics) and [custom metrics](/using-k6/metrics#custom-metrics).
-- [Checks](/using-k6/checks) and [thresholds](/using-k6/thresholds).
-- [Groups](/using-k6/tags-and-groups#groups) and [tags](/using-k6/tags-and-groups#tags).
-
-You can customize the summary shown to `stdout`, redirect it to a file or `stderr`, or build and export your own completely custom report (e.g. HTML, JSON, JUnit/XUnit XML, etc.) via the [`handleSummary()` callback](/results-visualization/end-of-test-summary#handlesummary-callback).
-
-
-<CodeGroup labels={[]}>
-
-```bash
-data_received..............: 148 MB 2.5 MB/s
-data_sent..................: 1.0 MB 17 kB/s
-http_req_blocked...........: avg=1.92ms   min=1µs      med=5µs      max=288.73ms p(90)=11µs     p(95)=17µs
-http_req_connecting........: avg=1.01ms   min=0s       med=0s       max=166.44ms p(90)=0s       p(95)=0s
-http_req_duration..........: avg=143.14ms min=112.87ms med=136.03ms max=1.18s    p(90)=164.2ms  p(95)=177.75ms
-http_req_receiving.........: avg=5.53ms   min=49µs     med=2.11ms   max=1.01s    p(90)=9.25ms   p(95)=11.8ms
-http_req_sending...........: avg=30.01µs  min=7µs      med=24µs     max=1.89ms   p(90)=48µs     p(95)=63µs
-http_req_tls_handshaking...: avg=0s       min=0s       med=0s       max=0s       p(90)=0s       p(95)=0s
-http_req_waiting...........: avg=137.57ms min=111.44ms med=132.59ms max=589.4ms  p(90)=159.95ms p(95)=169.41ms
-http_reqs..................: 13491  224.848869/s
-iteration_duration.........: avg=445.48ms min=413.05ms med=436.36ms max=1.48s    p(90)=464.94ms p(95)=479.66ms
-iterations.................: 13410  223.498876/s
-vus........................: 100    min=100 max=100
-vus_max....................: 100    min=100 max=100
-```
-
-</CodeGroup>
-
-> To learn more about the metrics k6 collects and reports, read the [Metrics guide](/using-k6/metrics).
-
-### Trend metrics
-
-[Trend metrics](/using-k6/metrics#metric-types) collect trend statistics (min/max/avg/percentiles) for a series of values.
-On stdout, they are printed like this:
-
-<CodeGroup labels={[]}>
-
-```bash
-http_req_duration..........: avg=143.14ms min=112.87ms med=136.03ms max=1.18s    p(90)=164.2ms  p(95)=177.75ms
-```
-
-</CodeGroup>
-
-To change the stats reported for `Trend` metrics, you can use the [`summaryTrendStats` option](/using-k6/options#summary-trend-stats).
-You can also make k6 display time values with a fixed time unit (seconds, milliseconds or microseconds) via the [`summaryTimeUnit` option](/using-k6/options#summary-time-unit).
-And, as mentioned above, you can completely customize the whole report via the [`handleSummary()` callback](/results-visualization/end-of-test-summary#handlesummary-callback).
-
-<CodeGroup labels={[]}>
-
-```bash
-$ k6 run --summary-trend-stats="min,avg,med,p(99),p(99.9),max,count" --summary-time-unit=ms  script.js
-```
-
-</CodeGroup>
-
-### Export summary
-
-To get your aggregated test results in a machine-readable format,
-you can export the end-of-test summary report to a JSON file.
-This helps with things like integration with dashboards, external alerts, etc.
-
-We recommend the [`handleSummary()` callback](/results-visualization/end-of-test-summary#handlesummary-callback).
-It lets you customize the end-of-test summary and export the report data to any desired format (e.g. JSON, CSV, XML (JUnit/xUnit/etc.), HTML, TXT, etc.).
-
-You can also use the [`--summary-export` flag](/using-k6/options#summary-export), though [we now discourage using it](/results-visualization/end-of-test-summary#summary-export-to-a-json-file)).
 
 ## External outputs
 

--- a/src/data/markdown/translated-guides/en/01 Getting started/04 Results Output.md
+++ b/src/data/markdown/translated-guides/en/01 Getting started/04 Results Output.md
@@ -58,13 +58,6 @@ k6 run --iterations=100 --vus=10 \
 --summary-trend-stats="med,p(95),p(99.9)" --summary-time-unit="ms" script.js
 ```
 
-<Blockquote mod="note" title="">
-
-With a single iteration and VU, the min, max, median, average, and p values would all be the same.
-
-</Blockquote>
-
-
 ### Custom reports with `handleSummary()`
 
 At the end of the test, k6 automatically creates an object with all aggregated statistics.


### PR DESCRIPTION
- Emphasize metrics as core of the results that can be output.
- Organize doc in terms of three: metrics, summary, granular
- ~Add examples of thresholds for more active display of metric uses~
- Remove dense reference data about result metrics
- ~Add examples of summary config, with tabular comparison~
- ~Present trivial example of handleSummary that users can try~
- General edits for flow