### PR TITLE
docs: move docker example from xk6-browser github to docs page

### DIFF
--- a/.vale/Vocab/docs/accept.txt
+++ b/.vale/Vocab/docs/accept.txt
@@ -172,3 +172,4 @@ eql
 instanceof
 contentful
 xpath
+Dockerfile

--- a/src/data/markdown/docs/05 Examples/01 Examples/05 data-parameterization.md
+++ b/src/data/markdown/docs/05 Examples/01 Examples/05 data-parameterization.md
@@ -10,7 +10,7 @@ excerpt: |
 
 This page gives some examples of how to parameterize data in a test script.
 Parameterization is typically necessary when Virtual Users (VUs) will make a POST, PUT, or PATCH request in a test.
-You can also use parameterization when you need to add test data from a seperate file.
+You can also use parameterization when you need to add test data from a separate file.
 
 Parameterization helps to prevent server-side caching from impacting your load test.
 This will, in turn, make your test more realistic.

--- a/src/data/markdown/docs/20 jslib/01 jslib/03 k6chaijs/35 error handling.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/03 k6chaijs/35 error handling.md
@@ -3,7 +3,7 @@ title: 'Error handling'
 excerpt: 'How to handle errors in k6chaijs.'
 ---
 
-When you execute a load test, your System Under Test (SUT) may often become oversaturated and start responding with errors. In this case,  you need to consider what the iteration execution should do:
+When you execute a load test, your System Under Test (SUT) may often become over saturated and start responding with errors. In this case,  you need to consider what the iteration execution should do:
 
 1. to embrace the system error and continue the execution of the scenario
 2. or to exit

--- a/src/data/markdown/docs/30 xk6-browser/01 Get started/03 Running xk6-browser.md
+++ b/src/data/markdown/docs/30 xk6-browser/01 Get started/03 Running xk6-browser.md
@@ -239,40 +239,7 @@ Since it's all in one script, this allows for greater collaboration amongst team
 
 ## Run xk6-browser tests in a Docker container
 
-Apart from running the tests locally, you can also run your xk6-browser scripts in a Docker container using Docker Compose by creating the following Dockerfile and docker-compose file:
-
-<CodeGroup labels={["Dockerfile", "docker-compose.yaml"]} lineNumbers={[true]}>
-
-```bash
-FROM golang:1.19-bullseye as builder
-
-RUN go install -trimpath go.k6.io/xk6/cmd/xk6@latest
-
-RUN  xk6 build --output "/tmp/k6" --with github.com/grafana/xk6-browser
-
-FROM debian:bullseye
-
-ARG CHROMIUM_VERSION=106.0.5249.61-1~deb11u1
-
-RUN apt-get update && \
-    apt-get install -y chromium=${CHROMIUM_VERSION}
-
-COPY --from=builder /tmp/k6 /usr/bin/k6
-
-ENV XK6_HEADLESS=true
-
-ENTRYPOINT ["k6"]
-```
-
-```yaml
-version: '3.4'
-
-services:
-  xk6-browser:
-    build: .
-```
-
-</CodeGroup>
+If you prefer working with Docker, you can run your xk6-browser test scripts in a Docker container using Docker Compose by creating a [Dockerfile](https://github.com/grafana/xk6-browser/blob/main/Dockerfile) and [docker-compose](https://github.com/grafana/xk6-browser/blob/main/docker-compose.yaml) file:
 
 To run the test, use the following command and replace `script.js` with your file.
 

--- a/src/data/markdown/docs/30 xk6-browser/01 Get started/03 Running xk6-browser.md
+++ b/src/data/markdown/docs/30 xk6-browser/01 Get started/03 Running xk6-browser.md
@@ -239,7 +239,7 @@ Since it's all in one script, this allows for greater collaboration amongst team
 
 ## Run xk6-browser tests in a Docker container
 
-If you prefer working with Docker, you can run your xk6-browser test scripts in a Docker container using Docker Compose by creating a [Dockerfile](https://github.com/grafana/xk6-browser/blob/main/Dockerfile) and [docker-compose](https://github.com/grafana/xk6-browser/blob/main/docker-compose.yaml) file:
+If you prefer working with Docker, you can run your xk6-browser test scripts in a Docker container using Docker Compose by creating a [Dockerfile](https://github.com/grafana/xk6-browser/blob/main/Dockerfile) and [docker-compose](https://github.com/grafana/xk6-browser/blob/main/docker-compose.yaml) file.
 
 To run the test, use the following command and replace `script.js` with your file.
 


### PR DESCRIPTION
As discussed in https://github.com/grafana/xk6-browser/pull/656#discussion_r1026379295