### PR TITLE
Troubleshooting: improve instructions for `gpg` error

### DIFF
--- a/src/data/markdown/translated-guides/en/01 Get started/02 Installation.md
+++ b/src/data/markdown/translated-guides/en/01 Get started/02 Installation.md
@@ -10,6 +10,7 @@ k6 has packages for Linux, Mac, and Windows. Alternatively, you can use a Docker
 ### Debian/Ubuntu
 
 ```bash
+sudo gpg -k
 sudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
 echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
 sudo apt-get update

--- a/src/data/markdown/translated-guides/en/01 Get started/02 Installation/01 Troubleshooting.md
+++ b/src/data/markdown/translated-guides/en/01 Get started/02 Installation/01 Troubleshooting.md
@@ -15,41 +15,6 @@ sudo apt-get update && sudo apt-get install -y ca-certificates gnupg2
 This example is for Debian/Ubuntu and derivatives. Consult your distribution's documentation if you use another one.
 
 
-## apt-key is deprecated
-
-Some Ubuntu and Debian users might run into an `apt-key` deprecation warning while adding k6's repository key to their system's keyring:
-
-> `Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8))`
-
-To avoid this and be future-proof, users should delete the existing `security@k6.io` repository key on their system, and update their sources list accordingly.
-
-```bash
-# delete existing key
-sudo apt-key del k6
-
-# import the key the recommended way
-sudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
-
-# update the repository
-echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
-sudo apt-get update
-```
-
-
-## Error importing k6's GPG key
-
-The `gpg` command to import k6's package signing key might fail with:
-```bash
-gpg: keybox '/usr/share/keyrings/k6-archive-keyring.gpg' created
-gpg: failed to create temporary file '/root/.gnupg/.#lk0x000055db689f2310.a86c4b090dc7.7': No such file or directory
-gpg: connecting dirmngr at '/root/.gnupg/S.dirmngr' failed: No such file or directory
-gpg: keyserver receive failed: No dirmngr
-```
-
-This happens if it's the first time that the user runs `gpg` , so the directory `/root/.gnupg/` doesn't exist yet.
-To create the directory, run `sudo gpg -k` and try to import the key again.
-
-
 ## Behind a firewall or proxy
 
 Some users have reported that they can't download the key from Ubuntu's keyserver.

--- a/src/data/markdown/translated-guides/es/01 Getting started/02 Installation.md
+++ b/src/data/markdown/translated-guides/es/01 Getting started/02 Installation.md
@@ -10,10 +10,11 @@ k6 tiene paquetes para Linux, Mac, y Windows. Alternativamente, puede usar un co
 ### Debian/Ubuntu
 
 ```bash
-$ sudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
-$ echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
-$ sudo apt-get update
-$ sudo apt-get install k6
+sudo gpg -k
+sudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
+echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
+sudo apt-get update
+sudo apt-get install k6
 ```
 
 
@@ -22,8 +23,8 @@ $ sudo apt-get install k6
 Usando `dnf` o `yum`:
 
 ```bash
-$ sudo dnf install https://dl.k6.io/rpm/repo.rpm
-$ sudo dnf install k6
+sudo dnf install https://dl.k6.io/rpm/repo.rpm
+sudo dnf install k6
 ```
 
 
@@ -32,7 +33,7 @@ $ sudo dnf install k6
 Usando [Homebrew](https://brew.sh/):
 
 ```bash
-$ brew install k6
+brew install k6
 ```
 
 
@@ -50,7 +51,7 @@ Alternativamente, puede descargar y ejecutar [el instalador oficial más recient
 ## Docker
 
 ```bash
-$ docker pull grafana/k6
+docker pull grafana/k6
 ```
 
 ## Binarios

--- a/src/data/markdown/translated-guides/es/01 Getting started/02 Installation/01 Troubleshooting.md
+++ b/src/data/markdown/translated-guides/es/01 Getting started/02 Installation/01 Troubleshooting.md
@@ -14,41 +14,6 @@ sudo apt-get update && sudo apt-get install -y ca-certificates gnupg2
 
 Este ejemplo es para Debian/Ubuntu y derivados. Consulte la documentación de su distribución si usa una diferente.
 
-
-## apt-key es deprecado
-
-Algunos usuarios de Debian/Ubuntu y derivados podrían encontrar una advertencia utilizando `apt-key` para añadir la clave de firma del repositorio de k6:
-
-> `Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8))`
-
-Para evitar esto, y estar a prueba del futuro, se recomienda remover la clave existente de `security@k6.io`, y actualizar la lista de repositorios.
-
-```bash
-# borra la clave existente
-sudo apt-key del k6
-
-# importa la clave de la forma recomendada
-sudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
-
-# actualiza el repositorio
-echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
-sudo apt-get update
-```
-
-
-## Error importando la clave GPG de k6
-
-El comando `gpg` para importar la clave de firma podría fallar con:
-```bash
-gpg: keybox '/usr/share/keyrings/k6-archive-keyring.gpg' created
-gpg: failed to create temporary file '/root/.gnupg/.#lk0x000055db689f2310.a86c4b090dc7.7': No such file or directory
-gpg: connecting dirmngr at '/root/.gnupg/S.dirmngr' failed: No such file or directory
-gpg: keyserver receive failed: No dirmngr
-```
-
-Esto pasaría si es la primera vez que ejecuta `gpg` para ese usuario, por lo que el directorio `/root/.gnupg/` no existe. Puede crearlo ejecutando `sudo gpg -k` e intentando importar la clave nuevamente.
-
-
 ## En caso de usar un muro de fuego o proxy
 
 Algunos usuarios han reportado no poder importar la clave de firma de k6 desde el servidor de Ubuntu usando el comando `gpg`, debido a que la solicitud es bloqueada por un muro de fuego o proxy en su red. Si tiene este problema, puede intentar hacerlo de la siguiente manera:


### PR DESCRIPTION
Add `gpg -k` to Linux installation instructions

Remove unnecessary troubleshooting sections