### PR TITLE
Updates UUID example

### DIFF
--- a/src/data/markdown/docs/05 Examples/01 Examples/11 generating-uuids.md
+++ b/src/data/markdown/docs/05 Examples/01 Examples/11 generating-uuids.md
@@ -61,11 +61,11 @@ export default function () {
 ## Generate v1 UUIDs
 
 
-Universally unique identifiers are handy in many scenarios, as k6 doesn't have built-in support
-for version 1 UUID, you'll have to resort to third-party libraries.
+As k6 doesn't have built-in support
+for version 1 UUID, you'll have to use a third-party library.
+
 This example uses a Node.js library called [uuid](https://www.npmjs.com/package/uuid)
 and [Browserify](http://browserify.org/) (to make it work in k6).
-
 For this to work, we first need to go through a few required steps:
 
 1. Make sure you have the necessary prerequisites installed:
@@ -100,7 +100,7 @@ For this to work, we first need to go through a few required steps:
 
    </CodeGroup>
 
-Here's an example generating a v1 and v4 UUID:
+This example generates a v1 UUID:
 
 <CodeGroup labels={["generate-uuids.js"]} lineNumbers={[false]}>
 
@@ -111,10 +111,6 @@ export default function () {
   // Generate a UUID v1
   const uuid1 = uuid.v1();
   console.log(uuid1);
-
-  // Generate a UUID v4
-  const uuid4 = uuid.v4();
-  console.log(uuid4);
 }
 ```
 

--- a/src/data/markdown/docs/05 Examples/01 Examples/11 generating-uuids.md
+++ b/src/data/markdown/docs/05 Examples/01 Examples/11 generating-uuids.md
@@ -21,45 +21,7 @@ export default function () {
 
 If you really need other UUID versions, you must rely on an external library.
 
-## Send v4 UUIDs in a POST request
-
-This example script:
-1. Makes a variable from a v4 UUID and logs the value to the console.
-1. Makes the UUID an ID for an example object, then sends the object to a test server.
-
-<CodeGroup labels={["uuid.js"]} lineNumbers={[]} showCopyButton={[true]}>
-
-```javascript
-import { randomString, uuidv4 } from 'https://jslib.k6.io/k6-utils/1.4.0/index.js';
-import http from 'k6/http';
-
-const url = 'https://httpbin.test.k6.io/post';
-
-export default function () {
-  // create a uuid
-  const id = uuidv4();
-  console.log(id);
-
-  //make it a user ID in a POST request
-  const data = {
-    userId: id,
-    username: randomString(8),
-    password: randomString(8),
-  };
-  const res = http.post(url, JSON.stringify(data), {
-    headers: { 'Content-Type': 'application/json' },
-  });
-
-  console.log(JSON.parse(res));
-}
-```
-
-</CodeGroup>
-
-
-
 ## Generate v1 UUIDs
-
 
 As k6 doesn't have built-in support
 for version 1 UUID, you'll have to use a third-party library.

--- a/src/data/markdown/docs/05 Examples/01 Examples/11 generating-uuids.md
+++ b/src/data/markdown/docs/05 Examples/01 Examples/11 generating-uuids.md
@@ -3,15 +3,67 @@ title: 'Generating UUIDs'
 excerpt: 'Scripting example on how to generate UUIDs in your load test.'
 ---
 
-Scripting example on how to generate UUIDs in your load test.
+If you want to make a version 4 UUID,
+you can use the [`uuidv4` function](/javascript-api/jslib/utils/uuidv4/) from the [k6 JS lib repository](https://jslib.k6.io/).
 
-Note that if you don't need v1 UUIDs, consider using the `uuidv4` function from
-the [k6 JS lib repository](https://jslib.k6.io/).
+<CodeGroup labels={[""]} lineNumbers={[]} showCopyButton={[true]}>
 
-## Generate v1 and v4 UUIDs
+```javascript
+import { uuidv4 } from 'https://jslib.k6.io/k6-utils/1.4.0/index.js';
+
+export default function () {
+  const randomUUID = uuidv4();
+  console.log(randomUUID); // 35acae14-f7cb-468a-9866-1fc45713149a
+}
+```
+
+</CodeGroup>
+
+If you really need other UUID versions, you must rely on an external library.
+
+## Send v4 UUIDs in a POST request
+
+This example script:
+1. Makes a variable from a v4 UUID and logs the value to the console.
+1. Makes the UUID an ID for an example object, then sends the object to a test server.
+
+<CodeGroup labels={["uuid.js"]} lineNumbers={[]} showCopyButton={[true]}>
+
+```javascript
+import { randomString, uuidv4 } from 'https://jslib.k6.io/k6-utils/1.4.0/index.js';
+import http from 'k6/http';
+
+const url = 'https://httpbin.test.k6.io/post';
+
+export default function () {
+  // create a uuid
+  const id = uuidv4();
+  console.log(id);
+
+  //make it a user ID in a POST request
+  const data = {
+    userId: id,
+    username: randomString(8),
+    password: randomString(8),
+  };
+  const res = http.post(url, JSON.stringify(data), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+  console.log(JSON.parse(res));
+}
+```
+
+</CodeGroup>
+
+
+
+## Generate v1 UUIDs
+
 
 Universally unique identifiers are handy in many scenarios, as k6 doesn't have built-in support
-for UUIDs, we'll have to resort to using a Node.js library called [uuid](https://www.npmjs.com/package/uuid)
+for version 1 UUID, you'll have to resort to third-party libraries.
+This example uses a Node.js library called [uuid](https://www.npmjs.com/package/uuid)
 and [Browserify](http://browserify.org/) (to make it work in k6).
 
 For this to work, we first need to go through a few required steps:


### PR DESCRIPTION
Partially solves Issue #261.

I tested the example, but before merging there are some things to consider.

- Is it necessary to document an example of a v1 uuids? If so, we still need to include the browserify example. Not sure how needed v1 UUIDs are, though.
- Is this POST request example needed? Or is the first `console.log` enough? If that's enough and we don't need the v1 example, can just we route this page to the documentation for the function?