### PR TITLE
Update centralized Makefile to fix missing menu

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,9 +1,2 @@
-.DEFAULT_GOAL: help
-
-# Adapted from https://www.thapaliya.com/en/writings/well-documented-makefiles/
-.PHONY: help
-help: ## Display this help.
-help:
-	@awk 'BEGIN {FS = ": ##"; printf "Usage:\n  make <target>\n\nTargets:\n"} /^[a-zA-Z0-9_\.\-\/%]+: ##/ { printf "  %-45s %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
-
+# Include any additional project specific targets here.
 include docs.mk

--- a/docs/variables.mk
+++ b/docs/variables.mk
@@ -1,0 +1,2 @@
+# List of projects to provide to the make-docs script.
+PROJECTS = grafana-cloud/k6 grafana-cloud


### PR DESCRIPTION
- Add wildcard doc-validator target
- Standardize general doc-validator target
- Build multiple documentation sets together

Unfortunately this exposes a bunch of build errors in Grafana Cloud content that needs fixing.
I will look to fix those up today.