### PR TITLE
Update k6 browser API docs

### DIFF
--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/11 Request.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/11 Request.md
@@ -22,6 +22,6 @@ excerpt: "Browser module: Request Class"
 | <a href="https://playwright.dev/docs/api/class-request#request-redirected-to" target="_blank" >request.redirectedTo()</a> | - |
 | <a href="https://playwright.dev/docs/api/class-request#request-resource-type" target="_blank" >request.resourceType()</a> | - |
 | <a href="https://playwright.dev/docs/api/class-request#request-response" target="_blank" >request.response()</a> | - |
-| <a href="https://playwright.dev/docs/api/class-request#request-sizes" target="_blank" >request.size()</a> | Unlike Playwright this method returns an object containing the sizes of request headers and body, e.g. `{ headers: 100, body: 200 }` |
+| [request.size()](/javascript-api/k6-experimental/browser/request/size) | Unlike Playwright this method returns an object containing the sizes of request headers and body. |
 | <a href="https://playwright.dev/docs/api/class-request#request-timing" target="_blank" >request.timing()</a> | - |
 | <a href="https://playwright.dev/docs/api/class-request#request-url" target="_blank" >request.url()</a> | - |

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/11 Request.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/11 Request.md
@@ -22,6 +22,6 @@ excerpt: "Browser module: Request Class"
 | <a href="https://playwright.dev/docs/api/class-request#request-redirected-to" target="_blank" >request.redirectedTo()</a> | - |
 | <a href="https://playwright.dev/docs/api/class-request#request-resource-type" target="_blank" >request.resourceType()</a> | - |
 | <a href="https://playwright.dev/docs/api/class-request#request-response" target="_blank" >request.response()</a> | - |
-| [request.size()](/javascript-api/k6-experimental/browser/request/size) | Unlike Playwright this method returns an object containing the sizes of request headers and body. |
+| [request.size()](/javascript-api/k6-experimental/browser/request/size) | Unlike Playwright, this method returns an object containing the sizes of request headers and body. |
 | <a href="https://playwright.dev/docs/api/class-request#request-timing" target="_blank" >request.timing()</a> | - |
 | <a href="https://playwright.dev/docs/api/class-request#request-url" target="_blank" >request.url()</a> | - |

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/11 Request/size.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/11 Request/size.md
@@ -3,7 +3,7 @@ title: 'size()'
 excerpt: 'Browser module: Request.size method'
 ---
 
-Similar to Playwright's [`request.sizes()`](https://playwright.dev/docs/api/class-request#request-sizes) this method returns the size (in bytes) of body and header sections of the [Request](/javascript-api/k6-experimental/browser/request).
+Similar to Playwright's [`request.sizes()`](https://playwright.dev/docs/api/class-request#request-sizes), this method returns the size (in bytes) of body and header sections of the [Request](/javascript-api/k6-experimental/browser/request).
 
 ### Returns
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/11 Request/size.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/11 Request/size.md
@@ -1,0 +1,12 @@
+---
+title: 'size()'
+excerpt: 'Browser module: Request.size method'
+---
+
+Similar to Playwright's [`request.sizes()`](https://playwright.dev/docs/api/class-request#request-sizes) this method returns the size (in bytes) of body and header sections of the [Request](/javascript-api/k6-experimental/browser/request).
+
+### Returns
+
+| Type   | Description                           |
+|--------|---------------------------------------|
+| object | `{ body: <bytes>, headers: <bytes> }` |

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/11-request.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/11-request.md
@@ -18,8 +18,10 @@ excerpt: "Browser module: Request Class"
 | <a href="https://playwright.dev/docs/api/class-request#request-method" target="_blank" >request.method()</a> | - |
 | <a href="https://playwright.dev/docs/api/class-request#request-post-data" target="_blank" >request.postData()</a> | - |
 | <a href="https://playwright.dev/docs/api/class-request#request-post-data-buffer" target="_blank" >request.postDataBuffer()</a> | - |
+| <a href="https://playwright.dev/docs/api/class-request#request-redirected-from" target="_blank" >request.redirectedFrom()</a> | - |
+| <a href="https://playwright.dev/docs/api/class-request#request-redirected-to" target="_blank" >request.redirectedTo()</a> | - |
 | <a href="https://playwright.dev/docs/api/class-request#request-resource-type" target="_blank" >request.resourceType()</a> | - |
 | <a href="https://playwright.dev/docs/api/class-request#request-response" target="_blank" >request.response()</a> | - |
-| <a href="https://playwright.dev/docs/api/class-request#request-sizes" target="_blank" >request.sizes()</a> | - |
+| <a href="https://playwright.dev/docs/api/class-request#request-sizes" target="_blank" >request.size()</a> | Unlike Playwright this method returns an object containing the sizes of request headers and body, e.g. `{ headers: 100, body: 200 }` |
 | <a href="https://playwright.dev/docs/api/class-request#request-timing" target="_blank" >request.timing()</a> | - |
 | <a href="https://playwright.dev/docs/api/class-request#request-url" target="_blank" >request.url()</a> | - |

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/12-response.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/12-response.md
@@ -23,5 +23,5 @@ excerpt: "Browser module: Response Class"
 | <a href="https://playwright.dev/docs/api/class-response#response-server-addr" target="_blank" >response.serverAddr()</a> | - | - |
 | <a href="https://playwright.dev/docs/api/class-response#response-status" target="_blank" >response.status()</a> | - | - |
 | <a href="https://playwright.dev/docs/api/class-response#response-status-text" target="_blank" >response.statusText()</a> | - | - |
-| response.size() | - | Similar to [`Request.size()`](/javascript-api/k6-experimental/browser/request/ returns the size of response headers and body sections, e.g. `{ headers: 100, body: 200 }` |
+| response.size() | - | Similar to [`Request.size()`](/javascript-api/k6-experimental/browser/request/size) returns the size of response headers and body sections. |
 | <a href="https://playwright.dev/docs/api/class-response#response-url" target="_blank" >response.url()</a> | - | - |

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/12-response.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/12-response.md
@@ -7,21 +7,21 @@ excerpt: "Browser module: Response Class"
 
 ## Supported APIs
 
-| Method | Playwright Relevant Distinctions |
-| - |  - |
-| <a href="https://playwright.dev/docs/api/class-response#response-all-headers" target="_blank" >response.allHeaders()</a> | - |
-| <a href="https://playwright.dev/docs/api/class-response#response-body" target="_blank" >response.body()</a> | - |
-| <a href="https://playwright.dev/docs/api/class-response#response-frame" target="_blank" >response.frame()</a> | - |
-| <a href="https://playwright.dev/docs/api/class-response#response-headers" target="_blank" >response.headers()</a> | - |
-| <a href="https://playwright.dev/docs/api/class-response#response-headers-array" target="_blank" >response.headersArray()</a> | - |
-| <a href="https://playwright.dev/docs/api/class-response#response-header-value" target="_blank" >response.headerValue(name)</a> | - |
-| <a href="https://playwright.dev/docs/api/class-response#response-header-values" target="_blank" >response.headerValues(name)</a> | - |
-| <a href="https://playwright.dev/docs/api/class-response#response-json" target="_blank" >response.json()</a> | - |
-| <a href="https://playwright.dev/docs/api/class-response#response-ok" target="_blank" >response.ok()</a> | - |
-| <a href="https://playwright.dev/docs/api/class-response#response-request" target="_blank" >response.request()</a> | - |
-| <a href="https://playwright.dev/docs/api/class-response#response-security-details" target="_blank" >response.securityDetails()</a> | - |
-| <a href="https://playwright.dev/docs/api/class-response#response-server-addr" target="_blank" >response.serverAddr()</a> | - |
-| <a href="https://playwright.dev/docs/api/class-response#response-status" target="_blank" >response.status()</a> | - |
-| <a href="https://playwright.dev/docs/api/class-response#response-status-text" target="_blank" >response.statusText()</a> | - |
-| <a href="https://playwright.dev/docs/api/class-response#response-text" target="_blank" >response.text()</a> | - |
-| <a href="https://playwright.dev/docs/api/class-response#response-url" target="_blank" >response.url()</a> | - |
+| Method | Playwright Relevant Distinctions | Description |
+| - |  - | - |
+| <a href="https://playwright.dev/docs/api/class-response#response-all-headers" target="_blank" >response.allHeaders()</a> | - | - |
+| <a href="https://playwright.dev/docs/api/class-response#response-body" target="_blank" >response.body()</a> | - | - |
+| <a href="https://playwright.dev/docs/api/class-response#response-frame" target="_blank" >response.frame()</a> | - | - |
+| <a href="https://playwright.dev/docs/api/class-response#response-headers" target="_blank" >response.headers()</a> | - | - |
+| <a href="https://playwright.dev/docs/api/class-response#response-headers-array" target="_blank" >response.headersArray()</a> | - | - |
+| <a href="https://playwright.dev/docs/api/class-response#response-header-value" target="_blank" >response.headerValue(name)</a> | - | - |
+| <a href="https://playwright.dev/docs/api/class-response#response-header-values" target="_blank" >response.headerValues(name)</a> | - | - |
+| <a href="https://playwright.dev/docs/api/class-response#response-json" target="_blank" >response.json()</a> | - | - |
+| <a href="https://playwright.dev/docs/api/class-response#response-ok" target="_blank" >response.ok()</a> | - | - |
+| <a href="https://playwright.dev/docs/api/class-response#response-request" target="_blank" >response.request()</a> | - | - |
+| <a href="https://playwright.dev/docs/api/class-response#response-security-details" target="_blank" >response.securityDetails()</a> | - | - |
+| <a href="https://playwright.dev/docs/api/class-response#response-server-addr" target="_blank" >response.serverAddr()</a> | - | - |
+| <a href="https://playwright.dev/docs/api/class-response#response-status" target="_blank" >response.status()</a> | - | - |
+| <a href="https://playwright.dev/docs/api/class-response#response-status-text" target="_blank" >response.statusText()</a> | - | - |
+| response.size() | - | Similar to [`Request.size()`](/javascript-api/k6-experimental/browser/request/ returns the size of response headers and body sections, e.g. `{ headers: 100, body: 200 }` |
+| <a href="https://playwright.dev/docs/api/class-response#response-url" target="_blank" >response.url()</a> | - | - |

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/12-response.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/12-response.md
@@ -23,5 +23,5 @@ excerpt: "Browser module: Response Class"
 | <a href="https://playwright.dev/docs/api/class-response#response-server-addr" target="_blank" >response.serverAddr()</a> | - | - |
 | <a href="https://playwright.dev/docs/api/class-response#response-status" target="_blank" >response.status()</a> | - | - |
 | <a href="https://playwright.dev/docs/api/class-response#response-status-text" target="_blank" >response.statusText()</a> | - | - |
-| response.size() | - | Similar to [`Request.size()`](/javascript-api/k6-experimental/browser/request/size) returns the size of response headers and body sections. |
+| response.size() | - | Similar to [`Request.size()`](/javascript-api/k6-experimental/browser/request/size), this returns the size of response headers and body sections. |
 | <a href="https://playwright.dev/docs/api/class-response#response-url" target="_blank" >response.url()</a> | - | - |


### PR DESCRIPTION
This PR updates the list of methods of `Request` and `Response` types of the k6 browser API to match the actual implementation.