### PR TITLE
Update documentation to reflect changes in aws v0.7.2

### DIFF
--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws.md
@@ -4,17 +4,18 @@ excerpt: "aws is a library implementing APIs for accessing a selection of AWS se
 description: "aws is a library implementing APIs for accessing a selection of AWS servicese"
 ---
 
-The `aws` module is a JavaScript library that wraps around some Amazon AWS services API. 
+The `aws` module is a JavaScript library that wraps around some Amazon AWS services API.
 
 The library exposes a couple of configuration and client classes allowing to interact with a subset of AWS services in the context of k6 load test scripts:
 - [S3Client](/javascript-api/jslib/aws/s3client): a class to list S3 buckets and the objects they contain, as well as uploading, downloading and deleting objects from them.
 - [SecretsManagerClient](/javascript-api/jslib/aws/secretsmanagerclient): a class to list, get, create, update, and delete secrets from the AWS secrets manager service.
 - [KMSClient](/javascript-api/jslib/aws/kmsclient): a class to list and generate keys from the AWS Key Management Service.
 - [SystemsManagerClient](/javascript-api/jslib/aws/systemsmanagerclient): a class to fetch parameters from the AWS Systems Manager Service.
+- [SQSClient](/javascript-api/jslib/aws/sqsclient): a class to list and send messages to SQS queues.
 - [SignatureV4](/javascript-api/jslib/aws/signaturev4): a class to sign and pre-sign requests to AWS services using the [Signature V4](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html) algorithm.
 - [AWSConfig](/javascript-api/jslib/aws/awsconfig/): a class is used by each client classes to provide them access to AWS credentials as well as configuration.
 
-> ⭐️ Source code available on [GitHub](https://github.com/grafana/k6-jslib-aws). 
+> ⭐️ Source code available on [GitHub](https://github.com/grafana/k6-jslib-aws).
 > Please request features and report bugs through [GitHub issues](https://github.com/grafana/k6-jslib-aws/issues).
 
 
@@ -22,7 +23,7 @@ The library exposes a couple of configuration and client classes allowing to int
 
 #### This library is in active development
 
-This library is stable enough to be useful, but pay attention to the new versions released on [jslib.k6.io](https://jslib.k6.io) and [k6-jslib-aws/releases](https://github.com/grafana/k6-jslib-aws/releases).   
+This library is stable enough to be useful, but pay attention to the new versions released on [jslib.k6.io](https://jslib.k6.io) and [k6-jslib-aws/releases](https://github.com/grafana/k6-jslib-aws/releases).
 
 This documentation is for the last version only. If you discover that some code below does not work, it most likely means that you are using an older version.
 
@@ -35,5 +36,6 @@ This documentation is for the last version only. If you discover that some code 
 | [S3Client](/javascript-api/jslib/aws/s3client)                         | Client class to interact with AWS S3 buckets and objects.            |
 | [SecretsManager](/javascript-api/jslib/aws/secretsmanagerclient)       | Client class to interact with AWS secrets stored in Secrets Manager. |
 | [KMSClient](/javascript-api/jslib/aws/kmsclient)                       | Client class to interact with AWS Key Management Service.            |
+| [SQSClient](/javascript-api/jslib/aws/sqsclient)                       | Client class to interact with AWS Simple Queue Service.              |
 | [SystemsManagerClient](/javascript-api/jslib/aws/systemsmanagerclient) | Client class to interact with AWS Systems Manager Service.           |
 | [AWSConfig](/javascript-api/jslib/aws/awsconfig)                       | Class to configure AWS client classes.                               |

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/01 S3Client.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/01 S3Client.md
@@ -37,7 +37,7 @@ import { check } from 'k6';
 import exec from 'k6/execution';
 import http from 'k6/http';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.7.1/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.7.2/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/02 SecretsManagerClient.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/02 SecretsManagerClient.md
@@ -35,7 +35,7 @@ S3 Client methods will throw errors in case of failure.
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.7.1/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.7.2/secrets-manager.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/03 KMSClient.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/03 KMSClient.md
@@ -8,7 +8,7 @@ excerpt: 'KMSClient allows interacting with the AWS Key Management Service'
 `KMSClient` interacts with the AWS Key Management Service.
 With it, the user can list all the Key Management Service keys in the caller's AWS account and region. They can also generate symmetric data keys to use outside of AWS Key Management Service. `KMSClient` operations are blocking. k6 recommends reserving their use to the [`setup`](/using-k6/test-lifecycle/) and [`teardown`](/using-k6/test-lifecycle/) stages as much as possible.
 
-Both the dedicated `kms.js` jslib bundle and the all-encompassing `aws.js` bundle include the `KMSClient`. 
+Both the dedicated `kms.js` jslib bundle and the all-encompassing `aws.js` bundle include the `KMSClient`.
 
 ### Methods
 
@@ -33,7 +33,7 @@ Both the dedicated `kms.js` jslib bundle and the all-encompassing `aws.js` bundl
 ```javascript
 import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.2/index.js';
 
-import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.7.1/kms.js';
+import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.7.2/kms.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/04 SystemsManagerClient.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/04 SystemsManagerClient.md
@@ -8,7 +8,7 @@ excerpt: 'SystemsManagerClient allows interacting with the AWS Systems Manager S
 `SystemsManagerClient` interacts with the AWS Systems Manager Service.
 With it, the user can get parameters from the Systems Manager Service in the caller's AWS account and region. `SystemsManagerClient` operations are blocking. k6 recommends reserving their use to the [`setup`](/using-k6/test-lifecycle/) and [`teardown`](/using-k6/test-lifecycle/) stages as much as possible.
 
-Both the dedicated `ssm.js` jslib bundle and the all-encompassing `aws.js` bundle include the `SystemsManagerClient`. 
+Both the dedicated `ssm.js` jslib bundle and the all-encompassing `aws.js` bundle include the `SystemsManagerClient`.
 
 ### Methods
 
@@ -32,7 +32,7 @@ Both the dedicated `ssm.js` jslib bundle and the all-encompassing `aws.js` bundl
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SystemsManagerClient } from 'https://jslib.k6.io/aws/0.7.1/ssm.js';
+import { AWSConfig, SystemsManagerClient } from 'https://jslib.k6.io/aws/0.7.2/ssm.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/05 AwsConfig.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/05 AwsConfig.md
@@ -35,7 +35,7 @@ import exec from 'k6/execution';
 
 // Note that you AWSConfig is also included in the dedicated service
 // client bundles such as `s3.js` and `secrets-manager.js`
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.7.1/aws.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.7.2/aws.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/05 AwsConfig.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/05 AwsConfig.md
@@ -18,6 +18,12 @@ It takes an options object as its single parameter, with the following propertie
 | secretAccessKey            | string | The AWS secret access credential to use for authentication.                                                               |
 | sessionToken (optional)    | string | The AWS secret access token to use for authentication.                                                               |
 
+### Methods
+
+| Name                | Description                                                                                                                                |
+| :------------------ | :----------------------------------------------------------------------------------------------------------------------------------------- |
+| `fromEnvironment()` | Creates an `AWSConfig` using the `AWS_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN` environment variables. |
+
 ### Throws
 
 S3 Client methods will throw errors in case of failure.

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/06 SignatureV4.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/06 SignatureV4.md
@@ -10,7 +10,7 @@ The `presign` operation produces a pre-signed request with authorization informa
 
 SignatureV4 is included in both the dedicated jslib `signature.js` bundle and the `aws.js` one, containing all the service's clients.
 
-Instantiating a new `SignatureV4` requires a single options object argument with the following properties: 
+Instantiating a new `SignatureV4` requires a single options object argument with the following properties:
 
 | Property      | Type                                                                                      | Description                                                                                                                                                                                                                                                             |
 | :------------ | :---------------------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -44,7 +44,7 @@ SignatureV4 methods throw errors on failure.
 ```javascript
 import http from 'k6/http.js'
 
-import { AWSConfig, SignatureV4 } from 'https://jslib.k6.io/aws/0.7.1/aws.js'
+import { AWSConfig, SignatureV4 } from 'https://jslib.k6.io/aws/0.7.2/aws.js'
 
 const awsConfig = new AWSConfig({
     region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/07 SQSClient.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/07 SQSClient.md
@@ -1,0 +1,59 @@
+---
+title: 'SQSClient'
+head_title: 'SQSClient'
+description: 'SQSClient enables interaction with the AWS Simple Queue Service (SQS)'
+excerpt: 'SQSClient allows interacting with the AWS Simple Queue Service (SQS)'
+---
+
+`SQSClient` interacts with the AWS Simple Queue Service (SQS). With it, the user can send messages to specified queues and list available queues in the current region. `SQSClient` operations are blocking. k6 recommends reserving their use for the [`setup`](/using-k6/test-lifecycle/) and [`teardown`](/using-k6/test-lifecycle/) stages as much as possible.
+
+Both the dedicated `sqs.js` jslib bundle and the all-encompassing `aws.js` bundle include the `SQSClient`.
+
+### Methods
+
+| Function                                                         | Description                                          |
+| :--------------------------------------------------------------- | :--------------------------------------------------- |
+| [`sendMessage`](/javascript-api/jslib/aws/sqsclient/sqsclient-sendmessage) | Delivers a message to the specified queue.           |
+| [`listQueues`](/javascript-api/jslib/aws/sqsclient/sqsclient-listqueues)   | Returns a list of your queues in the current region. |
+
+### Throws
+
+`SQSClient` methods throw errors in case of failure.
+
+| Error                   | Condition                                                 |
+| :---------------------- | :-------------------------------------------------------- |
+| `InvalidSignatureError` | when using invalid credentials                            |
+| `SQSServiceError`       | when AWS replied to the requested operation with an error |
+
+### Example
+
+<CodeGroup labels={[]}>
+
+```javascript
+import exec from 'k6/execution'
+
+import { AWSConfig, SQSClient } from 'https://jslib.k6.io/aws/0.7.2/sqs.js'
+
+const awsConfig = new AWSConfig({
+    region: __ENV.AWS_REGION,
+    accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+    secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+    sessionToken: __ENV.AWS_SESSION_TOKEN,
+})
+
+const sqs = new SQSClient(awsConfig)
+const testQueue = 'https://sqs.us-east-1.amazonaws.com/000000000/test-queue'
+
+export default function () {
+    // If our test queue does not exist, abort the execution.
+    const queuesResponse = sqs.listQueues()
+    if (queuesResponse.queueUrls.filter((q) => q === testQueue).length == 0) {
+        exec.test.abort()
+    }
+
+    // Send message to test queue
+    sqs.sendMessage(testQueue, JSON.stringify({value: '123'}));
+}
+```
+
+</CodeGroup>

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/KMSClient/01 listKeys.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/KMSClient/01 listKeys.md
@@ -19,7 +19,7 @@ excerpt: "KMSClient.listKeys lists all the KMS keys in the caller's AWS account 
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.7.1/kms.js';
+import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.7.2/kms.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/KMSClient/02 generateDataKey.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/KMSClient/02 generateDataKey.md
@@ -26,7 +26,7 @@ excerpt: 'KMSClient.generateDataKey generates a symmetric data key for use outsi
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.7.1/kms.js';
+import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.7.2/kms.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/KMSClient/98 KMSDataKey.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/KMSClient/98 KMSDataKey.md
@@ -21,7 +21,7 @@ For instance, the [`generateDataKey`](/javascript-api/jslib/aws/kmsclient/kmscli
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.7.1/kms.js';
+import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.7.2/kms.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/KMSClient/99 KMSKey.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/KMSClient/99 KMSKey.md
@@ -4,7 +4,7 @@ description: 'KMSKey is returned by the KMSClient.* methods that query KMS keys'
 excerpt: 'KMSKey is returned by the KMSClient.* methods that query KMS keys'
 ---
 
-`KMSClient.*` methods querying Key Management Service keys return some `KMSKey` instances. Namely, `listKeys()` returns an array of `KMSKey` objects. The `KMSKey` object describes an Amazon Key Management Service key.  
+`KMSClient.*` methods querying Key Management Service keys return some `KMSKey` instances. Namely, `listKeys()` returns an array of `KMSKey` objects. The `KMSKey` object describes an Amazon Key Management Service key.
 
 | Name            | Type   | Description                  |
 | :-------------- | :----- | :--------------------------- |
@@ -18,7 +18,7 @@ excerpt: 'KMSKey is returned by the KMSClient.* methods that query KMS keys'
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.7.1/kms.js';
+import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.7.2/kms.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/01 listBuckets().md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/01 listBuckets().md
@@ -19,7 +19,7 @@ excerpt: 'S3Client.listBuckets lists the buckets the authenticated user has acce
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.7.1/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.7.2/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/02 listObjects(bucketName, [prefix]).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/02 listObjects(bucketName, [prefix]).md
@@ -24,7 +24,7 @@ excerpt: 'S3Client.listObjects lists the objects contained in a bucket'
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.7.1/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.7.2/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/03 getObject(bucketName, objectKey).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/03 getObject(bucketName, objectKey).md
@@ -24,7 +24,7 @@ excerpt: 'S3Client.getObject downloads an object from a bucket'
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.7.1/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.7.2/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/04 putObject(bucketName, objectKey, data).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/04 putObject(bucketName, objectKey, data).md
@@ -17,7 +17,7 @@ excerpt: 'S3Client.putObject uploads an object to a bucket'
 <CodeGroup labels={[]}>
 
 ```javascript
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.7.1/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.7.2/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/05 deleteObject(bucketName, objectKey).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/05 deleteObject(bucketName, objectKey).md
@@ -18,7 +18,7 @@ excerpt: 'S3Client.deleteObject deletes an object from a bucket'
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.7.1/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.7.2/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/98 Object.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/98 Object.md
@@ -27,7 +27,7 @@ import {
   // listBuckets,
   AWSConfig,
   S3Client,
-} from 'https://jslib.k6.io/aws/0.7.1/s3.js';
+} from 'https://jslib.k6.io/aws/0.7.2/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/99 Bucket.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/99 Bucket.md
@@ -4,7 +4,7 @@ description: 'Bucket is returned by the S3Client.* methods who query S3 buckets.
 excerpt: 'Bucket is returned by the S3Client.* methods who query S3 buckets.'
 ---
 
-Bucket is returned by the S3Client.* methods that query S3 buckets. Namely, `listBuckets()` returns an array of Bucket objects. The Bucket object describes an Amazon S3 bucket.  
+Bucket is returned by the S3Client.* methods that query S3 buckets. Namely, `listBuckets()` returns an array of Bucket objects. The Bucket object describes an Amazon S3 bucket.
 
 | Name                  | Type   | Description                  |
 | :-------------------- | :----- | :--------------------------- |
@@ -16,7 +16,7 @@ Bucket is returned by the S3Client.* methods that query S3 buckets. Namely, `lis
 <CodeGroup labels={[]}>
 
 ```javascript
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.7.1/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.7.2/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SQSClient/01 sendMessage.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SQSClient/01 sendMessage.md
@@ -1,0 +1,54 @@
+---
+title: 'SQSClient.sendMessage()'
+description: "SQSClient.sendMessage sends a message to the specified Amazon SQS queue"
+excerpt: "SQSClient.sendMessage sends a message to the specified Amazon SQS queue"
+---
+
+`SQSClient.sendMessage(queueUrl, messageBody, options)` sends a message to the specified Amazon Simple Queue Service (SQS) queue.
+
+### Parameters
+
+| Name          | Type              | Description                                                                                                                                                                                                           |
+| :------------ | :---------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `queueUrl`    | string            | The URL of the Amazon SQS queue to which a message is sent. Queue URLs and names are case-sensitive.                                                                                                                  |
+| `messageBody` | string            | The message to send. The minimum size is one character. The maximum size is 256 KB.                                                                                                                                   |
+| `options`     | object (optional) | Options for the request. Accepted properties are `messageDeduplicationId` (optional string) setting the message deduplication id, and `messageGroupId` (optional string) setting the message group ID for FIFO queues |
+
+### Returns
+
+| Type     | Description                                                                                                                                                                                                                  |
+| :------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `object` | The message that was sent, as an object containing an `id` string property holding the unique identifier for the message, and a `bodyMD5` string property holding the MD5 digest of the non-URL-encoded message body string. |
+
+### Example
+
+<CodeGroup labels={[]}>
+
+```javascript
+import exec from 'k6/execution'
+
+import { AWSConfig, SQSClient } from 'https://jslib.k6.io/aws/0.7.2/sqs.js'
+
+const awsConfig = new AWSConfig({
+    region: __ENV.AWS_REGION,
+    accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+    secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+    sessionToken: __ENV.AWS_SESSION_TOKEN,
+})
+
+const sqs = new SQSClient(awsConfig)
+const testQueue = 'https://sqs.us-east-1.amazonaws.com/000000000/test-queue'
+
+export default function () {
+    // If our test queue does not exist, abort the execution.
+    const queuesResponse = sqs.listQueues()
+    if (queuesResponse.queueUrls.filter((q) => q === testQueue).length == 0) {
+        exec.test.abort()
+    }
+
+    // Send message to test queue
+    sqs.sendMessage(testQueue, JSON.stringify({value: '123'}));
+}
+```
+
+</CodeGroup>

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SQSClient/02 listQueues.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SQSClient/02 listQueues.md
@@ -1,0 +1,54 @@
+---
+title: 'SQSClient.listQueues()'
+description: "SQSClient.listQueues retrieves a list of available Amazon SQS queues"
+excerpt: "SQSClient.listQueues retrieves a list of available Amazon SQS queues"
+---
+
+`SQSClient.listQueues(options)` retrieves a list of available Amazon Simple Queue Service (SQS) queues.
+
+### Parameters
+
+| Name          | Type              | Description                                                                                                                                                                  |
+| :------------ | :---------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `options`     | object (optional) | Options for the request. Accepted properties are: `queueNamePrefix` (optional string) setting the prefix filter for the returned queue list, `maxResults` (optional number) setting the maximum number of results to include in the response (1 <= `maxResults` <= 1000>), and `nextToken` (optional string) setting the pagination token to request the next set of results. |
+
+### Returns
+
+| Type                                                        | Description                                                               |
+| :---------------------------------------------------------- | :------------------------------------------------------------------------ |
+| `object` | An object with an `urls` property containing an array of queue URLs, and an optional `nextToken` containing a pagination token to include in the next request when relevant. |
+
+### Example
+
+<CodeGroup labels={[]}>
+
+```javascript
+import exec from 'k6/execution'
+
+import { AWSConfig, SQSClient } from 'https://jslib.k6.io/aws/0.7.2/sqs.js'
+
+const awsConfig = new AWSConfig({
+    region: __ENV.AWS_REGION,
+    accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+    secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+    sessionToken: __ENV.AWS_SESSION_TOKEN,
+})
+
+const sqs = new SQSClient(awsConfig)
+const testQueue = 'https://sqs.us-east-1.amazonaws.com/000000000/test-queue'
+
+export default function () {
+    // List all queues in the AWS account
+    const queuesResponse = sqs.listQueues()
+
+    // If our test queue does not exist, abort the execution.
+    if (queuesResponse.queueUrls.filter((q) => q === testQueue).length == 0) {
+        exec.test.abort()
+    }
+
+    // Send message to test queue
+    sqs.sendMessage(testQueue, JSON.stringify({value: '123'}));
+}
+```
+
+</CodeGroup>

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/01 listSecrets().md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/01 listSecrets().md
@@ -19,7 +19,7 @@ excerpt: 'SecretsManagerClient.listSecrets lists the secrets the authenticated u
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.7.1/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.7.2/secrets-manager.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/02 getSecret(secretID).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/02 getSecret(secretID).md
@@ -23,7 +23,7 @@ excerpt: 'SecretsManagerClient.getSecret(secretID) downloads a secret from AWS s
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.7.1/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.7.2/secrets-manager.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/03 createSecret(name, secretString, description, [versionID], [tags]).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/03 createSecret(name, secretString, description, [versionID], [tags]).md
@@ -19,7 +19,7 @@ excerpt: 'SecretsManagerClient.createSecret creates a new secret'
 <CodeGroup labels={[]}>
 
 ```javascript
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.7.1/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.7.2/secrets-manager.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/04 deleteSecret.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/04 deleteSecret.md
@@ -16,7 +16,7 @@ excerpt: 'SecretsManagerClient.deleteSecret deletes a secret'
 <CodeGroup labels={[]}>
 
 ```javascript
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.7.1/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.7.2/secrets-manager.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/05 putSecretValue(secretID, secretString, [versionID]).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/05 putSecretValue(secretID, secretString, [versionID]).md
@@ -20,7 +20,7 @@ excerpt: "SecretsManagerClient.putSecretValue updates an existing secret's value
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.7.1/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.7.2/secrets-manager.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/99 Secret.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/99 Secret.md
@@ -25,7 +25,7 @@ Secret is returned by the SecretsManagerClient.* methods that query secrets. Nam
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.7.1/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.7.2/secrets-manager.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SignatureV4/01 sign().md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SignatureV4/01 sign().md
@@ -46,7 +46,7 @@ You can override SignatureV4 options in the context of this specific request. To
 ```javascript
 import http from 'k6/http.js'
 
-import { AWSConfig, SignatureV4 } from 'https://jslib.k6.io/aws/0.7.1/kms.js'
+import { AWSConfig, SignatureV4 } from 'https://jslib.k6.io/aws/0.7.2/kms.js'
 
 const awsConfig = new AWSConfig({
     region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SignatureV4/02 presign().md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SignatureV4/02 presign().md
@@ -55,7 +55,7 @@ import {
     SignatureV4,
     AMZ_CONTENT_SHA256_HEADER,
     UNSIGNED_PAYLOAD,
-} from 'https://jslib.k6.io/aws/0.7.1/kms.js'
+} from 'https://jslib.k6.io/aws/0.7.2/kms.js'
 
 const awsConfig = new AWSConfig({
     region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SystemsManagerClient/01 getParameter.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SystemsManagerClient/01 getParameter.md
@@ -19,7 +19,7 @@ excerpt: "SystemsManagerClient.getParameter gets a Systems Manager parameter in 
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SystemsManagerClient } from 'https://jslib.k6.io/aws/0.7.1/ssm.js';
+import { AWSConfig, SystemsManagerClient } from 'https://jslib.k6.io/aws/0.7.2/ssm.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SystemsManagerClient/99 SystemsManagerParameter.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SystemsManagerClient/99 SystemsManagerParameter.md
@@ -25,7 +25,7 @@ excerpt: 'SystemsManagerParameter is returned by the SystemsManagerClient.* meth
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SystemsManagerClient } from 'https://jslib.k6.io/aws/0.7.1/ssm.js';
+import { AWSConfig, SystemsManagerClient } from 'https://jslib.k6.io/aws/0.7.2/ssm.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,


### PR DESCRIPTION
This PR updates the documentation to reflect recent changes to the AWS jslib v0.7.2 which addresses a couple of bugs, adds a `SQSClient` class, and a new way to initialize an `AWSConfig` object from the environment.

Looking forward to your feedback and suggestions 🙇🏻 👋🏻  