### PR TITLE
feat: added ability to provide custom heading to doc pages

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1007,7 +1007,7 @@ async function fetchDocPagesData(graphql) {
                   slug
                   head_title
                   excerpt
-                  hideHeading
+                  heading
                   redirect
                   redirectTarget
                   hideFromSidebar
@@ -1050,7 +1050,7 @@ async function fetchGuidesPagesData(graphql) {
                   slug
                   head_title
                   excerpt
-                  hideHeading
+
                   redirect
                   redirectTarget
                   hideFromSidebar
@@ -1093,7 +1093,7 @@ async function fetchJavascriptAPIPagesData(graphql) {
                   slug
                   head_title
                   excerpt
-                  hideHeading
+
                   redirect
                   redirectTarget
                   hideFromSidebar
@@ -1184,7 +1184,6 @@ const createRedirects = ({ actions }) => {
     redirectInBrowser: true,
     isPermanent: true,
   });
-  // TODO: move to appropriate place
   createRedirect({
     fromPath: '/javascript-api/xk6-browser/get-started/welcome/',
     toPath: '/javascript-api/xk6-browser/',
@@ -1805,11 +1804,6 @@ exports.onCreateNode = ({ node, actions }) => {
       node,
       name: 'shouldCreatePage',
       value: node.frontmatter.shouldCreatePage || true,
-    });
-    createNodeField({
-      node,
-      name: 'hideHeading',
-      value: node.frontmatter.hideHeading || false,
     });
   }
 };

--- a/src/components/pages/doc-page/doc-page-title-group/doc-page-title-group.module.scss
+++ b/src/components/pages/doc-page/doc-page-title-group/doc-page-title-group.module.scss
@@ -11,32 +11,6 @@
   @include md-down {
     max-width: 100%;
   }
-  &.no-heading {
-    margin: 0;
-    margin-bottom: 50px;
-    max-width: calc(100% - 120px);
-    @include lg-down {
-      max-width: 100%;
-    }
-    .links {
-      justify-content: space-between;
-      width: 100%;
-      flex-direction: row;
-      position: initial;
-      top: initial;
-      right: initial;
-      transform: none;
-      @include sm-down {
-        flex-direction: column;
-      }
-      .githubLink {
-        margin-bottom: 0;
-        @include sm-down {
-          margin-bottom: 15px;
-        }
-      }
-    }
-  }
 }
 
 .title {

--- a/src/components/pages/doc-page/doc-page-title-group/doc-page-title-group.view.js
+++ b/src/components/pages/doc-page/doc-page-title-group/doc-page-title-group.view.js
@@ -29,17 +29,13 @@ export const DocPageTitleGroup = ({
   articleSrc,
   githubUrl,
   githubTitle,
-  hideHeading,
+  heading,
 }) => {
   const { locale } = useLocale();
 
   return (
-    <div
-      className={classNames(styles.wrapper, {
-        [styles.noHeading]: hideHeading,
-      })}
-    >
-      {!hideHeading && <Heading className={styles.title}>{title}</Heading>}
+    <div className={classNames(styles.wrapper)}>
+      <Heading className={styles.title}>{heading || title}</Heading>
       <div className={styles.links}>
         {githubUrl && (
           <GithubLink githubUrl={githubUrl} githubTitle={githubTitle} />

--- a/src/data/markdown/docs/30 xk6-browser/01 Get started/01 Welcome.md
+++ b/src/data/markdown/docs/30 xk6-browser/01 Get started/01 Welcome.md
@@ -1,7 +1,7 @@
 ---
 title: 'Welcome'
+heading: 'xk6-browser Documentation'
 excerpt: 'xk6-browser brings browser automation and end-to-end testing to k6 while supporting core k6 features. Interact with real browsers and collect frontend metrics as part of your k6 tests.'
-hideHeading: true
 ---
 
 ## What is xk6-browser?

--- a/src/templates/doc-page.js
+++ b/src/templates/doc-page.js
@@ -98,7 +98,7 @@ export default function DocPage(props) {
             articleSrc={frontmatter.fileOrigin}
             githubUrl={githubUrl}
             githubTitle={githubTitle}
-            hideHeading={frontmatter.hideHeading}
+            heading={frontmatter.heading}
           />
           <DocPageContent
             label={codeStyles.codeContainer}


### PR DESCRIPTION
**Describe the changes**
This PR reverts the hidden heading at xk6-browser welcome page. Also it adds the ability to specify a custom `heading` which is going to be displayed instead of `title` property of provided ([see](https://github.com/grafana/k6-docs/compare/docs-xk6-browser-fixes?expand=1#diff-da90df2f39ee506f38ccc68db142cff3c99db60a8c537e137df085fb73be4dedR3) 

Closes #872 