### PR TITLE
New Relic; fixing rate of requests query

### DIFF
--- a/src/data/markdown/translated-guides/en/03 Results output/200 Real-time/00 NewRelic.md
+++ b/src/data/markdown/translated-guides/en/03 Results output/200 Real-time/00 NewRelic.md
@@ -120,7 +120,7 @@ SELECT max(k6.http_req_duration.summary) AS 'Max Duration', average(k6.http_req_
 <CodeGroup labels={[""]}>
 
 ```plain
-SELECT rate(max(k6.http_reqs.per_second), 1 seconds) FROM Metric TIMESERIES
+SELECT rate(max(k6.http_reqs), 1 seconds) FROM Metric TIMESERIES
 ```
 
 </CodeGroup>


### PR DESCRIPTION
with `rate(max(k6.http_reqs.per_second), 1 seconds)`, rate is calculated twice based on our testing.

`max_http_reqs` - getting max reqs
`max(k6.http_reqs.per_second)` - gives max reqs per second which is rate
`rate(max(k6.http_reqs), 1 seconds)` - getting rate of max reqs per second 
`rate(max(k6.http_reqs.per_second), 1 seconds)` - getting rate to another rate (max reqs per second ) which doesn't look right

In our testing max(k6.http_reqs.per_second) and rate(max(k6.http_reqs), 1 seconds) got similar results .. 