### PR TITLE
Clarify what "failed HTTP requests" means for the `--throw` option

### DIFF
--- a/src/data/markdown/translated-guides/en/02 Using k6/05 k6 Options/02 Reference.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/05 k6 Options/02 Reference.md
@@ -1316,7 +1316,7 @@ export const options = {
 ## Throw
 
 A boolean, true or false, specifying whether k6 should throw exceptions when certain errors occur, or if it should just log them with a warning. Behaviors that currently depend on this option:
- - failed [HTTP requests](/javascript-api/k6-http/)
+ - failing to make [HTTP requests](/javascript-api/k6-http/), e.g. due to a network error
  - adding invalid values to [custom metrics](/using-k6/metrics/#custom-metrics)
  - setting invalid [per-VU metric tags](/javascript-api/k6-execution/#tags)
 


### PR DESCRIPTION
Some users were confused about the meaning of "failed HTTP requests" in the context of the `--throw` option, so this should hopefully clarify it.

This is also confusing since we have the `http_req_failed` metric, which actually refers to requests that received a specific response code, but there's not much we can do about that now...