### PR TITLE
feat: re-enable xk6-prometheus

### DIFF
--- a/src/data/doc-extensions/extensions.json
+++ b/src/data/doc-extensions/extensions.json
@@ -527,6 +527,21 @@
       "cloudEnabled": false
     },
     {
+      "name": "xk6-prometheus",
+      "description": "Prometheus HTTP exporter for k6",
+      "url": "https://github.com/szkiba/xk6-prometheus",
+      "logo": "https://raw.githubusercontent.com/szkiba/xk6-prometheus/v0.2.0/assets/xk6-prometheus.png",
+      "author": {
+        "name": "Iván Szkiba",
+        "url": "https://github.com/szkiba"
+      },
+      "stars": "41",
+      "type": ["Output"],
+      "categories": ["Reporting", "Observability"],
+      "tiers": ["Community"],
+      "cloudEnabled": false
+    },
+    {
       "name": "xk6-cache",
       "description": "Enable vendoring remote HTTP modules to a single source-control-friendly file",
       "url": "https://github.com/szkiba/xk6-cache",


### PR DESCRIPTION
Please add the [xk6-prometheus](https://github.com/szkiba/xk6-prometheus) extension. It was added earlier, but has since disappeared from the list (see [this](https://github.com/grafana/k6-docs/blob/fc6f7e24496202f22a9af177a716695c1d3ca397/src/data/ecosystem/extensions.js#L412) from 2021)

xk6-prometheus is a k6 extension implements Prometheus HTTP exporter as k6 output extension.