### PR TITLE
refactor: remove networkidle option on browser tests

### DIFF
--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser.md
@@ -35,7 +35,7 @@ export default async function () {
   const page = context.newPage();
 
   try {
-    await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' })
+    await page.goto('https://test.k6.io/')
   } finally {
     page.close();
     browser.close();

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/01 Browser class.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/01 Browser class.md
@@ -32,7 +32,7 @@ export default async function () {
   const page = context.newPage();
 
   try {
-    await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
+    await page.goto('https://test.k6.io/');
   } finally {
     page.close();
     browser.close();

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/01 Browser class/newcontext--options--.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/01 Browser class/newcontext--options--.md
@@ -69,7 +69,7 @@ export default async function () {
   const page = context.newPage();
 
   try {
-    await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
+    await page.goto('https://test.k6.io/');
   } finally {
     page.close();
     browser.close();

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/01 Browser class/newpage--options--.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/01 Browser class/newpage--options--.md
@@ -67,7 +67,7 @@ export default async function () {
   });
 
   try {
-    await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
+    await page.goto('https://test.k6.io/');
   } finally {
     page.close();
     browser.close();

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/02 BrowserContext/newPage.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/02 BrowserContext/newPage.md
@@ -26,7 +26,7 @@ export default async function () {
   const page = context.newPage();
 
   try {
-    await page.goto('https://test.k6.io/browser.php', { waitUntil: 'networkidle' });
+    await page.goto('https://test.k6.io/browser.php');
   } finally {
     page.close();
     browser.close();

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/02 BrowserContext/setDefaultNavigationTimeout.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/02 BrowserContext/setDefaultNavigationTimeout.md
@@ -31,7 +31,7 @@ export default async function () {
   context.setDefaultNavigationTimeout(1000); // 1s
 
   try {
-    await page.goto('https://httpbin.test.k6.io/delay/5', { waitUntil: 'networkidle' });
+    await page.goto('https://httpbin.test.k6.io/delay/5');
   } finally {
     page.close();
     browser.close();

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/02 BrowserContext/setOffline.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/02 BrowserContext/setOffline.md
@@ -26,11 +26,8 @@ export default async function () {
   const page = context.newPage();
 
   try {
-    await page
-      .goto('https://test.k6.io/browser.php', { 
-        // Will not be able to load the page
-        waitUntil: 'networkidle' 
-    });
+    // Will not be able to load the page
+    await page.goto('https://test.k6.io/browser.php');
   } finally {
     page.close();
     browser.close();

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/03 BrowserType.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/03 BrowserType.md
@@ -27,7 +27,7 @@ export default async function () {
   const page = context.newPage();
 
   try {
-    await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
+    await page.goto('https://test.k6.io/');
     page.screenshot({ path: `example-chromium.png` });
   } finally {
     page.close();

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/03 BrowserType/connect--options--.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/03 BrowserType/connect--options--.md
@@ -37,7 +37,7 @@ export default async function () {
   const page = context.newPage();
 
   try {
-    await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
+    await page.goto('https://test.k6.io/');
     page.screenshot({ path: `example-chromium.png` });
   } finally {
     page.close();

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/03 BrowserType/launch--options--.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/03 BrowserType/launch--options--.md
@@ -100,7 +100,7 @@ export default async function () {
   const page = context.newPage();
 
   try {
-    await page.goto('http://whatsmyuseragent.org/', { waitUntil: 'networkidle' });
+    await page.goto('http://whatsmyuseragent.org/');
     page.screenshot({ path: `example-chromium.png` });
   } finally {
     page.close();

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/04-element-handle.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/04-element-handle.md
@@ -62,7 +62,7 @@ export default async function () {
 
   // Goto front page, find login link and click it
   try {
-    await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
+    await page.goto('https://test.k6.io/');
     const messagesLink = page.locator('a[href="/my_messages.php"]');
 
     await Promise.all([page.waitForNavigation(), messagesLink.click()]);

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/08 Locator.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/08 Locator.md
@@ -54,9 +54,7 @@ export default async function () {
   const page = context.newPage();
   
   try {
-    await page.goto("https://test.k6.io/flip_coin.php", {
-      waitUntil: "networkidle",
-    })
+    await page.goto("https://test.k6.io/flip_coin.php")
 
     /*
     In this example, we will use two locators, matching a

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/10-page.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/10-page.md
@@ -84,7 +84,7 @@ export default async function () {
 
   // Goto front page, find login link and click it
   try {
-    await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
+    await page.goto('https://test.k6.io/');
     const messagesLink = page.locator('a[href="/my_messages.php"]');
 
     await Promise.all([page.waitForNavigation(), messagesLink.click()]);

--- a/src/data/markdown/translated-guides/en/03 Using k6 browser/01 Overview.md
+++ b/src/data/markdown/translated-guides/en/03 Using k6 browser/01 Overview.md
@@ -33,7 +33,7 @@ export default async function () {
   const page = browser.newPage();
 
   try {
-    await page.goto('https://test.k6.io/my_messages.php', { waitUntil: 'networkidle' });
+    await page.goto('https://test.k6.io/my_messages.php');
 
     page.locator('input[name="login"]').type('admin');
     page.locator('input[name="password"]').type('123');

--- a/src/data/markdown/translated-guides/en/03 Using k6 browser/02 Running browser tests.md
+++ b/src/data/markdown/translated-guides/en/03 Using k6 browser/02 Running browser tests.md
@@ -35,7 +35,7 @@ To run a simple local script:
     const page = browser.newPage();
 
     try {
-      await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
+      await page.goto('https://test.k6.io/');
       page.screenshot({ path: 'screenshot.png' });
     } finally {
       page.close();
@@ -48,7 +48,7 @@ To run a simple local script:
 
   The preceding code imports the `chromium` [BrowserType](/javascript-api/k6-experimental/browser/browsertype/) (currently the only available `BrowserType` implementation), and uses its `launch` method to start up a Chromium [Browser](/javascript-api/k6-experimental/browser/) process. Two parameters are passed to it. One is the `headless` parameter with the value `false` so you can see the browser launching, and `timeout` parameter with the value `60s` which will be the timeout used for various actions and navigation. For a full list of parameters that you can pass, check out the documentation for [BrowserType.launch()](/javascript-api/k6-experimental/browser/browsertype/launch/).
   
-  After it starts, you can interact with it using the [browser-level APIs](/javascript-api/k6-experimental/browser/#browser-level-apis). This example visits a test URL, waits until the network is idle and takes a screenshot of the page. Afterwards, it closes the page and the browser.
+  After it starts, you can interact with it using the [browser-level APIs](/javascript-api/k6-experimental/browser/#browser-level-apis). This example visits a test URL and takes a screenshot of the page. Afterwards, it closes the page and the browser.
 
   <Blockquote mod="note" title="">
 
@@ -96,7 +96,7 @@ export default async function () {
   const page = browser.newPage();
 
   try {
-    await page.goto('https://test.k6.io/my_messages.php', { waitUntil: 'networkidle' });
+    await page.goto('https://test.k6.io/my_messages.php');
 
     // Enter login credentials
     page.locator('input[name="login"]').type('admin');
@@ -135,7 +135,7 @@ export default async function () {
   const page = browser.newPage();
 
   try {
-    await page.goto('https://test.k6.io/my_messages.php', { waitUntil: 'networkidle' });
+    await page.goto('https://test.k6.io/my_messages.php');
 
     page.locator('input[name="login"]').type('admin');
     page.locator('input[name="password"]').type('123');
@@ -205,7 +205,7 @@ export async function browser() {
   const page = browser.newPage();
 
   try {
-    await page.goto('https://test.k6.io/browser.php', { waitUntil: 'networkidle' });
+    await page.goto('https://test.k6.io/browser.php');
 
     page.locator('#checkbox1').check();
 

--- a/src/data/markdown/translated-guides/en/08 Testing Guides/03 Load testing websites.md
+++ b/src/data/markdown/translated-guides/en/08 Testing Guides/03 Load testing websites.md
@@ -192,7 +192,7 @@ export default async function () {
 
   // 01. Go to the homepage
   try {
-    await page.goto('https://mywebsite.com', { waitUntil: 'networkidle' });
+    await page.goto('https://mywebsite.com');
 
     page.waitForSelector('p[class="woocommerce-result-count"]"]');
     page.screenshot({ path: 'screenshots/01_homepage.png' });

--- a/src/data/markdown/versioned-js-api/v0.43/javascript api/07 k6-experimental/01 browser.md
+++ b/src/data/markdown/versioned-js-api/v0.43/javascript api/07 k6-experimental/01 browser.md
@@ -35,7 +35,7 @@ export default async function () {
   const page = context.newPage();
 
   try {
-    await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
+    await page.goto('https://test.k6.io/');
   } finally {
     page.close();
     browser.close();

--- a/src/data/markdown/versioned-js-api/v0.43/javascript api/07 k6-experimental/01 browser/01 Browser class.md
+++ b/src/data/markdown/versioned-js-api/v0.43/javascript api/07 k6-experimental/01 browser/01 Browser class.md
@@ -32,7 +32,7 @@ export default async function () {
   const page = context.newPage();
 
   try {
-    await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
+    await page.goto('https://test.k6.io/');
   } finally {
     page.close();
     browser.close();

--- a/src/data/markdown/versioned-js-api/v0.43/javascript api/07 k6-experimental/01 browser/01 Browser class/newcontext--options--.md
+++ b/src/data/markdown/versioned-js-api/v0.43/javascript api/07 k6-experimental/01 browser/01 Browser class/newcontext--options--.md
@@ -69,7 +69,7 @@ export default async function () {
   const page = context.newPage();
 
   try {
-    await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
+    await page.goto('https://test.k6.io/');
   } finally {
     page.close();
     browser.close();

--- a/src/data/markdown/versioned-js-api/v0.43/javascript api/07 k6-experimental/01 browser/01 Browser class/newpage--options--.md
+++ b/src/data/markdown/versioned-js-api/v0.43/javascript api/07 k6-experimental/01 browser/01 Browser class/newpage--options--.md
@@ -67,7 +67,7 @@ export default async function () {
   });
 
   try {
-    await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
+    await page.goto('https://test.k6.io/');
   } finally {
     page.close();
     browser.close();

--- a/src/data/markdown/versioned-js-api/v0.43/javascript api/07 k6-experimental/01 browser/02 BrowserContext/newPage.md
+++ b/src/data/markdown/versioned-js-api/v0.43/javascript api/07 k6-experimental/01 browser/02 BrowserContext/newPage.md
@@ -26,7 +26,7 @@ export default async function () {
   const page = context.newPage();
 
   try {
-    await page.goto('https://test.k6.io/browser.php', { waitUntil: 'networkidle' });
+    await page.goto('https://test.k6.io/browser.php');
   } finally {
     page.close();
     browser.close();

--- a/src/data/markdown/versioned-js-api/v0.43/javascript api/07 k6-experimental/01 browser/02 BrowserContext/setDefaultNavigationTimeout.md
+++ b/src/data/markdown/versioned-js-api/v0.43/javascript api/07 k6-experimental/01 browser/02 BrowserContext/setDefaultNavigationTimeout.md
@@ -31,7 +31,7 @@ export default async function () {
   context.setDefaultNavigationTimeout(1000); // 1s
 
   try {
-    await page.goto('https://httpbin.test.k6.io/delay/5', { waitUntil: 'networkidle' });
+    await page.goto('https://httpbin.test.k6.io/delay/5');
   } finally {
     page.close();
     browser.close();

--- a/src/data/markdown/versioned-js-api/v0.43/javascript api/07 k6-experimental/01 browser/02 BrowserContext/setOffline.md
+++ b/src/data/markdown/versioned-js-api/v0.43/javascript api/07 k6-experimental/01 browser/02 BrowserContext/setOffline.md
@@ -26,10 +26,8 @@ export default async function () {
   const page = context.newPage();
 
   try {
-    await page.goto('https://test.k6.io/browser.php', {
-      // Will not be able to load the page
-      waitUntil: 'networkidle',
-    });
+    // Will not be able to load the page
+    await page.goto('https://test.k6.io/browser.php');
   } finally {
     page.close();
     browser.close();

--- a/src/data/markdown/versioned-js-api/v0.43/javascript api/07 k6-experimental/01 browser/03 BrowserType.md
+++ b/src/data/markdown/versioned-js-api/v0.43/javascript api/07 k6-experimental/01 browser/03 BrowserType.md
@@ -27,7 +27,7 @@ export default async function () {
   const page = context.newPage();
 
   try {
-    await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
+    await page.goto('https://test.k6.io/');
     page.screenshot({ path: `example-chromium.png` });
   } finally {
     page.close();

--- a/src/data/markdown/versioned-js-api/v0.43/javascript api/07 k6-experimental/01 browser/03 BrowserType/launch--options--.md
+++ b/src/data/markdown/versioned-js-api/v0.43/javascript api/07 k6-experimental/01 browser/03 BrowserType/launch--options--.md
@@ -101,7 +101,7 @@ export default async function () {
   const page = context.newPage();
 
   try {
-    await page.goto('http://whatsmyuseragent.org/', { waitUntil: 'networkidle' });
+    await page.goto('http://whatsmyuseragent.org/');
     page.screenshot({ path: `example-chromium.png` });
   } finally {
     page.close();

--- a/src/data/markdown/versioned-js-api/v0.43/javascript api/07 k6-experimental/01 browser/04-element-handle.md
+++ b/src/data/markdown/versioned-js-api/v0.43/javascript api/07 k6-experimental/01 browser/04-element-handle.md
@@ -62,7 +62,7 @@ export default async function () {
 
   // Goto front page, find login link and click it
   try {
-    await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
+    await page.goto('https://test.k6.io/');
     await Promise.all([
       page.waitForNavigation(),
       page.locator('a[href="/my_messages.php"]').click(),

--- a/src/data/markdown/versioned-js-api/v0.43/javascript api/07 k6-experimental/01 browser/08 Locator.md
+++ b/src/data/markdown/versioned-js-api/v0.43/javascript api/07 k6-experimental/01 browser/08 Locator.md
@@ -54,9 +54,7 @@ export default async function () {
   const page = context.newPage();
 
   try {
-    await page.goto('https://test.k6.io/flip_coin.php', {
-      waitUntil: 'networkidle',
-    });
+    await page.goto('https://test.k6.io/flip_coin.php');
 
     /*
     In this example, we will use two locators, matching a

--- a/src/data/markdown/versioned-js-api/v0.43/javascript api/07 k6-experimental/01 browser/10-page.md
+++ b/src/data/markdown/versioned-js-api/v0.43/javascript api/07 k6-experimental/01 browser/10-page.md
@@ -84,7 +84,7 @@ export default async function () {
 
   // Goto front page, find login link and click it
   try {
-    await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
+    await page.goto('https://test.k6.io/');
     await Promise.all([
       page.waitForNavigation(),
       page.locator('a[href="/my_messages.php"]').click(),


### PR DESCRIPTION
As agreed with the k6 browser team, we will remove the use of `networkidle` on our browser docs because this option is not recommended by Playwright.