### PR TITLE
Use duration strings in disruptor api

### DIFF
--- a/src/data/markdown/docs/40 xk6-disruptor/03 API/01 Faults/01 Grpc.md
+++ b/src/data/markdown/docs/40 xk6-disruptor/03 API/01 Faults/01 Grpc.md
@@ -7,15 +7,15 @@ A gRPC Fault describes the characteristics of the faults to be injected in the g
 
 A gRPC fault is described by the following attributes:
 
-| Attribute | Description |
-| --------- | ------------|
-| averageDelay | average delay added to requests in milliseconds (default `0ms`) |
-| delayVariation| variation in the injected delay in milliseconds (default `0ms`) |
-| statusMessage | message to be returned when an error is injected |
-| statusCode | status to be returned when an error is injected |
-| errorRate | rate of requests that will return an error, represented as a float in the range `0.0` to `1.0` (default `0.0`) |
-| exclude | comma-separated list of services to be excluded from disruption |
-| port | port on which the requests will be intercepted |
+| Attribute      | Type   | Description |
+| -------------- | ------ | -------|
+| averageDelay   | string | average delay added to requests represented as a string (default `0`) |
+| delayVariation | string | variation in the injected delay (default `0`) |
+| statusMessage  | string | message to be returned when an error is injected |
+| statusCode     | number | status to be returned when an error is injected |
+| errorRate      | number | rate of requests that will return an error, represented as a float in the range `0.0` to `1.0` (default `0.0`) |
+| exclude        | string | comma-separated list of services to be excluded from disruption |
+| port           | number | port on which the requests will be intercepted |
 
 <Blockquote mod="note">
 
@@ -29,7 +29,7 @@ This example defines a gRPC fault that introduces a delay of `50ms` in all reque
 
 ```javascript
 const fault = {
-  averageDelay: 50,
+  averageDelay: '50ms',
   statusCode: 10,
   errorRate: 0.1,
 };

--- a/src/data/markdown/docs/40 xk6-disruptor/03 API/01 Faults/02 HTTP .md
+++ b/src/data/markdown/docs/40 xk6-disruptor/03 API/01 Faults/02 HTTP .md
@@ -7,15 +7,15 @@ A HTTP Fault describes the characteristics of the faults to be injected in the H
 
 A HTTP fault is described by the following attributes:
 
-| Attribute | Description |
-| --------- | ------------|
-| averageDelay | average delay added to requests in milliseconds (default `0ms`) |
-| delayVariation| variation in the injected delay in milliseconds (default `0ms`) |
-| errorBody | body to be returned when an error is injected |
-| errorCode | error code to return |
-| errorRate | rate of requests that will return an error, represented as a float in the range `0.0` to `1.0` (default `0.0`) |
-| exclude | comma-separated list of urls to be excluded from disruption (e.g. /health) |
-| port | port on which the requests will be intercepted |
+| Attribute     | Type   | Description |
+| ------------- | ------ | --------|
+| averageDelay  | string | average delay added to requests represented as a string (default `0`) |
+| delayVariation| string | variation in the injected delay (default `0`) |
+| errorBody     | string | body to be returned when an error is injected |
+| errorCode     | number | error code to return |
+| errorRate     | number | rate of requests that will return an error, represented as a float in the range `0.0` to `1.0` (default `0.0`) |
+| exclude       | string | comma-separated list of urls to be excluded from disruption (e.g. /health) |
+| port          | number | port on which the requests will be intercepted |
 
 <Blockquote mod="note">
 
@@ -29,7 +29,7 @@ This example defines a HTTP fault that introduces a delay of `50ms` in all reque
 
 ```javascript
 const fault = {
-  averageDelay: 50,
+  averageDelay: '50ms',
   errorCde: 500,
   errorRate: 0.1,
 };

--- a/src/data/markdown/docs/40 xk6-disruptor/03 API/02 PodDisruptor.md
+++ b/src/data/markdown/docs/40 xk6-disruptor/03 API/02 PodDisruptor.md
@@ -36,7 +36,7 @@ const selector = {
 };
 
 const fault = {
-  averageDelay: 100,
+  averageDelay: '100ms',
   errorRate: 0.1,
   errorCode: 500,
 };
@@ -48,7 +48,7 @@ export default function () {
     throw new Error('expected list to have one target');
   }
 
-  disruptor.injectHTTPFaults(fault, 30);
+  disruptor.injectHTTPFaults(fault, '30s');
 }
 ```
 

--- a/src/data/markdown/docs/40 xk6-disruptor/03 API/02 PodDisruptor/01 Constructor.md
+++ b/src/data/markdown/docs/40 xk6-disruptor/03 API/02 PodDisruptor/01 Constructor.md
@@ -7,36 +7,36 @@ excerpt: 'xk6-disruptor: PodDisruptor constructor'
 The `PodDisruptor()` constructor creates a new instance of a [PodDisruptor](/javascript-api/xk6-disruptor/api/poddisruptor) class.
 
 
-| Parameter | Description |
-| --------- | ----------- |
-| [selector](#selector) | criteria for selecting the target pods |
-| [options](#options) | options for controlling the behavior of the disruptor |
+| Parameter | Type | Description |
+| --------- | -----| ------ |
+| selector  | object | [criteria](#selector) for selecting the target pods |
+| options (optional) | object | [options](#options) for controlling the behavior of the disruptor |
 
 ### Selector
 
 The `selector` defines the criteria a pod must satisfy to be a valid target:
 
-| Attribute | Description |
-| --------- | ----------- |
-| namespace | namespace the selector will look for pods |
-| select | [attributes](#pod-attributes) that a pod must match to be selected |
-| exclude | [attributes](#pod-attributes) that exclude a pod (even if it matches the select attributes) |
+| Attribute | Type | Description |
+| --------- | -----|------------ |
+| namespace | string | namespace the selector will look for pods |
+| select    | object | [attributes](#pod-attributes) that a pod must match to be selected |
+| exclude   | object | [attributes](#pod-attributes) that exclude a pod (even if it matches the select attributes) |
 
 You can use the following attributes to select or exclude pods:
 
 ### Pod attributes
 
-| Attribute | Description |
-| --------- | ----------- |
-| labels    | map with the labels to be matched for selection or exclusion |
+| Attribute | Type   | Description |
+| --------- | -------| ----------- |
+| labels    | object | map with the labels to be matched for selection or exclusion |
 
 ### Options
 
 The `options` control the creation and behavior of the `PodDisruptor`:
 
-| Attribute | Description |
-| --------- | ----------- |
-| injectTimeout | maximum time to wait for the disruptor to be ready in the target pods, in seconds (default 30s). Zero value forces default. Negative values force no waiting. |
+| Attribute | Type | Description |
+| --------- | -----|------ |
+| injectTimeout | string | maximum time to wait for the disruptor to be ready in the target pods (default 30s) |
 
 ## Example
 

--- a/src/data/markdown/docs/40 xk6-disruptor/03 API/02 PodDisruptor/02 injectGrpcFaults.md
+++ b/src/data/markdown/docs/40 xk6-disruptor/03 API/02 PodDisruptor/02 injectGrpcFaults.md
@@ -5,21 +5,21 @@ excerpt: 'xk6-disruptor: PodDisruptor.injectGrpcFaults method'
 
 injectGrpcFaults injects gRPC faults in the requests served by a target Pod.
 
-| Parameter | Description |
-| ---------- | ----------- |
-| fault | description of the [gRPC faults](/javascript-api/xk6-disruptor/api/faults/grpc) to be injected |
-| duration | duration of the disruption in seconds |
-| [options](#options) | options that control the injection of the fault |
+| Parameter | Type   | Description |
+| --------- | ------ |------- |
+| fault     | object | description of the [gRPC faults](/javascript-api/xk6-disruptor/api/faults/grpc) to be injected |
+| duration  | string | duration of the disruption |
+| options (optional)   | object | [options](#options) that control the injection of the fault |
 
 
 ## options
 
 The injection of the fault is controlled by the following options:
 
-| Option | Description |
-| ------ | ----------- |
-| proxyPort | port the agent will use to listen for requests in the target pods ( default `8080`) |
-| iface | network interface where the agent will capture the traffic ( default `eth0`) |
+| Option    | Type   | Description |
+| --------- | ------ | -------- |
+| proxyPort | number | port the agent will use to listen for requests in the target pods ( default `8080`) |
+| iface     | string | network interface where the agent will capture the traffic ( default `eth0`) |
 
 
 ## Example
@@ -28,9 +28,9 @@ The injection of the fault is controlled by the following options:
 
 ```javascript
     const fault = {
-        averageDelay: 50,
+        averageDelay: "50ms",
         statusCode: 13,
         errorRate: 0.1
     }
-    disruptor.injectGrpcFaults(fault, 30)
+    disruptor.injectGrpcFaults(fault, "30s")
 ```

--- a/src/data/markdown/docs/40 xk6-disruptor/03 API/02 PodDisruptor/03 injectHTTPFaults.md
+++ b/src/data/markdown/docs/40 xk6-disruptor/03 API/02 PodDisruptor/03 injectHTTPFaults.md
@@ -5,21 +5,21 @@ excerpt: 'xk6-disruptor: PodDisruptor.injectHTTPFaults method'
 
 injectHTTPFaults injects HTTP faults in the requests served by a target Pod.
 
-| Parameter | Description |
-| ---------- | ----------- |
-| fault | description of the [http faults](/javascript-api/xk6-disruptor/api/faults/http) to be injected |
-| duration | duration of the disruption in seconds |
-| [options](#options) | options that control the injection of the fault |
+| Parameter | Type   | Description |
+| --------- | ------ | ------- |
+| fault     | object | description of the [http faults](/javascript-api/xk6-disruptor/api/faults/http) to be injected |
+| duration  | string | duration of the disruption |
+| options (optional)   | object | [options](#options) that control the injection of the fault |
 
 
 ## options
 
 The injection of the fault is controlled by the following options:
 
-| Option | Description |
-| ------ | ----------- |
-| proxyPort | port the agent will use to listen for requests in the target pods ( default `8080`) |
-| iface | network interface where the agent will capture the traffic ( default `eth0`) |
+| Option    | Type   | Description |
+| --------- | ------ | -------- |
+| proxyPort | number | port the agent will use to listen for requests in the target pods ( default `8080`) |
+| iface     | string | network interface where the agent will capture the traffic ( default `eth0`) |
 
 <Blockquote mod="note">
 
@@ -37,9 +37,9 @@ This is normal and means that one request was "in transit" at the time the fault
 
 ```javascript
     const fault = {
-        averageDelay: 50,
+        averageDelay: "50ms",
         errorCode: 500,
         errorRate: 0.1
     }
-    disruptor.injectHTTPFaults(fault, 30)
+    disruptor.injectHTTPFaults(fault, "30s")
 ```

--- a/src/data/markdown/docs/40 xk6-disruptor/03 API/03 ServiceDisruptor.md
+++ b/src/data/markdown/docs/40 xk6-disruptor/03 API/03 ServiceDisruptor.md
@@ -26,7 +26,7 @@ The following example:
 import { ServiceDisruptor } from 'k6/x/disruptor';
 
 const fault = {
-  averageDelay: 100,
+  averageDelay: '100ms',
   errorRate: 0.1,
   errorCode: 500,
 };
@@ -38,7 +38,7 @@ export default function () {
     throw new Error('expected list to have one target');
   }
 
-  disruptor.injectHTTPFaults(fault, 30);
+  disruptor.injectHTTPFaults(fault, '30s');
 }
 ```
 

--- a/src/data/markdown/docs/40 xk6-disruptor/03 API/03 ServiceDisruptor/01 Constructor.md
+++ b/src/data/markdown/docs/40 xk6-disruptor/03 API/03 ServiceDisruptor/01 Constructor.md
@@ -7,20 +7,20 @@ excerpt: 'xk6-disruptor: ServiceDisruptor constructor'
 The `ServiceDisruptor()` constructor creates a new instance of a [ServiceDisruptor](/javascript-api/xk6-disruptor/api/servicedisruptor) class.
 
 
-| Parameter | Description |
-| --------- | ----------- |
-| service   | name of the service |
-| namespace | namespace on which the service is defined |
-| [options](#options) | options for controlling the behavior of the disruptor |
+| Parameter | Type | Description |
+| --------- | ---- | ----------- |
+| service   | string | name of the service |
+| namespace | string | namespace on which the service is defined |
+| options (optional) | object | [options](#options) for controlling the behavior of the disruptor |
 
 
 ### Options
 
 The following options control the creation and behavior of the `ServiceDisruptor`:
 
-| Attribute | Description |
-| --------- | ----------- |
-| injectTimeout | maximum time for waiting the disruptor to be ready in the target pods, in seconds (default 30s). Zero value forces default. Negative values force no waiting. |
+| Attribute | Type | Description |
+| --------- | ---- |------ |
+| injectTimeout | string | maximum time for waiting the disruptor to be ready in the target pods (default 30s) |
 
 ## Example
 

--- a/src/data/markdown/docs/40 xk6-disruptor/03 API/03 ServiceDisruptor/02 injectGrpcFaults.md
+++ b/src/data/markdown/docs/40 xk6-disruptor/03 API/03 ServiceDisruptor/02 injectGrpcFaults.md
@@ -5,21 +5,20 @@ excerpt: 'xk6-disruptor: ServiceDisruptor.injectGrpcFaults method'
 
 injectGrpcFaults injects gRPC faults in the requests served by a target Service.
 
-| Parameters | Description |
-| ---------- | ----------- |
-| fault | description of the [gRPC faults](/javascript-api/xk6-disruptor/api/faults/grpc) to be injected |
-| duration | duration of the disruption in seconds |
-| [options](#options) | options that control the injection of the fault |
+| Parameters | Type   | Description |
+| ---------- | ------ | ------- |
+| fault      | object | description of the [gRPC faults](/javascript-api/xk6-disruptor/api/faults/grpc) to be injected |
+| duration   | string | duration of the disruption |
+| options (optional)   | object | [options](#options) that control the injection of the fault |
 
 ## Options
 
 The injection of the fault is controlled by the following options:
 
-| Option | Description |
-| ------ | ----------- |
-| proxyPort | port the agent will use to listen for requests in the target pods ( default `8080`) |
-| iface | network interface where the agent will capture the traffic ( default `eth0`) |
-
+| Option    | Type   | Description |
+| --------- | ------ | ------- |
+| proxyPort | number | port the agent will use to listen for requests in the target pods ( default `8080`) |
+| iface     | string | network interface where the agent will capture the traffic ( default `eth0`) |
 
 ## Example
 
@@ -27,9 +26,9 @@ The injection of the fault is controlled by the following options:
 
 ```javascript
     const fault = {
-        averageDelay: 50,
+        averageDelay: "50ms",
         statusCode: 13,
         errorRate: 0.1
     }
-    disruptor.injectGrpcFaults(fault, 30)
+    disruptor.injectGrpcFaults(fault, "30s")
 ```

--- a/src/data/markdown/docs/40 xk6-disruptor/03 API/03 ServiceDisruptor/03 injectHTTPFaults.md
+++ b/src/data/markdown/docs/40 xk6-disruptor/03 API/03 ServiceDisruptor/03 injectHTTPFaults.md
@@ -5,20 +5,20 @@ excerpt: 'xk6-disruptor: ServiceDisruptor.injectHTTPFaults method'
 
 injectHTTPFaults injects HTTP faults in the requests served by a target Service.
 
-| Parameters | Description |
-| ---------- | ----------- |
-| fault | description of the [http faults](/javascript-api/xk6-disruptor/api/faults/http) to be injected |
-| duration | duration of the disruption in seconds |
-| [options](#options) | options that control the injection of the fault |
+| Parameters | Type   | Description |
+| ---------- | ------ | ----------- |
+| fault      | object | description of the [http faults](/javascript-api/xk6-disruptor/api/faults/http) to be injected |
+| duration   | string | duration of the disruption |
+| options (optional)   | object | [options](#options) that control the injection of the fault |
 
 ## Options
 
 The injection of the fault is controlled by the following options:
 
-| Option | Description |
-| ------ | ----------- |
-| proxyPort | port the agent will use to listen for requests in the target pods ( default `8080`) |
-| iface | network interface where the agent will capture the traffic ( default `eth0`) |
+| Option    | Type   | Description |
+| --------- | ------ | ----------- |
+| proxyPort | number | port the agent will use to listen for requests in the target pods ( default `8080`) |
+| iface     | string | network interface where the agent will capture the traffic ( default `eth0`) |
 
 <Blockquote mod="note">
 
@@ -36,9 +36,9 @@ This is normal and means that one request was "in transit" at the time the fault
 
 ```javascript
     const fault = {
-        averageDelay: 50,
+        averageDelay: "50ms",
         errorCode: 500,
         errorRate: 0.1
     }
-    disruptor.injectHTTPFaults(fault, 30)
+    disruptor.injectHTTPFaults(fault, "30s")
 ```

--- a/src/data/markdown/docs/40 xk6-disruptor/04 Examples/01 Inject Grpc faults into Service.md
+++ b/src/data/markdown/docs/40 xk6-disruptor/04 Examples/01 Inject Grpc faults into Service.md
@@ -78,13 +78,13 @@ export function disrupt() {
     }
 
     const fault = {
-        averageDelay: 300,
+        averageDelay: "300ms",
         statusCode: grpc.StatusInternal,
         errorRate: 0.1,
         port: 9000,
     }
     const disruptor = new ServiceDisruptor('grpcbin','grpcbin')
-    disruptor.injectGrpcFaults(fault, 30)
+    disruptor.injectGrpcFaults(fault, "30s")
 }
 ```
 
@@ -303,12 +303,12 @@ export function disrupt() {
 
     // inject errors in requests
     const fault = {
-        averageDelay: 300,
+        averageDelay: "300ms",
         statusCode: grpc.StatusInternal,
         errorRate: 0.1,
         port: 9000,
     }
-    disruptor.injectGrpcFaults(fault, 30)
+    disruptor.injectGrpcFaults(fault, "30s")
 }
 
 export const options = {

--- a/src/data/markdown/docs/40 xk6-disruptor/04 Examples/02 Inject HTTP faults into Pod.md
+++ b/src/data/markdown/docs/40 xk6-disruptor/04 Examples/02 Inject HTTP faults into Pod.md
@@ -63,11 +63,11 @@ export function disrupt(data) {
     const podDisruptor = new PodDisruptor(selector)
     // delay traffic from one random replica of the deployment
     const fault = {
-        averageDelay: 50,
+        averageDelay: "50ms",
         errorCode: 500,
         errorRate: 0.1
     }
-    podDisruptor.injectHTTPFaults(fault, 30)
+    podDisruptor.injectHTTPFaults(fault, "30s")
 }
 ```
 
@@ -291,11 +291,11 @@ export function disrupt(data) {
 
     // delay traffic from one random replica of the deployment
     const fault = {
-        averageDelay: 50,
+        averageDelay: "50ms",
         errorCode: 500,
         errorRate: 0.1
     }
-    podDisruptor.injectHTTPFaults(fault, 30)
+    podDisruptor.injectHTTPFaults(fault, "30s")
 }
 
 export const options = {


### PR DESCRIPTION
Update documentation to reflect changes in the API introduced in https://github.com/grafana/xk6-disruptor/pull/137