### PR TITLE
Update summary jslib documentation to integrate v0.0.2

### DIFF
--- a/src/data/markdown/docs/02 javascript api/13 k6-experimental-redis/10 Client.md
+++ b/src/data/markdown/docs/02 javascript api/13 k6-experimental-redis/10 Client.md
@@ -20,7 +20,7 @@ import { check } from 'k6';
 import http from 'k6/http';
 import redis from 'k6/experimental/redis';
 import exec from 'k6/execution';
-import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.1/index.js';
+import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.2/index.js';
 
 export const options = {
   scenarios: {

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/03 KMSClient.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/03 KMSClient.md
@@ -31,7 +31,7 @@ Both the dedicated `kms.js` jslib bundle and the all-encompassing `aws.js` bundl
 <CodeGroup labels={[]}>
 
 ```javascript
-import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.1/index.js';
+import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.2/index.js';
 
 import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.6.0/kms.js';
 

--- a/src/data/markdown/translated-guides/en/03 Results output/100 End-of-test/150-custom-summary.md
+++ b/src/data/markdown/translated-guides/en/03 Results output/100 End-of-test/150-custom-summary.md
@@ -146,7 +146,7 @@ export default k6example; // use some predefined example to generate some data
 export const options = { vus: 5, iterations: 10 };
 
 // These are still very much WIP and untested, but you can use them as is or write your own!
-import { jUnit, textSummary } from 'https://jslib.k6.io/k6-summary/0.0.1/index.js';
+import { jUnit, textSummary } from 'https://jslib.k6.io/k6-summary/0.0.2/index.js';
 
 export function handleSummary(data) {
   console.log('Preparing the end-of-test summary...');

--- a/src/data/markdown/translated-guides/es/04 Results visualization/00 End-of-test Summary.md
+++ b/src/data/markdown/translated-guides/es/04 Results visualization/00 End-of-test Summary.md
@@ -76,7 +76,7 @@ export default k6example; // use some predefined example to generate some data
 export const options = { vus: 5, iterations: 10 };
 
 // These are still very much WIP and untested, but you can use them as is or write your own!
-import { jUnit, textSummary } from 'https://jslib.k6.io/k6-summary/0.0.1/index.js';
+import { jUnit, textSummary } from 'https://jslib.k6.io/k6-summary/0.0.2/index.js';
 
 export function handleSummary(data) {
   console.log('Preparing the end-of-test summary...');


### PR DESCRIPTION
There's a newer version of the k6-summary jslib available. It doesn't change anything to the interface and doesn't justify updating the content of the documentation. However, this PR updates all references to the k6-summary jslib throughout the documentation to use the latest version `v0.0.2` 🤝 