### PR TITLE
fix(Scenarios guide): wrong link to constant-arrival-rate

### DIFF
--- a/src/data/markdown/translated-guides/en/02 Using k6/14 Scenarios.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/14 Scenarios.md
@@ -73,8 +73,8 @@ Choices include:
 
 - **By iteration rate.**
 
-    - [`constant-arrival-rate`](/using-k6/scenarios/executors/constant-arrival-rate) starts iterations at a constant rate.
-    - [`ramping-arrival-rate`](/using-k6/scenarios/executors/ramping-arrival-rate) ramps the iteration rate according to your configured stages.
+    - [`constant-arrival-rate`](/using-k6/scenarios/executors/constant-arrival-rate/) starts iterations at a constant rate.
+    - [`ramping-arrival-rate`](/using-k6/scenarios/executors/ramping-arrival-rate/) ramps the iteration rate according to your configured stages.
 
 Along with the generic scenario options, each executor object has additional options specific to its workload.
 For the full list, refer to [Executors](/using-k6/scenarios/executors/).

--- a/src/data/markdown/translated-guides/en/02 Using k6/14 Scenarios.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/14 Scenarios.md
@@ -73,7 +73,7 @@ Choices include:
 
 - **By iteration rate.**
 
-    - [`constant-arrival-rate`](/using-k6/scenarios/executors/constant-vus/) starts iterations at a constant rate.
+    - [`constant-arrival-rate`](/using-k6/scenarios/executors/constant-arrival-rate) starts iterations at a constant rate.
     - [`ramping-arrival-rate`](/using-k6/scenarios/executors/ramping-arrival-rate) ramps the iteration rate according to your configured stages.
 
 Along with the generic scenario options, each executor object has additional options specific to its workload.


### PR DESCRIPTION
Navigating from https://k6.io/docs/ click "Scenarios", scroll to "Scenarios executors" — the `constant-arrival-rate` link points to the wrong page, constant-vus:

![image](https://user-images.githubusercontent.com/365338/217844317-92b1700b-ae92-40f4-b27b-df73aa9a7738.png)

Took me a lot of confusion to notice this!

Please merge, it's a trivial 1-line fix.