### PR TITLE
feat: add excerpt and heading frontmatter fields to algolia

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -162,7 +162,7 @@ if (
       appId: process.env.GATSBY_ALGOLIA_APP_ID,
       apiKey: process.env.ALGOLIA_ADMIN_KEY,
       enablePartialUpdates: true,
-      matchFields: ['title', 'slug', 'content'],
+      matchFields: ['title', 'slug', 'content', 'excerpt', 'heading'],
       queries,
       chunkSize: 10000, // default: 1000
     },

--- a/src/utils/algolia.js
+++ b/src/utils/algolia.js
@@ -18,7 +18,7 @@ const processMdxEntry = (
   const {
     mdxAST,
     objectID,
-    frontmatter: { title, redirect, slug: customSlug },
+    frontmatter: { title, excerpt, heading, redirect, slug: customSlug },
   } = entry;
   if (redirect) {
     // avoid pushing empty records
@@ -88,6 +88,8 @@ const processMdxEntry = (
   while (pointer--) {
     cache[pointer] = {
       title,
+      excerpt,
+      heading,
       objectID: `${objectID}-${pointer}`,
       slug: removeParametersFromJavaScriptAPISlug(
         pageSlug.startsWith('/') ? pageSlug : `/${pageSlug}`,
@@ -135,6 +137,8 @@ const docPagesQuery = `{
           title
           redirect
           slug
+          excerpt
+          heading
         }
         mdxAST
       }
@@ -157,6 +161,8 @@ const guidesPagesQuery = `{
           title
           redirect
           slug
+          excerpt
+          heading
         }
         mdxAST
       }

--- a/src/utils/algolia.js
+++ b/src/utils/algolia.js
@@ -116,8 +116,8 @@ const flatten = (arr, kind = 'docs') => {
 // custom index entry for extensions page
 const processExtensions = (extensionsList) =>
   extensionsList.map((extension) => ({
-    title: extension.name,
-    objectID: `extensions-${extension.name}`,
+    title: `${extension.name} extension`,
+    objectID: `${extension.name}-extension`,
     slug: '/extensions/',
     content: extension.description,
     _tags: ['en', 'es'],
@@ -187,7 +187,8 @@ const settings = {
   distinct: true,
 };
 
-const indexName = process.env.GATSBY_ALGOLIA_INDEX_NAME || 'k6_docs';
+const indexName = process.env.GATSBY_ALGOLIA_INDEX_NAME || 'dev_k6_docs';
+console.warn({ indexName, env: process.env.GATSBY_ALGOLIA_INDEX_NAME });
 
 const queries = [
   {


### PR DESCRIPTION
This PR adds `excerpt` and `heading` frontmatter fields to Algolia index