### PR TITLE
Fix orientation of 'Running k6' car icon

### DIFF
--- a/src/components/pages/doc-welcome/quickstart/quickstart.component.js
+++ b/src/components/pages/doc-welcome/quickstart/quickstart.component.js
@@ -26,7 +26,7 @@ export const Quickstart = () => {
           urlLocale === 'es'
             ? '/es/empezando/ejecucion-de-k6/'
             : '/get-started/running-k6/',
-        title: `🏎💨 ${t('welcome.quickstart.running-k6.title')}`,
+        title: `🏎️💨 ${t('welcome.quickstart.running-k6.title')}`,
         text: t('welcome.quickstart.running-k6.text'),
       },
       {


### PR DESCRIPTION
I'm not sure if this was caused by a font change on our side or some Unicode update on my system, since this used to look fine a few months ago, but on Linux and recent stable versions of Firefox and Chromium, the car icon is rendered pointing to the right, while the "wind" icon is pointing to the left. So it looks like the car is racing backwards :smile:

This still uses the same [U+1F3CE](https://www.utf8icons.com/character/127950/racing-car) glyph as before, but for some reason renders properly with the car pointing to the left for me. :man_shrugging: **Please test that this renders correctly on Windows, macOS, iOS and Android.**

This is why it would be a good idea to abandon emojis for this use case, and switch to SVGs (#781).

### Before

- Chromium 107.0.5304.87
  ![2022-12-20-181430_327x164_scrot](https://user-images.githubusercontent.com/1009277/208733346-f49c61aa-e14e-4aa1-8b00-6ea63dc469c8.png)

- Firefox 107.0.1
  ![2022-12-20-181444_291x165_scrot](https://user-images.githubusercontent.com/1009277/208733395-0ac8b747-03cf-400e-886f-27c22cb5c3ed.png)

### After

- Chromium 107.0.5304.87
  ![2022-12-20-181503_328x164_scrot](https://user-images.githubusercontent.com/1009277/208733504-d811581b-0add-4df0-a020-229d340221a2.png)

- Firefox 107.0.1
  ![2022-12-20-181518_314x177_scrot](https://user-images.githubusercontent.com/1009277/208733567-8b9c9374-3a14-4c18-bd85-51efd5867c6d.png)
