### PR TITLE
feat: add caption support for mdx images

### DIFF
--- a/CONTRIBUTING/gatsby-reference.md
+++ b/CONTRIBUTING/gatsby-reference.md
@@ -108,6 +108,12 @@ Default image syntax for markdown files
 
 Note, that path begins with `/`, not just `images/`.
 
+Every image with the contents of the title attribute, when this is not empty, turns into image with the caption
+
+```md
+![Alt of an image](../internal-images/insights-url-table-full.png "Title that will be used a caption")
+```
+
 Store images relative to a source `.md` file, and access them from `.md` files by using relative path. `image-sharp-plugin` will handle your image: compress, convert and lazy load.
 
 ### Example file structure

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -77,6 +77,7 @@ const plugins = [
             withWebp: true,
             disableBgImage: true,
             wrapperStyle: 'margin-left: 0;',
+            showCaptions: ['title'],
           },
         },
       ],

--- a/src/components/blocks/html-content/html-content.scss
+++ b/src/components/blocks/html-content/html-content.scss
@@ -1,4 +1,6 @@
-a.gatsby-resp-image-link {
+a.gatsby-resp-image-link,
+.gatsby-resp-image-figure {
+  margin: 0;
   border-bottom: none;
   outline: none;
   text-decoration: none;
@@ -14,6 +16,12 @@ a.gatsby-resp-image-link {
     top: 0;
     left: 0;
     color: transparent;
+  }
+  .gatsby-resp-image-figcaption {
+    margin: 10px 0;
+    font-size: 15px;
+    line-height: 20px;
+    color: $color-secondary;
   }
 }
 

--- a/src/data/markdown/docs/03 cloud/03 Manage/03 Notifications.md
+++ b/src/data/markdown/docs/03 cloud/03 Manage/03 Notifications.md
@@ -19,7 +19,7 @@ When you [schedule a test](/cloud/manage/scheduled-tests) or add it to your cont
 you'll likely want to configure a notification for failed events, thus automating test execution and observation.
 
 
-![k6 Notifications](./images/Notifications/notification-type-selection.png)
+![k6 Notifications](./images/Notifications/notification-type-selection.png "Built-in notifications options in k6 Cloud")
 
 ## Add a Slack notification
 


### PR DESCRIPTION
This PR adds a caption to each image with the contents of the title attribute, when this is not empty.
For example: `![Alt text](./image.png "Title that will be used a caption")` is converted to:
<img width="855" alt="Screenshot 2022-12-09 at 13 52 39" src="https://user-images.githubusercontent.com/13874601/206688180-9d216085-a67a-4f30-aa86-8dac2fce0963.png">
