### PR TITLE
Minor fixes

### DIFF
--- a/src/components/pages/doc-welcome/features/doc-welcome-features.view.js
+++ b/src/components/pages/doc-welcome/features/doc-welcome-features.view.js
@@ -21,7 +21,17 @@ export const Features = () => {
       <div className={'row'}>
         <div className="col-md-12">
           <Trait className={styles.trait}>
-            {t('welcome.features.cli-tool')}
+            <Link
+              className={'link'}
+              to={
+                urlLocale === 'es'
+                  ? '/es/usando-k6/opciones/'
+                  : '/using-k6/k6-options/how-to/'
+              }
+            >
+              {t('welcome.features.cli-tool')}
+            </Link>{' '}
+            {t('welcome.features.cli-tool.dev-friendly-apis')}
           </Trait>
 
           <Trait className={styles.trait}>

--- a/src/data/markdown/docs/05 Examples/01 Examples/02 http-authentication.md
+++ b/src/data/markdown/docs/05 Examples/01 Examples/02 http-authentication.md
@@ -134,7 +134,7 @@ For this to work, we first need to do the following:
    <CodeGroup labels={[""]} lineNumbers={[false]}>
 
    ```bash
-    $ browserify node_modules/aws4/aws4.js -s aws4 > aws4.js
+   $ browserify node_modules/aws4/aws4.js -s aws4 > aws4.js
    ```
 
    </CodeGroup>

--- a/src/data/markdown/translated-guides/en/02 Using k6/14 Scenarios/01 Executors/05 constant-arrival-rate.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/14 Scenarios/01 Executors/05 constant-arrival-rate.md
@@ -42,7 +42,7 @@ this executor has the following options:
 When you want to maintain a constant number of iterations without being affected by the
 performance of the system under test.
 
-## Examples
+## Example
 
 In this example, we'll start a constant rate of 30 iterations per second for 30 seconds, allowing k6 to dynamically schedule up to 50 VUs.
 

--- a/src/data/markdown/translated-guides/en/02 Using k6/14 Scenarios/01 Executors/06 ramping-arrival-rate.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/14 Scenarios/01 Executors/06 ramping-arrival-rate.md
@@ -37,7 +37,7 @@ this executor has the following options:
 If you need your tests to not be affected by the system-under-test's performance, and
 would like to ramp the number of iterations up or down during specific periods of time.
 
-## Examples
+## Example
 
 In this example, we'll run a four-stage test. We initially stay at the defined rate of starting 300 iterations per minute over a minute period. Then, ramping up the iteration rate from 300 to 600 iterations started per minute over the next two minutes period, and staying at this rate for four more minutes. Finally, down to starting 60 iterations per minute over the last two minutes period.
 

--- a/src/data/markdown/translated-guides/en/02 Using k6/14 Scenarios/01 Executors/07 externally-controlled.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/14 Scenarios/01 Executors/07 externally-controlled.md
@@ -35,7 +35,7 @@ If you want to control the number of VUs while the test is running.
 Important: this is the only executor that is not supported in `k6 cloud`, it can only be used
 locally with `k6 run`.
 
-## Examples
+## Example
 
 In this example, we'll execute a test controllable at runtime, starting with 10 VUs up to
 a maximum of 50, and a total duration of 10 minutes.

--- a/src/i18n/guides-translations.js
+++ b/src/i18n/guides-translations.js
@@ -22,7 +22,9 @@ export const localizedMessages = {
     'welcome.features.title': 'Key features',
     'welcome.features.description':
       'k6 is packed with features, which you can learn all about in the documentation. Key features include:',
-    'welcome.features.cli-tool': 'CLI tool with developer-friendly APIs.',
+    'welcome.features.cli-tool': 'CLI tool',
+    'welcome.features.cli-tool.dev-friendly-apis':
+      'with developer-friendly APIs.',
     'welcome.features.scripting':
       'Scripting in JavaScript ES2015/ES6 - with support for',
     'welcome.features.modules': 'local and remote modules',
@@ -103,7 +105,9 @@ export const localizedMessages = {
     'welcome.features.description':
       'k6 está compuesto de varias funcionalidades, que puede conocer en la documentación. Las principales características son las siguientes:',
     'welcome.features.cli-tool':
-      'Herramienta CLI con APIs amigables para el desarrollador.',
+      'Herramienta CLI',
+    'welcome.features.cli-tool.dev-friendly-apis':
+      'con APIs amigables para el desarrollador.',
     'welcome.features.scripting':
       'Scripting en JavaScript ES2015/ES6, con soporte para módulos locales y remotos.',
     'welcome.features.modules': 'Módulos locales and remotos',


### PR DESCRIPTION
Fixes #958, #926

And https://k6.io/docs/examples/http-authentication/#aws-signature-v4-authentication where the command `browserify node_modules/aws4/aws4.js -s aws4 > aws4.js` had a white space and the copy was adding $.