### PR TITLE
Add xk6-opentelemetry extension

### DIFF
--- a/src/data/doc-extensions/extensions.json
+++ b/src/data/doc-extensions/extensions.json
@@ -829,6 +829,18 @@
       },
       "official": false,
       "categories": ["Data"]
+    },
+    {
+      "name": "xk6-opentelemetry",
+      "description": "Generate OpenTelemetry signals",
+      "url": "https://github.com/thmshmm/xk6-opentelemetry",
+      "logo": "",
+      "author": {
+        "name": "Thomas Hamm",
+        "url": "https://github.com/thmshmm"
+      },
+      "official": false,
+      "categories": ["Observability"]
     }
   ]
 }


### PR DESCRIPTION
Hi, I would like to add my xk6-opentelemetry extension to the list.

It supports creating OTel logs and metrics. Support for traces is coming soon.
