### PR TITLE
fix: extensions counts when filtering

### DIFF
--- a/src/components/pages/doc-extensions/extension-selection/extension-selection.view.js
+++ b/src/components/pages/doc-extensions/extension-selection/extension-selection.view.js
@@ -95,10 +95,13 @@ export const ExtensionSelection = ({ data, description = '' }) => {
   );
 
   const totalActiveExtensions = useMemo(
-    () =>
-      activeCategories
-        .map((category) => filteredExtensionsByCategory(category))
-        .flat(),
+    () => [
+      ...new Set(
+        activeCategories
+          .map((category) => filteredExtensionsByCategory(category))
+          .flat(),
+      ),
+    ],
     [activeCategories, activeTier, activeType, extensions],
   );
 
@@ -352,7 +355,8 @@ export const ExtensionSelection = ({ data, description = '' }) => {
             <p className={styles.result}>
               <span>
                 <b className={styles.number}>{totalActiveExtensions.length}</b>{' '}
-                result{totalActiveExtensions.length === 1 ? '' : 's'} found
+                result
+                {totalActiveExtensions.length === 1 ? '' : 's'} found
               </span>{' '}
               <Button
                 className={styles.clearButton}
@@ -391,7 +395,7 @@ export const ExtensionSelection = ({ data, description = '' }) => {
           </div>
         </div>
       )}
-      <div className="">
+      <div>
         {/* eslint-disable-next-line no-nested-ternary */}
         {totalActiveExtensions.length === 0 ? (
           <div className={styles.notFoundWrapper}>

--- a/src/components/shared/form-message/form-message.view.js
+++ b/src/components/shared/form-message/form-message.view.js
@@ -1,4 +1,3 @@
-import MarketoForm from 'components/shared/marketo-form';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -26,7 +25,7 @@ const FormMessage = ({ type }) => (
   </div>
 );
 
-MarketoForm.propTypes = {
+FormMessage.propTypes = {
   type: PropTypes.string.isRequired,
 };
 

--- a/src/templates/docs/bundle-builder.js
+++ b/src/templates/docs/bundle-builder.js
@@ -102,7 +102,7 @@ const BundleBuilderPage = ({ pageContext: { sidebarTree, navLinks } }) => {
             Don&apos;t see what you need? Learn how you can{' '}
             <Link
               to={'/extensions/get-started/create/'}
-              class={docPageContent.link}
+              className={docPageContent.link}
             >
               create
             </Link>{' '}


### PR DESCRIPTION
This PR fixes the extension count when filtering on the [Bundle page](https://mdr-ci.staging.k6.io/docs/refs/pull/1165/merge/extensions/get-started/bundle/).