### PR TITLE
Add guide for building k6 with extensions using docker

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1565,6 +1565,12 @@ const createRedirects = ({ actions }) => {
   });
 
   createRedirect({
+    fromPath: '/extensions/guides/build-a-k6-binary-with-extensions/',
+    toPath: '/extensions/guides/build-a-k6-binary-using-go/',
+    isPermanent: true,
+  });
+
+  createRedirect({
     fromPath: '/cloud/integrations/grafana-plugin/',
     toPath: '/cloud/integrations/grafana-app/',
     isPermanent: true,

--- a/src/components/pages/doc-extensions/what-is-xk6/what-is-xk6.view.js
+++ b/src/components/pages/doc-extensions/what-is-xk6/what-is-xk6.view.js
@@ -2,6 +2,8 @@ import { Heading } from 'components/shared/heading';
 import { Link } from 'gatsby';
 import React from 'react';
 
+import Blockquote from '../../../shared/blockquote';
+
 import styles from './what-is-xk6.module.scss';
 
 export const WhatIsXk6 = () => (
@@ -26,5 +28,17 @@ export const WhatIsXk6 = () => (
       </Link>{' '}
       to generate the CLI command that will build your customized k6 binary.
     </p>
+
+    <Blockquote mod="note" title="Support for Docker">
+      You now have a new option that doesn&apos;t require setting a Go
+      environment!{' '}
+      <Link
+        to="/extensions/guides/how-to-build-k6-using-docker/"
+        className="link"
+      >
+        Use Docker
+      </Link>{' '}
+      to build your custom binary.
+    </Blockquote>
   </section>
 );

--- a/src/components/pages/doc-extensions/what-is-xk6/what-is-xk6.view.js
+++ b/src/components/pages/doc-extensions/what-is-xk6/what-is-xk6.view.js
@@ -33,7 +33,7 @@ export const WhatIsXk6 = () => (
       You now have a new option that doesn&apos;t require setting a Go
       environment!{' '}
       <Link
-        to="/extensions/guides/how-to-build-k6-using-docker/"
+        to="/extensions/guides/build-a-k6-binary-using-docker/"
         className="link"
       >
         Use Docker

--- a/src/data/markdown/docs/07 extensions/03 Guides/02 bundling.md
+++ b/src/data/markdown/docs/07 extensions/03 Guides/02 bundling.md
@@ -1,5 +1,5 @@
 ---
-title: 'Build a k6 binary with extensions'
+title: 'Build a k6 binary using Go'
 excerpt: 'Guide to build a k6 binary that includes one or many extensions using xk6.'
 ---
 
@@ -8,7 +8,7 @@ you need to build a binary using Go.
 
 <Blockquote mod="note" title="Support for Docker">
 
-  Not interested in setting up a Go environment? You can [use Docker instead](/extensions/guides/how-to-build-k6-using-docker/).
+  Not interested in setting up a Go environment? You can [use Docker instead](/extensions/guides/build-a-k6-binary-using-docker/).
 
 </Blockquote>
 

--- a/src/data/markdown/docs/07 extensions/03 Guides/02 bundling.md
+++ b/src/data/markdown/docs/07 extensions/03 Guides/02 bundling.md
@@ -4,8 +4,13 @@ excerpt: 'Guide to build a k6 binary that includes one or many extensions using 
 ---
 
 To use an extension that you found on the [Extension page](/extensions/get-started/explore/) or the [xk6 GitHub topic](https://github.com/topics/xk6),
-you need to build a binary.
+you need to build a binary using Go.
 
+<Blockquote mod="note" title="Support for Docker">
+
+  Not interested in setting up a Go environment? You can [use Docker instead](/extensions/guides/how-to-build-k6-using-docker/).
+
+</Blockquote>
 
 ## Before you start
 

--- a/src/data/markdown/docs/07 extensions/03 Guides/build-k6-using-docker.md
+++ b/src/data/markdown/docs/07 extensions/03 Guides/build-k6-using-docker.md
@@ -4,11 +4,11 @@ excerpt: ''
 hideFromSidebar: false
 ---
 
-The easiest way to use [xk6](https://github.com/grafana/xk6) is via our [Docker image](https://hub.docker.com/r/grafana/xk6/). This avoids having to setup a local Go environment, and install xk6 manually.
+Using the [xk6 Docker image](https://hub.docker.com/r/grafana/xk6/) can simplify the process of creating a custom k6 binary. It avoids having to setup a local Go environment, and install xk6 manually.
 
 ## Building your first extension
 
-For example, to build a k6 v0.43.1 binary with the [`xk6-kafka`](https://github.com/mostafa/xk6-kafka) and [`xk6-output-influxdb`](https://github.com/grafana/xk6-output-influxdb) extensions, you would run one of the following based upon your operating system:
+For example, to build a k6 v0.43.1 binary with the [`xk6-kafka`](https://github.com/mostafa/xk6-kafka) and [`xk6-output-influxdb`](https://github.com/grafana/xk6-output-influxdb) extensions, run one of the commands below, depending on your operating system:
 
 <CodeGroup labels={["Linux", "Mac", "Windows PowerShell", "Windows"]}>
 
@@ -41,20 +41,20 @@ docker run --rm -e GOOS=windows -v "%cd%:/xk6" ^
 
 </CodeGroup>
 
-This would create a `k6` (or `k6.exe`) binary in the current working directory.
+This creates a `k6` (or `k6.exe`) binary in the current working directory.
 
 ## Breaking down the command
 
-We'll admit, the example command line looks terrifying. Let's focus on the first part, which pertains strictly to Docker:
+The example command line may look a bit intimidating at first, but let's focus on the first part, which pertains strictly to Docker:
 
 ```bash
 docker run --rm -u "$(id -u):$(id -g)" -v "${PWD}:/xk6"
 ```
 
 This tells Docker to run a new container from an image. 
-`--rm` means the container will be destroyed once your build is completed.
-`-u` specifies the user and group IDs of the account on the host machine. This is important for the `k6` file to have the same file permissions as the host user.
-`-v` is required to mount the current working directory inside the container, so that the `k6` binary can be written to it.
+- `--rm` means the container will be destroyed once your build is completed.
+- `-u` specifies the user and group IDs of the account on the host machine. This is important for the `k6` file to have the same file permissions as the host user.
+- `-v` is required to mount the current working directory inside the container, so that the `k6` binary can be written to it.
 
 For Windows and Mac, we additionally include the target system as an environment variable:
 
@@ -62,7 +62,7 @@ For Windows and Mac, we additionally include the target system as an environment
 -e GOOS=<target os>
 ```
 
-The remainder is straight from the [xk6 documentation](https://github.com/grafana/xk6/#command-usage) with the exception that we are using the `grafana/xk6` _image_ rather than a local installation of `xk6`:
+The remainder is straight from the [xk6 documentation](https://github.com/grafana/xk6/#command-usage), with the exception that we use the `grafana/xk6` _image_ rather than a local installation of `xk6`:
 
 ```plain
 grafana/xk6 build [<k6_version>]
@@ -85,16 +85,16 @@ The use of `--replace` should be considered an advanced feature to be avoided un
 </Blockquote>
 
 Referring back to our executed command, note that:
-- We specify the version as `v0.43.1`. Had we specified `latest`, or omitted a version, would mean that we'll build using the _latest_ source code for k6. 
+- We specify the version as `v0.43.1`. When you omit the version or specify `latest`, you build using the _latest_ source code for k6.
   Consider using a stable [release version](https://github.com/grafana/k6/releases) as a best practice unless you genuinely want the _bleeding edge_.
-- With each `--with`, we specified a full GitHub URI for the extension repository. 
-  If not specifying a version, the default is `latest` once again. 
+- We specify a full GitHub URI for the extension repository with each `--with`.
+If a version is not specified, the default is again the `latest`.
   Check your extension repository for stable release versions, if available, to lock in your version as we've done with `xk6-kafka@v0.17.0` and `xk6-output-influxdb@v0.3.0`.
 - For Windows, we used the `--output` option to name our result as `k6.exe`; if not specified, our new binary is `k6` within the current directory.
-  If a directory is specified, then the new binary would be `k6` within _that_ directory. 
-  If a path to a non-existent file, e.g. `/tmp/k6-extended`, this will be the path and filename for the binary.
+If you specify a directory, the new binary will be `k6` within _that_ directory.
+If you specify a path to a non-existent file, e.g. `/tmp/k6-extended`, this will be the path and filename for the binary.
 
-Running `./k6 version` (or `k6.exe version`) should show your build is based upon the appropriate version.
+Run `./k6 version` (or `k6.exe version`) to check that your build is based on the appropriate `k6` version and contains the desired extensions. For example:
 
 ## Running your extended binary
 

--- a/src/data/markdown/docs/07 extensions/03 Guides/build-k6-using-docker.md
+++ b/src/data/markdown/docs/07 extensions/03 Guides/build-k6-using-docker.md
@@ -64,6 +64,8 @@ For Windows and Mac, we additionally include the target system as an environment
 
 The remainder is straight from the [xk6 documentation](https://github.com/grafana/xk6/#command-usage), with the exception that we use the `grafana/xk6` _image_ rather than a local installation of `xk6`:
 
+<CodeGroup labels={["Command usage"]} showCopyButton={[false]}>
+
 ```plain
 grafana/xk6 build [<k6_version>]
     [--output <file>]
@@ -75,6 +77,8 @@ Flags:
   --replace  enables override of dependencies for k6 and extensions [default: none]
   --with     the extension module to be included in the binary [default: none]
 ```
+
+</CodeGroup>
 
 > For this portion, use the [interactive builder](/extensions/get-started/bundle/) and prefix the `grafana/` to avoid typing mistakes!
 
@@ -95,6 +99,18 @@ If you specify a directory, the new binary will be `k6` within _that_ directory.
 If you specify a path to a non-existent file, e.g. `/tmp/k6-extended`, this will be the path and filename for the binary.
 
 Run `./k6 version` (or `k6.exe version`) to check that your build is based on the appropriate `k6` version and contains the desired extensions. For example:
+
+<CodeGroup labels={["Verify build"]} showCopyButton={[false]}>
+
+```bash
+$ ./k6 version
+k6 v0.43.1 ((devel), go1.20.1, darwin/amd64)
+Extensions:
+  github.com/grafana/xk6-output-influxdb v0.3.0, xk6-influxdb [output]
+  github.com/mostafa/xk6-kafka v0.17.0, k6/x/kafka [js]
+```
+
+</CodeGroup>
 
 ## Running your extended binary
 

--- a/src/data/markdown/docs/07 extensions/03 Guides/build-k6-using-docker.md
+++ b/src/data/markdown/docs/07 extensions/03 Guides/build-k6-using-docker.md
@@ -1,0 +1,123 @@
+---
+title: 'How to build k6 using Docker'
+excerpt: ''
+hideFromSidebar: false
+---
+
+The easiest way to use [xk6](https://github.com/grafana/xk6) is via our [Docker image](https://hub.docker.com/r/grafana/xk6/). This avoids having to setup a local Go environment, and install xk6 manually.
+
+## Building your first extension
+
+For example, to build a k6 v0.43.1 binary with the [`xk6-kafka`](https://github.com/mostafa/xk6-kafka) and [`xk6-output-influxdb`](https://github.com/grafana/xk6-output-influxdb) extensions, you would run one of the following based upon your operating system:
+
+<CodeGroup labels={["Linux", "Mac", "Windows PowerShell", "Windows"]}>
+
+```bash
+docker run --rm -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" grafana/xk6 build v0.43.1 \
+  --with github.com/mostafa/xk6-kafka@v0.17.0 \
+  --with github.com/grafana/xk6-output-influxdb@v0.3.0
+```
+
+```bash
+docker run --rm -e GOOS=darwin -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" \
+  grafana/xk6 build v0.43.1 \
+  --with github.com/mostafa/xk6-kafka@v0.17.0 \
+  --with github.com/grafana/xk6-output-influxdb@v0.3.0
+```
+
+```powershell
+docker run --rm -e GOOS=windows -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" `
+  grafana/xk6 build v0.43.1 --output k6.exe `
+  --with github.com/mostafa/xk6-kafka@v0.17.0 `
+  --with github.com/grafana/xk6-output-influxdb@v0.3.0
+```
+
+```batch
+docker run --rm -e GOOS=windows -v "%cd%:/xk6" ^
+  grafana/xk6 build v0.43.1 --output k6.exe ^
+  --with github.com/mostafa/xk6-kafka@v0.17.0 ^
+  --with github.com/grafana/xk6-output-influxdb@v0.3.0
+```
+
+</CodeGroup>
+
+This would create a `k6` (or `k6.exe`) binary in the current working directory.
+
+## Breaking down the command
+
+We'll admit, the example command line looks terrifying. Let's focus on the first part, which pertains strictly to Docker:
+
+```bash
+docker run --rm -u "$(id -u):$(id -g)" -v "${PWD}:/xk6"
+```
+
+This tells Docker to run a new container from an image. 
+`--rm` means the container will be destroyed once your build is completed.
+`-u` specifies the user and group IDs of the account on the host machine. This is important for the `k6` file to have the same file permissions as the host user.
+`-v` is required to mount the current working directory inside the container, so that the `k6` binary can be written to it.
+
+For Windows and Mac, we additionally include the target system as an environment variable:
+
+```bash
+-e GOOS=<target os>
+```
+
+The remainder is straight from the [xk6 documentation](https://github.com/grafana/xk6/#command-usage) with the exception that we are using the `grafana/xk6` _image_ rather than a local installation of `xk6`:
+
+```plain
+grafana/xk6 build [<k6_version>]
+    [--output <file>]
+    [--with <module[@version][=replacement]>...]
+    [--replace <module=replacement>...]
+
+Flags:
+  --output   specifies the new binary name [default: 'k6']
+  --replace  enables override of dependencies for k6 and extensions [default: none]
+  --with     the extension module to be included in the binary [default: none]
+```
+
+> For this portion, use the [interactive builder](/extensions/get-started/bundle/) and prefix the `grafana/` to avoid typing mistakes!
+
+<Blockquote mod="attention">
+
+The use of `--replace` should be considered an advanced feature to be avoided unless required.
+
+</Blockquote>
+
+Referring back to our executed command, note that:
+- We specify the version as `v0.43.1`. Had we specified `latest`, or omitted a version, would mean that we'll build using the _latest_ source code for k6. 
+  Consider using a stable [release version](https://github.com/grafana/k6/releases) as a best practice unless you genuinely want the _bleeding edge_.
+- With each `--with`, we specified a full GitHub URI for the extension repository. 
+  If not specifying a version, the default is `latest` once again. 
+  Check your extension repository for stable release versions, if available, to lock in your version as we've done with `xk6-kafka@v0.17.0` and `xk6-output-influxdb@v0.3.0`.
+- For Windows, we used the `--output` option to name our result as `k6.exe`; if not specified, our new binary is `k6` within the current directory.
+  If a directory is specified, then the new binary would be `k6` within _that_ directory. 
+  If a path to a non-existent file, e.g. `/tmp/k6-extended`, this will be the path and filename for the binary.
+
+Running `./k6 version` (or `k6.exe version`) should show your build is based upon the appropriate version.
+
+## Running your extended binary
+
+Now that we have our newly built k6 binary, we can run scripts using the functionalities
+of the bundled extensions.
+
+<CodeGroup labels={["Linux/Mac", "Windows"]}>
+
+```bash
+./k6 run my-script.js
+```
+
+```batch
+k6.exe run my-script.js
+```
+
+</CodeGroup>
+
+> Be sure to specify the binary just built in the current directory as `./k6`, or else
+> Linux/Mac could execute another k6 binary on your system path. Windows shells will
+> first search for the binary in the current directory by default.
+
+## Encountering issues?
+
+If you're having issues, search the [k6 Community Forum](https://community.k6.io/c/extensions/). 
+Someone may have had the same issue in the past.

--- a/src/data/markdown/docs/07 extensions/03 Guides/build-k6-using-docker.md
+++ b/src/data/markdown/docs/07 extensions/03 Guides/build-k6-using-docker.md
@@ -1,5 +1,5 @@
 ---
-title: 'How to build k6 using Docker'
+title: 'Build a k6 binary using Docker'
 excerpt: ''
 hideFromSidebar: false
 ---

--- a/src/data/markdown/docs/40 xk6-disruptor/01 Get started/03 Installation.md
+++ b/src/data/markdown/docs/40 xk6-disruptor/01 Get started/03 Installation.md
@@ -15,7 +15,7 @@ The quickest way to get started is to [download a release binary from GitHub](ht
 
 You can also use [xk6](https://github.com/grafana/xk6) to build a k6 binary.
 
-To find out more about how to use xk6 or what it is, check out either [Build a k6 binary using Go](/extensions/guides/build-a-k6-binary-using-go/) or [Build a k6 binary using Docker](/extensions/guides/build-a-k6-binary-using-docker/).
+To find out more about how to use xk6 or what it is, check out this guide - [Build a k6 binary using Go](/extensions/guides/build-a-k6-binary-using-go/).
 
 
 To build the k6 binary with the xk6-disruptor extension:

--- a/src/data/markdown/docs/40 xk6-disruptor/01 Get started/03 Installation.md
+++ b/src/data/markdown/docs/40 xk6-disruptor/01 Get started/03 Installation.md
@@ -15,7 +15,7 @@ The quickest way to get started is to [download a release binary from GitHub](ht
 
 You can also use [xk6](https://github.com/grafana/xk6) to build a k6 binary.
 
-To find out more about how to use xk6 or what it is, check out this guide - [Build a k6 binary with extensions](/extensions/guides/build-a-k6-binary-with-extensions/).
+To find out more about how to use xk6 or what it is, check out either [Build a k6 binary using Go](/extensions/guides/build-a-k6-binary-using-go/) or [Build a k6 binary using Docker](/extensions/guides/build-a-k6-binary-using-docker/).
 
 
 To build the k6 binary with the xk6-disruptor extension:

--- a/src/templates/docs/bundle-builder.js
+++ b/src/templates/docs/bundle-builder.js
@@ -72,10 +72,10 @@ const BundleBuilderPage = ({ pageContext: { sidebarTree, navLinks } }) => {
           <Blockquote>
             To build successfully, ensure your environment is as described in{' '}
             <Link
-              to="/extensions/guides/build-a-k6-binary-with-extensions/"
+              to="/extensions/guides/build-a-k6-binary-using-go/"
               className="link"
             >
-              Build a k6 binary with extensions
+              Build a k6 binary using Go
             </Link>
             .
           </Blockquote>


### PR DESCRIPTION
[xk6#62](https://github.com/grafana/xk6/pull/62) created a docker image of xk6 to use when a Go environment is not desired. This adds a guide to documentation for using the image to build custom k6 binaries.