### PR TITLE
docs: add k6 version for the browser module

### DIFF
--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser.md
@@ -9,6 +9,12 @@ The browser module APIs aim for rough compatibility with the [Playwright API for
 
 Note that because k6 does not run in NodeJS, the browser module APIs will slightly differ from their Playwright counterparts.
 
+<Blockquote mod="note" title="">
+
+To work with the browser module, make sure you are using [k6 version 0.43.0](https://github.com/grafana/k6/releases/tag/v0.43.0) or above.
+
+</Blockquote>
+
 ## Modules
 
 The table below lists the importable properties from the top level module (`'k6/experimental/browser'`).

--- a/src/data/markdown/translated-guides/en/03 Using k6 browser/01 Overview.md
+++ b/src/data/markdown/translated-guides/en/03 Using k6 browser/01 Overview.md
@@ -11,6 +11,12 @@ The [Browser module](https://github.com/grafana/xk6-browser) brings browser auto
 
 This module aims to provide rough compatibility with the Playwright API, so you don’t need to learn a completely new API.
 
+<Blockquote mod="note" title="">
+
+To work with the browser module, make sure you are using [k6 version 0.43.0](https://github.com/grafana/k6/releases/tag/v0.43.0) or above.
+
+</Blockquote>
+
 ## Use case for browser testing
 
 The main use case for the browser module is to test performance on the browser level. Browser-level testing  provides a way to measure user experience and  find issues that are difficult to catch on the protocol level. Browser-level testing can help you answer questions like:


### PR DESCRIPTION
As suggested by one of our users, https://k6io.slack.com/archives/C3E688J8Z/p1683213296899049, this PR adds which k6 version you need to be in to use the browser module