### PR TITLE
Update redis module's documentation to use `async/await` syntax

### DIFF
--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis.md
@@ -27,4 +27,4 @@ which operate in a synchronous manner,
 the Redis `Client` operates in an asynchronous manner.
 In practice, this means that using the Redis `Client`'s methods won't block test execution,
 and that the test will continue to run even if the Redis `Client` isn't ready to respond to the request.
-However, achieving a seemingly synchronous behavior can be done using the `async/await` syntax. When preceding an asynchronous Redis `Client` operation with the `await` keyword in the context of an `async` function, the execution of the function will wait for the operation to complete before continuing its execution.
+The `async/await` syntax can be used to make the code look synchronous while still being asynchronous, and not blocking the test execution.

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis.md
@@ -27,7 +27,4 @@ which operate in a synchronous manner,
 the Redis `Client` operates in an asynchronous manner.
 In practice, this means that using the Redis `Client`'s methods won't block test execution,
 and that the test will continue to run even if the Redis `Client` isn't ready to respond to the request.
-
-This new execution model does introduce a potential caveat: to depend on operations against Redis, all following operations should be made in the context of a [promise chain](https://javascript.info/promise-chaining).
-As the [Redis Client example](/javascript-api/k6-experimental/redis/client#example) demonstrates, whenever there is a dependency on a Redis operation result or return value, the operation should be wrapped in a promise itself.
-This way, a user can perform asynchronous interactions with Redis in a seemingly synchronous manner.
+However, achieving a seemingly synchronous behavior can be done using the `async/await` syntax. When preceding an asynchronous Redis `Client` operation with the `await` keyword in the context of an `async` function, the execution of the function will wait for the operation to complete before continuing its execution.

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis.md
@@ -27,4 +27,5 @@ which operate in a synchronous manner,
 the Redis `Client` operates in an asynchronous manner.
 In practice, this means that using the Redis `Client`'s methods won't block test execution,
 and that the test will continue to run even if the Redis `Client` isn't ready to respond to the request.
-The `async/await` syntax can be used to make the code look synchronous while still being asynchronous, and not blocking the test execution.
+The `async` and `await` keywords enable asynchronous, promise-based behavior to be written in a cleaner style, avoiding the need to explicitly configure promise chains
+(for details, refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function)).

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client.md
@@ -62,7 +62,8 @@ export async function measureRedisPerformance() {
 
   await redisClient.set(key, 1);
   await redisClient.incrBy(key, 10);
-  if (await redisClient.get(key) !== '11') {
+  const value = await redisClient.get(key);
+  if (value !== '11') {
     throw new Error('foo should have been incremented to 11');
   }
 
@@ -81,7 +82,7 @@ export async function measureUsingRedisData() {
   // we have filled in setup().
   const randomID = await redisClient.srandmember('crocodile_ids');
   const url = `https://test-api.k6.io/public/crocodiles/${randomID}`;
-  const res = http.get(url);
+  const res = await http.asyncRequest("GET", url);
 
   check(res, {'status is 200': (r) => r.status === 200});
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client.md
@@ -53,51 +53,43 @@ const redisClient = new redis.Client({
 // in the context of the measureUsingRedisData function.
 const crocodileIDs = new Array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
 
-export function measureRedisPerformance() {
+export async function measureRedisPerformance() {
   // VUs are executed in a parallel fashion,
   // thus, to ensure that parallel VUs are not
   // modifying the same key at the same time,
   // we use keys indexed by the VU id.
   const key = `foo-${exec.vu.idInTest}`;
 
-  redisClient
-    .set(`foo-${exec.vu.idInTest}`, 1)
-    .then(() => redisClient.get(`foo-${exec.vu.idInTest}`))
-    .then((value) => redisClient.incrBy(`foo-${exec.vu.idInTest}`, value))
-    .then((_) => redisClient.del(`foo-${exec.vu.idInTest}`))
-    .then((_) => redisClient.exists(`foo-${exec.vu.idInTest}`))
-    .then((exists) => {
-      if (exists !== 0) {
-        throw new Error('foo should have been deleted');
-      }
-    });
+  await redisClient.set(key, 1);
+  await redisClient.incrBy(key, 10);
+  if (await redisClient.get(key) !== '11') {
+    throw new Error('foo should have been incremented to 11');
+  }
+
+  await redisClient.del(key);
+  if (await redisClient.exists(key) !== 0) {
+    throw new Error('foo should have been deleted');
+  }
 }
 
-export function setup() {
-  redisClient.sadd('crocodile_ids', ...crocodileIDs);
+export async function setup() {
+    await redisClient.sadd('crocodile_ids', ...crocodileIDs);
 }
 
-export function measureUsingRedisData() {
+export async function measureUsingRedisData() {
   // Pick a random crocodile id from the dedicated redis set,
   // we have filled in setup().
-  redisClient
-    .srandmember('crocodile_ids')
-    .then((randomID) => {
-      const url = `https://test-api.k6.io/public/crocodiles/${randomID}`;
-      const res = http.get(url);
+  const randomID = await redisClient.srandmember('crocodile_ids');
+  const url = `https://test-api.k6.io/public/crocodiles/${randomID}`;
+  const res = http.get(url);
 
-      check(res, {
-        'status is 200': (r) => r.status === 200,
-        'content-type is application/json': (r) => r.headers['content-type'] === 'application/json',
-      });
+  check(res, {'status is 200': (r) => r.status === 200});
 
-      return url;
-    })
-    .then((url) => redisClient.hincrby('k6_crocodile_fetched', url, 1));
+  await redisClient.hincrby('k6_crocodile_fetched', url, 1);
 }
 
-export function teardown() {
-  redisClient.del('crocodile_ids');
+export async function teardown() {
+    await redisClient.del('crocodile_ids');
 }
 
 export function handleSummary(data) {

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-decr.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-decr.md
@@ -35,13 +35,18 @@ const redisClient = new redis.Client({
   password: redis_password,
 });
 
-export default function () {
-  redisClient
-    .set('mykey', 10, 0)
-    .then((_) => redisClient.incr('mykey'))
-    .then((value) => redisClient.incrBy('mykey', value))
-    .then((value) => redisClient.decrBy('mykey', value))
-    .then((_) => redisClient.decr('mykey'));
+export default async function () {
+    await redisClient.set('mykey', 10, 0);
+    
+    let value;
+    value = await redisClient.incr('mykey');
+    value = await redisClient.incrBy('mykey', value);
+    value = await redisClient.decrBy('mykey', value);
+    value = await redisClient.decr('mykey');
+
+    if (value !== -1) {
+        throw new Error('mykey should have been -1');
+    }
 }
 ```
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-decrby.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-decrby.md
@@ -39,14 +39,9 @@ const redisClient = new redis.Client({
 export default async function () {
     await redisClient.set('mykey', 10, 0);
     
-    let value;
-    value = await redisClient.incr('mykey');
-    value = await redisClient.incrBy('mykey', value);
-    value = await redisClient.decrBy('mykey', value);
-    value = await redisClient.decr('mykey');
-
-    if (value !== -1) {
-        throw new Error('mykey should have been -1');
+    const value = await redisClient.decrBy('mykey', 2);
+    if (value !== 8) {
+        throw new Error('mykey should have been 8');
     }
 }
 ```

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-decrby.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-decrby.md
@@ -36,13 +36,18 @@ const redisClient = new redis.Client({
   password: redis_password,
 });
 
-export default function () {
-  redisClient
-    .set('mykey', 10, 0)
-    .then((_) => redisClient.incr('mykey'))
-    .then((value) => redisClient.incrBy('mykey', value))
-    .then((value) => redisClient.decrBy('mykey', value))
-    .then((_) => redisClient.decr('mykey'));
+export default async function () {
+    await redisClient.set('mykey', 10, 0);
+    
+    let value;
+    value = await redisClient.incr('mykey');
+    value = await redisClient.incrBy('mykey', value);
+    value = await redisClient.decrBy('mykey', value);
+    value = await redisClient.decr('mykey');
+
+    if (value !== -1) {
+        throw new Error('mykey should have been -1');
+    }
 }
 ```
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-del.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-del.md
@@ -35,19 +35,18 @@ const redisClient = new redis.Client({
   password: redis_password,
 });
 
-export default function () {
-  redisClient
-    .set('mykey', 'myvalue', 0)
-    .then((_) => redisClient.exists('mykey'))
-    .then((exists) => {
-      if (exists === false) {
+export default async function () {
+    await redisClient.set('mykey', 'myvalue', 0);
+    
+    const exists = await redisClient.exists('mykey');
+    if (exists === false) {
         throw new Error('mykey should exist');
-      }
+    }
 
-      return redisClient.get('mykey');
-    })
-    .then((value) => console.log(`set key 'mykey' to value: ${value}`))
-    .then(() => redisClient.del('mykey'));
+    const value = await redisClient.get('mykey');
+    console.log(`set key 'mykey' to value: ${value}`);
+
+    await redisClient.del('mykey');
 }
 ```
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-exists.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-exists.md
@@ -35,19 +35,20 @@ const redisClient = new redis.Client({
   password: redis_password,
 });
 
-export default function () {
-  redisClient
-    .set('mykey', 'myvalue', 0)
-    .then((_) => redisClient.exists('mykey'))
-    .then((exists) => {
-      if (exists === false) {
-        throw new Error('mykey should exist');
-      }
+export default async function () {
+    let exists = await redisClient.exists('mykey');
+    if (exists === true) {
+        throw new Error('mykey should not exist');
+    }
 
-      return redisClient.get('mykey');
-    })
-    .then((value) => console.log(`set key 'mykey' to value: ${value}`))
-    .then(() => redisClient.del('mykey'));
+    await redisClient.set('mykey', 'myvalue', 0);
+    
+    exists = await redisClient.exists('mykey');
+    if (exists === false) {
+        throw new Error('mykey should exist');
+    }
+    
+    await redisClient.del('mykey');
 }
 ```
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-expire.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-expire.md
@@ -36,18 +36,16 @@ const redisClient = new redis.Client({
   password: redis_password,
 });
 
-export default function () {
-  redisClient
-    .set('mykey', 'myvalue', 10)
-    .then((_) => redisClient.expire('mykey', 100))
-    .then((_) => redisClient.ttl('mykey'))
-    .then((ttl) => {
-      if (ttl <= 10) {
-        throw new Error('mykey should have a ttl of 10 <= x < 100');
-      }
+export default async function () {
+    await redisClient.set('mykey', 'myvalue', 10);
+    await redisClient.expire('mykey', 100);
+    
+    const ttl = await redisClient.ttl('mykey');
+    if (ttl <= 10) {
+    throw new Error('mykey should have a ttl of 10 <= x < 100');
+    }
 
-      return redisClient.persist('mykey', 100);
-    });
+    await redisClient.persist('mykey', 100);
 }
 ```
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-expire.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-expire.md
@@ -41,11 +41,9 @@ export default async function () {
     await redisClient.expire('mykey', 100);
     
     const ttl = await redisClient.ttl('mykey');
-    if (ttl <= 10) {
+    if (ttl <= 10 || ttl >= 100) {
     throw new Error('mykey should have a ttl of 10 <= x < 100');
     }
-
-    await redisClient.persist('mykey', 100);
 }
 ```
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-get.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-get.md
@@ -35,19 +35,18 @@ const redisClient = new redis.Client({
   password: redis_password,
 });
 
-export default function () {
-  redisClient
-    .set('mykey', 'myvalue', 0)
-    .then((_) => redisClient.exists('mykey'))
-    .then((exists) => {
-      if (exists === false) {
-        throw new Error('mykey should exist');
-      }
+export default async function () {
+    await redisClient.set('mykey', 'myvalue', 0)
+    
+    const exists = await redisClient.exists('mykey');
+    if (exists === false) {
+    throw new Error('mykey should exist');
+    }
 
-      return redisClient.get('mykey');
-    })
-    .then((value) => console.log(`set key 'mykey' to value: ${value}`))
-    .then(() => redisClient.del('mykey'));
+    const value = await redisClient.get('mykey');
+    console.log(`set key 'mykey' to value: ${value}`);
+    
+    await redisClient.del('mykey');
 }
 ```
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-get.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-get.md
@@ -40,7 +40,7 @@ export default async function () {
     
     const exists = await redisClient.exists('mykey');
     if (exists === false) {
-    throw new Error('mykey should exist');
+      throw new Error('mykey should exist');
     }
 
     const value = await redisClient.get('mykey');

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-getdel.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-getdel.md
@@ -37,8 +37,12 @@ const redisClient = new redis.Client({
 
 export default async function () {
     await redisClient.set('mykey', 'oldvalue', 0);
-    await redisClient.getSet('mykey', 'newvalue');
-    await redisClient.getDel('mykey');
+    let value = await redisClient.getSet('mykey', 'newvalue');
+    
+    value = await redisClient.getDel('mykey');
+    if (value !== 'newvalue') {
+        throw new Error('mykey should have been newvalue');
+    }
 }
 ```
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-getdel.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-getdel.md
@@ -35,11 +35,10 @@ const redisClient = new redis.Client({
   password: redis_password,
 });
 
-export default function () {
-  redisClient
-    .set('mykey', 'oldvalue', 0)
-    .then((_) => redisClient.getSet('mykey', 'newvalue'))
-    .then((_) => redisClient.getDel('mykey'));
+export default async function () {
+    await redisClient.set('mykey', 'oldvalue', 0);
+    await redisClient.getSet('mykey', 'newvalue');
+    await redisClient.getDel('mykey');
 }
 ```
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-getset.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-getset.md
@@ -36,11 +36,10 @@ const redisClient = new redis.Client({
   password: redis_password,
 });
 
-export default function () {
-  redisClient
-    .set('mykey', 'oldvalue', 0)
-    .then((_) => redisClient.getSet('mykey', 'newvalue'))
-    .then((_) => redisClient.getDel('mykey'));
+export default async function () {
+    await redisClient.set('mykey', 'oldvalue', 0);
+    await redisClient.getSet('mykey', 'newvalue');
+    await redisClient.getDel('mykey');
 }
 ```
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-hdel.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-hdel.md
@@ -36,11 +36,10 @@ const redisClient = new redis.Client({
   password: redis_password,
 });
 
-export default function () {
-  redisClient
-    .hset('myhash', 'myfield', 'myvalue')
-    .then((_) => redisClient.hget('myhash', 'myfield'))
-    .then((_) => redisClient.hdel('myhash', 'myfield'));
+export default async function () {
+    await redisClient.hset('myhash', 'myfield', 'myvalue');
+    await redisClient.hget('myhash', 'myfield');
+    await redisClient.hdel('myhash', 'myfield');
 }
 ```
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-hget.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-hget.md
@@ -36,11 +36,10 @@ const redisClient = new redis.Client({
   password: redis_password,
 });
 
-export default function () {
-  redisClient
-    .hset('myhash', 'myfield', 'myvalue')
-    .then((_) => redisClient.hget('myhash', 'myfield'))
-    .then((_) => redisClient.hdel('myhash', 'myfield'));
+export default async function () {
+    await redisClient.hset('myhash', 'myfield', 'myvalue');
+    await redisClient.hget('myhash', 'myfield');
+    await redisClient.hdel('myhash', 'myfield');
 }
 ```
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-hgetall.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-hgetall.md
@@ -35,14 +35,11 @@ const redisClient = new redis.Client({
   password: redis_password,
 });
 
-export default function () {
-  redisClient
-    .hset('myhash', 'myfield', 'myvalue')
-    .then((_) => redisClient.hset('myhash', 'myotherfield', 'myothervalue'))
-    .then((_) => redisClient.hgetall('myhash'))
-    .then((object) => {
-      console.log(`myhash has key:value pairs ${JSON.stringify(object)}`);
-    });
+export default async function () {
+    await redisClient.hset('myhash', 'myfield', 'myvalue');
+    await redisClient.hset('myhash', 'myotherfield', 'myothervalue');
+    const object = await redisClient.hgetall('myhash');
+    console.log(`myhash has key:value pairs ${JSON.stringify(object)}`);
 }
 ```
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-hincrby.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-hincrby.md
@@ -37,10 +37,9 @@ const redisClient = new redis.Client({
   password: redis_password,
 });
 
-export default function () {
-  redisClient
-    .hset('myhash', 'myfield', 10)
-    .then((_) => redisClient.hincrby('myhash', 'myfield', 20));
+export default async function () {
+    await redisClient.hset('myhash', 'myfield', 10);
+    await redisClient.hincrby('myhash', 'myfield', 20);
 }
 ```
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-hkeys.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-hkeys.md
@@ -41,7 +41,7 @@ export default async function () {
     
     const keys = await redisClient.hkeys('myhash');
     if (keys.length !== 2) {
-    throw new Error('myhash should have 2 keys');
+      throw new Error('myhash should have 2 keys');
     }
 
     console.log(`myhash has keys ${keys}`);

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-hkeys.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-hkeys.md
@@ -35,18 +35,16 @@ const redisClient = new redis.Client({
   password: redis_password,
 });
 
-export default function () {
-  redisClient
-    .hset('myhash', 'myfield', 'myvalue')
-    .then((_) => redisClient.hset('myhash', 'myotherfield', 'myothervalue'))
-    .then((_) => redisClient.hkeys('myhash'))
-    .then((keys) => {
-      if (keys.length !== 2) {
-        throw new Error('myhash should have 2 keys');
-      }
+export default async function () {
+    await redisClient.hset('myhash', 'myfield', 'myvalue');
+    await redisClient.hset('myhash', 'myotherfield', 'myothervalue');
+    
+    const keys = await redisClient.hkeys('myhash');
+    if (keys.length !== 2) {
+    throw new Error('myhash should have 2 keys');
+    }
 
-      console.log(`myhash has keys ${keys}`);
-    });
+    console.log(`myhash has keys ${keys}`);
 }
 ```
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-hlen.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-hlen.md
@@ -35,11 +35,10 @@ const redisClient = new redis.Client({
   password: redis_password,
 });
 
-export default function () {
-  redisClient
-    .hset('myhash', 'myfield', 10)
-    .then((_) => redisClient.hset('myhash', 'myotherfield', 20))
-    .then((_) => redisClient.hlen('myhash'));
+export default async function () {
+  await redisClient.hset('myhash', 'myfield', 10);
+  await redisClient.hset('myhash', 'myotherfield', 20);
+  await redisClient.hlen('myhash');
 }
 ```
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-hset.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-hset.md
@@ -37,11 +37,10 @@ const redisClient = new redis.Client({
   password: redis_password,
 });
 
-export default function () {
-  redisClient
-    .hset('myhash', 'myfield', 'myvalue')
-    .then((_) => redisClient.hget('myhash', 'myfield'))
-    .then((_) => redisClient.hdel('myhash', 'myfield'));
+export default async function () {
+  await redisClient.hset('myhash', 'myfield', 'myvalue');
+  await redisClient.then((_) => redisClient.hget('myhash', 'myfield'));
+  await redisClient.hdel('myhash', 'myfield');
 }
 ```
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-hset.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-hset.md
@@ -39,7 +39,7 @@ const redisClient = new redis.Client({
 
 export default async function () {
   await redisClient.hset('myhash', 'myfield', 'myvalue');
-  await redisClient.then((_) => redisClient.hget('myhash', 'myfield'));
+  await redisClient.hget('myhash', 'myfield');
   await redisClient.hdel('myhash', 'myfield');
 }
 ```

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-hsetnx.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-hsetnx.md
@@ -41,9 +41,9 @@ export default async function () {
     await redisClient.hsetnx('myhash', 'myfield', 'myvalue')
     await redisClient.hsetnx('myhash', 'myotherfield', 'myothervalue');
     
-    const s = await redisClient.hsetnx('myhash', 'myfield', 'mynewvalue');
-    if (s === true) {
-    throw new Error('hsetnx should have failed on existing field');
+    const set = await redisClient.hsetnx('myhash', 'myfield', 'mynewvalue');
+    if (set === true) {
+      throw new Error('hsetnx should have failed on existing field');
     }
 }
 ```

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-hsetnx.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-hsetnx.md
@@ -37,16 +37,14 @@ const redisClient = new redis.Client({
   password: redis_password,
 });
 
-export default function () {
-  redisClient
-    .hsetnx('myhash', 'myfield', 'myvalue')
-    .then((_) => redisClient.hsetnx('myhash', 'myotherfield', 'myothervalue'))
-    .then((_) => redisClient.hsetnx('myhash', 'myfield', 'mynewvalue'))
-    .then((set) => {
-      if (set === true) {
-        throw new Error('hsetnx should have failed on existing field');
-      }
-    });
+export default async function () {
+    await redisClient.hsetnx('myhash', 'myfield', 'myvalue')
+    await redisClient.hsetnx('myhash', 'myotherfield', 'myothervalue');
+    
+    const s = await redisClient.hsetnx('myhash', 'myfield', 'mynewvalue');
+    if (s === true) {
+    throw new Error('hsetnx should have failed on existing field');
+    }
 }
 ```
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-hvals.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-hvals.md
@@ -35,18 +35,16 @@ const redisClient = new redis.Client({
   password: redis_password,
 });
 
-export default function () {
-  redisClient
-    .hset('myhash', 'myfield', 'myvalue')
-    .then((_) => redisClient.hset('myhash', 'myotherfield', 'myothervalue'))
-    .then((_) => redisClient.hvals('myhash'))
-    .then((values) => {
-      if (values.length !== 2) {
-        throw new Error('myhash should have 2 values');
-      }
+export default async function () {
+  await redisClient.hset('myhash', 'myfield', 'myvalue');
+  await redisClient.hset('myhash', 'myotherfield', 'myothervalue');
+  
+  const values = await redisClient.hvals('myhash');
+  if (values.length !== 2) {
+    throw new Error('myhash should have 2 values');
+  }
 
-      console.log(`myhash has values ${values}`);
-    });
+  console.log(`myhash has values ${values}`);
 }
 ```
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-incr.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-incr.md
@@ -35,13 +35,16 @@ const redisClient = new redis.Client({
   password: redis_password,
 });
 
-export default function () {
-  redisClient
-    .set('mykey', 10, 0)
-    .then((_) => redisClient.incr('mykey'))
-    .then((value) => redisClient.incrBy('mykey', value))
-    .then((value) => redisClient.decrBy('mykey', value))
-    .then((_) => redisClient.decr('mykey'));
+export default async function () {
+    await redisClient.set('mykey', 10, 0);
+    
+    let value = await redisClient.incr('mykey');
+    value = await redisClient.incrBy('mykey', value);
+    value = await redisClient.decrBy('mykey', value);
+    value = await redisClient.decr('mykey');
+    if (value !== -1) {
+        throw new Error('mykey should have been -1');
+    }
 }
 ```
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-incrby.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-incrby.md
@@ -36,13 +36,16 @@ const redisClient = new redis.Client({
   password: redis_password,
 });
 
-export default function () {
-  redisClient
-    .set('mykey', 10, 0)
-    .then((_) => redisClient.incr('mykey'))
-    .then((value) => redisClient.incrBy('mykey', value))
-    .then((value) => redisClient.decrBy('mykey', value))
-    .then((_) => redisClient.decr('mykey'));
+export default async function () {
+    await redisClient.set('mykey', 10, 0);
+    
+    let value = await redisClient.incr('mykey');
+    value = await redisClient.incrBy('mykey', value);
+    value = await redisClient.decrBy('mykey', value);
+    value = await redisClient.decr('mykey');
+    if (value !== -1) {
+        throw new Error('mykey should have been -1');
+    }
 }
 ```
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-lindex.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-lindex.md
@@ -35,19 +35,17 @@ const redisClient = new redis.Client({
   password: redis_password,
 });
 
-export default function () {
-  redisClient
-    .rpush('mylist', 'first')
-    .then((_) => redisClient.rpush('mylist', 'second'))
-    .then((_) => redisClient.rpush('mylist', 'third'))
-    .then((_) => redisClient.lindex('mylist', 0))
-    .then((item) => {
-      if (item !== 'first') {
+export default async function () {
+    await redisClient.rpush('mylist', 'first');
+    await redisClient.rpush('mylist', 'second');
+    await redisClient.rpush('mylist', 'third');
+    
+    const item = await redisClient.lindex('mylist', 0);
+    if (item !== 'first') {
         throw new Error('lindex operation should have returned first');
-      }
+    }
 
-      return redisClient.lrange('mylist', 1, 2);
-    });
+    await redisClient.lrange('mylist', 1, 2);
 }
 ```
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-lpop.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-lpop.md
@@ -35,13 +35,13 @@ const redisClient = new redis.Client({
   password: redis_password,
 });
 
-export default function () {
-  redisClient
-    .lpush('mylist', 'first')
-    .then((_) => redisClient.rpush('mylist', 'second'))
-    .then((_) => redisClient.lpop('mylist'))
-    .then((item) => redisClient.rpush('mylist', item))
-    .then((_) => redisClient.rpop('mylist'));
+export default async function () {
+    await redisClient.lpush('mylist', 'first');
+    await redisClient.rpush('mylist', 'second');
+
+    const item = await redisClient.lpop('mylist');
+    await redisClient.rpush('mylist', item);
+    await redisClient.rpop('mylist');
 }
 ```
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-lpush.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-lpush.md
@@ -36,13 +36,13 @@ const redisClient = new redis.Client({
   password: redis_password,
 });
 
-export default function () {
-  redisClient
-    .lpush('mylist', 'first')
-    .then((_) => redisClient.rpush('mylist', 'second'))
-    .then((_) => redisClient.lpop('mylist'))
-    .then((item) => redisClient.rpush('mylist', item))
-    .then((_) => redisClient.rpop('mylist'));
+export default async function () {
+    await redisClient.lpush('mylist', 'first');
+    await redisClient.rpush('mylist', 'second');
+    
+    let item = await redisClient.lpop('mylist');
+    item = redisClient.rpush('mylist', item);
+    item = redisClient.rpop('mylist');
 }
 ```
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-lrange.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-lrange.md
@@ -44,7 +44,7 @@ export default async function () {
     
     const item = redisClient.lindex('mylist', 0);
     if (item !== 'first') {
-    throw new Error('lindex operation should have returned first');
+      throw new Error('lindex operation should have returned first');
     }
 
     await redisClient.lrange('mylist', 1, 2);

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-lrange.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-lrange.md
@@ -37,19 +37,17 @@ const redisClient = new redis.Client({
   password: redis_password,
 });
 
-export default function () {
-  redisClient
-    .rpush('mylist', 'first')
-    .then((_) => redisClient.rpush('mylist', 'second'))
-    .then((_) => redisClient.rpush('mylist', 'third'))
-    .then((_) => redisClient.lindex('mylist', 0))
-    .then((item) => {
-      if (item !== 'first') {
-        throw new Error('lindex operation should have returned first');
-      }
+export default async function () {
+    await redisClient.rpush('mylist', 'first');
+    await redisClient.rpush('mylist', 'second');
+    await redisClient.rpush('mylist', 'third');
+    
+    const item = redisClient.lindex('mylist', 0);
+    if (item !== 'first') {
+    throw new Error('lindex operation should have returned first');
+    }
 
-      return redisClient.lrange('mylist', 1, 2);
-    });
+    await redisClient.lrange('mylist', 1, 2);
 }
 ```
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-lrem.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-lrem.md
@@ -46,7 +46,7 @@ export default async function () {
     
     const length = await redisClient.lrem('mylist', 1, 'first');
     if (length !== 1) {
-    throw new Error('lrem operations should have left 1 item behind');
+      throw new Error('lrem operations should have left 1 item behind');
     }
 
     await redisClient.lpop('mylist');

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-lrem.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-lrem.md
@@ -37,21 +37,19 @@ const redisClient = new redis.Client({
   password: redis_password,
 });
 
-export default function () {
-  redisClient
-    .rpush('mylist', 'first')
-    .then((_) => redisClient.rpush('mylist', 'second'))
-    .then((_) => redisClient.rpush('mylist', 'first'))
-    .then((_) => redisClient.rpush('mylist', 'second'))
-    .then((_) => redisClient.lrem('mylist', 0, 'second'))
-    .then((_) => redisClient.lrem('mylist', 1, 'first'))
-    .then((length) => {
-      if (length !== 1) {
-        throw new Error('lrem operations should have left 1 item behind');
-      }
+export default async function () {
+    await redisClient.rpush('mylist', 'first');
+    await redisClient.rpush('mylist', 'second');
+    await redisClient.rpush('mylist', 'first');
+    await redisClient.rpush('mylist', 'second');
+    await redisClient.lrem('mylist', 0, 'second');
+    
+    const length = await redisClient.lrem('mylist', 1, 'first');
+    if (length !== 1) {
+    throw new Error('lrem operations should have left 1 item behind');
+    }
 
-      return redisClient.lpop('mylist');
-    });
+    await redisClient.lpop('mylist');
 }
 ```
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-lset.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-lset.md
@@ -37,13 +37,12 @@ const redisClient = new redis.Client({
   password: redis_password,
 });
 
-export default function () {
-  redisClient
-    .rpush('mylist', 'first')
-    .then((_) => redisClient.rpush('mylist', 'second'))
-    .then((_) => redisClient.rpush('mylist', 'third'))
-    .then((_) => redisClient.lset('mylist', 0, 1))
-    .then((_) => redisClient.lset('mylist', 1, 2));
+export default async function () {
+    await redisClient.rpush('mylist', 'first');
+    await redisClient.rpush('mylist', 'second');
+    await redisClient.rpush('mylist', 'third');
+    await redisClient.lset('mylist', 0, 1);
+    await redisClient.lset('mylist', 1, 2);
 }
 ```
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-mget.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-mget.md
@@ -35,13 +35,13 @@ const redisClient = new redis.Client({
   password: redis_password,
 });
 
-export default function () {
-  redisClient
-    .set('first', 1, 0)
-    .then((_) => redisClient.set('second', 2, 0))
-    .then((_) => redisClient.set('third', 3, 0))
-    .then((_) => redisClient.mget('first', 'second', 'third'))
-    .then((values) => console.log(`set values are: ${values}`));
+export default async function () {
+  await redisClient.set('first', 1, 0)
+  await redisClient.set('second', 2, 0);
+  await redisClient.set('third', 3, 0);
+  
+  const values = await redisClient.mget('first', 'second', 'third');
+  console.log(`set values are: ${values}`);
 }
 ```
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-persist.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-persist.md
@@ -35,18 +35,16 @@ const redisClient = new redis.Client({
   password: redis_password,
 });
 
-export default function () {
-  redisClient
-    .set('mykey', 'myvalue', 10)
-    .then((_) => redisClient.expire('mykey', 100))
-    .then((_) => redisClient.ttl('mykey'))
-    .then((ttl) => {
-      if (ttl <= 10) {
-        throw new Error('mykey should have a ttl of 10 <= x < 100');
-      }
+export default async function () {
+  await redisClient.set('mykey', 'myvalue', 10)
+  await redisClient.expire('mykey', 100);
 
-      return redisClient.persist('mykey', 100);
-    });
+  const ttl = await redisClient.ttl('mykey');
+  if (ttl <= 10) {
+    throw new Error('mykey should have a ttl of 10 <= x < 100');
+  }
+
+  await redisClient.persist('mykey', 100);
 }
 ```
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-randomkey.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-randomkey.md
@@ -28,13 +28,13 @@ const redisClient = new redis.Client({
   password: redis_password,
 });
 
-export default function () {
-  redisClient
-    .set('first', 1, 0)
-    .then((_) => redisClient.set('second', 2, 0))
-    .then((_) => redisClient.set('third', 3, 0))
-    .then((_) => redisClient.randomKey())
-    .then((key) => console.log(`picked random key is: ${key}`));
+export default async function () {
+  await redisClient.set('first', 1, 0);
+  await redisClient.set('second', 2, 0);
+  await redisClient.set('third', 3, 0);
+  
+  const key = await redisClient.randomKey();
+  console.log(`picked random key is: ${key}`);
 }
 ```
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-rpop.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-rpop.md
@@ -35,13 +35,13 @@ const redisClient = new redis.Client({
   password: redis_password,
 });
 
-export default function () {
-  redisClient
-    .lpush('mylist', 'first')
-    .then((_) => redisClient.rpush('mylist', 'second'))
-    .then((_) => redisClient.lpop('mylist'))
-    .then((item) => redisClient.rpush('mylist', item))
-    .then((_) => redisClient.rpop('mylist'));
+export default async function () {
+  await redisClient.lpush('mylist', 'first')
+  await redisClient.rpush('mylist', 'second');
+  
+  const item = await redisClient.lpop('mylist');
+  await redisClient.rpush('mylist', item);
+  await redisClient.rpop('mylist');
 }
 ```
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-rpush.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-rpush.md
@@ -36,13 +36,13 @@ const redisClient = new redis.Client({
   password: redis_password,
 });
 
-export default function () {
-  redisClient
-    .lpush('mylist', 'first')
-    .then((_) => redisClient.rpush('mylist', 'second'))
-    .then((_) => redisClient.lpop('mylist'))
-    .then((item) => redisClient.rpush('mylist', item))
-    .then((_) => redisClient.rpop('mylist'));
+export default async function () {
+  await redisClient.lpush('mylist', 'first');
+  await redisClient.rpush('mylist', 'second');
+  
+  const item = await redisClient.lpop('mylist');
+  await redisClient.rpush('mylist', item);
+  await redisClient.rpop('mylist');
 }
 ```
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-sadd.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-sadd.md
@@ -36,16 +36,14 @@ const redisClient = new redis.Client({
   password: redis_password,
 });
 
-export default function () {
-  redisClient
-    .sadd('myset', 'foo')
-    .then((_) => redisClient.sadd('myset', 'bar'))
-    .then((_) => redisClient.sismember('myset', 'foo'))
-    .then((isit) => {
-      if (isit === false) {
-        throw new Error('sismember should have returned true');
-      }
-    });
+export default async function () {
+  await redisClient.sadd('myset', 'foo');
+  await redisClient.sadd('myset', 'bar');
+  
+  const isit = await redisClient.sismember('myset', 'foo');
+  if (isit === false) {
+    throw new Error('sismember should have returned true');
+  }
 }
 ```
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-sendCommand.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-sendCommand.md
@@ -36,12 +36,11 @@ const redisClient = new redis.Client({
   password: redis_password,
 });
 
-export default function () {
-  redisClient.sendCommand('ECHO', 'Hello world').then((result) => {
-    if (result !== 'Hello world') {
-      throw new Error('ECHO should have returned "Hello world"');
-    }
-  });
+export default async function () {
+  const result = await redisClient.sendCommand('ECHO', 'Hello world');
+  if (result !== 'Hello world') {
+    throw new Error('ECHO should have returned "Hello world"');
+  }
 }
 ```
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-set.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-set.md
@@ -37,19 +37,18 @@ const redisClient = new redis.Client({
   password: redis_password,
 });
 
-export default function () {
-  redisClient
-    .set('mykey', 'myvalue', 0)
-    .then((_) => redisClient.exists('mykey'))
-    .then((exists) => {
-      if (exists === false) {
-        throw new Error('mykey should exist');
-      }
+export default async function () {
+  await redisClient.set('mykey', 'myvalue', 0);
+  
+  const exists = await redisClient.exists('mykey');
+  if (exists === false) {
+    throw new Error('mykey should exist');
+  }
 
-      return redisClient.get('mykey');
-    })
-    .then((value) => console.log(`set key 'mykey' to value: ${value}`))
-    .then(() => redisClient.del('mykey'));
+  const value = await redisClient.get('mykey');
+  console.log(`set key 'mykey' to value: ${value}`)
+  
+  await redisClient.del('mykey');
 }
 ```
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-sismember.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-sismember.md
@@ -36,16 +36,14 @@ const redisClient = new redis.Client({
   password: redis_password,
 });
 
-export default function () {
-  redisClient
-    .sadd('myset', 'foo')
-    .then((_) => redisClient.sadd('myset', 'bar'))
-    .then((_) => redisClient.sismember('myset', 'foo'))
-    .then((isit) => {
-      if (isit === false) {
-        throw new Error('sismember should have returned true');
-      }
-    });
+export default async function () {
+  await redisClient.sadd('myset', 'foo');
+  await redisClient.sadd('myset', 'bar');
+
+  const isit = await redisClient.sismember('myset', 'foo');
+  if (isit === false) {
+    throw new Error('sismember should have returned true');
+  }
 }
 ```
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-smembers.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-smembers.md
@@ -35,17 +35,15 @@ const redisClient = new redis.Client({
   password: redis_password,
 });
 
-export default function () {
-  redisClient
-    .sadd('myset', 'foo')
-    .then((_) => redisClient.sadd('myset', 'bar'))
-    .then((_) => redisClient.sadd('myset', 'foo'))
-    .then((_) => redisClient.smembers('myset'))
-    .then((members) => {
-      if (members.length !== 2) {
-        throw new Error('sismember should have length 2');
-      }
-    });
+export default async function () {
+  await redisClient.sadd('myset', 'foo');
+  await redisClient.sadd('myset', 'bar');
+  await redisClient.sadd('myset', 'foo');
+  
+  const members = await redisClient.smembers('myset');
+  if (members.length !== 2) {
+    throw new Error('sismember should have length 2');
+  }
 }
 ```
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-spop.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-spop.md
@@ -35,17 +35,14 @@ const redisClient = new redis.Client({
   password: redis_password,
 });
 
-export default function () {
-  redisClient
-    .sadd('myset', 'foo')
-    .then((_) => redisClient.sadd('myset', 'bar'))
-    .then((_) => redisClient.spop('myset', 'foo'))
-    .then((_) => redisClient.smembers('myset'))
-    .then((members) => {
-      if (members.length !== 1) {
-        throw new Error('sismember should have length 1');
-      }
-    });
+export default async function () {
+  await redisClient.sadd('myset', 'foo')
+  await redisClient.sadd('myset', 'bar');
+  await redisClient.spop('myset', 'foo');
+  const members = await redisClient.smembers('myset');
+  if (members.length !== 1) {
+    throw new Error('sismember should have length 1');
+  }
 }
 ```
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-srandmember.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-srandmember.md
@@ -35,17 +35,15 @@ const redisClient = new redis.Client({
   password: redis_password,
 });
 
-export default function () {
-  redisClient
-    .sadd('myset', 'foo')
-    .then((_) => redisClient.sadd('myset', 'bar'))
-    .then((_) => redisClient.spop('myset', 'foo'))
-    .then((_) => redisClient.smembers('myset'))
-    .then((members) => {
-      if (members.length !== 1) {
-        throw new Error('sismember should have length 1');
-      }
-    });
+export default async function () {
+  await redisClient.sadd('myset', 'foo');
+  await redisClient.sadd('myset', 'bar');
+  await redisClient.spop('myset', 'foo');
+  
+  const members = await redisClient.smembers('myset');
+  if (members.length !== 1) {
+    throw new Error('sismember should have length 1');
+  }
 }
 ```
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-srem.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-srem.md
@@ -36,17 +36,15 @@ const redisClient = new redis.Client({
   password: redis_password,
 });
 
-export default function () {
-  redisClient
-    .sadd('myset', 'foo')
-    .then((_) => redisClient.sadd('myset', 'bar'))
-    .then((_) => redisClient.srem('myset', 'foo'))
-    .then((_) => redisClient.smembers('myset'))
-    .then((members) => {
-      if (members.length !== 1) {
-        throw new Error('sismember should have length 1');
-      }
-    });
+export default async function () {
+  await redisClient.sadd('myset', 'foo');
+  await redisClient.sadd('myset', 'bar');
+  await redisClient.srem('myset', 'foo');
+  
+  const members = await redisClient.smembers('myset');
+  if (members.length !== 1) {
+    throw new Error('sismember should have length 1');
+  }
 }
 ```
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-ttl.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-ttl.md
@@ -35,18 +35,16 @@ const redisClient = new redis.Client({
   password: redis_password,
 });
 
-export default function () {
-  redisClient
-    .set('mykey', 'myvalue', 10)
-    .then((_) => redisClient.expire('mykey', 100))
-    .then((_) => redisClient.ttl('mykey'))
-    .then((ttl) => {
-      if (ttl <= 10) {
-        throw new Error('mykey should have a ttl of 10 <= x < 100');
-      }
+export default async function () {
+  await redisClient.set('mykey', 'myvalue', 10);
+  await redisClient.expire('mykey', 100);
+  
+  const ttl = await redisClient.ttl('mykey');
+  if (ttl <= 10) {
+    throw new Error('mykey should have a ttl of 10 <= x < 100');
+  }
 
-      return redisClient.persist('mykey', 100);
-    });
+  await redisClient.persist('mykey', 100);
 }
 ```
 


### PR DESCRIPTION
This Pull Request updates all the redis module's documentation examples to use the recently introduced `async/await` syntax. I have verified that examples work in a separate context. This Pull Request also rephrases the description of how to deal with Promises in light of the recent introduction of the `async/await` syntax.

Let me know what you think, and if I've missed something 🙇🏻 