### PR TITLE
chore: fix workflow config syntax

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -124,11 +124,12 @@ jobs:
           recurse: true
           retry: true
           skip: ".*(\\.js|\\.css)$"
-          linksToSkip: |
-            "https://linkedin.com/, googleapis.com,
+          linksToSkip: >-
+            https://linkedin.com,
+            googleapis.com,
             staging.k6.io/docs/xk6-browser,
             staging.k6.io/docs/using-k6/k6-options/options-reference/,
             https://staging.k6.io/docs/using-k6/k6-options/how-to-use-options/,
-            staging.k6.io/docs/get-started/k6-resources/"
+            staging.k6.io/docs/get-started/k6-resources/
           verbosity: "ERROR"
           markdown: false


### PR DESCRIPTION
You can skip quotes