### PR TITLE
feat: add xk6-top extension

### DIFF
--- a/src/data/doc-extensions/extensions.json
+++ b/src/data/doc-extensions/extensions.json
@@ -841,6 +841,18 @@
       },
       "official": false,
       "categories": ["Data"]
+    },
+    {
+      "name": "xk6-top",
+      "description": "Updating the current k6 metrics summaries on the terminal during the test run",
+      "url": "https://github.com/szkiba/xk6-top",
+      "logo": "https://raw.githubusercontent.com/szkiba/xk6-top/78393869e5885030de22ea70aadff186557c7b15/assets/xk6-top-logo.png",
+      "author": {
+        "name": "Iván Szkiba",
+        "url": "https://github.com/szkiba"
+      },
+      "official": false,
+      "categories": ["Reporting", "Observability"]
     }
   ]
 }


### PR DESCRIPTION
Add [xk6-top](https://github.com/szkiba/xk6-top) extension to the extension list.

[xk6-top](https://github.com/szkiba/xk6-top) is a k6 extension to updating the current k6 metrics summaries on the terminal during the test run. Metric summaries are updated on the terminal screen at regular intervals.
