### PR TITLE
[fix] Remove duplicate Manage teams header

### DIFF
--- a/src/data/markdown/docs/03 cloud/05 Project and Team Management/02 Teams.md
+++ b/src/data/markdown/docs/03 cloud/05 Project and Team Management/02 Teams.md
@@ -37,8 +37,6 @@ To add Teams and Team members, you need the following:
 
 ## Managing teams
 
-## Managing teams
-
 To manage teams from k6 Cloud, use the left sidebar and select **Teams**. 
 
 ![Team menu](images/05-Teams/teams-menu.png)


### PR DESCRIPTION
Teams doc page has duplicate **Managing teams** header. This PR removes that.

![Screenshot 2022-10-20 at 09 30 58](https://user-images.githubusercontent.com/10167318/196885839-e9093059-82ed-41d6-883f-6c7107d57db3.png)
