### PR TITLE
Remove New Relic percentile query and clarify limitation

### DIFF
--- a/src/data/markdown/translated-guides/en/03 Results output/200 Real-time/00 NewRelic.md
+++ b/src/data/markdown/translated-guides/en/03 Results output/200 Real-time/00 NewRelic.md
@@ -99,16 +99,6 @@ SELECT latest(k6.vus) FROM Metric TIMESERIES
 
 </CodeGroup>
 
-**90th Percentile Request Duration**
-
-<CodeGroup labels={[""]}>
-
-```plain
-SELECT sum(k6.http_req_duration.sum.percentiles) AS '90th' FROM Metric WHERE percentile = 90 TIMESERIES
-```
-
-</CodeGroup>
-
 **Max, Median, and Average Request Duration**
 
 <CodeGroup labels={[""]}>

--- a/src/data/markdown/translated-guides/en/03 Results output/200 Real-time/00 NewRelic.md
+++ b/src/data/markdown/translated-guides/en/03 Results output/200 Real-time/00 NewRelic.md
@@ -87,6 +87,12 @@ You can also add these metrics to [dashboards](https://docs.newrelic.com/docs/qu
 
 ### Example NRQL Queries
 
+<Blockquote mod="note" title="">
+
+New Relic doesn't support calculating percentiles from metric data, which is the data format sent by this k6 output. See [this New Relic forum post](https://discuss.newrelic.com/t/percentiles-of-values-from-metrics-api-with-nrql-not-working/95832) and [the documentation about the metric data type](https://docs.newrelic.com/docs/data-apis/understand-data/metric-data/query-metric-data-type/) for details.
+
+</Blockquote>
+
 Here are some example NRQL queries you can easily copy and paste into widgets in a New Relic dashboard, you can however stick with the [chart builder](https://docs.newrelic.com/docs/query-your-data/explore-query-data/query-builder/introduction-query-builder). Find all your k6 Metrics under the metrics tab, prefixed with `k6.`
 
 **Number of Virtual Users**

--- a/src/data/markdown/translated-guides/es/04 Results visualization/09 NewRelic.md
+++ b/src/data/markdown/translated-guides/es/04 Results visualization/09 NewRelic.md
@@ -87,6 +87,12 @@ También puede añadir estas métricas a los [dashboards](https://docs.newrelic.
 
 ### Ejemplo de las consultas NRQL
 
+<Blockquote mod="note" title="">
+
+New Relic no tiene soporte para calcular percentiles sobre datos enviados como métricas, que es el formato enviado por esta integración. Vea [este hilo en el foro de New Relic](https://discuss.newrelic.com/t/percentiles-of-values-from-metrics-api-with-nrql-not-working/95832) y [la documentación sobre el tipo de dato `metric`](https://docs.newrelic.com/docs/data-apis/understand-data/metric-data/query-metric-data-type/) (en inglés) para más detalle.
+
+</Blockquote>
+
 A continuación se muestran algunos ejemplos de consultas NRQL que puedes copiar y pegar fácilmente en los widgets de un dashboard de New Relic, sin embargo, puedes seguir con el [constructor de gráficos](https://docs.newrelic.com/docs/query-your-data/explore-query-data/query-builder/introduction-query-builder). Encuentre todas sus métricas de k6 en la pestaña de métricas, con el prefijo `k6.`.
 
 

--- a/src/data/markdown/translated-guides/es/04 Results visualization/09 NewRelic.md
+++ b/src/data/markdown/translated-guides/es/04 Results visualization/09 NewRelic.md
@@ -100,16 +100,6 @@ SELECT latest(k6.vus) FROM Metric TIMESERIES
 
 </CodeGroup>
 
-**Percentil 90 -  Duración de la solicitud**
-
-<CodeGroup labels={[""]}>
-
-```plain
-SELECT sum(k6.http_req_duration.sum.percentiles) AS '90th' FROM Metric WHERE percentile = 90 TIMESERIES
-```
-
-</CodeGroup>
-
 **Duración máxima, mediana y media de las solicitudes**
 
 <CodeGroup labels={[""]}>


### PR DESCRIPTION
As reported on the forum ([1](https://community.k6.io/t/percentiles-calculation-on-new-relic/3690), [2](https://community.k6.io/t/how-to-get-the-correct-values-for-p-90-on-k6-newrelic/5192)), our documented p(90) query for New Relic doesn't produce the expected results.

After some investigation, it seems [it's not possible to calculate percentiles from metric data](https://discuss.newrelic.com/t/percentiles-of-values-from-metrics-api-with-nrql-not-working/95832) that our StatsD output produces. So instead of confusing users, it's better to delete this and clarify the limitation.