### PR TITLE
Update redis' documentation to reflect changes to type annotations

### DIFF
--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-getset.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-getset.md
@@ -10,7 +10,7 @@ Atomically sets `key` to `value` and returns the value previously stored at `key
 | Parameter | Type   | Description            |
 | :-------- | :----- | :--------------------- |
 | `key`     | string | the key to get and set |
-| `value`   | string, number or boolean    | the value to set       |
+| `value`   | string, number, or boolean    | the value to set       |
 
 
 ### Returns

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-getset.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-getset.md
@@ -10,7 +10,7 @@ Atomically sets `key` to `value` and returns the value previously stored at `key
 | Parameter | Type   | Description            |
 | :-------- | :----- | :--------------------- |
 | `key`     | string | the key to get and set |
-| `value`   | any    | the value to set       |
+| `value`   | string, number or boolean    | the value to set       |
 
 
 ### Returns

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-lpush.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-lpush.md
@@ -10,7 +10,7 @@ Inserts all the specified values at the head of the list stored at `key`. If `ke
 | Parameter | Type   | Description                           |
 | :-------- | :----- | :------------------------------------ |
 | `key`     | string | key holding the list to left push to. |
-| `values`  | a variadic array of strings, numbers or booleans  | values to push to the list.           |
+| `values`  | a variadic array of strings, numbers, or booleans  | values to push to the list.           |
 
 
 ### Returns

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-lpush.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-lpush.md
@@ -10,7 +10,7 @@ Inserts all the specified values at the head of the list stored at `key`. If `ke
 | Parameter | Type   | Description                           |
 | :-------- | :----- | :------------------------------------ |
 | `key`     | string | key holding the list to left push to. |
-| `values`  | any[]  | values to push to the list.           |
+| `values`  | a variadic array of strings, numbers or booleans  | values to push to the list.           |
 
 
 ### Returns
@@ -39,7 +39,7 @@ const redisClient = new redis.Client({
 export default async function () {
     await redisClient.lpush('mylist', 'first');
     await redisClient.rpush('mylist', 'second');
-    
+
     let item = await redisClient.lpop('mylist');
     item = redisClient.rpush('mylist', item);
     item = redisClient.rpop('mylist');

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-mget.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-mget.md
@@ -3,7 +3,7 @@ title: 'Client.mget(keys)'
 excerpt: 'Returns the values of all specified keys.'
 ---
 
-Returns the values of all specified keys. 
+Returns the values of all specified keys.
 
 ### Parameters
 
@@ -39,7 +39,7 @@ export default async function () {
   await redisClient.set('first', 1, 0)
   await redisClient.set('second', 2, 0);
   await redisClient.set('third', 3, 0);
-  
+
   const values = await redisClient.mget('first', 'second', 'third');
   console.log(`set values are: ${values}`);
 }

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-rpush.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-rpush.md
@@ -10,7 +10,7 @@ Inserts all the specified values at the tail of the list stored at `key`. If `ke
 | Parameter | Type   | Description                            |
 | :-------- | :----- | :------------------------------------- |
 | `key`     | string | key holding the list to right push to. |
-| `values`  | any[]  | values to push to the list.            |
+| `values`  | a variadic array of strings, numbers or booleans  | values to push to the list.            |
 
 
 ### Returns
@@ -39,7 +39,7 @@ const redisClient = new redis.Client({
 export default async function () {
   await redisClient.lpush('mylist', 'first');
   await redisClient.rpush('mylist', 'second');
-  
+
   const item = await redisClient.lpop('mylist');
   await redisClient.rpush('mylist', item);
   await redisClient.rpop('mylist');

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-rpush.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-rpush.md
@@ -10,7 +10,7 @@ Inserts all the specified values at the tail of the list stored at `key`. If `ke
 | Parameter | Type   | Description                            |
 | :-------- | :----- | :------------------------------------- |
 | `key`     | string | key holding the list to right push to. |
-| `values`  | a variadic array of strings, numbers or booleans  | values to push to the list.            |
+| `values`  | a variadic array of strings, numbers, or booleans  | values to push to the list.            |
 
 
 ### Returns

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-sadd.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-sadd.md
@@ -10,7 +10,7 @@ Adds the specified members to the set stored at `key`. Specified members that ar
 | Parameter | Type   | Description                                |
 | :-------- | :----- | :----------------------------------------- |
 | `key`     | string | key holding the set to add the members to. |
-| `members` | a variadic array of strings, numbers or booleans  | members to add to the set.                 |
+| `members` | a variadic array of strings, numbers, or booleans  | members to add to the set.                 |
 
 
 ### Returns

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-sadd.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-sadd.md
@@ -10,7 +10,7 @@ Adds the specified members to the set stored at `key`. Specified members that ar
 | Parameter | Type   | Description                                |
 | :-------- | :----- | :----------------------------------------- |
 | `key`     | string | key holding the set to add the members to. |
-| `members` | any[]  | members to add to the set.                 |
+| `members` | a variadic array of strings, numbers or booleans  | members to add to the set.                 |
 
 
 ### Returns
@@ -39,7 +39,7 @@ const redisClient = new redis.Client({
 export default async function () {
   await redisClient.sadd('myset', 'foo');
   await redisClient.sadd('myset', 'bar');
-  
+
   const isit = await redisClient.sismember('myset', 'foo');
   if (isit === false) {
     throw new Error('sismember should have returned true');

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-sendCommand.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-sendCommand.md
@@ -10,14 +10,14 @@ In the event a Redis command you wish to use is not implemented yet, the `sendCo
 | Parameter | Type   | Description                                                                                                    |
 | :-------- | :----- | :------------------------------------------------------------------------------------------------------------- |
 | `command` | string | command name to issue to the Redis server, as described in [Redis' documentation](https://redis.io/commands/). |
-| `args`    | any[]  | command arguments to pass to the Redis server.                                                                 |
+| `args`    | a variadic array of strings, numbers or booleans  | command arguments to pass to the Redis server.                                                                 |
 
 
 ### Returns
 
 | Type           | Resolves with                                                                                | Rejected when |
 | :------------- | :------------------------------------------------------------------------------------------- | :------------ |
-| `Promise<any>` | On success, the promise resolves with any result the server would reply to the command sent. |               |
+| `Promise<any>` | On success, the promise resolves with string, number or boolean result the server would reply to the command sent. |               |
 
 ### Example
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-sendCommand.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-sendCommand.md
@@ -10,7 +10,7 @@ In the event a Redis command you wish to use is not implemented yet, the `sendCo
 | Parameter | Type   | Description                                                                                                    |
 | :-------- | :----- | :------------------------------------------------------------------------------------------------------------- |
 | `command` | string | command name to issue to the Redis server, as described in [Redis' documentation](https://redis.io/commands/). |
-| `args`    | a variadic array of strings, numbers or booleans  | command arguments to pass to the Redis server.                                                                 |
+| `args`    | a variadic array of strings, numbers, or booleans  | command arguments to pass to the Redis server.                                                                 |
 
 
 ### Returns

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-sendCommand.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-sendCommand.md
@@ -17,7 +17,7 @@ In the event a Redis command you wish to use is not implemented yet, the `sendCo
 
 | Type           | Resolves with                                                                                | Rejected when |
 | :------------- | :------------------------------------------------------------------------------------------- | :------------ |
-| `Promise<any>` | On success, the promise resolves with string, number or boolean result the server would reply to the command sent. |               |
+| `Promise<any>` | On success, the promise resolves with string, number, or boolean result the server would reply to the command sent. |               |
 
 ### Example
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-set.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-set.md
@@ -10,7 +10,7 @@ Set the value of a key, with a time to live equal to the expiration time paramet
 | Parameter    | Type    | Description                                                         |
 | :----------- | :------ | :------------------------------------------------------------------ |
 | `key`        | string  | the key to set                                                      |
-| `value`      | any     | the value to set                                                    |
+| `value`      | string, number or boolean     | the value to set                                                    |
 | `expiration` | integer | the time to live in seconds. the `0` value indicates no expiration. |
 
 
@@ -39,7 +39,7 @@ const redisClient = new redis.Client({
 
 export default async function () {
   await redisClient.set('mykey', 'myvalue', 0);
-  
+
   const exists = await redisClient.exists('mykey');
   if (exists === false) {
     throw new Error('mykey should exist');
@@ -47,7 +47,7 @@ export default async function () {
 
   const value = await redisClient.get('mykey');
   console.log(`set key 'mykey' to value: ${value}`)
-  
+
   await redisClient.del('mykey');
 }
 ```

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-set.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-set.md
@@ -10,7 +10,7 @@ Set the value of a key, with a time to live equal to the expiration time paramet
 | Parameter    | Type    | Description                                                         |
 | :----------- | :------ | :------------------------------------------------------------------ |
 | `key`        | string  | the key to set                                                      |
-| `value`      | string, number or boolean     | the value to set                                                    |
+| `value`      | string, number, or boolean     | the value to set                                                    |
 | `expiration` | integer | the time to live in seconds. the `0` value indicates no expiration. |
 
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-sismember.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-sismember.md
@@ -10,7 +10,7 @@ Returns if member is a member of the set stored at `key`.
 | Parameter | Type   | Description                                                |
 | :-------- | :----- | :--------------------------------------------------------- |
 | `key`     | string | key holding the set to check if the member is a member of. |
-| `member`  | any    | member to check if is a member of the set.                 |
+| `member`  | string, number or boolean    | member to check if is a member of the set.                 |
 
 
 ### Returns

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-sismember.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-sismember.md
@@ -10,7 +10,7 @@ Returns if member is a member of the set stored at `key`.
 | Parameter | Type   | Description                                                |
 | :-------- | :----- | :--------------------------------------------------------- |
 | `key`     | string | key holding the set to check if the member is a member of. |
-| `member`  | string, number or boolean    | member to check if is a member of the set.                 |
+| `member`  | string, number, or boolean    | member to check if is a member of the set.                 |
 
 
 ### Returns

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-srem.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-srem.md
@@ -10,7 +10,7 @@ Removes the specified members from the set stored at `key`. Specified members th
 | Parameter | Type   | Description                                     |
 | :-------- | :----- | :---------------------------------------------- |
 | `key`     | string | key holding the set to remove the members from. |
-| `members` | a variadic array of strings, numbers or booleans  | members to remove from the set.                 |
+| `members` | a variadic array of strings, numbers, or booleans  | members to remove from the set.                 |
 
 
 ### Returns

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-srem.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 redis/10 Client/Client-srem.md
@@ -10,7 +10,7 @@ Removes the specified members from the set stored at `key`. Specified members th
 | Parameter | Type   | Description                                     |
 | :-------- | :----- | :---------------------------------------------- |
 | `key`     | string | key holding the set to remove the members from. |
-| `members` | any[]  | members to remove from the set.                 |
+| `members` | a variadic array of strings, numbers or booleans  | members to remove from the set.                 |
 
 
 ### Returns
@@ -40,7 +40,7 @@ export default async function () {
   await redisClient.sadd('myset', 'foo');
   await redisClient.sadd('myset', 'bar');
   await redisClient.srem('myset', 'foo');
-  
+
   const members = await redisClient.smembers('myset');
   if (members.length !== 1) {
     throw new Error('sismember should have length 1');


### PR DESCRIPTION
closes #1071

This PR reflect the change we're making to the redis' module type annotations, as per the [DefinetlyType v0.44 update PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65075).