### PR TITLE
Add extension xk6-output-prometheus-pushgateway

### DIFF
--- a/src/data/doc-extensions/extensions.json
+++ b/src/data/doc-extensions/extensions.json
@@ -805,6 +805,18 @@
       },
       "official": false,
       "categories": ["Reporting"]
+    },
+    {
+      "name": "xk6-output-prometheus-pushgateway",
+      "url": "https://github.com/martymarron/xk6-output-prometheus-pushgateway",
+      "description": "Export results to Prometheus pushgateway",
+      "logo": "",
+      "author": {
+        "name": "Masashi Kurita",
+        "url": "https://github.com/martymarron"
+      },
+      "official": false,
+      "categories": ["Reporting", "Observability"]
     }
   ]
 }


### PR DESCRIPTION
This PR adds a new extension [xk6-output-prometheus-pushgateway](https://github.com/martymarron/xk6-output-prometheus-pushgateway) that export results to [Prometheus pushgateway](https://prometheus.io/docs/practices/pushing/).