### PR TITLE
chore: add fallback fonts, using fontpie

### DIFF
--- a/src/styles/parts/fonts.scss
+++ b/src/styles/parts/fonts.scss
@@ -83,3 +83,25 @@
   line-gap-override: 0%;
   size-adjust: 96.31%;
 }
+
+@font-face {
+  font-family: 'Roboto Mono Fallback';
+  font-style: normal;
+  font-weight: 300;
+  src: local('Courier New');
+  ascent-override: 104.79%;
+  descent-override: 27.1%;
+  line-gap-override: 0%;
+  size-adjust: 100%;
+}
+
+@font-face {
+  font-family: 'Roboto Mono Fallback';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Courier New');
+  ascent-override: 104.79%;
+  descent-override: 27.1%;
+  line-gap-override: 0%;
+  size-adjust: 100%;
+}

--- a/src/styles/parts/fonts.scss
+++ b/src/styles/parts/fonts.scss
@@ -50,3 +50,36 @@
   src: url('../../fonts/tt-norms-pro/tt-pro-bold-webfont.woff2') format('woff2'),
     url('../../fonts/tt-norms-pro/tt-pro-bold-webfont.woff') format('woff');
 }
+
+@font-face {
+  font-family: 'TT Norms Pro Fallback';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Arial');
+  ascent-override: 107.86%;
+  descent-override: 24.05%;
+  line-gap-override: 0%;
+  size-adjust: 99.69%;
+}
+
+@font-face {
+  font-family: 'TT Norms Pro Fallback';
+  font-style: normal;
+  font-weight: 500;
+  src: local('Arial');
+  ascent-override: 106.34%;
+  descent-override: 24.09%;
+  line-gap-override: 0%;
+  size-adjust: 101.57%;
+}
+
+@font-face {
+  font-family: 'TT Norms Pro Fallback';
+  font-style: normal;
+  font-weight: 700;
+  src: local('Arial Bold');
+  ascent-override: 113.16%;
+  descent-override: 26.97%;
+  line-gap-override: 0%;
+  size-adjust: 96.31%;
+}

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -1,5 +1,5 @@
 // Font families
-$font-family-primary: 'TT Norms Pro', sans-serif;
+$font-family-primary: 'TT Norms Pro', 'TT Norms Pro Fallback', sans-serif;
 $font-family-secondary: 'Roboto Mono', Monaco, Consolas, mono;
 
 // Font sizes and line heights

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -1,6 +1,7 @@
 // Font families
 $font-family-primary: 'TT Norms Pro', 'TT Norms Pro Fallback', sans-serif;
-$font-family-secondary: 'Roboto Mono', Monaco, Consolas, mono;
+$font-family-secondary: 'Roboto Mono', 'Roboto Mono Fallback', Monaco, Consolas,
+  mono;
 
 // Font sizes and line heights
 $font-size-base: 17px;


### PR DESCRIPTION
This pull request adds fallback fonts using [fontpie](https://github.com/pixel-point/fontpie):


**Steps to test**
1. Open the [pages]()
2. Confirm that everything looks and works as expected.