### PR TITLE
Update example file path in Docker setup instructions

### DIFF
--- a/src/data/markdown/translated-guides/en/04 Results output/200 Real-time/00 InfluxDB - Grafana.md
+++ b/src/data/markdown/translated-guides/en/04 Results output/200 Real-time/00 InfluxDB - Grafana.md
@@ -117,7 +117,7 @@ $ docker-compose up -d \
     influxdb \
     grafana
 $ docker-compose run -v \
-    $PWD/samples:/scripts \
+    $PWD/examples:/scripts \
     k6 run /scripts/es6sample.js
 ```
 


### PR DESCRIPTION
Fix incorrect file path in Docker setup instructions for k6, InfluxDB, and Grafana. Change the path from $PWD/samples to $PWD/examples to reflect the correct location of the es6sample.js file.