### PR TITLE
Fix typos and add missing options to aws jslib's sign()

### DIFF
--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws.md
@@ -37,5 +37,6 @@ This documentation is for the last version only. If you discover that some code 
 | [KMSClient](/javascript-api/jslib/aws/kmsclient)                       | Client class to interact with AWS Key Management Service.            |
 | [S3Client](/javascript-api/jslib/aws/s3client)                         | Client class to interact with AWS S3 buckets and objects.            |
 | [SecretsManager](/javascript-api/jslib/aws/secretsmanagerclient)       | Client class to interact with AWS secrets stored in Secrets Manager. |
+| [SignatureV4](/javascript-api/jslib/aws/signaturev4) | Class to sign and pre-sign requests to AWS services. |
 | [SQSClient](/javascript-api/jslib/aws/sqsclient)                       | Client class to interact with AWS Simple Queue Service.              |
 | [SystemsManagerClient](/javascript-api/jslib/aws/systemsmanagerclient) | Client class to interact with AWS Systems Manager Service.           |

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SignatureV4/00 sign().md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SignatureV4/00 sign().md
@@ -17,10 +17,11 @@ The first parameter of the `sign` method consists of an Object with the followin
 | hostname      | string                   | The hostname the request is sent to                                                                                                                                                                                                                                     |
 | path          | string                   | The path of the request                                                                                                                                                                                                                                                 |
 | headers       | Object                   | The headers of the HTTP request                                                                                                                                                                                                                                         |
-| body?         | string or ArrayBuffer    | The optional body of the HTTP request                                                                                                                                                                                                                                   |
 | uriEscapePath | boolean                  | Whether to uri-escape the request URI path as part of computing the canonical request string. This is required for every AWS service, except Amazon S3, as of late 2017.                                                                                                |
 | applyChecksum | boolean                  | Whether to calculate a checksum of the request body and include it as either a request header (when signing) or as a query string parameter (when pre-signing). This is required for AWS Glacier and Amazon S3 and optional for every other AWS service as of late 2017. |
-|               |                          |                                                                                                                                                                                                                                                                         |
+| body (optional)         | string or ArrayBuffer    | The optional body of the HTTP request                                                                                                                                                                                                                                   |
+| query (optional) | `Object.<string, string \| Array.<string>>` | The optional query parameters of the HTTP request |
+
 
 You can override SignatureV4 options in the context of this specific request. To do this, pass a second parameter to the `sign` method, which is an Object with the following parameters.
 
@@ -46,7 +47,7 @@ You can override SignatureV4 options in the context of this specific request. To
 ```javascript
 import http from 'k6/http.js'
 
-import { AWSConfig, SignatureV4 } from 'https://jslib.k6.io/aws/0.7.2/kms.js'
+import { AWSConfig, SignatureV4 } from 'https://jslib.k6.io/aws/0.7.2/signature.js'
 
 const awsConfig = new AWSConfig({
     region: __ENV.AWS_REGION,


### PR DESCRIPTION
This PR closes #1007 

It:
- addresses the example's import to reflect the relevant file instead: `signature.js`
- expands on the `sign` operation's documentation to make sure all available options are listed

closes #1007 