### PR TITLE
Document k6/experimental/browser.Worker

### DIFF
--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser.md
@@ -41,7 +41,7 @@ export default async function () {
   const page = context.newPage();
 
   try {
-    await page.goto('https://test.k6.io/')
+    await page.goto('https://test.k6.io/');
   } finally {
     page.close();
     browser.close();
@@ -68,3 +68,4 @@ export default async function () {
 | [Request](/javascript-api/k6-experimental/browser/request/) <BWIPT />               | Used to keep track of the request the [`Page`](/javascript-api/k6-experimental/browser/page/) makes.                                                                        |
 | [Response](/javascript-api/k6-experimental/browser/response/) <BWIPT />             | Represents the response received by the [`Page`](/javascript-api/k6-experimental/browser/page/).                                                                            |
 | [Touchscreen](/javascript-api/k6-experimental/browser/touchscreen/)                 | Used to simulate touch interactions with the associated [`Page`](/javascript-api/k6-experimental/browser/page/).                                                            |
+| [Worker](/javascript-api/k6-experimental/browser/worker/)                           | Represents a [WebWorker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API).                                                            |

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/14 Worker.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/14 Worker.md
@@ -1,0 +1,14 @@
+---
+title: "Worker"
+excerpt: "Browser module: Worker Class"
+---
+
+<BrowserDocsWIP/>
+
+## Supported APIs
+
+| Method | Playwright Relevant Distinctions |
+| - |  - |
+| <a href="https://playwright.dev/docs/api/class-worker#worker-url" target="_blank" >worker.url()</a> | - |
+| <a href="https://playwright.dev/docs/api/class-worker#worker-evaluate" target="_blank" >worker.evaluate(pageFunction[, arg])</a> | - | - |
+| <a href="https://playwright.dev/docs/api/class-worker#worker-evaluate-handle" target="_blank" >worker.evaluateHandle(pageFunction[, arg])</a> | - | - |


### PR DESCRIPTION
This PR adds missing documentation for k6 browser API `Worker` class.