### PR TITLE
Add `Dockerfile-standalone` for a static docker build

### DIFF
--- a/Dockerfile-standalone
+++ b/Dockerfile-standalone
@@ -1,0 +1,31 @@
+FROM node:16-slim as builder
+
+EXPOSE 8000
+
+RUN mkdir /app
+WORKDIR /app
+
+COPY package*.json /app/
+
+RUN npm install
+
+COPY . /app/
+
+ARG URL=http://localhost:8080
+
+# We use --mount args to reuse gatsby cache. We need to mount both .cache/ and public/ as gatsby refuses to use the
+# former if the latter does not exist.
+# public/ is a mountpoint for this command only, so we copy it to public-persist/ so we can use the build output later.
+# build:gatsby must be used as opposed to run, as the latter will not obey PATH_PREFIX.
+RUN --mount=type=cache,target=/app/.cache --mount=type=cache,target=/app/public \
+    PATH_PREFIX=/docs \
+    GATSBY_DEFAULT_MAIN_URL=$URL \
+    GATSBY_DEFAULT_DOC_URL=$URL/docs/ \
+    GATSBY_DEFAULT_BLOG_URL=https://k6.io/blog \
+    npm run build:gatsby && \
+    cp -r public public-persist
+
+FROM nginx:1.23-alpine3.17
+
+RUN echo '<a href="/docs">/docs</a>' > /usr/share/nginx/html/index.html
+COPY --from=builder /app/public-persist /usr/share/nginx/html/docs

--- a/README.md
+++ b/README.md
@@ -56,4 +56,17 @@ Then visit http://localhost:8100
 
 > If you want to re-run the `--build` command, you may get an error about not having access to delete a `cache/` folder. Use `sudo` to delete this manually before retrying.
 
+### Static Docker build
 
+Additionally, the `Dockerfile-standalone` Dockefile allows to produce a lightweight static build which also does not need local files to run. This can be useful in certain scenarios, for example for sharing the build output easily.
+
+In order to build the static version in docker, run:
+
+```shell
+docker build -f Dockerfile-standalone . -t k6-docs
+```
+
+To serve the site locally, run:
+```shell
+docker run --rm -ti -p 8080:80 k6-docs
+```


### PR DESCRIPTION
This PR provides an alternative way of building the docs locally, that aims to be more reproducible and shareable than the default `Dockerfile`.

The `Dockerfile-standalone` copies all files in the build step and instructs Gatsby to produce a production build, so it does not have a dependency on the local environment to run. It leverages docker build-time mounts to reuse Gatsby cache, making subsequent builds as fast as if they were local. Finally it serves the generated HTML using nginx, which makes the image lighter for sharing or hosting it somewhere.

Not sure if you will be interested on having this, feel free to just close the PR if you aren't :)