### PR TITLE
Add documentation for new wildcard Hosts feature

### DIFF
--- a/src/data/markdown/translated-guides/en/02 Using k6/05 k6 Options/02 Reference.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/05 k6 Options/02 Reference.md
@@ -421,7 +421,7 @@ $ k6 cloud --exit-on-running script.js
 ## Hosts
 
 An object with overrides to DNS resolution, similar to what you can do with `/etc/hosts` on
-Linux/Unix or `C:\\Windows\\System32\\drivers\\etc\\hosts` on Windows. For instance, you could set
+Linux/Unix or `C:\Windows\System32\drivers\etc\hosts` on Windows. For instance, you could set
 up an override which routes all requests for `test.k6.io` to `1.2.3.4`.
 
 You can also redirect only from certain ports or to certain ports.

--- a/src/data/markdown/translated-guides/en/02 Using k6/05 k6 Options/02 Reference.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/05 k6 Options/02 Reference.md
@@ -424,7 +424,9 @@ An object with overrides to DNS resolution, similar to what you can do with `/et
 Linux/Unix or `C:\Windows\System32\drivers\etc\hosts` on Windows. For instance, you could set
 up an override which routes all requests for `test.k6.io` to `1.2.3.4`.
 
-You can also redirect only from certain ports or to certain ports.
+Starting from v0.28.0, you can also redirect only from certain ports or to certain ports.
+
+Starting from v0.42.0, you can use an asterisk (`*`) at the start of the host name, to avoid repetition. For example, `*.k6.io` would apply the override for all subdomains of `k6.io`.
 
 <Blockquote mod="note" title="">
 
@@ -444,14 +446,14 @@ export const options = {
   hosts: {
     'test.k6.io': '1.2.3.4',
     'test.k6.io:443': '1.2.3.4:8443',
+    '*.k6.io': '1.2.3.4',  // applies for all subdomains of k6.io
   },
 };
 ```
 
 </CodeGroup>
 
-With the above code any request made to `test.k6.io` will be redirected to `1.2.3.4` without changing
-it port unless it's port is `443` which will be redirected to port `8443`.
+With the above code any request made to `test.k6.io` or any subdomains of `k6.io` will be redirected to `1.2.3.4` without changing its port, unless the port is `443` which will be redirected to port `8443`.
 
 ## HTTP debug
 

--- a/src/data/markdown/translated-guides/en/02 Using k6/05 k6 Options/02 Reference.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/05 k6 Options/02 Reference.md
@@ -424,9 +424,9 @@ An object with overrides to DNS resolution, similar to what you can do with `/et
 Linux/Unix or `C:\Windows\System32\drivers\etc\hosts` on Windows. For instance, you could set
 up an override which routes all requests for `test.k6.io` to `1.2.3.4`.
 
-Starting from v0.28.0, you can also redirect only from certain ports or to certain ports.
-
-Starting from v0.42.0, you can use an asterisk (`*`) at the start of the host name, to avoid repetition. For example, `*.k6.io` would apply the override for all subdomains of `k6.io`.
+k6 also supports ways to narrow or widen the scope of your redirects:
+- You can redirect only from or to certain ports.
+- Starting from v0.42.0, you can use an asterisk (`*`) as a wild card at the start of the host name to avoid repetition. For example, `*.k6.io` would apply the override for all subdomains of `k6.io`.
 
 <Blockquote mod="note" title="">
 
@@ -453,7 +453,9 @@ export const options = {
 
 </CodeGroup>
 
-With the above code any request made to `test.k6.io` or any subdomains of `k6.io` will be redirected to `1.2.3.4` without changing its port, unless the port is `443` which will be redirected to port `8443`.
+The preceding code will redirect any request made to any subdomain of `k6.io` to `1.2.3.4`.
+The port will remain the same, unless the redirect is from `test.k6.io` on port `443`.
+In this case, it redirects to port `8443`.
 
 ## HTTP debug
 

--- a/src/data/markdown/translated-guides/en/02 Using k6/05 k6 Options/02 Reference.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/05 k6 Options/02 Reference.md
@@ -444,18 +444,16 @@ This does not modify the actual HTTP `Host` header, but rather where it will be 
 ```javascript
 export const options = {
   hosts: {
-    'test.k6.io': '1.2.3.4',
+    'test.k6.io':     '1.2.3.4',
     'test.k6.io:443': '1.2.3.4:8443',
-    '*.k6.io': '1.2.3.4',  // applies for all subdomains of k6.io
+    '*.grafana.com':  '1.2.3.4',
   },
 };
 ```
 
 </CodeGroup>
 
-The preceding code will redirect any request made to any subdomain of `k6.io` to `1.2.3.4`.
-The port will remain the same, unless the redirect is from `test.k6.io` on port `443`.
-In this case, it redirects to port `8443`.
+The preceding code will redirect requests made to `test.k6.io` to `1.2.3.4`, keeping the same port. If the request is done to port `443`, it will redirect it to port `8443` instead. It will also redirect requests to any subdomain of `grafana.com` to `1.2.3.4`.
 
 ## HTTP debug
 

--- a/src/data/markdown/translated-guides/es/02 Using k6/05 Options.md
+++ b/src/data/markdown/translated-guides/es/02 Using k6/05 Options.md
@@ -456,6 +456,8 @@ Un objeto con anulaciones de la resolución DNS, similar a lo que puede hacer co
 
 A partir de la versión v0.28.0 también se soporta el redireccionamiento sólo desde ciertos puertos y/o hacia ciertos puertos.
 
+A partir de la versión v0.42.0 puede utilizar un asterisco (`*`) al principio del nombre del servidor, para evitar repetición. Por ejemplo, `*.k6.io` aplicaría la anulación para todos los subdominios de `k6.io`.
+
 > ### ⚠️ Tenga en cuenta que!
 >
 > Esto no modifica la cabecera HTTP Host propiamente dicha, sino hacia dónde se dirigirá.
@@ -471,13 +473,14 @@ export const options = {
   hosts: {
     'test.k6.io': '1.2.3.4',
     'test.k6.io:443': '1.2.3.4:8443',
+    '*.k6.io': '1.2.3.4',  // aplica para todos los subdominios de k6.io
   },
 };
 ```
 
 </CodeGroup>
 
-Con el código anterior cualquier petición hecha a `test.k6.io` será redirigida a `1.2.3.4` sin cambiar su puerto a menos que su puerto sea `443` que será redirigido al puerto `8443`.
+Con el código anterior cualquier petición hecha a `test.k6.io` o cualquier subdominio de `k6.io` será redirigida a `1.2.3.4` sin cambiar su puerto, a menos que su puerto sea `443` que será redirigido al puerto `8443`.
 
 ## HTTP Debug
 

--- a/src/data/markdown/translated-guides/es/02 Using k6/05 Options.md
+++ b/src/data/markdown/translated-guides/es/02 Using k6/05 Options.md
@@ -452,7 +452,7 @@ $ k6 cloud --exit-on-running script.js
 
 ## Hosts
 
-Un objeto con anulaciones de la resolución DNS, similar a lo que puede hacer con `/etc/hosts` en Linux/Unix o `C:\\Windows\\System32\\drivers\\etc\\hosts` en Windows. Por ejemplo, puede configurar una anulación que dirija todas las solicitudes de test.k6.io a 1.2.3.4.
+Un objeto con anulaciones de la resolución DNS, similar a lo que puede hacer con `/etc/hosts` en Linux/Unix o `C:\Windows\System32\drivers\etc\hosts` en Windows. Por ejemplo, puede configurar una anulación que dirija todas las solicitudes de test.k6.io a 1.2.3.4.
 
 A partir de la versión v0.28.0 también se soporta el redireccionamiento sólo desde ciertos puertos y/o hacia ciertos puertos.
 

--- a/src/data/markdown/translated-guides/es/02 Using k6/05 Options.md
+++ b/src/data/markdown/translated-guides/es/02 Using k6/05 Options.md
@@ -472,16 +472,16 @@ También es posible ampliar o especificar la anulación:
 ```javascript
 export const options = {
   hosts: {
-    'test.k6.io': '1.2.3.4',
+    'test.k6.io':     '1.2.3.4',
     'test.k6.io:443': '1.2.3.4:8443',
-    '*.k6.io': '1.2.3.4',  // aplica para todos los subdominios de k6.io
+    '*.grafana.com':  '1.2.3.4',
   },
 };
 ```
 
 </CodeGroup>
 
-Con el código anterior cualquier petición hecha a cualquier subdominio de `k6.io` será redirigida a `1.2.3.4`. El puerto se mantendrá igual, a menos que la petición es a `test.k6.io` al puerto `443`. En este caso, será redirigida al puerto `8443`.
+Con el código anterior cualquier petición hecha a `test.k6.io` será redirigida a `1.2.3.4`, manteniendo el mismo puerto. Si la petición es al puerto `443`, será redirigida al puerto `8443`. También redigirá peticiones a cualquier subdominio de `grafana.com` a `1.2.3.4`.
 
 
 ## HTTP Debug

--- a/src/data/markdown/translated-guides/es/02 Using k6/05 Options.md
+++ b/src/data/markdown/translated-guides/es/02 Using k6/05 Options.md
@@ -454,9 +454,10 @@ $ k6 cloud --exit-on-running script.js
 
 Un objeto con anulaciones de la resolución DNS, similar a lo que puede hacer con `/etc/hosts` en Linux/Unix o `C:\Windows\System32\drivers\etc\hosts` en Windows. Por ejemplo, puede configurar una anulación que dirija todas las solicitudes de test.k6.io a 1.2.3.4.
 
-A partir de la versión v0.28.0 también se soporta el redireccionamiento sólo desde ciertos puertos y/o hacia ciertos puertos.
+También es posible ampliar o especificar la anulación:
+- Redirigiendo desde o hacia puertos en específico.
+- A partir de la version v0.42.0, puede utilizar un asterisco (`*`) al principio del nombre del servidor, para evitar repetición. Por ejemplo, `*.k6.io` aplicaría la anulación para todos los subdominios de `k6.io`.
 
-A partir de la versión v0.42.0 puede utilizar un asterisco (`*`) al principio del nombre del servidor, para evitar repetición. Por ejemplo, `*.k6.io` aplicaría la anulación para todos los subdominios de `k6.io`.
 
 > ### ⚠️ Tenga en cuenta que!
 >
@@ -480,7 +481,8 @@ export const options = {
 
 </CodeGroup>
 
-Con el código anterior cualquier petición hecha a `test.k6.io` o cualquier subdominio de `k6.io` será redirigida a `1.2.3.4` sin cambiar su puerto, a menos que su puerto sea `443` que será redirigido al puerto `8443`.
+Con el código anterior cualquier petición hecha a cualquier subdominio de `k6.io` será redirigida a `1.2.3.4`. El puerto se mantendrá igual, a menos que la petición es a `test.k6.io` al puerto `443`. En este caso, será redirigida al puerto `8443`.
+
 
 ## HTTP Debug
 


### PR DESCRIPTION
This documents support for using a wildcard with the `hosts` option, which was recently added in v0.42.0. See https://github.com/grafana/k6/pull/2747.