### PR TITLE
chore(extensions): Adding tracetest extension

### DIFF
--- a/src/data/doc-extensions/extensions.json
+++ b/src/data/doc-extensions/extensions.json
@@ -1,6 +1,18 @@
 {
   "extensions": [
     {
+      "name": "xk6-tracetest",
+      "description": "Support for Tracetest test execution and tracing client",
+      "url": "https://github.com/kubeshop/xk6-tracetest",
+      "logo": "",
+      "author": {
+        "name": "Oscar R. Reyes",
+        "url": "https://github.com/xoscar"
+      },
+      "official": false,
+      "categories": ["Observability"]
+    },
+    {
       "name": "xk6-prompt",
       "description": "Support for input arguments via UI.",
       "url": "https://github.com/Juandavi1/xk6-prompt",


### PR DESCRIPTION
This PR adds the Tracetest extension to the list.

Hello everyone, at Tracetest we spend a couple of days working on a k6 extension for users to interact with the tracetest instance through the k6 scripts.

The idea is to allow users to run tests based when executing load tests to an instrumented service, there is the option to use the tracetest output (part of this binary) or explicitly call the `tracetest.runTest` function with a trace id that comes from the HTTP responses.

As this is the initial version, we only support the HTTP client for plug-and-play. We'll be adding more protocols as the extension and requirements from users evolve.

Extension Repo URL: https://github.com/kubeshop/xk6-tracetest

Here's a video with information on how it can be used:
https://www.loom.com/share/880b3ec1f81b49269274155af2264972

Shoutout to @javaducky for the feedback and the support

