### PR TITLE
docs for httpx v0.1.0

### DIFF
--- a/src/data/markdown/docs/20 jslib/01 jslib/02 httpx.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/02 httpx.md
@@ -13,7 +13,7 @@ It's a http client with features that are not yet available in the native module
 httpx module integrates well with the expect library. 
 
 
-The source code is [on GitHub](https://github.com/k6io/k6-jslib-httpx). . 
+The source code is [on GitHub](https://github.com/k6io/k6-jslib-httpx).
 Please request features and report bugs through [GitHub issues](https://github.com/k6io/k6-jslib-httpx/issues).
 
 <Blockquote mod='attention'>
@@ -29,22 +29,23 @@ This documentation is for the only last version only. If you discover that some 
 
 ### Methods
 
-| Function | Description |
-| -------- | ----------- |
-| [request(method, url, [body], [params])](/javascript-api/jslib/httpx/request)  | Generic method for making arbitrary HTTP requests. |
-| [get(url, [body], [params])](/javascript-api/jslib/httpx/get)  | Makes GET request |
-| [post(url, [body], [params])](/javascript-api/jslib/httpx/post)  | Makes POST request |
-| [put(url, [body], [params])](/javascript-api/jslib/httpx/put)  | Makes PUT request |
-| [patch(url, [body], [params])](/javascript-api/jslib/httpx/patch)  | Makes PATCH request |
-| [delete(url, [body], [params])](/javascript-api/jslib/httpx/delete)  | Makes DELETE request |
-| [batch(requests)](/javascript-api/jslib/httpx/batch)  | Batch multiple HTTP requests together, to issue them in parallel. |
-| [setBaseUrl(url)](/javascript-api/jslib/httpx/setbaseurl)  | Sets the base URL for the session |
-| [addHeader(key, value)](/javascript-api/jslib/httpx/addheader)  | Adds a header to the session |
-| [addHeaders(object)](/javascript-api/jslib/httpx/addheaders)  | Adds multiple headers to the session |
-| [clearHeader(name)](/javascript-api/jslib/httpx/clearheader)  | Removes header from the session |
-| [addTag(key, value)](/javascript-api/jslib/httpx/addtag)  | Adds a tag to the session |
-| [addTags(object)](/javascript-api/jslib/httpx/addtags)  | Adds multiple tags to the session |
-| [clearTag(name)](/javascript-api/jslib/httpx/cleartag)  | Removes tag from the session |
+| Function                                                                                | Description                                                       |
+|-----------------------------------------------------------------------------------------|-------------------------------------------------------------------|
+| [asyncRequest(method, url, [body], [params])](/javascript-api/jslib/httpx/asyncrequest) | Generic method for making arbitrary, asynchronous HTTP requests.  |
+| [request(method, url, [body], [params])](/javascript-api/jslib/httpx/request)           | Generic method for making arbitrary HTTP requests.                |
+| [get(url, [body], [params])](/javascript-api/jslib/httpx/get)                           | Makes GET request                                                 |
+| [post(url, [body], [params])](/javascript-api/jslib/httpx/post)                         | Makes POST request                                                |
+| [put(url, [body], [params])](/javascript-api/jslib/httpx/put)                           | Makes PUT request                                                 |
+| [patch(url, [body], [params])](/javascript-api/jslib/httpx/patch)                       | Makes PATCH request                                               |
+| [delete(url, [body], [params])](/javascript-api/jslib/httpx/delete)                     | Makes DELETE request                                              |
+| [batch(requests)](/javascript-api/jslib/httpx/batch)                                    | Batch multiple HTTP requests together, to issue them in parallel. |
+| [setBaseUrl(url)](/javascript-api/jslib/httpx/setbaseurl)                               | Sets the base URL for the session                                 |
+| [addHeader(key, value)](/javascript-api/jslib/httpx/addheader)                          | Adds a header to the session                                      |
+| [addHeaders(object)](/javascript-api/jslib/httpx/addheaders)                            | Adds multiple headers to the session                              |
+| [clearHeader(name)](/javascript-api/jslib/httpx/clearheader)                            | Removes header from the session                                   |
+| [addTag(key, value)](/javascript-api/jslib/httpx/addtag)                                | Adds a tag to the session                                         |
+| [addTags(object)](/javascript-api/jslib/httpx/addtags)                                  | Adds multiple tags to the session                                 |
+| [clearTag(name)](/javascript-api/jslib/httpx/cleartag)                                  | Removes tag from the session                                      |
 
 
 
@@ -55,7 +56,7 @@ This documentation is for the only last version only. If you discover that some 
 
 ```javascript
 import { fail } from 'k6';
-import { Httpx } from 'https://jslib.k6.io/httpx/0.0.3/index.js';
+import { Httpx } from 'https://jslib.k6.io/httpx/0.1.0/index.js';
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.2.0/index.js';
 
 const USERNAME = `user${randomIntBetween(1, 100000)}@example.com`; // random email address

--- a/src/data/markdown/docs/20 jslib/01 jslib/02 httpx.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/02 httpx.md
@@ -38,7 +38,7 @@ This documentation is for the only last version only. If you discover that some 
 | [put(url, [body], [params])](/javascript-api/jslib/httpx/put)                           | Makes PUT request                                                 |
 | [patch(url, [body], [params])](/javascript-api/jslib/httpx/patch)                       | Makes PATCH request                                               |
 | [delete(url, [body], [params])](/javascript-api/jslib/httpx/delete)                     | Makes DELETE request                                              |
-| [batch(requests)](/javascript-api/jslib/httpx/batch)                                    | Batch multiple HTTP requests together, to issue them in parallel. |
+| [batch(requests)](/javascript-api/jslib/httpx/batch)                                    | Batches multiple HTTP requests together to issue them in parallel. |
 | [setBaseUrl(url)](/javascript-api/jslib/httpx/setbaseurl)                               | Sets the base URL for the session                                 |
 | [addHeader(key, value)](/javascript-api/jslib/httpx/addheader)                          | Adds a header to the session                                      |
 | [addHeaders(object)](/javascript-api/jslib/httpx/addheaders)                            | Adds multiple headers to the session                              |

--- a/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/08 asyncRequest(method, url, [body], [params]).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/08 asyncRequest(method, url, [body], [params]).md
@@ -1,14 +1,12 @@
 ---
-title: 'request(method, url, [body], [params])'
-head_title: 'httpx.request()'
-description: 'Generic method for making arbitrary HTTP requests'
-excerpt: 'Generic method for making arbitrary HTTP requests'
+title: 'asyncRequest(method, url, [body], [params])'
+head_title: 'httpx.asyncRequest()'
+description: 'Generic method for making asynchronous HTTP requests'
+excerpt: 'Generic method for making asynchronous HTTP requests'
 ---
 
-Generic method for making arbitrary HTTP requests. 
-
-Consider using specific methods for making common requests ([get](/javascript-api/jslib/httpx/get), [post](/javascript-api/jslib/httpx/post), [put](/javascript-api/jslib/httpx/put), [patch](/javascript-api/jslib/httpx/patch))
-
+Generic method for making arbitrary asynchronous HTTP requests. 
+Note, this method returns a Promise. You must use the `await` keyword to resolve it. 
 
 | Parameter         | Type                                                                                      | Description                                                                                 |
 |-------------------|-------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
@@ -20,9 +18,9 @@ Consider using specific methods for making common requests ([get](/javascript-ap
 
 ### Returns
 
-| Type                                         | Description           |
-| -------------------------------------------- | --------------------- |
-| [Response](/javascript-api/k6-http/response) | HTTP [Response](/javascript-api/k6-http/response) object. |
+| Type                  | Description                                                |
+|-----------------------|------------------------------------------------------------|
+| Promise with Response | HTTP [Response](/javascript-api/k6-http/response) object.  |
 
 
 ### Example
@@ -37,12 +35,19 @@ const session = new Httpx({
   timeout: 20000, // 20s timeout.
 });
 
-export default function testSuite() {
-  const resp_get = session.request('GET', `/status/200`);
-  const resp_post = session.request('POST', `/status/200`, { key: 'value' });
-  const resp_put = session.request('PUT', `/status/200`, { key: 'value' });
-  const resp_patch = session.request('PATCH', `/status/200`, { key: 'value' });
-  const resp_delete = session.request('DELETE', `/status/200`);
+export default async function testSuite() {
+  const resp_get = await session.asyncRequest('GET', `/status/200`);
+  const resp_post = await session.asyncRequest('POST', `/status/200`, { key: 'value' });
+  const resp_put = await session.asyncRequest('PUT', `/status/200`, { key: 'value' });
+  const resp_patch = await session.asyncRequest('PATCH', `/status/200`, { key: 'value' });
+  const resp_delete = await session.asyncRequest('DELETE', `/status/200`);
+
+  // specific methods are also available.
+  const respGet = await session.asyncGet(`/status/200`);
+  const respPost = await session.asyncPost(`/status/200`, { key: 'value' });
+  const respPut = await session.asyncPut(`/status/200`, { key: 'value' });
+  const respPatch = await session.asyncPatch(`/status/200`, { key: 'value' });
+  const respDelete = await session.asyncDelete(`/status/200`);
 }
 ```
 

--- a/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/08 asyncRequest(method, url, [body], [params]).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/08 asyncRequest(method, url, [body], [params]).md
@@ -10,7 +10,7 @@ Note, this method returns a Promise. You must use the `await` keyword to resolve
 
 | Parameter         | Type                                                                                      | Description                                                                                 |
 |-------------------|-------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
-| method            | string                                                                                    | HTTP method. Note, the method must be uppercase (GET, POST, PUT, PATCH, OPTIONS, HEAD, etc) |
+| method            | string                                                                                    | HTTP method. Must be uppercase (GET, POST, PUT, PATCH, OPTIONS, HEAD, etc) |
 | url               | string                                                                                    | HTTP URL. If baseURL is set, provide only path.                                             |
 | body (optional)   | null / string / object / ArrayBuffer / [SharedArray](/javascript-api/k6-data/sharedarray) | Request body; objects will be `x-www-form-urlencoded`. Set to `null` to omit the body.      |
 | params (optional) | null or object {}                                                                         | Additional [parameters](/javascript-api/k6-http/params) for this specific request.          |

--- a/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/09 request(method, url, [body], [params]).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/09 request(method, url, [body], [params]).md
@@ -12,7 +12,7 @@ Consider using specific methods for making common requests ([get](/javascript-ap
 
 | Parameter         | Type                                                                                      | Description                                                                                 |
 |-------------------|-------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
-| method            | string                                                                                    | HTTP method. Note, the method must be uppercase (GET, POST, PUT, PATCH, OPTIONS, HEAD, etc) |
+| method            | string                                                                                    | HTTP method. Must be uppercase (GET, POST, PUT, PATCH, OPTIONS, HEAD, etc) |
 | url               | string                                                                                    | HTTP URL. If baseURL is set, provide only path.                                             |
 | body (optional)   | null / string / object / ArrayBuffer / [SharedArray](/javascript-api/k6-data/sharedarray) | Request body; objects will be `x-www-form-urlencoded`. Set to `null` to omit the body.      |
 | params (optional) | null or object {}                                                                         | Additional [parameters](/javascript-api/k6-http/params) for this specific request.          |

--- a/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/09 request(method, url, [body], [params]).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/09 request(method, url, [body], [params]).md
@@ -14,7 +14,7 @@ Consider using specific methods for making common requests ([get](/javascript-ap
 |-------------------|-------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
 | method            | string                                                                                    | HTTP method. Must be uppercase (GET, POST, PUT, PATCH, OPTIONS, HEAD, etc) |
 | url               | string                                                                                    | HTTP URL. If baseURL is set, provide only path.                                             |
-| body (optional)   | null / string / object / ArrayBuffer / [SharedArray](/javascript-api/k6-data/sharedarray) | Request body; objects will be `x-www-form-urlencoded`. Set to `null` to omit the body.      |
+| body (optional)   | null / string / object / ArrayBuffer / [SharedArray](/javascript-api/k6-data/sharedarray) | Request body; objects are `x-www-form-urlencoded`. To omit body, set to `null`.      |
 | params (optional) | null or object {}                                                                         | Additional [parameters](/javascript-api/k6-http/params) for this specific request.          |
 
 

--- a/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/10 get(url, [body], [params]).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/10 get(url, [body], [params]).md
@@ -7,16 +7,16 @@ excerpt: 'httpx.get makes GET requests'
 `session.get(url, body, params)` makes a GET request. Only the URL parameter is required
 
 
-| Parameter      | Type   | Description                                                                          |
-| -------------- | ------ | ------------------------------------------------------------------------------------ |
-| url  | string    | HTTP URL. If baseURL is set, provide only path. |
-| body (optional) | null / string / object / ArrayBuffer / [SharedArray](/javascript-api/k6-data/sharedarray) | Set to `null` to omit the body. |
-| params (optional) | null or object {} | Additional [parameters](/javascript-api/k6-http/params) for this specific request. |
+| Parameter         | Type                                                                                      | Description                                                                          |
+|-------------------|-------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
+| url               | string                                                                                    | HTTP URL. If baseURL is set, provide only path.                                      |
+| body (optional)   | null / string / object / ArrayBuffer / [SharedArray](/javascript-api/k6-data/sharedarray) | Set to `null` to omit the body.                                                      |
+| params (optional) | null or object {}                                                                         | Additional [parameters](/javascript-api/k6-http/params) for this specific request.   |
 
 ### Returns
 
-| Type                                         | Description           |
-| -------------------------------------------- | --------------------- |
+| Type                                         | Description                                               |
+| -------------------------------------------- |-----------------------------------------------------------|
 | [Response](/javascript-api/k6-http/response) | HTTP [Response](/javascript-api/k6-http/response) object. |
 
 ### Example
@@ -24,7 +24,7 @@ excerpt: 'httpx.get makes GET requests'
 <CodeGroup labels={[]}>
 
 ```javascript
-import { Httpx } from 'https://jslib.k6.io/httpx/0.0.4/index.js';
+import { Httpx } from 'https://jslib.k6.io/httpx/0.1.0/index.js';
 
 const session = new Httpx({
   baseURL: 'https://test-api.k6.io',

--- a/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/11 post(url, [body], [params]).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/11 post(url, [body], [params]).md
@@ -6,16 +6,16 @@ excerpt: 'httpx.post makes POST requests'
 ---
 
 
-| Parameter      | Type   | Description                                                                          |
-| -------------- | ------ | ------------------------------------------------------------------------------------ |
-| url  | string    | HTTP URL. If baseURL is set, provide only path. |
-| body (optional) | null / string / object / ArrayBuffer / [SharedArray](/javascript-api/k6-data/sharedarray) | Request body; objects will be `x-www-form-urlencoded`. Set to `null` to omit the body. |
-| params (optional) | null or object {} | Additional [parameters](/javascript-api/k6-http/params) for this specific request. |
+| Parameter         | Type                                                                                      | Description                                                                            |
+|-------------------|-------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------|
+| url               | string                                                                                    | HTTP URL. If baseURL is set, provide only path.                                        |
+| body (optional)   | null / string / object / ArrayBuffer / [SharedArray](/javascript-api/k6-data/sharedarray) | Request body; objects will be `x-www-form-urlencoded`. Set to `null` to omit the body. |
+| params (optional) | null or object {}                                                                         | Additional [parameters](/javascript-api/k6-http/params) for this specific request.     |
 
 ### Returns
 
-| Type                                         | Description           |
-| -------------------------------------------- | --------------------- |
+| Type                                         | Description                                               |
+|----------------------------------------------|-----------------------------------------------------------|
 | [Response](/javascript-api/k6-http/response) | HTTP [Response](/javascript-api/k6-http/response) object. |
 
 
@@ -24,7 +24,7 @@ excerpt: 'httpx.post makes POST requests'
 <CodeGroup labels={[]}>
 
 ```javascript
-import { Httpx } from 'https://jslib.k6.io/httpx/0.0.4/index.js';
+import { Httpx } from 'https://jslib.k6.io/httpx/0.1.0/index.js';
 
 const session = new Httpx({
   baseURL: 'https://test-api.k6.io',

--- a/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/11 post(url, [body], [params]).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/11 post(url, [body], [params]).md
@@ -9,7 +9,7 @@ excerpt: 'httpx.post makes POST requests'
 | Parameter         | Type                                                                                      | Description                                                                            |
 |-------------------|-------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------|
 | url               | string                                                                                    | HTTP URL. If baseURL is set, provide only path.                                        |
-| body (optional)   | null / string / object / ArrayBuffer / [SharedArray](/javascript-api/k6-data/sharedarray) | Request body; objects will be `x-www-form-urlencoded`. Set to `null` to omit the body. |
+| body (optional)   | null / string / object / ArrayBuffer / [SharedArray](/javascript-api/k6-data/sharedarray) | Request body; objects are `x-www-form-urlencoded`. To omit body, set to `null` . |
 | params (optional) | null or object {}                                                                         | Additional [parameters](/javascript-api/k6-http/params) for this specific request.     |
 
 ### Returns

--- a/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/12 put(url, [body], [params]).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/12 put(url, [body], [params]).md
@@ -11,7 +11,7 @@ excerpt: 'httpx.put makes PUT requests'
 | Parameter         | Type                                                                                      | Description                                                                            |
 |-------------------|-------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------|
 | url               | string                                                                                    | HTTP URL. If baseURL is set, provide only path.                                        |
-| body (optional)   | null / string / object / ArrayBuffer / [SharedArray](/javascript-api/k6-data/sharedarray) | Request body; objects will be `x-www-form-urlencoded`. Set to `null` to omit the body. |
+| body (optional)   | null / string / object / ArrayBuffer / [SharedArray](/javascript-api/k6-data/sharedarray) | Request body; objects are `x-www-form-urlencoded`. To omit body, set to `null`. |
 | params (optional) | null or object {}                                                                         | Additional [parameters](/javascript-api/k6-http/params) for this specific request.     |
 
 ### Returns

--- a/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/12 put(url, [body], [params]).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/12 put(url, [body], [params]).md
@@ -8,16 +8,16 @@ excerpt: 'httpx.put makes PUT requests'
 `session.put(url, body, params)` makes a PUT request. Only the first parameter is required
 
 
-| Parameter      | Type   | Description                                                                          |
-| -------------- | ------ | ------------------------------------------------------------------------------------ |
-| url  | string    | HTTP URL. If baseURL is set, provide only path. |
-| body (optional) | null / string / object / ArrayBuffer / [SharedArray](/javascript-api/k6-data/sharedarray) | Request body; objects will be `x-www-form-urlencoded`. Set to `null` to omit the body. |
-| params (optional) | null or object {} | Additional [parameters](/javascript-api/k6-http/params) for this specific request. |
+| Parameter         | Type                                                                                      | Description                                                                            |
+|-------------------|-------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------|
+| url               | string                                                                                    | HTTP URL. If baseURL is set, provide only path.                                        |
+| body (optional)   | null / string / object / ArrayBuffer / [SharedArray](/javascript-api/k6-data/sharedarray) | Request body; objects will be `x-www-form-urlencoded`. Set to `null` to omit the body. |
+| params (optional) | null or object {}                                                                         | Additional [parameters](/javascript-api/k6-http/params) for this specific request.     |
 
 ### Returns
 
-| Type                                         | Description           |
-| -------------------------------------------- | --------------------- |
+| Type                                         | Description                                               |
+|----------------------------------------------|-----------------------------------------------------------|
 | [Response](/javascript-api/k6-http/response) | HTTP [Response](/javascript-api/k6-http/response) object. |
 
 
@@ -26,7 +26,7 @@ excerpt: 'httpx.put makes PUT requests'
 <CodeGroup labels={[]}>
 
 ```javascript
-import { Httpx } from 'https://jslib.k6.io/httpx/0.0.4/index.js';
+import { Httpx } from 'https://jslib.k6.io/httpx/0.1.0/index.js';
 
 const session = new Httpx({
   baseURL: 'https://httpbin.test.k6.io',

--- a/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/13 patch(url, [body], [params]).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/13 patch(url, [body], [params]).md
@@ -8,16 +8,16 @@ excerpt: 'httpx.patch makes PATCH requests'
 `session.patch(url, body, params)` makes a PATCH request. Only the first parameter is required
 
 
-| Parameter      | Type   | Description                                                                          |
-| -------------- | ------ | ------------------------------------------------------------------------------------ |
-| url  | string    | HTTP URL. If baseURL is set, provide only path. |
-| body (optional) | null / string / object / ArrayBuffer / [SharedArray](/javascript-api/k6-data/sharedarray) | Request body; objects will be `x-www-form-urlencoded`. Set to `null` to omit the body. |
-| params (optional) | null or object {} | Additional [parameters](/javascript-api/k6-http/params) for this specific request. |
+| Parameter         | Type                                                                                      | Description                                                                            |
+|-------------------|-------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------|
+| url               | string                                                                                    | HTTP URL. If baseURL is set, provide only path.                                        |
+| body (optional)   | null / string / object / ArrayBuffer / [SharedArray](/javascript-api/k6-data/sharedarray) | Request body; objects will be `x-www-form-urlencoded`. Set to `null` to omit the body. |
+| params (optional) | null or object {}                                                                         | Additional [parameters](/javascript-api/k6-http/params) for this specific request.     |
 
 ### Returns
 
-| Type                                         | Description           |
-| -------------------------------------------- | --------------------- |
+| Type                                         | Description                                               |
+|----------------------------------------------|-----------------------------------------------------------|
 | [Response](/javascript-api/k6-http/response) | HTTP [Response](/javascript-api/k6-http/response) object. |
 
 
@@ -26,7 +26,7 @@ excerpt: 'httpx.patch makes PATCH requests'
 <CodeGroup labels={[]}>
 
 ```javascript
-import { Httpx } from 'https://jslib.k6.io/httpx/0.0.4/index.js';
+import { Httpx } from 'https://jslib.k6.io/httpx/0.1.0/index.js';
 
 const session = new Httpx({
   baseURL: 'https://httpbin.test.k6.io',

--- a/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/13 patch(url, [body], [params]).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/13 patch(url, [body], [params]).md
@@ -11,7 +11,7 @@ excerpt: 'httpx.patch makes PATCH requests'
 | Parameter         | Type                                                                                      | Description                                                                            |
 |-------------------|-------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------|
 | url               | string                                                                                    | HTTP URL. If baseURL is set, provide only path.                                        |
-| body (optional)   | null / string / object / ArrayBuffer / [SharedArray](/javascript-api/k6-data/sharedarray) | Request body; objects will be `x-www-form-urlencoded`. Set to `null` to omit the body. |
+| body (optional)   | null / string / object / ArrayBuffer / [SharedArray](/javascript-api/k6-data/sharedarray) | Request body; objects are `x-www-form-urlencoded`. To omit body, set to `null` . |
 | params (optional) | null or object {}                                                                         | Additional [parameters](/javascript-api/k6-http/params) for this specific request.     |
 
 ### Returns

--- a/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/14 delete(url, [body], [params]).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/14 delete(url, [body], [params]).md
@@ -7,16 +7,16 @@ excerpt: 'httpx.delete makes DELETE requests'
 `session.delete(url, body, params)` makes a DELETE request. Only the first parameter is required. Body is discouraged. 
 
 
-| Parameter      | Type   | Description                                                                          |
-| -------------- | ------ | ------------------------------------------------------------------------------------ |
-| url  | string    | HTTP URL. If baseURL is set, provide only path. |
-| body (optional) | null / string / object / ArrayBuffer / [SharedArray](/javascript-api/k6-data/sharedarray) | Request body; objects will be `x-www-form-urlencoded`. Set to `null` to omit the body. |
-| params (optional) | null or object {} | Additional [parameters](/javascript-api/k6-http/params) for this specific request. |
+| Parameter         | Type                                                                                      | Description                                                                            |
+|-------------------|-------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------|
+| url               | string                                                                                    | HTTP URL. If baseURL is set, provide only path.                                        |
+| body (optional)   | null / string / object / ArrayBuffer / [SharedArray](/javascript-api/k6-data/sharedarray) | Request body; objects will be `x-www-form-urlencoded`. Set to `null` to omit the body. |
+| params (optional) | null or object {}                                                                         | Additional [parameters](/javascript-api/k6-http/params) for this specific request.     |
 
 ### Returns
 
-| Type                                         | Description           |
-| -------------------------------------------- | --------------------- |
+| Type                                         | Description                                               |
+|----------------------------------------------|-----------------------------------------------------------|
 | [Response](/javascript-api/k6-http/response) | HTTP [Response](/javascript-api/k6-http/response) object. |
 
 
@@ -25,7 +25,7 @@ excerpt: 'httpx.delete makes DELETE requests'
 <CodeGroup labels={[]}>
 
 ```javascript
-import { Httpx } from 'https://jslib.k6.io/httpx/0.0.4/index.js';
+import { Httpx } from 'https://jslib.k6.io/httpx/0.1.0/index.js';
 
 const session = new Httpx({
   baseURL: 'https://httpbin.test.k6.io',

--- a/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/15 options(url, [body], [params]).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/15 options(url, [body], [params]).md
@@ -7,16 +7,16 @@ excerpt: 'httpx.options makes OPTIONS requests'
 `session.options(url, body, params)` makes an OPTIONS request. Only the first parameter is required
 
 
-| Parameter      | Type   | Description                                                                          |
-| -------------- | ------ | ------------------------------------------------------------------------------------ |
-| url  | string    | HTTP URL. If baseURL is set, provide only path. |
-| body (optional) | null / string / object / ArrayBuffer / [SharedArray](/javascript-api/k6-data/sharedarray) | Request body; objects will be `x-www-form-urlencoded`. Set to `null` to omit the body. |
-| params (optional) | null or object {} | Additional [parameters](/javascript-api/k6-http/params) for this specific request. |
+| Parameter         | Type                                                                                      | Description                                                                            |
+|-------------------|-------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------|
+| url               | string                                                                                    | HTTP URL. If baseURL is set, provide only path.                                        |
+| body (optional)   | null / string / object / ArrayBuffer / [SharedArray](/javascript-api/k6-data/sharedarray) | Request body; objects will be `x-www-form-urlencoded`. Set to `null` to omit the body. |
+| params (optional) | null or object {}                                                                         | Additional [parameters](/javascript-api/k6-http/params) for this specific request.     |
 
 ### Returns
 
-| Type                                         | Description           |
-| -------------------------------------------- | --------------------- |
+| Type                                         | Description                                               |
+|----------------------------------------------|-----------------------------------------------------------|
 | [Response](/javascript-api/k6-http/response) | HTTP [Response](/javascript-api/k6-http/response) object. |
 
 
@@ -25,7 +25,7 @@ excerpt: 'httpx.options makes OPTIONS requests'
 <CodeGroup labels={[]}>
 
 ```javascript
-import { Httpx } from 'https://jslib.k6.io/httpx/0.0.4/index.js';
+import { Httpx } from 'https://jslib.k6.io/httpx/0.1.0/index.js';
 
 const session = new Httpx({
   baseURL: 'https://httpbin.test.k6.io',

--- a/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/15 options(url, [body], [params]).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/15 options(url, [body], [params]).md
@@ -10,7 +10,7 @@ excerpt: 'httpx.options makes OPTIONS requests'
 | Parameter         | Type                                                                                      | Description                                                                            |
 |-------------------|-------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------|
 | url               | string                                                                                    | HTTP URL. If baseURL is set, provide only path.                                        |
-| body (optional)   | null / string / object / ArrayBuffer / [SharedArray](/javascript-api/k6-data/sharedarray) | Request body; objects will be `x-www-form-urlencoded`. Set to `null` to omit the body. |
+| body (optional)   | null / string / object / ArrayBuffer / [SharedArray](/javascript-api/k6-data/sharedarray) | Request body; objects are `x-www-form-urlencoded`. To omit the body, set to `null`. |
 | params (optional) | null or object {}                                                                         | Additional [parameters](/javascript-api/k6-http/params) for this specific request.     |
 
 ### Returns

--- a/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/16 head(url, [body], [params]).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/16 head(url, [body], [params]).md
@@ -25,7 +25,7 @@ excerpt: 'httpx.head makes HEAD requests'
 <CodeGroup labels={[]}>
 
 ```javascript
-import { Httpx } from 'https://jslib.k6.io/httpx/0.0.4/index.js';
+import { Httpx } from 'https://jslib.k6.io/httpx/0.1.0/index.js';
 
 const session = new Httpx({
   baseURL: 'https://httpbin.test.k6.io',

--- a/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/17 trace(url, [body], [params]).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/17 trace(url, [body], [params]).md
@@ -7,16 +7,16 @@ excerpt: 'httpx.trace makes TRACE requests'
 `session.trace(url, body, params)` makes a TRACE request. Only the first parameter is required
 
 
-| Parameter      | Type   | Description                                                                          |
-| -------------- | ------ | ------------------------------------------------------------------------------------ |
-| url  | string    | HTTP URL. If baseURL is set, provide only path. |
-| body (optional) | null / string / object / ArrayBuffer / [SharedArray](/javascript-api/k6-data/sharedarray) | Request body; objects will be `x-www-form-urlencoded`. Set to `null` to omit the body. |
-| params (optional) | null or object {} | Additional [parameters](/javascript-api/k6-http/params) for this specific request. |
+| Parameter         | Type                                                                                      | Description                                                                            |
+|-------------------|-------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------|
+| url               | string                                                                                    | HTTP URL. If baseURL is set, provide only path.                                        |
+| body (optional)   | null / string / object / ArrayBuffer / [SharedArray](/javascript-api/k6-data/sharedarray) | Request body; objects will be `x-www-form-urlencoded`. Set to `null` to omit the body. |
+| params (optional) | null or object {}                                                                         | Additional [parameters](/javascript-api/k6-http/params) for this specific request.     |
 
 ### Returns
 
-| Type                                         | Description           |
-| -------------------------------------------- | --------------------- |
+| Type                                         | Description                                               |
+|----------------------------------------------|-----------------------------------------------------------|
 | [Response](/javascript-api/k6-http/response) | HTTP [Response](/javascript-api/k6-http/response) object. |
 
 
@@ -25,7 +25,7 @@ excerpt: 'httpx.trace makes TRACE requests'
 <CodeGroup labels={[]}>
 
 ```javascript
-import { Httpx } from 'https://jslib.k6.io/httpx/0.0.4/index.js';
+import { Httpx } from 'https://jslib.k6.io/httpx/0.1.0/index.js';
 
 const session = new Httpx({
   baseURL: 'https://httpbin.test.k6.io',

--- a/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/19 batch(requests).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/19 batch(requests).md
@@ -7,16 +7,16 @@ excerpt: 'Issue multiple HTTP requests in parallel (like e.g. browsers tend to d
 
 Batch multiple HTTP requests together, to issue them in parallel over multiple TCP connections.
 
-| Parameter | Type            | Description                                                      |
-| --------- | --------------- | ---------------------------------------------------------------- |
-| requests  | array  | An array containing requests, in string or object form |
-| params (optional) | object | additional parameters for all requests in the batch |
+| Parameter         | Type         | Description                                                 |
+|-------------------|--------------|-------------------------------------------------------------|
+| requests          | array        | An array containing requests, in string or object form      |
+| params (optional) | object       | additional parameters for all requests in the batch         |
 
 
 ### Returns
 
-| Type   | Description |
-| ------ | ------------------- |
+| Type  | Description                                                               |
+|-------|---------------------------------------------------------------------------|
 | array | An array containing [Response](/javascript-api/k6-http/response) objects. |
 
 ### Example
@@ -24,7 +24,7 @@ Batch multiple HTTP requests together, to issue them in parallel over multiple T
 <CodeGroup labels={[]}>
 
 ```javascript
-import { Httpx, Get } from 'https://jslib.k6.io/httpx/0.0.2/index.js';
+import { Httpx, Get } from 'https://jslib.k6.io/httpx/0.1.0/index.js';
 import { describe } from 'https://jslib.k6.io/expect/0.0.4/index.js';
 
 const session = new Httpx({ baseURL: 'https://test-api.k6.io' });

--- a/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/19 batch(requests).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/19 batch(requests).md
@@ -10,7 +10,7 @@ Batch multiple HTTP requests together, to issue them in parallel over multiple T
 | Parameter         | Type         | Description                                                 |
 |-------------------|--------------|-------------------------------------------------------------|
 | requests          | array        | An array containing requests, in string or object form      |
-| params (optional) | object       | additional parameters for all requests in the batch         |
+| params (optional) | object       | Additional parameters for all requests in the batch         |
 
 
 ### Returns

--- a/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/20 setBaseUrl(url).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/20 setBaseUrl(url).md
@@ -5,9 +5,9 @@ excerpt: 'sets the base URL for the session'
 ---
 
 
-| Parameter | Type            | Description                                                      |
-| --------- | --------------- | ---------------------------------------------------------------- |
-| baseURL  | string  | Base URL to be used for all requests issued in the session |
+| Parameter   | Type         | Description                                                |
+|-------------|--------------|------------------------------------------------------------|
+| baseURL     | string       | Base URL to be used for all requests issued in the session |
 
 
 ### Example
@@ -15,7 +15,7 @@ excerpt: 'sets the base URL for the session'
 <CodeGroup labels={[]}>
 
 ```javascript
-import { Httpx } from 'https://jslib.k6.io/httpx/0.0.1/index.js';
+import { Httpx } from 'https://jslib.k6.io/httpx/0.1.0/index.js';
 
 const session = new Httpx();
 

--- a/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/21 addHeader(key, value).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/21 addHeader(key, value).md
@@ -5,10 +5,10 @@ excerpt: 'adds a header to the session'
 ---
 
 
-| Parameter | Type            | Description                                                      |
-| --------- | --------------- | ---------------------------------------------------------------- |
-| name  | string  | Header name |
-| value  | string  | Header value |
+| Parameter  | Type         | Description                  |
+|------------|--------------|------------------------------|
+| name       | string       | Header name                  |
+| value      | string       | Header value                 |
 
 
 ### Example
@@ -16,7 +16,7 @@ excerpt: 'adds a header to the session'
 <CodeGroup labels={[]}>
 
 ```javascript
-import { Httpx } from 'https://jslib.k6.io/httpx/0.0.1/index.js';
+import { Httpx } from 'https://jslib.k6.io/httpx/0.1.0/index.js';
 
 const session = new Httpx({ baseURL: 'https://test-api.k6.io' });
 

--- a/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/22 addHeaders(object).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/22 addHeaders(object).md
@@ -5,9 +5,9 @@ excerpt: 'adds multiple headers to the session'
 ---
 
 
-| Parameter | Type            | Description                                                      |
-| --------- | --------------- | ---------------------------------------------------------------- |
-| headers  | object  | Object |
+| Parameter   | Type         | Description                |
+|-------------|--------------|----------------------------|
+| headers     | object       | Object                     |
 
 
 ### Example
@@ -15,7 +15,7 @@ excerpt: 'adds multiple headers to the session'
 <CodeGroup labels={[]}>
 
 ```javascript
-import { Httpx } from 'https://jslib.k6.io/httpx/0.0.1/index.js';
+import { Httpx } from 'https://jslib.k6.io/httpx/0.1.0/index.js';
 
 const session = new Httpx();
 

--- a/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/23 clearHeader(name).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/23 clearHeader(name).md
@@ -5,9 +5,9 @@ excerpt: 'removes header from the session'
 ---
 
 
-| Parameter | Type            | Description                                                      |
-| --------- | --------------- | ---------------------------------------------------------------- |
-| name  | string  | Header name to be removed |
+| Parameter   | Type      | Description                   |
+|-------------|-----------|-------------------------------|
+| name        | string    | Header name to be removed     |
 
 
 ### Example
@@ -15,7 +15,7 @@ excerpt: 'removes header from the session'
 <CodeGroup labels={[]}>
 
 ```javascript
-import { Httpx } from 'https://jslib.k6.io/httpx/0.0.1/index.js';
+import { Httpx } from 'https://jslib.k6.io/httpx/0.1.0/index.js';
 
 const session = new Httpx({ headers: { Authorization: 'token1' } });
 

--- a/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/24 addTag(key, value).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/24 addTag(key, value).md
@@ -5,10 +5,10 @@ excerpt: 'adds a tag to the session'
 ---
 
 
-| Parameter | Type            | Description                                                      |
-| --------- | --------------- | ---------------------------------------------------------------- |
-| name  | string  | Tag name |
-| value  | string  | Tag value |
+| Parameter  | Type        | Description       |
+|------------|-------------|-------------------|
+| name       | string      | Tag name          |
+| value      | string      | Tag value         |
 
 
 ### Example
@@ -16,7 +16,7 @@ excerpt: 'adds a tag to the session'
 <CodeGroup labels={[]}>
 
 ```javascript
-import { Httpx } from 'https://jslib.k6.io/httpx/0.0.1/index.js';
+import { Httpx } from 'https://jslib.k6.io/httpx/0.1.0/index.js';
 
 const session = new Httpx({ baseURL: 'https://test-api.k6.io' });
 

--- a/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/25 addTags(object).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/25 addTags(object).md
@@ -5,16 +5,16 @@ excerpt: 'adds multiple tags to the session'
 ---
 
 
-| Parameter | Type            | Description                                                      |
-| --------- | --------------- | ---------------------------------------------------------------- |
-| headers  | object  | Object |
+| Parameter  | Type      | Description  |
+|------------|-----------|--------------|
+| headers    | object    | Object       |
 
 ### Example
 
 <CodeGroup labels={[]}>
 
 ```javascript
-import { Httpx } from 'https://jslib.k6.io/httpx/0.0.1/index.js';
+import { Httpx } from 'https://jslib.k6.io/httpx/0.1.0/index.js';
 
 const session = new Httpx();
 

--- a/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/26 clearTag(name).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/02 httpx/26 clearTag(name).md
@@ -5,9 +5,9 @@ excerpt: 'removes tag from the session'
 ---
 
 
-| Parameter | Type            | Description                                                      |
-| --------- | --------------- | ---------------------------------------------------------------- |
-| name  | string  | Tag name to be removed |
+| Parameter  | Type      | Description              |
+|------------|-----------|--------------------------|
+| name       | string    | Tag name to be removed   |
 
 
 ### Example
@@ -15,7 +15,7 @@ excerpt: 'removes tag from the session'
 <CodeGroup labels={[]}>
 
 ```javascript
-import { Httpx } from 'https://jslib.k6.io/httpx/0.0.1/index.js';
+import { Httpx } from 'https://jslib.k6.io/httpx/0.1.0/index.js';
 
 const session = new Httpx({ tags: { tagName: 'tagValue' } });
 


### PR DESCRIPTION
This PR adds:
 - docs for `httpx.asyncRequest()` released in v0.1.0 
 - fixes formatting on many pages for this library
 - updates all script examples to the latest version