### PR TITLE
Document the k6/experimental/webcrypto module

### DIFF
--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental.md
@@ -11,4 +11,5 @@ excerpt: "k6 experimental APIs"
 | [redis](/javascript-api/k6-experimental/redis/) | Functionality to interact with [Redis](https://redis.io/). |
 | [timers](/javascript-api/k6-experimental/timers/) | `setTimeout`, `clearTimeout`, `setInterval`, `clearInterval`  |
 | [tracing](/javascript-api/k6-experimental/tracing/) | Support for instrumenting HTTP requests with tracing information. |
+| [webcrypto](/javascript-api/k6-experimental/webcrypto/) | Implements the [WebCrypto API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API). |
 | [websockets](/javascript-api/k6-experimental/websockets/) | Implements the browser's [WebSocket API](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket).  |

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/06 webcrypto.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/06 webcrypto.md
@@ -1,0 +1,90 @@
+---
+title: 'webcrypto'
+excerpt: "k6 webcrypto experimental API"
+---
+
+<ExperimentalBlockquote />
+
+With this experimental module, you can use the [WebCrypto API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API) in your k6 scripts. Note however that this API is not yet fully implemented and some algorithms and features might still be missing.
+
+The Web Crypto API is a JavaScript API for performing cryptographic operations such as encryption, decryption, digital signature generation and verification, and key generation and management. It provides a standard interface for accessing cryptographic functionality, which can help ensure that cryptographic operations are performed correctly and securely.
+
+## API
+
+The module exports a top-level `crypto` object with the following properties and methods:
+
+| Interface/Function                                                                         | Description                                                                                                                                                                                   |
+| :----------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [getRandomValues](/javascript-api/k6-experimental/webcrypto/crypto/getrandomvalues) | Fills the passed `TypedArray` with cryptographically sound random values.                                                                                                                     |
+| [randomUUID](/javascript-api/k6-experimental/webcrypto/crypto/randomuuid)           | Returns a randomly generated, 36 character long v4 UUID.                                                                                                                                      |
+| [subtle](/javascript-api/k6-experimental/webcrypto/subtlecrypto)                    | the [SubtleCrypto](/javascript-api/k6-experimental/webcrypto/subtlecrypto) interface provides access to common cryptographic primitives, such as hashing, signing, encryption, or decryption. |
+
+## Example
+
+<CodeGroup labels={["example-webcrypto-module.js"]} lineNumbers={[]} showCopyButton={[true]}>
+
+```javascript
+import { crypto } from "k6/experimental/webcrypto";
+
+export default async function () {
+  const plaintext = stringToArrayBuffer("Hello, World!");
+
+  /**
+   * Generate a symmetric key using the AES-CBC algorithm.
+   */
+  const key = await crypto.subtle.generateKey(
+    {
+      name: "AES-CBC",
+      length: 256,
+    },
+    true,
+    ["encrypt", "decrypt"]
+  );
+
+  /**
+   * Encrypt the plaintext using the AES-CBC key with
+   * have generated.
+   */
+  const iv = crypto.getRandomValues(new Uint8Array(16));
+  const ciphertext = await crypto.subtle.encrypt(
+    {
+      name: "AES-CBC",
+      iv: iv,
+    },
+    key,
+    plaintext
+  );
+
+  /**
+   * Decrypt the ciphertext using the same key to verify
+   * that the resulting plaintext is the same as the original.
+   */
+  const deciphered = await crypto.subtle.decrypt(
+    {
+      name: "AES-CBC",
+      iv: iv,
+    },
+    key,
+    ciphertext,
+  );
+
+  console.log("deciphered text == original plaintext: ", arrayBufferToHex(deciphered) === arrayBufferToHex(plaintext))
+}
+
+function arrayBufferToHex(buffer) {
+  return [...new Uint8Array(buffer)]
+    .map((x) => x.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function stringToArrayBuffer(str) {
+  const buf = new ArrayBuffer(str.length * 2); // 2 bytes for each char
+  const bufView = new Uint16Array(buf);
+  for (let i = 0, strLen = str.length; i < strLen; i++) {
+    bufView[i] = str.charCodeAt(i);
+  }
+  return buf;
+}
+```
+
+</CodeGroup>

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/06 webcrypto/01 Crypto.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/06 webcrypto/01 Crypto.md
@@ -1,0 +1,19 @@
+---
+title: 'Crypto'
+excerpt: 'Crypto offers basic cryptography features.'
+---
+
+`Crypto` allows access to a cryptographically strong random number generator and to cryptographic primitives.
+
+## Properties
+
+| Name            | Type                                                                   | Description                                                                                                                         |
+| :-------------- | :--------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------- |
+| `Crypto.subtle` | [SubtleCrypto](/javascript-api/k6-experimental/webcrypto/subtlecrypto) | The SubtleCrypto interface provides access to common cryptographic primitives, such as hashing, signing, encryption, or decryption. |
+
+## Methods
+
+| Name | Type | Description |
+| :--- | :--- | :---------- |
+| `Crypto.getRandomValues()` | [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBufferView) | Returns an array of cryptographically secure random values. |
+| `Crypto.randomUUID()` | [ArrayBuffer]() | Returns a randomly generated, 36 character long v4 UUID. |

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/06 webcrypto/01 Crypto/01 getRandomValues.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/06 webcrypto/01 Crypto/01 getRandomValues.md
@@ -1,0 +1,47 @@
+---
+title: 'getRandomValues'
+excerpt: 'getRandomValues fills the passed TypedArray with cryptographically sound random values.'
+---
+
+The `getRandomValues()` method fills the passed `TypedArray` with cryptographically sound random values.
+
+## Usage
+
+```
+getRandomValues(typedArray)
+```
+
+## Parameters
+
+| Name         | Type         | Description                                                                                                                                                                                                      |
+| :----------- | :----------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `typedArray` | `TypedArray` | An integer-based `TypedArray` to fill with random values. Accepted `TypedArray` specific types are: `Int8Array`, `Uint8Array`, `Uint8ClampedArray`, `Int16Array`, `Uint16Array`, `Int32Array`, or `Uint32Array`. |
+
+## Return Value
+
+The same array passed as the `typedArray` parameter with its contents replaced with the newly generated random numbers. the `typedArray` parameter is modified in place, and no copy is made.
+
+## Throws
+
+| Type                 | Description                                                          |
+| :------------------- | :------------------------------------------------------------------- |
+| `QuotaExceededError` | if the `typedArray` is too large and its `byteLength` exceeds 65536. |
+
+## Example
+
+<CodeGroup labels={["example-webcrypto-getrandomvalues.js"]} lineNumbers={[]} showCopyButton={[true]}>
+
+```javascript
+import { crypto } from "k6/experimental/webcrypto";
+
+export default function () {
+  const array = new Uint32Array(10);
+  crypto.getRandomValues(array);
+
+  for (const num of array) {
+    console.log(num);
+  }
+}
+```
+
+</CodeGroup>

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/06 webcrypto/01 Crypto/02 randomUUID.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/06 webcrypto/01 Crypto/02 randomUUID.md
@@ -1,0 +1,32 @@
+---
+title: 'randomUUID'
+excerpt: 'randomUUID produces a 36-characters long string containing a cryptographically random UUID v4.'
+---
+
+The `randomUUID` method produces a 36-characters long string containing a cryptographically random UUID v4.
+
+## Usage
+
+```
+randomUUID()
+```
+
+## Return Value
+
+A string containing a 36-character cryptographically random UUID v4.
+
+## Example
+
+<CodeGroup labels={["example-webcrypto-randomuuid.js"]} lineNumbers={[]} showCopyButton={[true]}>
+
+```javascript
+import { crypto } from "k6/experimental/webcrypto";
+
+export default function () {
+  const myUUID = crypto.randomUUID();
+
+  console.log(myUUID);
+}
+```
+
+</CodeGroup>

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/06 webcrypto/02 SubtleCrypto.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/06 webcrypto/02 SubtleCrypto.md
@@ -1,0 +1,89 @@
+---
+title: 'SubtleCrypto'
+excerpt: 'SubtleCrypto offers low-level cryptographic functions.'
+---
+
+The `SubtleCrypto` interface provides a set of low-level cryptographic primitives such as encryption, decryption, digital signature generation and verification, and key generation and management. It is useful for using secure and efficient cryptographic operations within k6 scripts, without requiring to have a deep understanding of the underlying cryptographic algorithms and protocols.
+
+## Methods
+
+| Method                                                                            | Description                                                                                 |
+| :-------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------ |
+| [encrypt](/javascript-api/k6-experimental/webcrypto/subtlecrypto/encrypt)         | Encrypts the given plaintext data using the specified algorithm and key.                    |
+| [decrypt](/javascript-api/k6-experimental/webcrypto/subtlecrypto/decrypt)         | Decrypts the given ciphertext data using the specified algorithm and key.                   |
+| [sign](/javascript-api/k6-experimental/webcrypto/subtlecrypto/sign)               | Signs the given data using the specified algorithm and key.                                 |
+| [verify](/javascript-api/k6-experimental/webcrypto/subtlecrypto/verify)           | Verifies the signature of the given data using the specified algorithm and key.             |
+| [digest](/javascript-api/k6-experimental/webcrypto/subtlecrypto/digest)           | Computes the digest (hash) of the given data using the specified algorithm.                 |
+| [generateKey](/javascript-api/k6-experimental/webcrypto/subtlecrypto/generatekey) | Generates a new cryptographic key for use with the specified algorithm.                     |
+| [importKey](/javascript-api/k6-experimental/webcrypto/subtlecrypto/importkey)     | Imports a raw key material into the Web Crypto API, generating a new key object that can be |used with the specified algorithm.
+| [exportKey](/javascript-api/k6-experimental/webcrypto/subtlecrypto/exportkey)     | Exports the raw key material of the given key object.                                       |
+
+## Example
+
+<CodeGroup labels={["example-webcrypto-subtlecrypto.js"]} lineNumbers={[]} showCopyButton={[true]}>
+
+```javascript
+import { crypto } from "k6/experimental/webcrypto";
+
+export default async function () {
+  const plaintext = stringToArrayBuffer("Hello, World!");
+
+  /**
+   * Generate a symmetric key using the AES-CBC algorithm.
+   */
+  const key = await crypto.subtle.generateKey(
+    {
+      name: "AES-CBC",
+      length: 256,
+    },
+    true,
+    ["encrypt", "decrypt"]
+  );
+
+  /**
+   * Encrypt the plaintext using the AES-CBC key with
+   * have generated.
+   */
+  const iv = crypto.getRandomValues(new Uint8Array(16));
+  const ciphertext = await crypto.subtle.encrypt(
+    {
+      name: "AES-CBC",
+      iv: iv,
+    },
+    key,
+    plaintext
+  );
+
+  /**
+   * Decrypt the ciphertext using the same key to verify
+   * that the resulting plaintext is the same as the original.
+   */
+  const deciphered = await crypto.subtle.decrypt(
+    {
+      name: "AES-CBC",
+      iv: iv,
+    },
+    key,
+    ciphertext,
+  );
+
+  console.log("deciphered text == original plaintext: ", arrayBufferToHex(deciphered) === arrayBufferToHex(plaintext))
+}
+
+function arrayBufferToHex(buffer) {
+  return [...new Uint8Array(buffer)]
+    .map((x) => x.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function stringToArrayBuffer(str) {
+  const buf = new ArrayBuffer(str.length * 2); // 2 bytes for each char
+  const bufView = new Uint16Array(buf);
+  for (let i = 0, strLen = str.length; i < strLen; i++) {
+    bufView[i] = str.charCodeAt(i);
+  }
+  return buf;
+}
+```
+
+</CodeGroup>

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/06 webcrypto/02 SubtleCrypto/01 decrypt.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/06 webcrypto/02 SubtleCrypto/01 decrypt.md
@@ -1,0 +1,101 @@
+---
+title: 'decrypt'
+excerpt: 'decrypt decrypts some encrypted data'
+---
+
+The `decrypt()` method decrypts some encrypted data.
+
+## Usage
+
+```
+decrypt(algorithm, key, data)
+```
+
+## Parameters
+
+| Name        | Type                                                             | Description                                                                                                                                                 |
+| :---------- | :--------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `algorithm` | [AesCtrParams](/javascript-api/k6-experimental/webcrypto/aesctrparams), [AesCbcParams](/javascript-api/k6-experimental/webcrypto/aescbcparams), or [AesGcmParams](/javascript-api/k6-experimental/webcrypto/aesgcmparams) object         | defines the algorithm to use and any extra-parameters. The values given for the extra parameters must match those used in the corresponding [encrypt] call. |
+| `key`       | [CryptoKey](/javascript-api/k6-experimental/webcrypto/cryptokey) | The [key](/javascript-api/k6-experimental/webcrypto/cryptokey) to use for decryption.                                                                       |
+| `data`      | `ArrayBuffer`, `TypedArray`, or `DataView`                       | The encrypted data to be decrypted (also known as "ciphertext").                                                                                            |
+
+## Return Value
+
+A `Promise` that resolves to a new `ArrayBuffer` containing the decrypted data.
+
+## Throws
+
+| Type                 | Description                                                                                                                                                                                  |
+| :------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `InvalidAccessError` | Raised when the requested operation is not valid with the provided key. For instance when an invalid encryption algorithm is used, or a key not matching the selected algorithm is provided. |
+| `OperationError`     | Raised when the operation failed for an operation-specific reason. For instance, if the algorithm size is invalid, or errors occurred during the process of decrypting the ciphertext.       |
+
+## Example
+
+<CodeGroup labels={["example-webcrypto-decrypt.js"]} lineNumbers={[]} showCopyButton={[true]}>
+
+```javascript
+import { crypto } from "k6/experimental/webcrypto";
+
+export default async function () {
+  const plaintext = stringToArrayBuffer("Hello, World!");
+
+  /**
+   * Generate a symmetric key using the AES-CBC algorithm.
+   */
+  const key = await crypto.subtle.generateKey(
+    {
+      name: "AES-CBC",
+      length: 256,
+    },
+    true,
+    ["encrypt", "decrypt"]
+  );
+
+  /**
+   * Encrypt the plaintext using the AES-CBC key with
+   * have generated.
+   */
+  const iv = crypto.getRandomValues(new Uint8Array(16));
+  const ciphertext = await crypto.subtle.encrypt(
+    {
+      name: "AES-CBC",
+      iv: iv,
+    },
+    key,
+    plaintext
+  );
+
+  /**
+   * Decrypt the ciphertext using the same key to verify
+   * that the resulting plaintext is the same as the original.
+   */
+  const deciphered = await crypto.subtle.decrypt(
+    {
+      name: "AES-CBC",
+      iv: iv,
+    },
+    key,
+    ciphertext,
+  );
+
+  console.log("deciphered text == original plaintext: ", arrayBufferToHex(deciphered) === arrayBufferToHex(plaintext))
+}
+
+function arrayBufferToHex(buffer) {
+  return [...new Uint8Array(buffer)]
+    .map((x) => x.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function stringToArrayBuffer(str) {
+  const buf = new ArrayBuffer(str.length * 2); // 2 bytes for each char
+  const bufView = new Uint16Array(buf);
+  for (let i = 0, strLen = str.length; i < strLen; i++) {
+    bufView[i] = str.charCodeAt(i);
+  }
+  return buf;
+}
+```
+
+</CodeGroup>

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/06 webcrypto/02 SubtleCrypto/02 digest.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/06 webcrypto/02 SubtleCrypto/02 digest.md
@@ -1,0 +1,49 @@
+---
+title: 'digest'
+excerpt: 'digest decrypts some encrypted data'
+---
+
+The `digest()` method generates a cryptographically secure [digest](https://developer.mozilla.org/en-US/docs/Glossary/Digest) of the given data. A digest is a short fixed-length value derived from some input data. The `digest()` method is commonly used to compute a checksum of data or to verify the integrity of data.
+
+## Usage
+
+```
+digest(algorithm, data)
+```
+
+## Parameters
+
+| Name        | Type                                                      | Description                                                                                                                                                                               |
+| :---------- | :-------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `algorithm` | a `string` or object with a single `name` string property | names the hash function to use. Supported values are `"SHA-1"`, `"SHA-256"`, `"SHA-384"` and `"SHA-512"`. Note that the SHA-1 hash function is not considered safe for cryptographic use. |
+| `data`      | `ArrayBuffer`, `TypedArray`, or `DataView`                | The  data to be digested.                                                                                                                                                                 |
+
+## Return Value
+
+A `Promise` that resolves to a new `ArrayBuffer` containing the digest.
+
+## Example
+
+<CodeGroup labels={["example-webcrypto-digest.js"]} lineNumbers={[]} showCopyButton={[true]}>
+
+```javascript
+import { crypto } from "k6/experimental/webcrypto";
+
+export default async function () {
+  const digest = await crypto.subtle.digest("SHA-256", stringToArrayBuffer("Hello, world!"));
+
+  console.log(arrayBufferToHex(digest));
+}
+
+function arrayBufferToHex(buffer) {
+  return [...new Uint8Array(buffer)]
+    .map((x) => x.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function stringToArrayBuffer(s) {
+  return Uint8Array.from(new String(s), (x) => x.charCodeAt(0));
+}
+```
+
+</CodeGroup>

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/06 webcrypto/02 SubtleCrypto/03 encrypt.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/06 webcrypto/02 SubtleCrypto/03 encrypt.md
@@ -1,0 +1,101 @@
+---
+title: 'encrypt'
+excerpt: 'encrypt decrypts some encrypted data'
+---
+
+The `encrypt()` method encrypts some data.
+
+## Usage
+
+```
+encrypt(algorithm, key, data)
+```
+
+## Parameters
+
+| Name        | Type | Description |
+| :---------- | :--- | :---------- |
+| `algorithm` | [AesCtrParams](/javascript-api/k6-experimental/webcrypto/aesctrparams), [AesCbcParams](/javascript-api/k6-experimental/webcrypto/aescbcparams), or [AesGcmParams](/javascript-api/k6-experimental/webcrypto/aesgcmparams) object      | defines the algorithm to use and any extra-parameters.            |
+| `key`            | [CryptoKey](/javascript-api/k6-experimental/webcrypto/cryptokey)     | The [key](/javascript-api/k6-experimental/webcrypto/cryptokey) to use for encryption.             |
+| `data`            | `ArrayBuffer`, `TypedArray`, or `DataView`     | The data to be encrypted (also known as "plaintext").            |
+
+## Return Value
+
+A `Promise` that resolves to a new `ArrayBuffer` containing the encrypted data.
+
+## Throws
+
+| Type                 | Description                                                          |
+| :------------------- | :------------------------------------------------------------------- |
+| `InvalidAccessError` | Raised when the requested operation is not valid with the provided key. For instance when an invalid encryption algorithm is used, or a key not matching the selected algorithm is provided. |
+| `OperationError` | Raised when the operation failed for an operation-specific reason. For instance, if the algorithm size is invalid, or errors occurred during the process of decrypting the ciphertext. |
+
+## Example
+
+<CodeGroup labels={["example-webcrypto-encrypt.js"]} lineNumbers={[]} showCopyButton={[true]}>
+
+```javascript
+import { crypto } from "k6/experimental/webcrypto";
+
+export default async function () {
+  const plaintext = stringToArrayBuffer("Hello, World!");
+
+  /**
+   * Generate a symmetric key using the AES-CBC algorithm.
+   */
+  const key = await crypto.subtle.generateKey(
+    {
+      name: "AES-CBC",
+      length: 256,
+    },
+    true,
+    ["encrypt", "decrypt"]
+  );
+
+  /**
+   * Encrypt the plaintext using the AES-CBC key with
+   * have generated.
+   */
+  const iv = crypto.getRandomValues(new Uint8Array(16));
+  const ciphertext = await crypto.subtle.encrypt(
+    {
+      name: "AES-CBC",
+      iv: iv,
+    },
+    key,
+    plaintext
+  );
+
+  /**
+   * Decrypt the ciphertext using the same key to verify
+   * that the resulting plaintext is the same as the original.
+   */
+  const deciphered = await crypto.subtle.decrypt(
+    {
+      name: "AES-CBC",
+      iv: iv,
+    },
+    key,
+    ciphertext,
+  );
+
+  console.log("deciphered text == original plaintext: ", arrayBufferToHex(deciphered) === arrayBufferToHex(plaintext))
+}
+
+function arrayBufferToHex(buffer) {
+  return [...new Uint8Array(buffer)]
+    .map((x) => x.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function stringToArrayBuffer(str) {
+  const buf = new ArrayBuffer(str.length * 2); // 2 bytes for each char
+  const bufView = new Uint16Array(buf);
+  for (let i = 0, strLen = str.length; i < strLen; i++) {
+    bufView[i] = str.charCodeAt(i);
+  }
+  return buf;
+}
+```
+
+</CodeGroup>

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/06 webcrypto/02 SubtleCrypto/04 exportKey.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/06 webcrypto/02 SubtleCrypto/04 exportKey.md
@@ -1,0 +1,77 @@
+---
+title: 'exportKey'
+excerpt: 'exportKey exports a key in an external, portable format.'
+---
+
+The `exportKey()` method takes a [CryptoKey](/javascript-api/k6-experimental/webcrypto/cryptokey) object as input and exports it in an external, portable format.
+
+Note that for a key to be exportable, it must have been created with the `extractable` flag set to `true`.
+
+## Usage
+
+```
+exportKey(format, key)
+```
+
+## Parameters
+
+| Name        | Type | Description |
+| :---------- | :--- | :---------- |
+| `format` | `string`       | Defines the data format the key should be exported in. Currently supported formats: `raw`.            |
+| `key`            | [CryptoKey](/javascript-api/k6-experimental/webcrypto/cryptokey)     | The [key](/javascript-api/k6-experimental/webcrypto/cryptokey) to export.             |
+
+## Return Value
+
+A `Promise` that resolves to a new `ArrayBuffer` containing the key.
+
+## Throws
+
+| Type                 | Description                                         |
+| :------------------- | :-------------------------------------------------- |
+| `InvalidAccessError` | Raised when trying to export a non-extractable key. |
+| `NotSupportedError`  | Raised when trying to export in an unknown format.  |
+| `TypeError`          | Raised when trying to use an invalid format.        |
+
+## Example
+
+<CodeGroup labels={["example-webcrypto-exportKey.js"]} lineNumbers={[]} showCopyButton={[true]}>
+
+```javascript
+import { crypto } from "k6/experimental/webcrypto";
+
+export default async function () {
+  /**
+   * Generate a symmetric key using the AES-CBC algorithm.
+   */
+  const generatedKey = await crypto.subtle.generateKey(
+    {
+      name: "AES-CBC",
+      length: "256"
+    },
+    true,
+    [
+      "encrypt",
+      "decrypt",
+    ]
+  );
+
+  /**
+   * Export the key in raw format.
+   */
+  const exportedKey = await crypto.subtle.exportKey("raw", generatedKey);
+
+  /**
+   * Reimport the key in raw format to verfiy its integrity.
+   */
+  const importedKey = await crypto.subtle.importKey(
+    "raw",
+    exportedKey,
+    "AES-CBC",
+    true, ["encrypt", "decrypt"]
+  );
+
+  console.log(JSON.stringify(importedKey))
+}
+```
+
+</CodeGroup>

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/06 webcrypto/02 SubtleCrypto/05 generateKey.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/06 webcrypto/02 SubtleCrypto/05 generateKey.md
@@ -1,0 +1,56 @@
+---
+title: 'generateKey'
+excerpt: 'generateKey generates a new key.'
+---
+
+The `generateKey()` generates a new cryptographic key and returns it as a [CryptoKey](/javascript-api/k6-experimental/webcrypto/cryptokey) object that can be used with the Web Crypto API.
+
+## Usage
+
+```
+generateKey(algorithm, extractable, keyUsages)
+```
+
+## Parameters
+
+| Name          | Type                                                  | Description                                                                                                                                                                                                                  |
+| :------------ | :---------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `algorithm`   | `string`, [AesKeyGenParams](/javascript-api/k6-experimental/webcrypto/aeskeygenparams) or [HmacKeyGenParams](/javascript-api/k6-experimental/webcrypto/hmackeygenparams) | The type of key to generate. Can be either a string with any of the currently supported algorithms: `AES-CBC`, `AES-GCM`, `AES-CTR`, and `HMAC` as value, or any of the [AesKeyGenParams](/javascript-api/k6-experimental/webcrypto/aeskeygenparams) or [HmacKeyGenParams](/javascript-api/k6-experimental/webcrypto/hmackeygenparams) objects. |
+| `extractable` | `boolean`                                             | Indicates whether it will be possible to export the key using [exportKey](/javascript-api/k6-experimental/webcrypto/subtlecrypto/exportkey).                                                                                 |
+| `keyUsages`   | `Array<string>`                                       | An array of strings describing what operations can be performed with the key. Currently supported usages include: `encrypt`, `decrypt`, `sign`, and `verify`.                                                                |
+
+## Return Value
+
+A `Promise` that resolves with the generated key as a [CryptoKey](/javascript-api/k6-experimental/webcrypto/cryptokey) object.
+
+## Throws
+
+| Type          | Description                                                                                  |
+| :------------ | :------------------------------------------------------------------------------------------- |
+| `SyntaxError` | Raised when the `keyUsages` parameter is empty but the key is of type `secret` or `private`. |
+
+## Example
+
+<CodeGroup labels={["example-webcrypto-generateKey.js"]} lineNumbers={[]} showCopyButton={[true]}>
+
+```javascript
+import { crypto } from "k6/experimental/webcrypto";
+
+export default async function () {
+  const key = await crypto.subtle.generateKey(
+    {
+      name: "AES-CBC",
+      length: 256
+    },
+    true,
+    [
+      "encrypt",
+      "decrypt",
+    ]
+  );
+
+  console.log(JSON.stringify(key))
+}
+```
+
+</CodeGroup>

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/06 webcrypto/02 SubtleCrypto/06 importKey.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/06 webcrypto/02 SubtleCrypto/06 importKey.md
@@ -1,0 +1,77 @@
+---
+title: 'importKey'
+excerpt: 'importKey imports a key from an external, portable format and gives you a CryptoKey object.'
+---
+
+The `importKey()` imports a key from an external, portable format, and gives you a [CryptoKey](/javascript-api/k6-experimental/webcrypto/cryptokey) object that can be used with the Web Crypto API.
+
+## Usage
+
+```
+importKey(format, keyData, algorithm, extractable, keyUsages)
+```
+
+## Parameters
+
+| Name          | Type                                                      | Description                                                                                                                                                   |
+| :------------ | :-------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `format`      | `string`                                                  | Defines the data format of the key to import. Currently supported formats: `raw`.                                                                             |
+| `keyData`     | `ArrayBuffer`, `TypedArray` or `DataView`                 | the data to import the key from.                                                                                                                              |
+| `algorithm`   | a `string` or object with a single `name` string property | The algorithm to use to import the key. Currently supported algorithms: `AES-CBC`, `AES-GCM`, `AES-CTR`, and `HMAC`.                                          |
+| `extractable` | `boolean`                                                 | Indicates whether it will be possible to export the key using [exportKey](/javascript-api/k6-experimental/webcrypto/subtlecrypto/exportkey).                  |
+| `keyUsages`   | `Array<string>`                                           | An array of strings describing what operations can be performed with the key. Currently supported usages include: `encrypt`, `decrypt`, `sign`, and `verify`. |
+
+## Return Value
+
+A `Promise` that resolves with the imported key as a [CryptoKey](/javascript-api/k6-experimental/webcrypto/cryptokey) object.
+
+## Throws
+
+| Type          | Description                                                                                     |
+| :------------ | :---------------------------------------------------------------------------------------------- |
+| `SyntaxError` | Raised when the `keyUsages` parameter is empty but the key is of type `secret` or `private`.    |
+| `TypeError`   | Raised when trying to use an invalid format, or if the `keyData` is not suited for that format. |
+
+## Example
+
+<CodeGroup labels={["example-webcrypto-importKey.js"]} lineNumbers={[]} showCopyButton={[true]}>
+
+```javascript
+import { crypto } from "k6/experimental/webcrypto";
+
+export default async function () {
+  /**
+   * Generate a symmetric key using the AES-CBC algorithm.
+   */
+  const generatedKey = await crypto.subtle.generateKey(
+    {
+      name: "AES-CBC",
+      length: "256"
+    },
+    true,
+    [
+      "encrypt",
+      "decrypt",
+    ]
+  );
+
+  /**
+   * Export the key in raw format.
+   */
+  const exportedKey = await crypto.subtle.exportKey("raw", generatedKey);
+
+  /**
+   * Reimport the key in raw format to verfiy its integrity.
+   */
+  const importedKey = await crypto.subtle.importKey(
+    "raw",
+    exportedKey,
+    "AES-CBC",
+    true, ["encrypt", "decrypt"]
+  );
+
+  console.log(JSON.stringify(importedKey))
+}
+```
+
+</CodeGroup>

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/06 webcrypto/02 SubtleCrypto/07 sign.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/06 webcrypto/02 SubtleCrypto/07 sign.md
@@ -1,0 +1,78 @@
+---
+title: 'sign'
+excerpt: 'sign generates a digital signature.'
+---
+
+The `sign()` operation generates a digital signature of the provided `data`, using the given [CryptoKey](/javascript-api/k6-experimental/webcrypto/cryptokey) object.
+
+## Usage
+
+```
+sign(algorithm, key, data)
+```
+
+## Parameters
+
+| Name        | Type                                                             | Description                                                  |
+| :---------- | :--------------------------------------------------------------- | :----------------------------------------------------------- |
+| `algorithm` | `string` or object with a single `name` string property          | The signature algorithm to use. Currently supported: `HMAC`. |
+| `key`       | [CryptoKey](/javascript-api/k6-experimental/webcrypto/cryptokey) | The key to use for signing.                                  |
+| `data`      | `ArrayBuffer`, `TypedArray`, or `DataView`                       | The data to be signed.                                       |
+
+## Return Value
+
+A `Promise` that resolves with the signature as an `ArrayBuffer`.
+
+## Throws
+
+| Type                 | Description                                                                                                            |
+| :------------------- | :--------------------------------------------------------------------------------------------------------------------- |
+| `InvalidAccessError` | Raised when the signing key either does not support signing operation, or is incompatible with the selected algorithm. |
+
+## Example
+
+<CodeGroup labels={["example-webcrypto-sign.js"]} lineNumbers={[]} showCopyButton={[true]}>
+
+```javascript
+import { crypto } from "k6/experimental/webcrypto";
+
+export default async function () {
+  const generatedKey = await crypto.subtle.generateKey(
+    {
+      name: "HMAC",
+      hash: { name: "SHA-1" },
+    },
+    true,
+    [
+      "sign",
+      "verify",
+    ]
+  );
+
+  const data = string2ArrayBuffer("Hello World");
+
+  /**
+   * Signes the encoded data with the provided key using the HMAC algorithm
+   * the returned signature can be verified using the verify method.
+   */
+  const signature = await crypto.subtle.sign("HMAC", generatedKey, data);
+
+  /**
+   * Verifies the signature of the encoded data with the provided key using the HMAC algorithm.
+   */
+  const verified = await crypto.subtle.verify("HMAC", generatedKey, signature, data);
+
+  console.log("verified: ", verified)
+}
+
+function string2ArrayBuffer(str) {
+  const buf = new ArrayBuffer(str.length * 2); // 2 bytes for each char
+  const bufView = new Uint16Array(buf);
+  for (let i = 0, strLen = str.length; i < strLen; i++) {
+      bufView[i] = str.charCodeAt(i);
+  }
+  return buf;
+}
+```
+
+</CodeGroup>

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/06 webcrypto/02 SubtleCrypto/08 verify.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/06 webcrypto/02 SubtleCrypto/08 verify.md
@@ -1,0 +1,79 @@
+---
+title: 'verify'
+excerpt: 'verify verifies a digital signature.'
+---
+
+The `verify()` operation verifies a digital signature. It ensures that some data was signed by a known key and that the data has not been tampered with since it was signed.
+
+## Usage
+
+```
+verify(algorithm, key, signature, data)
+```
+
+## Parameters
+
+| Name        | Type                                                             | Description                                        |
+| :---------- | :--------------------------------------------------------------- | :------------------------------------------------- |
+| `algorithm` | `string` or object with a single `name` string property          | The algorithm to use. Currently supported: `HMAC`. |
+| `key`       | [CryptoKey](/javascript-api/k6-experimental/webcrypto/cryptokey) | The key that will be used to verify the signature. |
+| `signature` | `ArrayBuffer`                                                    | The signature to verify.                           |
+| `data`      | `ArrayBuffer`                                                    | The data whose signature is to be verified.        |
+
+## Return Value
+
+A `Promise` that resolves to a `boolean` value indicating if the signature is valid.
+
+## Throws
+
+| Type                 | Description                                         |
+| :------------------- | :-------------------------------------------------- |
+| `InvalidAccessError` | Raised when the key either does not support the `verify` operation, or is incompatible with the selected algorithm. |
+
+## Example
+
+<CodeGroup labels={["example-webcrypto-verify.js"]} lineNumbers={[]} showCopyButton={[true]}>
+
+```javascript
+import { crypto } from "k6/experimental/webcrypto";
+
+export default async function () {
+  const generatedKey = await crypto.subtle.generateKey(
+    {
+      name: "HMAC",
+      hash: { name: "SHA-1" },
+    },
+    true,
+    [
+      "sign",
+      "verify",
+    ]
+  );
+
+  const data = string2ArrayBuffer("Hello World");
+
+  /**
+   * Signes the encoded data with the provided key using the HMAC algorithm
+   * the returned signature can be verified using the verify method.
+   */
+  const signature = await crypto.subtle.sign("HMAC", generatedKey, data);
+
+  /**
+   * Verifies the signature of the encoded data with the provided key using the HMAC algorithm.
+   */
+  const verified = await crypto.subtle.verify("HMAC", generatedKey, signature, data);
+
+  console.log("verified: ", verified)
+}
+
+function string2ArrayBuffer(str) {
+  const buf = new ArrayBuffer(str.length * 2); // 2 bytes for each char
+  const bufView = new Uint16Array(buf);
+  for (let i = 0, strLen = str.length; i < strLen; i++) {
+      bufView[i] = str.charCodeAt(i);
+  }
+  return buf;
+}
+```
+
+</CodeGroup>

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/06 webcrypto/03 CryptoKey.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/06 webcrypto/03 CryptoKey.md
@@ -1,0 +1,15 @@
+---
+title: 'CryptoKey'
+excerpt: 'CryptoKey represents a cryptographic key used for encryption, decryption, signing, or verification.'
+---
+
+The `CryptoKey` object represents a cryptographic key used for [encryption](/javascript-api/k6-experimental/webcrypto/subtlecrypto/encrypt), [decryption](/javascript-api/k6-experimental/webcrypto/subtlecrypto/decrypt), [signing](/javascript-api/k6-experimental/webcrypto/subtlecrypto/sign), or [verification](/javascript-api/k6-experimental/webcrypto/subtlecrypto/verify) within the webcrypto module. The `CryptoKey` object is created using the SubtleCrypto.generateKey() or SubtleCrypto.importKey() methods.
+
+## Properties
+
+| Property    | Type       | Description                                                                                                                                                                                                  |
+| :---------- | :--------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| type        | `string`   | Indicates the type of the key material. Possible values are `public`, `private`, `secret`, `unspecified`, or `unknown`.                                                                            |
+| extractable | `boolean`  | Indicates whether the raw key material can be exported.                                                                                                                                           |
+| algorithm   | `object`   | An object containing the algorithm used to generate or import the key.                                                                                                                                       |
+| usages      | `string[]` | An array of strings indicating the cryptographic operations that the key can be used for. Possible values are `encrypt`, `decrypt`, `sign`, `verify`, `deriveKey`, `deriveBits`, `wrapKey`, and `unwrapKey`. |

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/06 webcrypto/04 AesKeyGenParams.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/06 webcrypto/04 AesKeyGenParams.md
@@ -1,0 +1,37 @@
+---
+title: 'AesKeyGenParams'
+excerpt: 'AesKeyGenParams represents the object that should be passed as the algorithm parameter into the generateKey operation, when generating an AES key.'
+---
+
+The `AesKeyGenParams` object represents the object that should be passed as the algorithm parameter into the [generateKey](/javascript-api/k6-experimental/webcrypto/subtlecrypto/generatekey) operation when generating an AES key.
+
+## Properties
+
+| Property | Type     | Description                                                                        |
+| :------- | :------- | :--------------------------------------------------------------------------------- |
+| name     | `string` | The name of the algorithm. Possible values are `AES-CBC`, `AES-CTR`, and `AES-GCM`.|
+| length   | `number` | The length of the key in bits. Possible values are 128, 192 or 256.                |
+
+## Example
+
+<CodeGroup labels={["example-webcrypto-aeskeygenparams.js"]} lineNumbers={[]} showCopyButton={[true]}>
+
+```javascript
+import { crypto } from "k6/experimental/webcrypto";
+
+export default async function () {
+  const key = await crypto.subtle.generateKey(
+    {
+      name: "AES-CBC",
+      length: 256
+    },
+    true,
+    [
+      "encrypt",
+      "decrypt",
+    ]
+  );
+}
+```
+
+</CodeGroup>

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/06 webcrypto/05 HmacKeyGenParams.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/06 webcrypto/05 HmacKeyGenParams.md
@@ -1,0 +1,39 @@
+---
+title: 'HmacKeyGenParams'
+excerpt: 'HmacKeyGenParams represents the object that should be passed as the algorithm parameter into the generateKey operation, when generating an HMAC key.'
+---
+
+The `HmacKeyGenParams` object represents the object that should be passed as the algorithm parameter into the [generateKey](/javascript-api/k6-experimental/webcrypto/subtlecrypto/generatekey) operation when generating an HMAC key.
+
+## Properties
+
+| Property          | Type     | Description                                                                                                                                                                                                                                     |
+| :---------------- | :------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| name              | `string` | The should be set to `HMAC`.                                                                                                                                                                                                                    |
+| hash              | `string` | The name of the digest function to use. Possible values are `SHA-1`, `SHA-256`, `SHA-384` and `SHA-512`.                                                                                                                                        |
+| length (optional) | `number` | The length of the key in bits. If this is omitted, the length of the key is equal to the block size of the hash function you have chosen. We recommend to leave this parameter empty, unless you have a good reason to use something different. |
+
+## Example
+
+<CodeGroup labels={["example-webcrypto-hmackeygenparams.js"]} lineNumbers={[]} showCopyButton={[true]}>
+
+```javascript
+import { crypto } from "k6/experimental/webcrypto";
+
+export default async function () {
+  const key = await crypto.subtle.generateKey(
+    {
+      name: "HMAC",
+      hash: { name: "SHA-512" },
+      length: 256,
+    },
+    true,
+    [
+      "sign",
+      "verify",
+    ]
+  );
+}
+```
+
+</CodeGroup>

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/06 webcrypto/06 AesCtrParams.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/06 webcrypto/06 AesCtrParams.md
@@ -1,0 +1,65 @@
+---
+title: 'AesCtrParams'
+excerpt: 'AesCtrParams represents the object that should be passed as the algorithm parameter into the encrypt and decrypt operation when using the AES-CTR algorithm.'
+---
+
+The `AesCtrParams` object represents the object that should be passed as the algorithm parameter into the [encrypt](/javascript-api/k6-experimental/webcrypto/subtlecrypto/encrypt) and [decrypt](/javascript-api/k6-experimental/webcrypto/subtlecrypto/decrypt) operation when using the AES-CTR algorithm.
+
+For more details, head to the MDN Web Crypto API documentation on [AES-CTR](https://developer.mozilla.org/en-US/docs/Web/API/AesCtrParams).
+
+## Properties
+
+| Property | Type                                       | Description                                                         |
+| :------- | :----------------------------------------- | :------------------------------------------------------------------ |
+| name     | `string`                                   | Should be set to `AES-CTR`.                                         |
+| counter  | `ArrayBuffer`, `TypedArray`, or `DataView` | The initial value of the counter block. This must be 16-bytes long, like the AES block size.                  |
+| length   | `number`                                   | The number of bits in the counter block that are used for the actual counter. It is recommended to use 64 (half of the counter block). |
+
+## Example
+
+<CodeGroup labels={["example-webcrypto-aesctrparams.js"]} lineNumbers={[]} showCopyButton={[true]}>
+
+```javascript
+import { crypto } from "k6/experimental/webcrypto";
+
+export default async function () {
+  const plaintext = stringToArrayBuffer("Hello, World!");
+
+  /**
+   * Generate a symmetric key using the AES-CTR algorithm.
+   */
+  const key = await crypto.subtle.generateKey(
+    {
+      name: "AES-CTR",
+      length: 256,
+    },
+    true,
+    ["encrypt", "decrypt"]
+  );
+
+  /**
+   * Encrypt the plaintext using the AES-CTR key with
+   * have generated.
+   */
+  const ciphertext = await crypto.subtle.encrypt(
+    {
+      name: "AES-CTR",
+      counter: crypto.getRandomValues(new Uint8Array(16)),
+      length: 128,
+    },
+    key,
+    plaintext
+  );
+}
+
+function stringToArrayBuffer(str) {
+  const buf = new ArrayBuffer(str.length * 2); // 2 bytes for each char
+  const bufView = new Uint16Array(buf);
+  for (let i = 0, strLen = str.length; i < strLen; i++) {
+    bufView[i] = str.charCodeAt(i);
+  }
+  return buf;
+}
+```
+
+</CodeGroup>

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/06 webcrypto/07 AesCbcParams.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/06 webcrypto/07 AesCbcParams.md
@@ -1,0 +1,63 @@
+---
+title: 'AesCbcParams'
+excerpt: 'AesCbcParams represents the object that should be passed as the algorithm parameter into the encrypt and decrypt operation when using the AES-CBC algorithm.'
+---
+
+The `AesCbcParams` object represents the object that should be passed as the algorithm parameter into the [encrypt](/javascript-api/k6-experimental/webcrypto/subtlecrypto/encrypt) and [decrypt](/javascript-api/k6-experimental/webcrypto/subtlecrypto/decrypt) operation when using the AES-CBC algorithm.
+
+For more details, head to the [MDN Web Crypto API documentation on AES-CBC](https://developer.mozilla.org/en-US/docs/Web/API/AesCbcParams).
+
+## Properties
+
+| Property | Type                                       | Description                                                         |
+| :------- | :----------------------------------------- | :------------------------------------------------------------------ |
+| name     | `string`                                   | Should be set to `AES-CBC`.                                         |
+| iv       | `ArrayBuffer`, `TypedArray`, or `DataView` | The initialization vector. Must be 16 bytes, unpredictable and cryptographically random. Yet, it doesn't need to be secret and can be transmitted along with the ciphertext. |
+
+## Example
+
+<CodeGroup labels={["example-webcrypto-aescbcparams.js"]} lineNumbers={[]} showCopyButton={[true]}>
+
+```javascript
+import { crypto } from "k6/experimental/webcrypto";
+
+export default async function () {
+  const plaintext = stringToArrayBuffer("Hello, World!");
+
+  /**
+   * Generate a symmetric key using the AES-CBC algorithm.
+   */
+  const key = await crypto.subtle.generateKey(
+    {
+      name: "AES-CBC",
+      length: 256,
+    },
+    true,
+    ["encrypt", "decrypt"]
+  );
+
+  /**
+   * Encrypt the plaintext using the AES-CBC key with
+   * have generated.
+   */
+  const ciphertext = await crypto.subtle.encrypt(
+    {
+      name: "AES-CBC",
+      iv: crypto.getRandomValues(new Uint8Array(16)),
+    },
+    key,
+    plaintext
+  );
+}
+
+function stringToArrayBuffer(str) {
+  const buf = new ArrayBuffer(str.length * 2); // 2 bytes for each char
+  const bufView = new Uint16Array(buf);
+  for (let i = 0, strLen = str.length; i < strLen; i++) {
+    bufView[i] = str.charCodeAt(i);
+  }
+  return buf;
+}
+```
+
+</CodeGroup>

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/06 webcrypto/08 AesGcmParams.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/06 webcrypto/08 AesGcmParams.md
@@ -1,0 +1,65 @@
+---
+title: 'AesGcmParams'
+excerpt: 'AesGcmParams represents the object that should be passed as the algorithm parameter into the encrypt and decrypt operation when using the AES-GCM algorithm.'
+---
+
+The `AesGcmParams` object represents the object that should be passed as the algorithm parameter into the [encrypt](/javascript-api/k6-experimental/webcrypto/subtlecrypto/encrypt) and [decrypt](/javascript-api/k6-experimental/webcrypto/subtlecrypto/decrypt) operation when using the AES-GCM algorithm.
+
+For more details, head to the [MDN Web Crypto API documentation on AES-GCM](https://developer.mozilla.org/en-US/docs/Web/API/AesGcmParams).
+
+## Properties
+
+| Property                  | Type                                       | Description                                                                                                                                                                                                                                                                                              |
+| :------------------------ | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| name                      | `string`                                   | Should be set to `AES-GCM`.                                                                                                                                                                                                                                                                              |
+| iv                        | `ArrayBuffer`, `TypedArray`, or `DataView` | The initialization vector. It must be 12 bytes long, unpredictable and cryptographically random. It must be unique for every encryption operation carried out with a given key. Never reuse an iv with the same key. Yet, it doesn't need to be secret and can be transmitted along with the ciphertext. |
+| additionalData (optional) | `ArrayBuffer`, `TypedArray` or `DataView`  | Additional data that should be authenticated, but not encrypted. It must be included in the calculation of the authentication tag, but not encrypted itself.                                                                                                                                             |
+| tagLength (optional)      | `number`                                   | The length of the authentication tag in bits. Should be set, and will default to 96.                                                                                                                                                                                                                     |
+
+## Example
+
+<CodeGroup labels={["example-webcrypto-aesgcmparams.js"]} lineNumbers={[]} showCopyButton={[true]}>
+
+```javascript
+import { crypto } from "k6/experimental/webcrypto";
+
+export default async function () {
+  const plaintext = stringToArrayBuffer("Hello, World!");
+
+  /**
+   * Generate a symmetric key using the AES-CBC algorithm.
+   */
+  const key = await crypto.subtle.generateKey(
+    {
+      name: "AES-GCM",
+      length: 256,
+    },
+    true,
+    ["encrypt", "decrypt"]
+  );
+
+  /**
+   * Encrypt the plaintext using the AES-CBC key with
+   * have generated.
+   */
+  const ciphertext = await crypto.subtle.encrypt(
+    {
+      name: "AES-GCM",
+      iv: crypto.getRandomValues(new Uint8Array(12)),
+    },
+    key,
+    plaintext
+  );
+}
+
+function stringToArrayBuffer(str) {
+  const buf = new ArrayBuffer(str.length * 2); // 2 bytes for each char
+  const bufView = new Uint16Array(buf);
+  for (let i = 0, strLen = str.length; i < strLen; i++) {
+    bufView[i] = str.charCodeAt(i);
+  }
+  return buf;
+}
+```
+
+</CodeGroup>


### PR DESCRIPTION
This PR adds a dedicated documentation section for the newly introduced `k6/experimental/webcrypto` module.

This was a long-haul batch of work and is probably riddled with mistakes and forgotten information. Please don't hesitate to poke and provide feedback and requests for corrections.

Although the module is not 100% on par with the specification yet, I described only the supported methods and algorithms without outlining what was missing. If you think we should write it in a clearer way somewhere, please let me know.

PS: I took a lot of inspiration from the wording used on MDN, I'd like to credit them, but then I'd need to do it everywhere. What would be the canonical way to do that?