### PR TITLE
ci/pr-deploy: cache node modules and gatsby output

### DIFF
--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
       - name: Restore cache
         uses: actions/cache@v2
         with:
@@ -45,6 +46,7 @@ jobs:
         with:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
       - name: Restore cache
         uses: actions/cache@v2
         with:
@@ -94,9 +96,21 @@ jobs:
         with:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
 
       - name: Install
         run: npm install
+
+      - name: Restore build cache
+        uses: actions/cache@v3
+        with:
+          # Gatsby requires both .cache and public. It will refuse to use .cache/ if public/ is not present.
+          path: |
+            .cache
+            public
+          # Cache will not be used by Gatsby if the following files change:
+          # https://www.gatsbyjs.com/docs/build-caching/
+          key: pr-gatsby-${{ hashFiles('package.json', 'gatsby-config.js', 'gatsby-node.js') }}
 
       - name: Build
         run: npm run build

--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -110,7 +110,9 @@ jobs:
             public
           # Cache will not be used by Gatsby if the following files change:
           # https://www.gatsbyjs.com/docs/build-caching/
-          key: pr-gatsby-${{ hashFiles('package.json', 'gatsby-config.js', 'gatsby-node.js') }}
+          key:  pr-gatsby-${{ hashFiles('package.json', 'gatsby-config.js', 'gatsby-node.js') }}-${{ github.ref }}
+          restore-keys: |
+            pr-gatsby-${{ hashFiles('package.json', 'gatsby-config.js', 'gatsby-node.js') }}-
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
While working in #1180 I noticed PR build took more than 10 minutes to build, which was a bit of an annoying wait. It should be possible to reduce this time by leveraging https://github.com/actions/cache to restore the gatsby build cache across builds.

The current key should make this cache reusable across all PRs in the repo that do not modify `package.json`, `gatsby-config.js` or `gatsby-node.js`.

### Before
![image](https://github.com/grafana/k6-docs/assets/969721/0c377e3f-bc26-4ab2-807d-ece594a07daa)

### After

![image](https://github.com/grafana/k6-docs/assets/969721/6506f6a4-95f5-4572-be98-591011616ef0)


### Summary

This PR cuts build time by ~10 minutes, and that saving should happen even the first time a PR is opened.