### PR TITLE
Fix http fault api and examples

### DIFF
--- a/src/data/markdown/docs/40 xk6-disruptor/03 API/01 Faults/01 HTTP .md
+++ b/src/data/markdown/docs/40 xk6-disruptor/03 API/01 Faults/01 HTTP .md
@@ -11,7 +11,7 @@ A HTTP fault is described by the following attributes:
 | --------- | ------------|
 | averageDelay | average delay added to requests in milliseconds (default `0ms`) |
 | delayVariation| variation in the injected delay in milliseconds (default `0ms`) |
-| errorBody | body to be returned when an error in injected |
+| errorBody | body to be returned when an error is injected |
 | errorCode | error code to return |
 | errorRate | rate of requests that will return an error, represented as a float in the range `0.0` to `1.0` (default `0.0`) |
 | exclude | comma-separated list of urls to be excluded from disruption (e.g. /health) |
@@ -29,8 +29,8 @@ This example defines a HTTP fault that introduces a delay of `50ms` in all reque
 
 ```javascript
 const fault = {
-  average_delay: 50,
-  error_code: 500,
-  error_rate: 0.1,
+  averageDelay: 50,
+  errorCde: 500,
+  errorRate: 0.1,
 };
 ```

--- a/src/data/markdown/docs/40 xk6-disruptor/04 Examples/01 Inject HTTP faults into Pod.md
+++ b/src/data/markdown/docs/40 xk6-disruptor/04 Examples/01 Inject HTTP faults into Pod.md
@@ -63,9 +63,9 @@ export function disrupt(data) {
     const podDisruptor = new PodDisruptor(selector)
     // delay traffic from one random replica of the deployment
     const fault = {
-        average_delay: 50,
-        error_code: 500,
-        error_rate: 0.1
+        averageDelay: 50,
+        errorCode: 500,
+        errorRate: 0.1
     }
     podDisruptor.injectHTTPFaults(fault, 30)
 }

--- a/src/data/markdown/docs/40 xk6-disruptor/04 Examples/01 Inject HTTP faults into Pod.md
+++ b/src/data/markdown/docs/40 xk6-disruptor/04 Examples/01 Inject HTTP faults into Pod.md
@@ -355,19 +355,10 @@ NAME              TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)        
 service/httpbin   LoadBalancer   10.96.169.78   172.18.255.200   80:31224/TCP   1m
 ```
 
-You can retrieve the external IP address in the environment variable `SVC_IP` using the following command:
+You must set the environment variable `SVC_IP` with the external IP address and port used to access the `httpbin` service from the test script.
 
-<CodeGroup labels={["Linux/MacOS", "Windows PowerShell"]}>
+You can learn more about how to get the external IP address in the [expose your application](/javascript-api/xk6-disruptor/get-started/expose-your-application) section.
 
-```bash
-SVC_IP=$(kubectl -n httpbin  get svc httpbin --output jsonpath='{.status.loadBalancer.ingress[0].ip}')
-```
-
-```Powershell
-$Env:SVC_IP=$(kubectl -n httpbin  get svc httpbin --output jsonpath='{.status.loadBalancer.ingress[0].ip}')
-```
-
-</CodeGroup>
 
 ### Manifests
 


### PR DESCRIPTION
* Fix the argument's case in examples
* Reference the get-started section for exposing the example application