### PR TITLE
Fix images and text on "Stress testing" guide

### DIFF
--- a/src/data/markdown/translated-guides/en/05 Test Types/03 Stress testing.md
+++ b/src/data/markdown/translated-guides/en/05 Test Types/03 Stress testing.md
@@ -93,8 +93,9 @@ export default function () {
 </CodeGroup>
 
 The VU chart of a stress test should look similar to this:
-5 minutes. We have also included a recovery stage at the end, where the system is gradually
-decreasing the load to 0.")
+![Virtual user chart of an API stress test](./images/stress-test.png)
+
+This configuration increases the load by 100 users every 2 minutes and stays at this level for 5 minutes. We have also included a recovery stage at the end, where the system is gradually decreasing the load to 0.
 
 If your infrastructure is configured to auto-scale, this test will help you to determine:
 
@@ -204,6 +205,10 @@ export default function () {
 </CodeGroup>
 
 The VU chart of a spike test should look similar to this:
+
+![Virtual user chart of a spike test](./images/spike-test.png)
+
+Note, the test starts with a period of 1 minute of low load, a quick spike to very high load, followed by a recovery period of low load.
 
 Remember that the point of this test is to suddenly overwhelm the system. Don't be afraid to increase the number of VUs beyond your worst-case prediction.
 Depending on your needs, you may want to extend the recovery stage to 10 or more minutes to see when the system finally recovers.


### PR DESCRIPTION
Some of the images on the ["Stress testing" guide](https://k6.io/docs/test-types/stress-testing/) were removed and some text was mangled in #978.

It seems @MattDodsonEnglish intentionally removed them in 74b33b39 because they were "misleading", but I'm not sure why he thought that. The images help visualize the test behavior, and not having them is worse, IMO. Maybe the exact VU number will change on different test runs, but the point is to show how the script options affect the load.

In any case, if we decide to remove them, we should also remove the text that introduces them, also change the Spanish translation, and remove the images themselves from the repo.