### PR TITLE
ci/staging: leverage node_modules and gatsby cache on staging as well

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -26,29 +26,9 @@ env:
   GATSBY_NEWSLETTER_FORM_ID: 1420
 
 jobs:
-  update-dependencies:
-    name: Update node module dependencies
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout project
-        uses: actions/checkout@v2
-      - name: Use Node.js 16.xs
-        uses: actions/setup-node@v2
-        with:
-          node-version: '16.x'
-          registry-url: 'https://registry.npmjs.org'
-      - name: Restore cache
-        uses: actions/cache@v2
-        with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
-      - name: Install dependencies
-        run: npm install
   lint:
     name: Lint code
     runs-on: ubuntu-latest
-    needs:
-      - update-dependencies
     steps:
       - name: Checkout project
         uses: actions/checkout@v2
@@ -57,13 +37,28 @@ jobs:
         with:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
-      - name: Restore cache
+          cache: 'npm'
+      - name: Restore node_modules cache
         uses: actions/cache@v2
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
-      - name: Install dependencies
+      - name: Install
         run: npm install
+      - name: Restore Gatsby cache
+        uses: actions/cache@v3
+        with:
+          # Gatsby requires both .cache and public. It will refuse to use .cache/ if public/ is not present.
+          path: |
+            .cache
+            public
+          # Cache will not be used by Gatsby if the following files change:
+          # https://www.gatsbyjs.com/docs/build-caching/
+          # We use the commit SHA on the key to prevent an ever-living cache entry keyed as "main".
+          key: pr-gatsby-${{ hashFiles('package.json', 'gatsby-config.js', 'gatsby-node.js') }}-${{ github.ref }}-${{ github.sha }}
+          restore-keys: |
+            pr-gatsby-${{ hashFiles('package.json', 'gatsby-config.js', 'gatsby-node.js') }}-${{ github.ref }}-
+            pr-gatsby-${{ hashFiles('package.json', 'gatsby-config.js', 'gatsby-node.js') }}-
       - name: Check formatting
         run: |
           npm run format
@@ -99,13 +94,26 @@ jobs:
         with:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
-      - name: Restore cache
+          cache: 'npm'
+      - name: Restore node_modules cache
         uses: actions/cache@v2
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
-      - name: Install dependencies
+      - name: Install
         run: npm install
+      - name: Restore Gatsby cache
+        uses: actions/cache@v3
+        with:
+          # Gatsby requires both .cache and public. It will refuse to use .cache/ if public/ is not present.
+          path: |
+            .cache
+            public
+          # Cache will not be used by Gatsby if the following files change:
+          # https://www.gatsbyjs.com/docs/build-caching/
+          key:  pr-gatsby-${{ hashFiles('package.json', 'gatsby-config.js', 'gatsby-node.js') }}-${{ github.ref }}
+          restore-keys: |
+            pr-gatsby-${{ hashFiles('package.json', 'gatsby-config.js', 'gatsby-node.js') }}-
       - name: Build project
         run: npm run build:gatsby
       - name: Checks if AWS CLI already installed


### PR DESCRIPTION
As mentioned in https://github.com/grafana/k6-docs/pull/1183#issuecomment-1556951247, and contrary to what I intended with #1182, the gatsby cache is not being currently reused across PRs. The reason why is outlined in the [GHA docs](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache):

> Workflow runs cannot restore caches created for child branches or sibling branches. For example, a cache created for the child feature-b branch would not be accessible to a workflow run triggered on the parent main branch. Similarly, a cache created for the feature-a branch with the base main would not be accessible to its sibling feature-c branch with the base main.

An easy way to fix this is to also use the cache on workflows targeting `main`, such as the deploy to staging job. This will also make this workflow faster.