### PR TITLE
Document new concurrency policy default - "Queue"

### DIFF
--- a/src/data/markdown/docs/03 cloud/01 Creating and running a test/999 Troubleshooting.md
+++ b/src/data/markdown/docs/03 cloud/01 Creating and running a test/999 Troubleshooting.md
@@ -229,12 +229,12 @@ Two options are available:
 - `Queue test`: the new test run will be queued for execution and started once a slot is opened. A queued test will timeout if no slot is available in 6 hours. This is the current default option.
 - `Abort test`: the new test run will be automatically aborted.
 
-<Blockquote mod="note" title="Concurrency limit policy default change">
+<Blockquote mod="note" title="Changes to the default concurrency policy">
 
-On 2023-01-31, the default concurrency policy changed from `Abort test` to `Queue test`.
+On January 31st, 2023, the default concurrency policy changed from `Abort test` to `Queue test`.
 To avoid confusion, k6 kept the old default for organizations who joined before the change.
 
-If your organization uses the old default and wants to upgrade to `Queue test` policy, simply follow the instructions below.
+If your organization uses the old default and wants to upgrade to `Queue test` policy, change the policy at **Organization settings > Settings**.
 
 </Blockquote>
 

--- a/src/data/markdown/docs/03 cloud/01 Creating and running a test/999 Troubleshooting.md
+++ b/src/data/markdown/docs/03 cloud/01 Creating and running a test/999 Troubleshooting.md
@@ -226,8 +226,8 @@ If you need to increase this limit, contact our support team.
 Additionally, you can change the concurrency limit policy that defines how k6 Cloud acts when the organization reaches the limit and a new test run is triggered.
 Two options are available:
 
-- `Abort test`: the new test run will be automatically aborted. This is the default option.
-- `Queue test`: the new test run will be queued for execution and started once a slot is opened. A queued test will timeout if no slot is available in 6 hours.
+- `Queue test`: the new test run will be queued for execution and started once a slot is opened. A queued test will timeout if no slot is available in 6 hours. This is the default option.
+- `Abort test`: the new test run will be automatically aborted.
 
 To change the concurrency limit policy, you must be the organization owner.
 You can change the policy at in your user menu, at **Organization settings > Settings**:

--- a/src/data/markdown/docs/03 cloud/01 Creating and running a test/999 Troubleshooting.md
+++ b/src/data/markdown/docs/03 cloud/01 Creating and running a test/999 Troubleshooting.md
@@ -234,7 +234,7 @@ Two options are available:
 On January 31st, 2023, the default concurrency policy changed from `Abort test` to `Queue test`.
 To avoid confusion, k6 kept the old default for organizations who joined before the change.
 
-If your organization uses the old default and wants to upgrade to `Queue test` policy, change the policy at **Organization settings > Settings**.
+If your organization uses the old default and wants to upgrade to `Queue test` policy, change the policy as described in the following section.
 
 </Blockquote>
 

--- a/src/data/markdown/docs/03 cloud/01 Creating and running a test/999 Troubleshooting.md
+++ b/src/data/markdown/docs/03 cloud/01 Creating and running a test/999 Troubleshooting.md
@@ -231,7 +231,7 @@ Two options are available:
 
 <Blockquote mod="note" title="Concurrency limit policy default change">
 
-On 31.01.2023, the default concurrency policy changed from `Abort test` to `Queue test`.
+On 2023-01-31, the default concurrency policy changed from `Abort test` to `Queue test`.
 To avoid confusion, k6 kept the old default for organizations who joined before the change.
 
 If your organization uses the old default and wants to upgrade to `Queue test` policy, simply follow the instructions below.

--- a/src/data/markdown/docs/03 cloud/01 Creating and running a test/999 Troubleshooting.md
+++ b/src/data/markdown/docs/03 cloud/01 Creating and running a test/999 Troubleshooting.md
@@ -226,7 +226,7 @@ If you need to increase this limit, contact our support team.
 Additionally, you can change the concurrency limit policy that defines how k6 Cloud acts when the organization reaches the limit and a new test run is triggered.
 Two options are available:
 
-- `Queue test`: the new test run will be queued for execution and started once a slot is opened. A queued test will timeout if no slot is available in 6 hours. This is the default option.
+- `Queue test`: the new test run will be queued for execution and started once a slot is opened. A queued test will timeout if no slot is available in 6 hours. This is the current default option.
 - `Abort test`: the new test run will be automatically aborted.
 
 To change the concurrency limit policy, you must be the organization owner.

--- a/src/data/markdown/docs/03 cloud/01 Creating and running a test/999 Troubleshooting.md
+++ b/src/data/markdown/docs/03 cloud/01 Creating and running a test/999 Troubleshooting.md
@@ -241,12 +241,12 @@ If your organization uses the old default and wants to upgrade to `Queue test` p
 ### Changing the concurrency limit policy
 
 To change the concurrency limit policy, you must be the organization owner.
-You can change the policy at in your user menu, at **Organization settings > Settings**:
+You can change the policy in your user menu, at **Organization settings > Settings**:
 
 ![Concurrency limit policy](./images/Troubleshooting/k6-concurrency-limit-policy.png)
 
 
-### Data uploads with k6 Cloud
+## Data uploads with k6 Cloud
 
 The [test builder](/test-authoring/test-builder) and [script editor](/cloud/creating-and-running-a-test/script-editor) in the k6 Cloud don't support uploading data files in your test.
 

--- a/src/data/markdown/docs/03 cloud/01 Creating and running a test/999 Troubleshooting.md
+++ b/src/data/markdown/docs/03 cloud/01 Creating and running a test/999 Troubleshooting.md
@@ -229,6 +229,17 @@ Two options are available:
 - `Queue test`: the new test run will be queued for execution and started once a slot is opened. A queued test will timeout if no slot is available in 6 hours. This is the current default option.
 - `Abort test`: the new test run will be automatically aborted.
 
+<Blockquote mod="note" title="Concurrency limit policy default change">
+
+On 31.01.2023, the default concurrency policy changed from `Abort test` to `Queue test`.
+To avoid confusion, k6 kept the old default for organizations who joined before the change.
+
+If your organization uses the old default and wants to upgrade to `Queue test` policy, simply follow the instructions below.
+
+</Blockquote>
+
+### Changing the concurrency limit policy
+
 To change the concurrency limit policy, you must be the organization owner.
 You can change the policy at in your user menu, at **Organization settings > Settings**:
 


### PR DESCRIPTION
We are changing the default concurrency policy to `Queue` in k6 cloud.