### PR TITLE
Rewrites HandleSummary() doc

### DIFF
--- a/src/data/markdown/translated-guides/en/03 Results output/100 End-of-test/150-custom-summary.md
+++ b/src/data/markdown/translated-guides/en/03 Results output/100 End-of-test/150-custom-summary.md
@@ -19,7 +19,7 @@ However, we plan to support the feature for k6 Cloud tests, too.
 
 ## About the `handleSummary()` callback
 
-After your VU code runs, k6 aggregates your metrics into a JavaScript object.
+After your test runs, k6 aggregates your metrics into a JavaScript object.
 The `handleSummary()` function takes this object as an argument (called `data` in all examples here).
 
 You can use `handleSummary()` to create a custom summary or return the default summary object.

--- a/src/data/markdown/translated-guides/en/03 Results output/100 End-of-test/150-custom-summary.md
+++ b/src/data/markdown/translated-guides/en/03 Results output/100 End-of-test/150-custom-summary.md
@@ -48,7 +48,7 @@ export function handleSummary(data) {
 
 Fundamentally, `handleSummary()` is just a function that can access a data object.
 As such, you can transform the summary data into any text format: JSON, HTML, console, XML, and so on.
-You can pipe your custom summary to standard out or standard error, write it to a file, or send it to a remote server.
+You can pipe your custom summary to [standard output or standard error](https://en.wikipedia.org/wiki/Standard_streams), write it to a file, or send it to a remote server.
 
 ## Use handleSummary()
 
@@ -62,14 +62,14 @@ k6 expects `handleSummary()` to return a `{key1: value1, key2: value2, ...}` map
 
 The keys must be strings.
 They determine where k6 displays or saves the content:
-- `stdout` for [standard output](https://en.wikipedia.org/wiki/Standard_streams)
+- `stdout` for standard output
 - `stderr` for standard error,
 - any relative or absolute path to a file on the system (this operation overwrites existing files)
 
 The value of a key can have a type of either `string` or [`ArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer).
 
 You can return mutiple summary outputs in a script.
-As an example, this `return` statement sends a report to standard out and writes the `data` object to a JSON file.
+As an example, this `return` statement sends a report to standard output and writes the `data` object to a JSON file.
 
 <CodeGroup labels={["example keys for handleSummary output"]}>
 
@@ -84,7 +84,7 @@ As an example, this `return` statement sends a report to standard out and writes
 
 ### Extract data properties
 
-This minimal `handleSummary()` extracts the `median` value for the `iteration_duration` metric and prints it on standard out:
+This minimal `handleSummary()` extracts the `median` value for the `iteration_duration` metric and prints it to standard output:
 
 <CodeGroup labels={["Print metric value"]} lineNumbers={[]} showCopyButton={[true]}>
 

--- a/src/data/markdown/translated-guides/en/03 Results output/100 End-of-test/150-custom-summary.md
+++ b/src/data/markdown/translated-guides/en/03 Results output/100 End-of-test/150-custom-summary.md
@@ -1,9 +1,9 @@
 ---
 title: Custom summary
-excerpt: With the handlesummary() function, you can customize every part of your report. Change the content, redirect output, and more.
+excerpt: With handlesummary(), you can customize every part of your report. Change the content, redirect output, and more.
 ---
 
-With the `handleSummary()` callback, you can completely customize your end-of-test summary.
+With `handleSummary()`, you can completely customize your end-of-test summary.
 In this document, you can read about:
 - How `handleSummary()` works
 - How to customize the content and output location of your summary
@@ -19,11 +19,11 @@ However, we plan to support the feature for k6 Cloud tests, too.
 
 ## About the `handleSummary()` callback
 
-After your VU code runs, k6 aggregates your metrics into an object.
+After your VU code runs, k6 aggregates your metrics into a JavaScript object.
 The `handleSummary()` function takes this object as an argument (called `data` in all examples here).
 k6 calls `handleSummary()` at the end of the test run, even after [`teardown()`](/using-k6/test-life-cycle).
 
-You can use `handleSummary()` to manipulate this object as you want.
+You can use `handleSummary()` to create a custom summary or return the default summary object.
 To get an idea of what the data looks like,
 run this script and open the output file, `summary.json`.
 
@@ -82,7 +82,7 @@ As an example, this `return` statement sends a report to standard output and wri
 
 </CodeGroup>
 
-### Extract data properties
+### Example: extract data properties
 
 This minimal `handleSummary()` extracts the `median` value for the `iteration_duration` metric and prints it to standard output:
 
@@ -108,7 +108,7 @@ export function handleSummary(data) {
 </CodeGroup>
 
 
-### Modify default output
+### Example: modify default output
 
 If `handleSummary()` is exported, k6 _does not_ print the default summary.
 However, if you want to keep the default output, you could import `textSummary` from the [K6 JS utilities library](https://jslib.k6.io/).
@@ -211,7 +211,7 @@ For compactness, these outputs were limited with the `summaryTrendStats` option.
 </Collapsible>
 
 
-### Custom reports to a remote server
+### Example: Send to remote servers and make custom reports
 
 You can also send the generated reports to a remote server (over any protocol that k6 supports).
 This script:

--- a/src/data/markdown/translated-guides/en/03 Results output/100 End-of-test/150-custom-summary.md
+++ b/src/data/markdown/translated-guides/en/03 Results output/100 End-of-test/150-custom-summary.md
@@ -1,34 +1,75 @@
 ---
 title: Custom summary
-excerpt: With the handle summary, you can customize every part of your report, 
+excerpt: With the handlesummary() function, you can customize every part of your report. Change the content, redirect output, and more.
 ---
 
-Use the `handleSummary()` function to completely customize the end-of-test summary report.
-
-k6 calls`handleSummary()` at the end of the test run, even after [`teardown()`](/using-k6/test-life-cycle).
-If `handleSummary()` is exported, k6 does _not_ print the default summary.
-
-Besides customizing the CLI summary, you can also transform the summary data into machine- or human-readable formats.
-This lets you create JS-helper functions that generate JSON, CSV, XML (JUnit/xUnit/etc.), HTML, etc. files from the summary data.
+With the `handleSummary()` callback, you can completely customize your end-of-test summary.
+In this document, you can read about:
+- How `handleSummary()` works
+- How to customize the content and output location of your summary
+- The data structure of the summary object
 
 <Blockquote mod="note"
-title="handleSummary() is available on only local tests."
->
+title="handleSummary() is available only for local tests.">
 
-However we plan to support the feature for k6 Cloud tests, too.
+However, we plan to support the feature for k6 Cloud tests, too.
 [Track progress in this issue](https://github.com/grafana/k6-cloud-feature-requests/issues/24).
 
 </Blockquote>
 
-## Data format returned by `handleSummary()`
+## About the `handleSummary()` callback
 
-k6 expects `handleSummary()` to return a `{key1: value1, key2: value2, ...}` map that represents the summary-report content.
-While the values can have a type of either `string` or `ArrayBuffer`, the keys must be strings.
+After your VU code runs, k6 aggregates your metrics into an object.
+The `handleSummary()` function takes this object as an argument (called `data` in all examples here).
+k6 calls `handleSummary()` at the end of the test run, even after [`teardown()`](/using-k6/test-life-cycle).
 
-The keys determine where k6 displays or saves the content:
+You can use `handleSummary()` to manipulate this object as you want.
+To get an idea of what the data looks like,
+run this script and open the output file, `summary.json`.
+
+<CodeGroup labels={["return summary as JSON"]} lineNumbers={[]} showCopyButton={[true]}>
+
+```javascript
+import http from 'k6/http';
+
+export default function () {
+  http.get('https://test.k6.io');
+}
+
+export function handleSummary(data) {
+  return {
+    'summary.json': JSON.stringify(data), //the default data object
+  };
+}
+```
+
+</CodeGroup>
+
+
+Fundamentally, `handleSummary()` is just a function that can access a data object.
+As such, you can transform the summary data into any text format: JSON, HTML, console, XML, and so on.
+You can pipe your custom summary to standard out or standard error, write it to a file, or send it to a remote server.
+
+## Use handleSummary()
+
+The following sections go over the `handleSummary()` syntax and provide some examples.
+
+To look up the structure of the summary object, refer to the reference section.
+
+### Syntax
+
+k6 expects `handleSummary()` to return a `{key1: value1, key2: value2, ...}` map that represents the summary metrics.
+
+The keys must be strings.
+They determine where k6 displays or saves the content:
 - `stdout` for [standard output](https://en.wikipedia.org/wiki/Standard_streams)
 - `stderr` for standard error,
 - any relative or absolute path to a file on the system (this operation overwrites existing files)
+
+The value of a key can have a type of either `string` or [`ArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer).
+
+You can return mutiple summary outputs in a script.
+As an example, this `return` statement sends a report to standard out and writes the `data` object to a JSON file.
 
 <CodeGroup labels={["example keys for handleSummary output"]}>
 
@@ -41,7 +82,227 @@ The keys determine where k6 displays or saves the content:
 
 </CodeGroup>
 
-To get an idea how `data` would look in your specific test run, just add `return { 'raw-data.json': JSON.stringify(data)};` in your `handleSummary()` function and inspect the resulting `raw-data.json` file. Here's a very abridged example of how it might look:
+### Extract data properties
+
+This minimal `handleSummary()` extracts the `median` value for the `iteration_duration` metric and prints it on standard out:
+
+<CodeGroup labels={["Print metric value"]} lineNumbers={[]} showCopyButton={[true]}>
+
+```javascript
+import http from 'k6/http';
+
+export default function () {
+  http.get('https://test.k6.io');
+}
+
+export function handleSummary(data) {
+  const med_latency = data.metrics.iteration_duration.values.med;
+  const latency_message = `The median latency was ${med_latency}\n`;
+
+  return {
+    stdout: latency_message,
+  };
+}
+```
+
+</CodeGroup>
+
+
+### Modify default output
+
+If `handleSummary()` is exported, k6 _does not_ print the default summary.
+However, if you want to keep the default output, you could import `textSummary` from the [K6 JS utilities library](https://jslib.k6.io/).
+For example, you could write a custom HTML report to a file, and use the `textSummary()` function to print the default report to the console.
+
+You can also use `textSummary()` to make minor modifications to the default end-of-test summary.
+To do so:
+1. Modify the `data` object however you want.
+1. In your `return` statement, pass the modified object as an argument to the `textSummary()` function.
+
+
+The `textSummary()` function comes with a few options:
+
+|Option| Description|
+|-------|-----------|
+|`indent`|How to start the summary indentation|
+|`enableColor`| Whether to print the summary in color.|
+
+
+For example, this `handleSummary()` modifies the default summary in the following ways:
+- It deletes the `http_req_duration{expected_response:true}` sub-metric.
+- It deletes all metrics whose key starts with `iteration`.
+- It begins each line with the `→` character.
+
+
+<CodeGroup labels={["Modify default"]} lineNumbers={[]} showCopyButton={[true]}>
+
+```javascript
+import http from 'k6/http';
+import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.2/index.js';
+
+export default function () {
+  http.get('https://test.k6.io');
+}
+
+export function handleSummary(data) {
+  delete data.metrics['http_req_duration{expected_response:true}'];
+
+  for (const key in data.metrics) {
+    if (key.startsWith('iteration')) delete data.metrics[key];
+  }
+
+  return {
+    stdout: textSummary(data, { indent: '→', enableColors: true }),
+  };
+}
+```
+
+</CodeGroup>
+
+In the collapsible, you can use the tabs to compare default and modified reports.
+
+
+<Collapsible title="Compare default and modified reports" isOpen="" tag="">
+
+Select `Modified` to see the output of the preceding script.
+For compactness, these outputs were limited with the `summaryTrendStats` option.
+
+<CodeGroup labels={["Default report", "Modified"]} lineNumbers={[]} showCopyButton={[true]}>
+
+
+```
+     data_received..................: 63 kB 42 kB/s
+     data_sent......................: 830 B 557 B/s
+     http_req_blocked...............: med=10.39µs  count=5 p(99)=451.07ms p(99.99)=469.67ms
+     http_req_connecting............: med=0s       count=5 p(99)=223.97ms p(99.99)=233.21ms
+     http_req_duration..............: med=202.26ms count=5 p(99)=225.81ms p(99.99)=226.71ms
+       { expected_response:true }...: med=202.26ms count=5 p(99)=225.81ms p(99.99)=226.71ms
+     http_req_failed................: 0.00% ✓ 0        ✗ 5
+     http_req_receiving.............: med=278.27µs count=5 p(99)=377.64µs p(99.99)=381.29µs
+     http_req_sending...............: med=47.57µs  count=5 p(99)=108.42µs p(99.99)=108.72µs
+     http_req_tls_handshaking.......: med=0s       count=5 p(99)=204.42ms p(99.99)=212.86ms
+     http_req_waiting...............: med=201.77ms count=5 p(99)=225.6ms  p(99.99)=226.5ms
+     http_reqs......................: 5     3.352646/s
+     iteration_duration.............: med=204.41ms count=5 p(99)=654.78ms p(99.99)=672.43ms
+     iterations.....................: 5     3.352646/s
+     vus............................: 1     min=1      max=1
+     vus_max........................: 1     min=1      max=1
+```
+
+```
+→    data_received..............: 63 kB 39 kB/s
+→    data_sent..................: 830 B 507 B/s
+→    http_req_blocked...........: med=10.98µs  count=5 p(99)=485.16ms p(99.99)=505.18ms
+→    http_req_connecting........: med=0s       count=5 p(99)=245.05ms p(99.99)=255.15ms
+→    http_req_duration..........: med=208.68ms count=5 p(99)=302.87ms p(99.99)=306.61ms
+→    http_req_failed............: 0.00% ✓ 0        ✗ 5
+→    http_req_receiving.........: med=206.12µs count=5 p(99)=341.05µs p(99.99)=344.13µs
+→    http_req_sending...........: med=47.8µs   count=5 p(99)=166.94µs p(99.99)=170.92µs
+→    http_req_tls_handshaking...: med=0s       count=5 p(99)=207.2ms  p(99.99)=215.74ms
+→    http_req_waiting...........: med=208.47ms count=5 p(99)=302.49ms p(99.99)=306.23ms
+→    http_reqs..................: 5     3.054928/s
+→    vus........................: 1     min=1      max=1
+→    vus_max....................: 1     min=1      max=1
+```
+
+</CodeGroup>
+
+
+</Collapsible>
+
+
+### Custom reports to a remote server
+
+You can also send the generated reports to a remote server (over any protocol that k6 supports).
+This script:
+
+- Turns the summary object into JSON and makes an HTTP request to send it to a remote server
+- Uses an imported helper function to turn the summary into a jUnit XML report
+- Prints the default report to `stdout`.
+
+<CodeGroup labels={["handleSummary() demo"]} lineNumbers={[true]}>
+
+```javascript
+import http from 'k6/http';
+import k6example from 'https://raw.githubusercontent.com/grafana/k6/master/samples/thresholds_readme_example.js';
+export default k6example; // use some predefined example to generate some data
+export const options = { vus: 5, iterations: 10 };
+
+// These are still very much WIP and untested, but you can use them as is or write your own!
+import { jUnit, textSummary } from 'https://jslib.k6.io/k6-summary/0.0.2/index.js';
+
+export function handleSummary(data) {
+  console.log('Preparing the end-of-test summary...');
+
+  // Send the results to some remote server or trigger a hook
+  const resp = http.post('https://httpbin.test.k6.io/anything', JSON.stringify(data));
+  if (resp.status != 200) {
+    console.error('Could not send summary, got status ' + resp.status);
+  }
+
+  return {
+    'stdout': textSummary(data, { indent: ' ', enableColors: true }), // Show the text summary to stdout...
+    '../path/to/junit.xml': jUnit(data), // but also transform it and save it as a JUnit XML...
+    'other/path/to/summary.json': JSON.stringify(data), // and a JSON with all the details...
+    // And any other JS transformation of the data you can think of,
+    // you can write your own JS helpers to transform the summary data however you like!
+  };
+}
+```
+
+</CodeGroup>
+
+These helper functions might change, so keep an eye on [jslib.k6.io](https://jslib.k6.io/) for the latest.
+Of course, we always welcome [PRs to the jslib](https://github.com/grafana/jslib.k6.io), too!
+
+## Summary data reference
+
+Summary data includes information about your test run time and all built-in and custom metrics (including checks).
+
+All metrics are in a top-level `metrics` object.
+In this object, each metric has an object whose key is the name of the metric.
+For example, if your `handleSummary()` argument is called `data`,
+the function can access the object about the `http_req_duration` metric at `data.metrics.http_req_duration`.
+
+
+
+### Metric schema
+
+The following table describes the schema for the metrics object.
+The specific values depend on the [metric type](/using-k6/metrics):
+
+<TableWithNestedRows>
+
+| Property             | Description                                                                    |
+|----------------------|--------------------------------------------------------------------------------|
+| type                 | String that gives the metric type                                              |
+| contains             | String that describes the data                                                    |
+| values               | Object with the summary metric values (properties differ for each metric type) |
+| thresholds           | Object with info about the thresholds for the metric (if applicable)                           |
+| thresholds.{name}    | Name of threshold (object)                                                     |
+| thresholds.{name}.ok | Whether threshold was crossed (boolean)                                        |
+
+</TableWithNestedRows>
+
+<Blockquote mod="note" title="">
+
+If you change the default trend metrics with the [`summaryTrendStats`](/using-k6/k6-options/reference/#summary-trend-stats) option,
+the keys for the values of the trend will change accordingly.
+
+</Blockquote>
+
+### Example summary JSON
+
+To see what the summary `data`  looks like in your specific test run:
+1. Add this to your handleSummary() function:
+
+  ```
+  return { 'raw-data.json': JSON.stringify(data)};`
+  ```
+
+1. Inspect the resulting `raw-data.json` file.
+
+The following is an abridged example of how it might look:
 
 <CodeGroup labels={["data passed to handleSummary()"]} lineNumbers={[true]}>
 
@@ -67,6 +328,12 @@ To get an idea how `data` would look in your specific test run, just add `return
         // Some of the global options of the k6 test run,
         // Currently only summaryTimeUnit and summaryTrendStats
     },
+
+    "state": {
+      "testRunDurationMs": 30898.965069,
+      // And information about TTY checkers
+    },
+
     "metrics": {
         // A map with metric and sub-metric names as the keys and objects with
         // details for the metric. These objects contain the following keys:
@@ -133,47 +400,6 @@ To get an idea how `data` would look in your specific test run, just add `return
 
 </CodeGroup>
 
-## Send reports to a remote server
-
-You can also send the generated reports to a remote server by making an HTTP request (or using any of the other protocols k6 already supports)! Here's a simple example:
-
-<CodeGroup labels={["handleSummary() demo"]} lineNumbers={[true]}>
-
-```javascript
-import http from 'k6/http';
-import k6example from 'https://raw.githubusercontent.com/grafana/k6/master/samples/thresholds_readme_example.js';
-export default k6example; // use some predefined example to generate some data
-export const options = { vus: 5, iterations: 10 };
-
-// These are still very much WIP and untested, but you can use them as is or write your own!
-import { jUnit, textSummary } from 'https://jslib.k6.io/k6-summary/0.0.2/index.js';
-
-export function handleSummary(data) {
-  console.log('Preparing the end-of-test summary...');
-
-  // Send the results to some remote server or trigger a hook
-  const resp = http.post('https://httpbin.test.k6.io/anything', JSON.stringify(data));
-  if (resp.status != 200) {
-    console.error('Could not send summary, got status ' + resp.status);
-  }
-
-  return {
-    'stdout': textSummary(data, { indent: ' ', enableColors: true }), // Show the text summary to stdout...
-    '../path/to/junit.xml': jUnit(data), // but also transform it and save it as a JUnit XML...
-    'other/path/to/summary.json': JSON.stringify(data), // and a JSON with all the details...
-    // And any other JS transformation of the data you can think of,
-    // you can write your own JS helpers to transform the summary data however you like!
-  };
-}
-```
-
-</CodeGroup>
-
-The preceding snippet uses some JS helper functions to transform the summary in various formats.
-These helper functions might change, so keep an eye on [jslib.k6.io](https://jslib.k6.io/) for the latest.
-
-Of course, we always welcome [PRs to the jslib](https://github.com/grafana/jslib.k6.io), too!
-
 ## Custom output examples
 
 These examples are community contributions.
@@ -184,4 +410,3 @@ We thank everyone who has shared!
 - [handleSummary and custom Slack integration](https://medium.com/geekculture/k6-custom-slack-integration-metrics-are-the-magic-of-tests-527aaf613595)
 - [Reporting to Xray](https://docs.getxray.app/display/XRAYCLOUD/Performance+and+load+testing+with+k6)
 - [HTML reporter](https://github.com/benc-uk/k6-reporter)
-


### PR DESCRIPTION
Besides sentence editing and content restructuring, this:
- Adds a small explanatory section
- Makes a progressive series of examples to show how it works
- Splits the reference into a separate section and describes the data model a bit more

Fixes: https://github.com/grafana/k6-docs/issues/679