### PR TITLE
Update k6 browser's BrowserType.Connect documentation

### DIFF
--- a/src/data/markdown/docs/30 k6-browser/02 API/03 BrowserType.md
+++ b/src/data/markdown/docs/30 k6-browser/02 API/03 BrowserType.md
@@ -7,7 +7,7 @@ The `BrowserType` is the entry point into launching a browser process; `chromium
 
 | Method                                                                                  | Description                                                                  |
 |-----------------------------------------------------------------------------------------|------------------------------------------------------------------------------|
-| browserType.connect([options]) <BWIPT id="17"/>                                         | Connect attaches k6 browser to an existing browser instance.                 |
+| [browserType.connect(wsURL, [options])](/javascript-api/k6-browser/api/browsertype/connect/) | Connect attaches k6 browser to an existing browser instance. |
 | [browserType.executablePath()](/javascript-api/k6-browser/api/browsertype/executablepath/) | Returns the path where the extension expects to find the browser executable. |
 | [browserType.launch([options])](/javascript-api/k6-browser/api/browsertype/launch/)        | Launches a new browser process.                                              |
 | browserType.launchPersistentContext(userDataDir, [options]) <BWIPT id="16"/>            | Launches the browser with persistent storage.                                |

--- a/src/data/markdown/docs/30 k6-browser/02 API/03 BrowserType/connect--options--.md
+++ b/src/data/markdown/docs/30 k6-browser/02 API/03 BrowserType/connect--options--.md
@@ -1,0 +1,49 @@
+---
+title: 'connect(wsURL, [options])'
+excerpt: 'Browser module: BrowserType.connect method'
+---
+
+Connects to an existing browser instance.
+
+| Parameter         | Type     | Default | Description                                                                                                                                                                                                                                                           |
+|-------------------|----------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| debug             | boolean  | `false` | All CDP messages and internal fine grained logs will be logged if set to `true`.                                                                                                                                                                                      |
+| slowMo            | string   | `null`  | Slow down input actions and navigation by the specified time e.g. `'500ms'`.                                                                                                                                                                                          |
+| timeout           | string   | `'30s'` | Default timeout to use for various actions and navigation.                                                                                                                                                                                                            |
+
+
+### Returns
+
+| Type   | Description                                            |
+|--------|--------------------------------------------------------|
+| object | [Browser](/javascript-api/k6-browser/api/browser/) object |
+
+
+## Example
+
+<CodeGroup labels={[]}>
+
+```javascript
+import { chromium } from 'k6/experimental/browser';
+
+export default async function () {
+  const wsURL = 'ws://localhost:9222/devtools/browser/a7ee4f2d-35cf-4478-a333-f597e1532ab0';
+  const browser = chromium.connect(wsURL, {
+    debug: true,
+    slowMo: '500ms',
+    timeout: '30s',
+  });
+  const context = browser.newContext();
+  const page = context.newPage();
+
+  try {
+    await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
+    page.screenshot({ path: `example-chromium.png` });
+  } finally {
+    page.close();
+    browser.close();
+  }
+}
+```
+
+</CodeGroup>


### PR DESCRIPTION
This PR updates the documentation for the k6 browser's `BrowserType.Connect` method by fixing the method signature and adding a dedicated page which documents the supported arguments and provides an example.

Closes: #1112 .