### PR TITLE
Sleep isn't needed at end of arrival rate iter

### DIFF
--- a/src/data/markdown/translated-guides/en/02 Using k6/14 Scenarios/01 Executors/05 constant-arrival-rate.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/14 Scenarios/01 Executors/05 constant-arrival-rate.md
@@ -39,8 +39,7 @@ this executor has the following options:
 ## When to use
 
 When you want to maintain a constant number of iterations without being affected by the
-performance of the system under test. To reliably achieve a fixed request rate, try to keep test function simple, with preferably only a single request call,
-and no additional processing or `sleep()` calls.
+performance of the system under test.
 
 <Blockquote mod="note" title="Don't put sleep at the end of an iteration">
 

--- a/src/data/markdown/translated-guides/en/02 Using k6/14 Scenarios/01 Executors/05 constant-arrival-rate.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/14 Scenarios/01 Executors/05 constant-arrival-rate.md
@@ -16,7 +16,6 @@ useful for a more accurate representation of RPS, for example.
 For explanations about how this executor works, refer to [Open and Closed models](/using-k6/scenarios/concepts/open-vs-closed)
 and [Arrival-rate VU allocation](/using-k6/scenarios/concepts/arrival-rate-vu-allocation).
 
-
 <Blockquote mod="Note" title="Iteration starts are spaced fractionally">
 
 Iterations **do not** start at exactly the same time.
@@ -40,7 +39,15 @@ this executor has the following options:
 ## When to use
 
 When you want to maintain a constant number of iterations without being affected by the
-performance of the system under test.
+performance of the system under test. To reliably achieve a fixed request rate, try to keep test function simple, with preferably only a single request call,
+and no additional processing or `sleep()` calls.
+
+<Blockquote mod="note" title="Don't put sleep at the end of an iteration">
+
+The arrival-rate executors already pace the iteration rate through the `rate` and `timeUnit` properties.
+It's unnecessary to use a `sleep()` function at the end of the VU code.
+
+</Blockquote>
 
 ## Example
 
@@ -82,15 +89,11 @@ export default function () {
   http.get('https://test.k6.io/contacts.php');
   // We're injecting a processing pause for illustrative purposes only!
   // Each iteration will be ~515ms, therefore ~2 iterations/second per VU maximum throughput.
-  sleep(0.5);
 }
 ```
 
 </CodeGroup>
 
-> **Note**: to reliably achieve a fixed request rate, it's recommended to keep
-> the function being executed very simple, with preferably only a single request call,
-> and no additional processing or `sleep()` calls.
 
 ## Observations
 

--- a/src/data/markdown/translated-guides/en/02 Using k6/14 Scenarios/01 Executors/05 constant-arrival-rate.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/14 Scenarios/01 Executors/05 constant-arrival-rate.md
@@ -44,7 +44,7 @@ performance of the system under test.
 <Blockquote mod="note" title="Don't put sleep at the end of an iteration">
 
 The arrival-rate executors already pace the iteration rate through the `rate` and `timeUnit` properties.
-It's unnecessary to use a `sleep()` function at the end of the VU code.
+So it's unnecessary to use a `sleep()` function at the end of the VU code.
 
 </Blockquote>
 

--- a/src/data/markdown/translated-guides/en/02 Using k6/14 Scenarios/01 Executors/06 ramping-arrival-rate.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/14 Scenarios/01 Executors/06 ramping-arrival-rate.md
@@ -37,9 +37,19 @@ this executor has the following options:
 If you need your tests to not be affected by the system-under-test's performance, and
 would like to ramp the number of iterations up or down during specific periods of time.
 
+<Blockquote mod="note" title="Don't put sleep at the end of an iteration">
+
+The arrival-rate executors already pace the iteration rate through the `rate` and `timeUnit` properties.
+It's unnecessary to use a `sleep()` function at the end of the VU code.
+
+</Blockquote>
+
 ## Example
 
-In this example, we'll run a four-stage test. We initially stay at the defined rate of starting 300 iterations per minute over a minute period. Then, ramping up the iteration rate from 300 to 600 iterations started per minute over the next two minutes period, and staying at this rate for four more minutes. Finally, down to starting 60 iterations per minute over the last two minutes period.
+This is an example of a four-stage test.
+It initially stays at the defined rate of starting 300 iterations per minute over a one minute period.
+After one minute, the iteration rate ramps to 600 iterations started per minute over the next two minutes, and stays at this rate for four more minutes.
+In the last two minutes, it ramps down to a target of 60 iterations per minute.
 
 <CodeGroup labels={[ "ramping-arr-rate.js" ]} lineNumbers={[true]}>
 


### PR DESCRIPTION
From discussion in #900