### PR TITLE
Realtime/Grafana Cloud title fix

### DIFF
--- a/src/data/markdown/translated-guides/en/03 Results output/200 Real-time.md
+++ b/src/data/markdown/translated-guides/en/03 Results output/200 Real-time.md
@@ -30,7 +30,7 @@ You can also stream real-time metrics to the following services:
 - [Amazon CloudWatch](/results-output/real-time/amazon-cloudwatch)
 - [Cloud](/results-output/real-time/cloud)
 - [Datadog](/results-output/real-time/datadog)
-- [Grafana Cloud / Prometheus](/results-output/real-time/grafana-cloud)
+- [Grafana Cloud](/results-output/real-time/grafana-cloud)
 - [InfluxDB](/results-output/real-time/influxdb-grafana)
 - [Netdata](/results-output/real-time/netdata)
 - [New Relic](/results-output/real-time/new-relic)


### PR DESCRIPTION
I think it is not relevant to explicit the data source. It could be any (e.g. InfluxDB or any other supported by Grafana). It is convenient using Prometheus, but we can omit to specify it in the title as we do on the dedicated page.