### PR TITLE
Bump aws jslib links to v0.7.1

### DIFF
--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/01 S3Client.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/01 S3Client.md
@@ -37,7 +37,7 @@ import { check } from 'k6';
 import exec from 'k6/execution';
 import http from 'k6/http';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.7.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.7.1/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/02 SecretsManagerClient.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/02 SecretsManagerClient.md
@@ -35,7 +35,7 @@ S3 Client methods will throw errors in case of failure.
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.7.0/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.7.1/secrets-manager.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/03 KMSClient.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/03 KMSClient.md
@@ -33,7 +33,7 @@ Both the dedicated `kms.js` jslib bundle and the all-encompassing `aws.js` bundl
 ```javascript
 import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.2/index.js';
 
-import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.7.0/kms.js';
+import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.7.1/kms.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/04 SystemsManagerClient.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/04 SystemsManagerClient.md
@@ -32,7 +32,7 @@ Both the dedicated `ssm.js` jslib bundle and the all-encompassing `aws.js` bundl
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SystemsManagerClient } from 'https://jslib.k6.io/aws/0.7.0/ssm.js';
+import { AWSConfig, SystemsManagerClient } from 'https://jslib.k6.io/aws/0.7.1/ssm.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/05 AwsConfig.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/05 AwsConfig.md
@@ -35,7 +35,7 @@ import exec from 'k6/execution';
 
 // Note that you AWSConfig is also included in the dedicated service
 // client bundles such as `s3.js` and `secrets-manager.js`
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.7.0/aws.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.7.1/aws.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/06 SignatureV4.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/06 SignatureV4.md
@@ -44,7 +44,7 @@ SignatureV4 methods throw errors on failure.
 ```javascript
 import http from 'k6/http.js'
 
-import { AWSConfig, SignatureV4 } from 'https://jslib.k6.io/aws/0.7.0/kms.js'
+import { AWSConfig, SignatureV4 } from 'https://jslib.k6.io/aws/0.7.1/kms.js'
 
 const awsConfig = new AWSConfig({
     region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/KMSClient/01 listKeys.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/KMSClient/01 listKeys.md
@@ -19,7 +19,7 @@ excerpt: "KMSClient.listKeys lists all the KMS keys in the caller's AWS account 
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.7.0/kms.js';
+import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.7.1/kms.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/KMSClient/02 generateDataKey.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/KMSClient/02 generateDataKey.md
@@ -26,7 +26,7 @@ excerpt: 'KMSClient.generateDataKey generates a symmetric data key for use outsi
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.7.0/kms.js';
+import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.7.1/kms.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/KMSClient/98 KMSDataKey.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/KMSClient/98 KMSDataKey.md
@@ -21,7 +21,7 @@ For instance, the [`generateDataKey`](/javascript-api/jslib/aws/kmsclient/kmscli
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.7.0/kms.js';
+import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.7.1/kms.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/KMSClient/99 KMSKey.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/KMSClient/99 KMSKey.md
@@ -18,7 +18,7 @@ excerpt: 'KMSKey is returned by the KMSClient.* methods that query KMS keys'
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.7.0/kms.js';
+import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.7.1/kms.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/01 listBuckets().md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/01 listBuckets().md
@@ -19,7 +19,7 @@ excerpt: 'S3Client.listBuckets lists the buckets the authenticated user has acce
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.7.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.7.1/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/02 listObjects(bucketName, [prefix]).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/02 listObjects(bucketName, [prefix]).md
@@ -24,7 +24,7 @@ excerpt: 'S3Client.listObjects lists the objects contained in a bucket'
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.7.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.7.1/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/03 getObject(bucketName, objectKey).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/03 getObject(bucketName, objectKey).md
@@ -24,7 +24,7 @@ excerpt: 'S3Client.getObject downloads an object from a bucket'
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.7.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.7.1/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/04 putObject(bucketName, objectKey, data).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/04 putObject(bucketName, objectKey, data).md
@@ -17,7 +17,7 @@ excerpt: 'S3Client.putObject uploads an object to a bucket'
 <CodeGroup labels={[]}>
 
 ```javascript
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.7.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.7.1/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/05 deleteObject(bucketName, objectKey).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/05 deleteObject(bucketName, objectKey).md
@@ -18,7 +18,7 @@ excerpt: 'S3Client.deleteObject deletes an object from a bucket'
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.7.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.7.1/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/98 Object.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/98 Object.md
@@ -27,7 +27,7 @@ import {
   // listBuckets,
   AWSConfig,
   S3Client,
-} from 'https://jslib.k6.io/aws/0.7.0/s3.js';
+} from 'https://jslib.k6.io/aws/0.7.1/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/99 Bucket.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/99 Bucket.md
@@ -16,7 +16,7 @@ Bucket is returned by the S3Client.* methods that query S3 buckets. Namely, `lis
 <CodeGroup labels={[]}>
 
 ```javascript
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.7.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.7.1/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/01 listSecrets().md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/01 listSecrets().md
@@ -19,7 +19,7 @@ excerpt: 'SecretsManagerClient.listSecrets lists the secrets the authenticated u
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.7.0/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.7.1/secrets-manager.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/02 getSecret(secretID).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/02 getSecret(secretID).md
@@ -23,7 +23,7 @@ excerpt: 'SecretsManagerClient.getSecret(secretID) downloads a secret from AWS s
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.7.0/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.7.1/secrets-manager.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/03 createSecret(name, secretString, description, [versionID], [tags]).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/03 createSecret(name, secretString, description, [versionID], [tags]).md
@@ -19,7 +19,7 @@ excerpt: 'SecretsManagerClient.createSecret creates a new secret'
 <CodeGroup labels={[]}>
 
 ```javascript
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.7.0/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.7.1/secrets-manager.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/04 deleteSecret(secretID, { recoveryWindow: 30, noRecovery: false}}).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/04 deleteSecret(secretID, { recoveryWindow: 30, noRecovery: false}}).md
@@ -16,7 +16,7 @@ excerpt: 'SecretsManagerClient.deleteSecret deletes a secret'
 <CodeGroup labels={[]}>
 
 ```javascript
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.7.0/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.7.1/secrets-manager.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/05 putSecretValue(secretID, secretString, [versionID]).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/05 putSecretValue(secretID, secretString, [versionID]).md
@@ -20,7 +20,7 @@ excerpt: "SecretsManagerClient.putSecretValue updates an existing secret's value
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.7.0/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.7.1/secrets-manager.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/99 Secret.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/99 Secret.md
@@ -25,7 +25,7 @@ Secret is returned by the SecretsManagerClient.* methods that query secrets. Nam
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.7.0/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.7.1/secrets-manager.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SignatureV4/01 sign().md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SignatureV4/01 sign().md
@@ -45,7 +45,7 @@ You can override SignatureV4 options in the context of this specific request. To
 ```javascript
 import http from 'k6/http.js'
 
-import { AWSConfig, SignatureV4 } from 'https://jslib.k6.io/aws/0.7.0/kms.js'
+import { AWSConfig, SignatureV4 } from 'https://jslib.k6.io/aws/0.7.1/kms.js'
 
 const awsConfig = new AWSConfig({
     region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SignatureV4/02 presign().md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SignatureV4/02 presign().md
@@ -55,7 +55,7 @@ import {
     SignatureV4,
     AMZ_CONTENT_SHA256_HEADER,
     UNSIGNED_PAYLOAD,
-} from 'https://jslib.k6.io/aws/0.7.0/kms.js'
+} from 'https://jslib.k6.io/aws/0.7.1/kms.js'
 
 const awsConfig = new AWSConfig({
     region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SystemsManagerClient/01 getParameter.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SystemsManagerClient/01 getParameter.md
@@ -19,7 +19,7 @@ excerpt: "SystemsManagerClient.getParameter gets a Systems Manager parameter in 
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SystemsManagerClient } from 'https://jslib.k6.io/aws/0.7.0/ssm.js';
+import { AWSConfig, SystemsManagerClient } from 'https://jslib.k6.io/aws/0.7.1/ssm.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SystemsManagerClient/99 SystemsManagerParameter.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SystemsManagerClient/99 SystemsManagerParameter.md
@@ -25,7 +25,7 @@ excerpt: 'SystemsManagerParameter is returned by the SystemsManagerClient.* meth
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SystemsManagerClient } from 'https://jslib.k6.io/aws/0.7.0/ssm.js';
+import { AWSConfig, SystemsManagerClient } from 'https://jslib.k6.io/aws/0.7.1/ssm.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,


### PR DESCRIPTION
This PR bumps the aws jslib version in the docs to [`0.7.1`](https://github.com/grafana/k6-jslib-aws/releases)

Do not merge yet, we still have to publish the version under http://jslib.k6.io/ (I'm working on that PR next)