### PR TITLE
 redo eslint configuration for examples 

### DIFF
--- a/src/data/markdown/.eslintrc.js
+++ b/src/data/markdown/.eslintrc.js
@@ -1,12 +1,11 @@
 module.exports = {
   root: true,
   env: {
-    browser: true,
-    node: true,
-    es6: true,
+    es2017: true,
+    commonjs: true,
   },
   parserOptions: {
-    ecmaVersion: 7,
+    ecmaVersion: '2017',
     sourceType: 'module',
   },
   extends: ['plugin:mdx/recommended', 'plugin:prettier/recommended'],
@@ -32,13 +31,6 @@ module.exports = {
         'use-isnan': 'error',
         'func-style': ['error', 'declaration', { allowArrowFunctions: true }],
         'prefer-const': 'error',
-        'no-restricted-syntax': [
-          'error',
-          {
-            selector: 'AwaitExpression',
-            message: 'async/await is not supported',
-          },
-        ],
       },
     },
   ],
@@ -47,6 +39,6 @@ module.exports = {
     __VU: 'readonly',
     __ENV: 'readonly',
     __ITER: 'readonly',
-    Promise: 'off',
+    open: 'readonly',
   },
 };

--- a/src/data/markdown/translated-guides/en/02 Using k6/07 Modules.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/07 Modules.md
@@ -200,7 +200,7 @@ module.exports = {
     signup: './src/signup.test.js',
   },
   output: {
-    path: path.resolve(__dirname, 'dist'),
+    path: path.resolve(__dirname, 'dist'), // eslint-disable-line
     libraryTarget: 'commonjs',
     filename: '[name].bundle.js',
   },


### PR DESCRIPTION
- Don't forbid async/await
- Don't enable everything that will work in node
- Add a bit more globals
- raise parser version to support async/await

This still means that if a syntax is not supported by the parser it will
give an error asking the user to add `requireConfigFile: false` instead
of telling them "you can't use this syntax".

Unfortunately it seems like the only way to fix that is to configure
this per each syntax which is a PITA. Hopefully k6 will soon support
even bigger parts of the syntax and that will be even less of a problem.