### PR TITLE
Chore: add trailing-slash option

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -260,7 +260,7 @@ if (process.env.BUCKET_NAME) {
 
 module.exports = {
   pathPrefix: process.env.PATH_PREFIX || `/docs`,
-
+  trailingSlash: 'always',
   siteMetadata: {
     siteTitle:
       'Docs k6.io - Performance testing for developers, like unit-testing, for performance', // <title>


### PR DESCRIPTION
According to this [PR](https://github.com/grafana/k6.io/pull/257)