### PR TITLE
feat: consistent blockquote title style

### DIFF
--- a/src/components/shared/blockquote/blockquote.module.scss
+++ b/src/components/shared/blockquote/blockquote.module.scss
@@ -15,16 +15,15 @@ blockquote {
   & div[class^='with-copy-button'] {
     margin-top: 15px;
   }
-}
-
-.kicker {
-  display: block;
-  font-size: $font-size-xs;
-  line-height: $line-height-xs;
-  color: $color-accent-primary;
-  font-weight: 600;
-  &.uppercased {
-    text-transform: uppercase;
+  .kicker {
+    display: block;
+    font-size: $font-size-xs;
+    line-height: $line-height-xs;
+    color: $color-accent-primary;
+    font-weight: 600;
+    &.uppercased {
+      text-transform: uppercase;
+    }
   }
 }
 


### PR DESCRIPTION
This PR makes the block quote title style more consistent. For example –> content [page](https://mdr-ci.staging.k6.io/docs/refs/pull/1164/merge/using-k6-browser/overview/) and extension [page](https://mdr-ci.staging.k6.io/docs/refs/pull/1164/merge/extensions/)