### PR TITLE
Add init block in the example

### DIFF
--- a/src/data/markdown/translated-guides/en/01 Get started/03 Running k6.md
+++ b/src/data/markdown/translated-guides/en/01 Get started/03 Running k6.md
@@ -95,6 +95,8 @@ This function defines the entry point for your VUs.
 <CodeGroup labels={[]}>
 
 ```javascript
+// init
+
 export default function () {
   // vu code: do things here...
 }


### PR DESCRIPTION
Changed the running example to clarify, adding an `// init` block.
Closes [#923](https://github.com/grafana/k6-docs/issues/923)