### PR TITLE
Add links for the extension user survey

### DIFF
--- a/src/templates/docs/bundle-builder.js
+++ b/src/templates/docs/bundle-builder.js
@@ -64,6 +64,16 @@ const BundleBuilderPage = ({ pageContext: { sidebarTree, navLinks } }) => {
           breadcrumbs={breadcrumbs}
         />
         <div className={docPageContent.inner}>
+          <Blockquote mod="attention" title="Looking for Feedback">
+            Help us improve extensions by completing this{' '}
+            <Link
+              to="https://docs.google.com/forms/d/e/1FAIpQLSeL1RdxAyaoznGKLAdlMa5sLmVWoytpxRCZZVzBeFGSyqGI6A/viewform"
+              className="link"
+            >
+              short survey
+            </Link>
+            .
+          </Blockquote>
           <p>
             Extensions are composable; you can combine any extensions, or mix
             and match different test cases. To generate the command for your

--- a/src/templates/docs/explore-extensions.js
+++ b/src/templates/docs/explore-extensions.js
@@ -10,6 +10,8 @@ import queryString from 'query-string';
 import React from 'react';
 import SeoMetaData from 'utils/seo-metadata';
 
+import Blockquote from '../../components/shared/blockquote';
+
 const breadcrumbs = [
   {
     name: 'Extensions',
@@ -72,6 +74,16 @@ const ExploreExtensionsPage = ({
           breadcrumbs={breadcrumbs}
         />
         <div className={docPageContent.inner}>
+          <Blockquote mod="attention" title="Looking for Feedback">
+            Help us improve extensions by completing this{' '}
+            <Link
+              to="https://docs.google.com/forms/d/e/1FAIpQLSeL1RdxAyaoznGKLAdlMa5sLmVWoytpxRCZZVzBeFGSyqGI6A/viewform"
+              className="link"
+            >
+              short survey
+            </Link>
+            .
+          </Blockquote>
           <p>
             With over 50 available extensions, the k6 extension ecosystem has
             many options to meet your requirements and help you incorporate new

--- a/src/templates/docs/extensions.js
+++ b/src/templates/docs/extensions.js
@@ -16,6 +16,8 @@ import { DocLayout } from 'layouts/doc-layout';
 import React, { useRef } from 'react';
 import SeoMetaData from 'utils/seo-metadata';
 
+import Blockquote from '../../components/shared/blockquote';
+
 const Extensions = ({ pageContext: { sidebarTree, navLinks } }) => {
   useScrollToAnchor();
 
@@ -38,6 +40,16 @@ const Extensions = ({ pageContext: { sidebarTree, navLinks } }) => {
         />
         <div className={docPageContent.inner}>
           <div ref={contentContainerRef} className={stickyContainerClasses}>
+            <Blockquote mod="attention" title="Looking for Feedback">
+              Help us improve extensions by completing this{' '}
+              <Link
+                to="https://docs.google.com/forms/d/e/1FAIpQLSeL1RdxAyaoznGKLAdlMa5sLmVWoytpxRCZZVzBeFGSyqGI6A/viewform"
+                className="link"
+              >
+                short survey
+              </Link>
+              .
+            </Blockquote>
             <ExtensionsQuickstart />
             <ExtensionsOverview />
             <WhatIsXk6 />


### PR DESCRIPTION
We're looking to gather information from the community about extensions usage. Add calls to action for completing the survey.