### PR TITLE
Update TLS supported versions list

### DIFF
--- a/src/data/markdown/translated-guides/en/02 Using k6/10 Protocols/04 SSL-TLS/SSL-TLS version and ciphers.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/10 Protocols/04 SSL-TLS/SSL-TLS version and ciphers.md
@@ -61,6 +61,7 @@ Here's the list of available SSL/TLS versions that you can choose from, ordered 
 - `http.TLS_1_0`
 - `http.TLS_1_1`
 - `http.TLS_1_2`
+- `http.TLS_1_3`
 
 ## Limiting cipher suites
 


### PR DESCRIPTION
We support `http.TLS_1_3` but it was missing from the list :-)