### PR TITLE
Clarify xk6-browser running instructions

### DIFF
--- a/src/data/markdown/docs/30 xk6-browser/30 xk6-browser.md
+++ b/src/data/markdown/docs/30 xk6-browser/30 xk6-browser.md
@@ -75,9 +75,13 @@ If you have downloaded the pre-built binary you will find the binary named `xk6-
 ./xk6-browser run browser_test.js
 ```
 
-> Note the `./` prefix, which tells your shell to run the binary located in the current working directory. This is required on macOS and Linux, but not on Windows if you're using the `cmd.exe` shell. If you're using PowerShell, you should specify `.\xk6-browser` instead.
->
-> If you installed xk6-browser via a system package, or you've placed the binary in a directory that's part of your `$PATH` environment variable, then you can omit the `./` or `.\` prefix.
+<Blockquote mod="note" title="">
+
+Note the `./` prefix, which tells your shell to run the binary located in the current working directory. This is required on macOS and Linux, but not on Windows if you're using the `cmd.exe` shell. If you're using PowerShell, you should specify `.\xk6-browser` instead.
+
+If you installed xk6-browser via a system package, or you've placed the binary in a directory that's part of your `$PATH` environment variable, then you can omit the `./` or `.\` prefix.
+
+</Blockquote>
 
 ## Module Properties
 

--- a/src/data/markdown/docs/30 xk6-browser/30 xk6-browser.md
+++ b/src/data/markdown/docs/30 xk6-browser/30 xk6-browser.md
@@ -13,11 +13,28 @@ xk6-browser is currently being developed as a [k6 extension](/extensions). You h
 
 The quickest way to get started is to [download a release binary from GitHub](https://github.com/grafana/xk6-browser/releases).
 
+We suggest this option if you don't want to build your own binary with [xk6](https://github.com/grafana/xk6), which can be challenging in some cases.
+
 ### Build from source
 
-If you're more adventurous or want to get the latest changes of the xk6-browser extension, you can also build from source. 
+If you're more adventurous or want to get the latest changes of the xk6-browser extension, you can also build a binary from source.
 
-<InstallationInstructions extensionUrl="github.com/grafana/xk6-browser"/>
+To build a binary with the extension, first, ensure you have installed [Go](https://golang.org/doc/install) and [Git](https://git-scm.com/). Then run the following commands in a terminal:
+
+```bash
+# Install xk6
+go install go.k6.io/xk6/cmd/xk6@latest
+
+# Build the xk6-browser binary
+xk6 build --output xk6-browser --with github.com/grafana/xk6-browser
+
+... [INFO] Build environment ready
+... [INFO] Building k6
+... [INFO] Build complete: xk6-browser
+```
+
+xk6 will create the `xk6-browser` binary in the current working directory.
+
 
 ## Your First Test
 
@@ -55,8 +72,12 @@ export default function () {
 If you have downloaded the pre-built binary you will find the binary named `xk6-browser`. Using the [example](#example), create a new file (such as `browser_test.js`) in the same directory as the pre-built binary, and paste the example in that file. Now run:
 
 ```
-xk6-browser run browser_test.js
+./xk6-browser run browser_test.js
 ```
+
+> Note the `./` prefix, which tells your shell to run the binary located in the current working directory. This is required on macOS and Linux, but not on Windows if you're using the `cmd.exe` shell. If you're using PowerShell, you should specify `.\xk6-browser` instead.
+>
+> If you installed xk6-browser via a system package, or you've placed the binary in a directory that's part of your `$PATH` environment variable, then you can omit the `./` or `.\` prefix.
 
 ## Module Properties
 
@@ -86,7 +107,7 @@ export default function () {
   page.goto('https://test.k6.io/browser.php/', {
     waitUntil: 'networkidle',
   });
-  
+
   page.close();
   browser.close();
 }
@@ -97,7 +118,7 @@ export default function () {
 
 ## Browser-level APIs
 
-`xk6-browser` uses [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/) (CDP) to instrument and interact with the browser. The `xk6-browser` APIs aims for rough compatibility with the [Playwright API for NodeJS](https://playwright.dev/docs/api/class-playwright). 
+`xk6-browser` uses [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/) (CDP) to instrument and interact with the browser. The `xk6-browser` APIs aims for rough compatibility with the [Playwright API for NodeJS](https://playwright.dev/docs/api/class-playwright).
 
 Note that because k6 does not run in NodeJS, `xk6-browser` APIs will slightly differ from their Playwright counterparts.
 
@@ -116,4 +137,3 @@ Note that because k6 does not run in NodeJS, `xk6-browser` APIs will slightly di
 | [Request](/javascript-api/xk6-browser/request/) <BWIPT />               | Used to keep track of the request the [`Page`](/javascript-api/xk6-browser/page/) makes.                                                                        |
 | [Response](/javascript-api/xk6-browser/response/) <BWIPT />             | Represents the response received by the [`Page`](/javascript-api/xk6-browser/page/).                                                                            |
 | [Touchscreen](/javascript-api/xk6-browser/touchscreen/)                 | Used to simulate touch interactions with the associated [`Page`](/javascript-api/xk6-browser/page/).                                                            |
-

--- a/src/data/markdown/docs/30 xk6-browser/30 xk6-browser.md
+++ b/src/data/markdown/docs/30 xk6-browser/30 xk6-browser.md
@@ -19,7 +19,9 @@ We suggest this option if you don't want to build your own binary with [xk6](htt
 
 If you're more adventurous or want to get the latest changes of the xk6-browser extension, you can also build a binary from source.
 
-To build a binary with the extension, first, ensure you have installed [Go](https://golang.org/doc/install) and [Git](https://git-scm.com/). Then run the following commands in a terminal:
+To build a binary with the extension:
+1. Ensure you have [Go](https://golang.org/doc/install) and [Git](https://git-scm.com/) installed.
+2. Run the following commands in a terminal:
 
 ```bash
 # Install xk6

--- a/src/data/markdown/docs/30 xk6-browser/30 xk6-browser.md
+++ b/src/data/markdown/docs/30 xk6-browser/30 xk6-browser.md
@@ -118,7 +118,7 @@ export default function () {
 
 ## Browser-level APIs
 
-`xk6-browser` uses [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/) (CDP) to instrument and interact with the browser. The `xk6-browser` APIs aims for rough compatibility with the [Playwright API for NodeJS](https://playwright.dev/docs/api/class-playwright).
+`xk6-browser` uses [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/) (CDP) to instrument and interact with the browser. The `xk6-browser` APIs aim for rough compatibility with the [Playwright API for NodeJS](https://playwright.dev/docs/api/class-playwright).
 
 Note that because k6 does not run in NodeJS, `xk6-browser` APIs will slightly differ from their Playwright counterparts.
 

--- a/src/data/markdown/docs/30 xk6-browser/30 xk6-browser.md
+++ b/src/data/markdown/docs/30 xk6-browser/30 xk6-browser.md
@@ -77,9 +77,9 @@ If you have downloaded the pre-built binary you will find the binary named `xk6-
 
 <Blockquote mod="note" title="">
 
-Note the `./` prefix, which tells your shell to run the binary located in the current working directory. This is required on macOS and Linux, but not on Windows if you're using the `cmd.exe` shell. If you're using PowerShell, you should specify `.\xk6-browser` instead.
+The `./` prefix tells your shell to run the binary located in the current working directory. This is required on macOS and Linux, but not on the Windows `cmd.exe` shell. On PowerShell, specify `.\xk6-browser` instead.
 
-If you installed xk6-browser via a system package, or you've placed the binary in a directory that's part of your `$PATH` environment variable, then you can omit the `./` or `.\` prefix.
+If you installed xk6-browser with a system package, or placed the binary in a directory that's part of your `$PATH` environment variable, you can omit the `./` or `.\` prefixes.
 
 </Blockquote>
 


### PR DESCRIPTION
We've had [reports on the forum](https://community.k6.io/t/issues-with-installing-xk6-browser-extension/4681) about confusions with running xk6-browser. The main issue was that the "Build from source" instructions build a `k6` binary, and the example mentions running `xk6-browser`. The `InstallationInstructions` element is not flexible enough to specify the output binary, so I chose to repeat the instructions inline instead.  We could also parametrize this via an `output` argument to the element, but I feel like we shouldn't complicate it too much, as there will often be slight changes of the instructions. It doesn't make much sense as a reusable element for me, anyway, and the need to use JSX/HTML instead of Markdown is cumbersome (this last point could probably be resolved with yet another Gatsby plugin).

The other change here is to clarify the `./` and `.\` prefix required on some systems, as that is another frequent source of confusion for users.