### PR TITLE
feat: update search hits with excerpt and heading

### DIFF
--- a/src/components/shared/search-box/hit-comps.js
+++ b/src/components/shared/search-box/hit-comps.js
@@ -5,10 +5,18 @@ import { Highlight, Snippet } from 'react-instantsearch-dom';
 
 import styles from './search-box.module.scss';
 
+const getKeyByValue = (object, value) =>
+  Object.keys(object).find((key) => object[key] === value);
+
 export const docPageHit =
   (clickHandler) =>
-  ({ hit }) =>
-    (
+  ({ hit }) => {
+    const hitTitleKey = hit.heading ? getKeyByValue(hit, hit.heading) : 'title';
+    const hitContentKey = hit.excerpt
+      ? getKeyByValue(hit, hit.excerpt)
+      : 'content';
+
+    return (
       <div>
         <Link
           to={`${hit.slug}`}
@@ -20,14 +28,15 @@ export const docPageHit =
             size={'sm'}
             className={`link ${styles.hitHeading}`}
           >
-            <Highlight attribute={'title'} hit={hit} tagName={'mark'} />
+            <Highlight attribute={hitTitleKey} hit={hit} tagName={'mark'} />
           </Heading>
         </Link>
         <Snippet
-          attribute={'content'}
+          attribute={hitContentKey}
           hit={hit}
           tagName={'mark'}
           className={styles.excerpt}
         />
       </div>
     );
+  };

--- a/src/components/shared/search-box/hit-comps.js
+++ b/src/components/shared/search-box/hit-comps.js
@@ -12,9 +12,10 @@ export const docPageHit =
   (clickHandler) =>
   ({ hit }) => {
     const hitTitleKey = hit.heading ? getKeyByValue(hit, hit.heading) : 'title';
-    const hitContentKey = hit.excerpt
-      ? getKeyByValue(hit, hit.excerpt)
-      : 'content';
+    const hitContentKey =
+      hit._snippetResult.content.matchLevel === 'none' && hit.excerpt
+        ? getKeyByValue(hit, hit.excerpt)
+        : 'content';
 
     return (
       <div>

--- a/src/utils/algolia.js
+++ b/src/utils/algolia.js
@@ -182,12 +182,13 @@ const extensionsQuery = `{extensionsData: docExtensionsJson {
 
 // additional config
 const settings = {
-  attributesToSnippet: ['content:20'],
+  attributesToSnippet: ['content:20', 'excerpt'],
   attributeForDistinct: 'title',
   distinct: true,
 };
 
 const indexName = process.env.GATSBY_ALGOLIA_INDEX_NAME || 'dev_k6_docs';
+// eslint-disable-next-line no-console
 console.warn({ indexName, env: process.env.GATSBY_ALGOLIA_INDEX_NAME });
 
 const queries = [


### PR DESCRIPTION
This PR updates search hits with `excerpt` and `heading` frontmatter fields