### PR TITLE
Document the k6/experimental/tracing module

### DIFF
--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental.md
@@ -9,4 +9,5 @@ excerpt: "k6 experimental APIs"
 | ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | [redis](/javascript-api/k6-experimental/redis/) | Functionality to interact with [Redis](https://redis.io/). |
 | [timers](/javascript-api/k6-experimental/timers/) | `setTimeout`, `clearTimeout`, `setInterval`, `clearInterval`  |
+| [tracing](/javascript-api/k6-experimental/tracing/) | Support for instrumenting HTTP requests with tracing information. |
 | [websockets](/javascript-api/k6-experimental/websockets/) | Implements the browser's [WebSocket API](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket).  |

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/04 tracing.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/04 tracing.md
@@ -1,0 +1,61 @@
+---
+title: "tracing"
+excerpt: "k6 Tracing experimental API"
+---
+
+<ExperimentalBlockquote />
+
+
+With this experimental module, you can _instrument_ you HTTP requests so that they emit traces as the test runs.
+
+## About trace contexts
+
+A _trace context_ is a set of standardized HTTP headers added to a request that lets a tracing system correlate the request with other requests as they navigate through a system. The trace context specifications, such as the supported [W3C Trace Context](https://www.w3.org/TR/trace-context/) and [Jaeger Trace Context](https://www.jaegertracing.io/docs/1.21/client-libraries/#propagation-format), define specific header names and an encoding format for the header values.
+
+A trace context generally consists of, at least, a `trace_id`, a `span_id`, and a `sampled` flag. The `trace_id` is a unique identifier for the trace, the `span_id` is a unique identifier for the request, and the `sampled` flag is a boolean that indicates whether the request should be traced. For instance, the [W3C Trace Context](https://www.w3.org/TR/trace-context/) defines the `Traceparent` header, whose value contains a `trace_id`, a `span_id` and a `sampled` flag, encoded as a dash (`-`) separated list of hexadecimal values. When a trace context header is attached to an HTTP request, we refer to it as being _propagated_ to the downstream service.
+
+## API
+
+| Class/Function                                                           | Description                                                                                                               |
+| :----------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------ |
+| [instrumentHTTP](/javascript-api/k6-experimental/tracing/instrumenthttp) | instruments the k6 http module with tracing capabilities.                                                                 |
+| [Client](/javascript-api/k6-experimental/tracing/client)                 | configurable Client that exposes instrumented HTTP operations and allows selectively instrumenting requests with tracing. |
+
+## Example
+
+This example demonstrates how to use the tracing API to instrument every HTTP request made in a script with tracing information.
+
+<CodeGroup labels={["example-tracing-module.js"]} lineNumbers={[]} showCopyButton={[true]}>
+
+```javascript
+import { check } from "k6";
+import tracing from "k6/experimental/tracing";
+import http from "k6/http";
+
+// instrumentHTTP will ensure that all requests made by the http module
+// from this point forward will have a trace context attached.
+//
+// The first argument is a configuration object that
+// can be used to configure the tracer.
+tracing.instrumentHTTP({
+  // possible values: "w3c", "jaeger"
+  propagator: "w3c",
+});
+
+export default () => {
+  // the instrumentHTTP call in the init context replaced
+  // the http module with a version that will automatically
+  // attach a trace context to every request.
+  //
+  // Because the instrumentHTTP call was configured with the
+  // w3c trace propagator, this request will as a result have
+  // a `traceparent` header attached.
+  const res = http.get("http://httpbin.org/get", {
+    headers: {
+      "X-Example-Header": "instrumented/get",
+    },
+  });
+};
+```
+
+</CodeGroup>

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/04 tracing.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/04 tracing.md
@@ -6,7 +6,7 @@ excerpt: "k6 Tracing experimental API"
 <ExperimentalBlockquote />
 
 
-With this experimental module, you can _instrument_ you HTTP requests so that they emit traces as the test runs.
+With this experimental module, you can _instrument_ HTTP requests so that they emit traces as the test runs.
 
 ## About trace contexts
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/04 tracing/01 instrumentHTTP.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/04 tracing/01 instrumentHTTP.md
@@ -1,0 +1,52 @@
+---
+title: 'instrumentHTTP'
+excerpt: 'instrumentHTTP instruments the k6 http module with tracing capabilities.'
+---
+
+The `instrumentHTTP` function instruments the k6 http module with tracing capabilities. It transparently replaces each of the k6 http module functions with versions that automatically attach a trace context to every request. Instrumented functions include [del](/javascript-api/k6-http/del), [get](/javascript-api/k6-http/get), [head](/javascript-api/k6-http/head), [options](/javascript-api/k6-http/options), [patch](/javascript-api/k6-http/patch), [post](/javascript-api/k6-http/post), [put](/javascript-api/k6-http/head), and [request](/javascript-api/k6-http/request).
+
+The `instrumentHTTP` automatically adds tracing information to HTTP requests performed using the `k6/http` module functions (mentioned above).
+This means that, to instrument the HTTP requests, you don't need to rewrite any code.
+Instead, call it once in the init context.
+From that point forward, all requests made by the HTTP module from that point forward will have a trace context header added to them, and the metadata for the data-point output will have the used `trace_id`. For details about propagation, refer to [About trace contexts](/javascript-api/k6-experimental/tracing#about-trace-contexts).
+
+## Parameters
+
+| Name      | Type                                                         | Description                                                                                                    |
+| :-------- | :----------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------- |
+| `options` | [`Options`](/javascript-api/k6-experimental/tracing/options) | Configures the tracing behavior with the provided [`Options`](/javascript-api/k6-experimental/tracing/options) object. |
+
+## Example
+
+This example demonstrates how calling the `instrumentHTTP` function in the init context of a script once ensures that all requests made by the HTTP module from that point forward will have a trace context header attached.
+
+<CodeGroup labels={["example-tracing-instrumentHTTP.js"]} lineNumbers={[]} showCopyButton={[true]}>
+
+```javascript
+import { check } from "k6";
+import tracing from "k6/experimental/tracing";
+import http from "k6/http";
+
+// instrumentHTTP will ensure that all requests made by the http module
+// will be traced. The first argument is a configuration object that
+// can be used to configure the tracer.
+//
+// Currently supported HTTP methods are: get, post, put, patch, head,
+// del, options, and request.
+tracing.instrumentHTTP({
+  // propagator defines the trace context propagation format.
+  // Currently supported: w3c and jaeger.
+  // Default: w3c
+  propagator: "w3c",
+});
+
+export default () => {
+  const res = http.get("http://httpbin.org/get", {
+    headers: {
+      "X-Example-Header": "instrumented/get",
+    },
+  });
+};
+```
+
+</CodeGroup>

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/04 tracing/02 Client.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/04 tracing/02 Client.md
@@ -1,0 +1,86 @@
+---
+title: 'Client'
+excerpt: 'Client is a HTTP client attaching tracing information to its requests.'
+---
+
+`Client` is an HTTP client constructor that attaches tracing information to its requests. Use it to include a tracing context in HTTP requests so that tracing backends (such as [Grafana Tempo](https://grafana.com/oss/tempo/)) can incorporate their results.
+
+ The `Client` class acts as a drop-in replacement for the standard `http` module and attaches a [trace context](https://www.w3.org/TR/trace-context/) to the requests headers, and add a `trace_id` to HTTP-related k6 output's data points metadata. It currently supports the [W3C Trace Context](https://www.w3.org/TR/trace-context/) and [Jaeger](https://www.jaegertracing.io/docs/1.21/client-libraries/#propagation-format) trace context propagation formats. For details about propagation, refer to [About trace contexts](/javascript-api/k6-experimental/tracing#about-trace-contexts).
+
+The `Client` constructor accepts an [`Options`](/javascript-api/k6-experimental/tracing/options) object as its only parameter.
+
+## Example
+
+This example demonstrates how to instantiate a tracing client and use it to instrument HTTP calls with trace context headers. It also illustrates how you can use it alongside the standard `http` module to perform non-instrumented HTTP calls.
+
+<CodeGroup labels={["example-tracing-client.js"]} lineNumbers={[]} showCopyButton={[true]}>
+
+
+```javascript
+import { check } from "k6";
+import tracing from "k6/experimental/tracing";
+import http from "k6/http";
+
+// Explicitly instantiating a tracing client allows to distringuish
+// instrumented from non-instrumented HTTP calls, by keeping APIs separate.
+// It also allows for finer-grained configuration control, by letting
+// users changing the tracing configuration on the fly during their
+// script's execution.
+const instrumentedHTTP = new tracing.Client({
+  propagator: "w3c",
+});
+
+const testData = { name: "Bert" };
+
+export default () => {
+  // Using the tracing client instance, HTTP calls will have
+  // their trace context headers set.
+  let res = instrumentedHTTP.request("GET", "http://httpbin.org/get", null, {
+    headers: {
+      "X-Example-Header": "instrumented/request",
+    },
+  });
+
+  // The tracing client offers more flexibility over
+  // the `instrumentHTTP` function, as it leaves the
+  // imported standard http module untouched. Thus,
+  // one can still perform non-instrumented HTTP calls
+  // using it.
+  res = http.post("http://httpbin.org/post", JSON.stringify(testData), {
+    headers: { "X-Example-Header": "noninstrumented/post" },
+  });
+
+  res = instrumentedHTTP.del("http://httpbin.org/delete", null, {
+    headers: { "X-Example-Header": "instrumented/delete" },
+  });
+};
+
+```
+
+</CodeGroup>
+
+
+## HTTP module functions equivalents
+
+The `Client` class exposes the same API as the standard `http` module. Except for the `batch` method, which is absent from `Client`. The following table lists the `Client` methods which have an equivalent in the standard `http` module:
+
+| Method | HTTP equivalent | Description |
+| :---------------------------------------------- | :------------------------------------------------ | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Client.del(url, [body], [params])` | [http.del](/javascript-api/k6-http/del) | Performs an instrumented HTTP DELETE request. The method has the same prototype as the `http.del` function and should transparently act as a drop-in replacement for it. |
+| `Client.get(url, [params])` | [http.get](/javascript-api/k6-http/get) | Performs an instrumented HTTP GET request. The method has the same prototype as the `http.get` function and should transparently act as a drop-in replacement for it. |
+| `Client.head(url, [params])` | [http.head](/javascript-api/k6-http/head) | Performs an instrumented HTTP HEAD request. The method has the same prototype as the `http.head` function and should transparently act as a drop-in replacement for it. |
+| `Client.options(url, [body], [params])` | [http.options](/javascript-api/k6-http/options) | Performs an instrumented HTTP OPTIONS request. The method has the same prototype as the `http.options` function and should transparently act as a drop-in replacement for it. |
+| `Client.patch(url, [body], [params])` | [http.patch](/javascript-api/k6-http/patch) | Performs an instrumented HTTP PATCH request. The method has the same prototype as the `http.patch` function and should transparently act as a drop-in replacement for it. |
+| `Client.post(url, [body], [params])` | [http.post](/javascript-api/k6-http/post) | Performs an instrumented HTTP POST request. The method has the same prototype as the `http.post` function and should transparently act as a drop-in replacement for it. |
+| `Client.put(url, [body], [params])` | [http.put](/javascript-api/k6-http/head) | Performs an instrumented HTTP HEAD request. The method has the same prototype as the `http.put` function and should transparently act as a drop-in replacement for it. |
+| `Client.request(method, url, [body], [params])` | [http.request](/javascript-api/k6-http/request) | Performs an instrumented HTTP request. The method has the same prototype as the `http.request` function and should transparently act as a drop-in replacement for it. |
+| `Client.asyncRequest(method, url, [body], [params])` | [http.asyncRequest](/javascript-api/k6-http/asyncrequest) | Performs an instrumented HTTP asynchronous request. The method has the same prototype as the `http.asyncRequest` function and should transparently act as a drop-in replacement for it. |
+
+
+## Configuration
+
+`Client` instances support being reconfigured using the following API:
+
+| Method | Description |
+| :-------------------------- | :---------------------------------------------------------------------------------------------------------------------- |
+| `Client.configure(options)` | Reconfigures the tracing client instance with the provided [`Options`](/javascript-api/k6-experimental/tracing/options) |

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/04 tracing/03 Options.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/04 tracing/03 Options.md
@@ -1,0 +1,12 @@
+---
+title: 'Options'
+excerpt: 'Options allows to configure the tracing instrumentation behavior.'
+---
+
+Use the `Options` object to configure the tracing instrumentation behavior. It is used during the instantiation of a [`Client`](/javascript-api/k6-experimental/tracing/client) instance and also as a parameter to the [`instrumentHTTP`](/javascript-api/k6-experimental/tracing/instrumenthttp) function. It controls the general behavior of the tracing instrumentation and is unspecific to any particular tracing client instance.
+
+## Options
+
+| Option name  | Type     | Default | Description                                                                    |
+| :----------- | :------- | :------ | :----------------------------------------------------------------------------- |
+| `propagator` | `string` | `w3c`   | The trace context propagation format. Currently supported: `w3c` and `jaeger`. |


### PR DESCRIPTION
Landing in `v0.43.0` is the newly introduced experimental tracing module. This Pull Request documents its usage.

Documenting this in an "accessible" way has been quite tricky, and I've probably missed a lot of details too, because Gatsby. So I'm really looking forward any kind of feedback 🙏🏻 

Let me know what you think 🙇🏻 

✋🏻 This PR should be merged hand in hand with the release of version `v0.43.0` ✋🏻 