### PR TITLE
Add `robots` option to frontmatter and edit the markdown of the "category" guides

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1036,7 +1036,7 @@ async function fetchGuidesPagesData(graphql) {
                   slug
                   head_title
                   excerpt
-
+                  robots
                   redirect
                   redirectTarget
                   hideFromSidebar
@@ -1132,12 +1132,6 @@ async function createDocPages({
     getJavascriptAPISidebar,
   })
     .concat(
-      getGuidesPagesProps({
-        nodesGuides,
-        reporter,
-        pathCollisionDetectorInstance,
-        getGuidesSidebar,
-      }),
       getJsAPIVersionedPagesProps({
         nodesJsAPI,
         reporter,
@@ -1158,6 +1152,12 @@ async function createDocPages({
         getGuidesSidebar,
         getJavascriptAPISidebar,
         reporter,
+      }),
+      getGuidesPagesProps({
+        nodesGuides,
+        reporter,
+        pathCollisionDetectorInstance,
+        getGuidesSidebar,
       }),
     )
     .map((pageProps) => actions.createPage(pageProps));

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -376,6 +376,8 @@ function getSupplementaryPagesProps({
       }),
     );
 
+  // the same thing in getGuidesPagesProps
+  // eslint-disable-next-line no-unused-vars
   const stubGuidesPagesProps = SUPPORTED_LOCALES.flatMap((locale) =>
     childrenToList(getGuidesSidebar(locale).children).map(({ name, meta }) => {
       const path = `${locale}/${meta.title}`;
@@ -422,7 +424,7 @@ function getSupplementaryPagesProps({
     }),
   );
 
-  return stubPagesProps.concat(notFoundProps, stubGuidesPagesProps);
+  return stubPagesProps.concat(notFoundProps);
 }
 
 function getTopLevelPagesProps({
@@ -1132,6 +1134,12 @@ async function createDocPages({
     getJavascriptAPISidebar,
   })
     .concat(
+      getGuidesPagesProps({
+        nodesGuides,
+        reporter,
+        pathCollisionDetectorInstance,
+        getGuidesSidebar,
+      }),
       getJsAPIVersionedPagesProps({
         nodesJsAPI,
         reporter,
@@ -1152,12 +1160,6 @@ async function createDocPages({
         getGuidesSidebar,
         getJavascriptAPISidebar,
         reporter,
-      }),
-      getGuidesPagesProps({
-        nodesGuides,
-        reporter,
-        pathCollisionDetectorInstance,
-        getGuidesSidebar,
       }),
     )
     .map((pageProps) => actions.createPage(pageProps));

--- a/src/components/shared/seo/seo.view.js
+++ b/src/components/shared/seo/seo.view.js
@@ -14,7 +14,7 @@ const getPageHref = (host, slug) => {
 };
 
 export const SEO = ({
-  data: { title, description, image, slug, canonicalUrl } = {},
+  data: { title, description, image, slug, canonicalUrl, robots } = {},
   facebook,
   pageTranslations = null,
   pageVersions = null,
@@ -80,6 +80,10 @@ export const SEO = ({
       currentRobotsContent.current = 'noindex';
     }
   }, []);
+
+  if (robots) {
+    currentRobotsContent.current = robots;
+  }
 
   if (pageTranslations) {
     if (pageTranslations.es) {

--- a/src/data/markdown/translated-guides/en/06 Test Types.md
+++ b/src/data/markdown/translated-guides/en/06 Test Types.md
@@ -4,4 +4,16 @@ excerpt: 'A series of conceptual articles explaining the different types of load
 robots: NOINDEX, FOLLOW
 ---
 
-Lorem ipsum... custom content
+[Load test types](/test-types/load-test-types/)
+
+[Smoke testing](/test-types/smoke-testing/)
+
+[Load testing](/test-types/load-testing/)
+
+[Stress testing](/test-types/stress-testing/)
+
+[Soak testing](/test-types/soak-testing/)
+
+[Spike testing](/test-types/spike-testing/)
+
+[Breakpoint testing](/breakpoint-testing/)

--- a/src/data/markdown/translated-guides/en/06 Test Types.md
+++ b/src/data/markdown/translated-guides/en/06 Test Types.md
@@ -4,16 +4,4 @@ excerpt: 'A series of conceptual articles explaining the different types of load
 robots: NOINDEX, FOLLOW
 ---
 
-[Load test types](/test-types/load-test-types/)
-
-[Smoke testing](/test-types/smoke-testing/)
-
-[Load testing](/test-types/load-testing/)
-
-[Stress testing](/test-types/stress-testing/)
-
-[Soak testing](/test-types/soak-testing/)
-
-[Spike testing](/test-types/spike-testing/)
-
-[Breakpoint testing](/breakpoint-testing/)
+A series of articles explaining the different [load test types](/test-types/load-test-types/).

--- a/src/data/markdown/translated-guides/en/06 Test Types.md
+++ b/src/data/markdown/translated-guides/en/06 Test Types.md
@@ -1,0 +1,7 @@
+---
+title: 'Test types'
+excerpt: 'A series of conceptual articles explaining the different types of load tests. Learn about planning, running, and interpreting different tests for different performance goals.'
+robots: NOINDEX, FOLLOW
+---
+
+Lorem ipsum... custom content

--- a/src/data/markdown/translated-guides/en/07 Testing Guides.md
+++ b/src/data/markdown/translated-guides/en/07 Testing Guides.md
@@ -1,0 +1,12 @@
+---
+title: 'Testing guides'
+excerpt: 'A series of guides to help you defining your load testing strategies.'
+---
+
+
+This section provides a list of frequently-asked guides to help you set your testing strategy for common cases:
+
+- [API load testing](/testing-guides/api-load-testing/)
+- [Automated performance testing](/testing-guides/automated-performance-testing/)
+- [Load testing websites](/testing-guides/load-testing-websites/)
+- [Running large tests](/testing-guides/running-large-tests/)

--- a/src/layouts/doc-layout/doc-layout.module.scss
+++ b/src/layouts/doc-layout/doc-layout.module.scss
@@ -163,6 +163,16 @@ h2.sidebar-section-title {
   }
 }
 
+.sidebarSectionInvisibleLink {
+  @extend .sidebar-section-title-link;
+  cursor: default;
+  color: #9c97b5;
+  &:hover {
+    color: #9c97b5;
+    border-color: transparent;
+  }
+}
+
 .sidebar-node {
   position: relative;
 }

--- a/src/layouts/doc-layout/doc-layout.view.js
+++ b/src/layouts/doc-layout/doc-layout.view.js
@@ -340,7 +340,11 @@ export const DocLayout = ({
                       tag={'h2'}
                     >
                       <Link
-                        className={styles.sidebarSectionTitleLink}
+                        className={
+                          sectionName === 'Guides'
+                            ? styles.sidebarSectionInvisibleLink
+                            : styles.sidebarSectionTitleLink
+                        }
                         to={sectionNode.meta.path}
                       >
                         {sectionNode.meta.title || sectionNode.name}

--- a/src/templates/doc-page.js
+++ b/src/templates/doc-page.js
@@ -121,6 +121,7 @@ export const Head = ({
       description: frontmatter.excerpt,
       slug: frontmatter.slug ? frontmatter.slug : location.pathname.slice(1),
       canonicalUrl: frontmatter.canonicalUrl,
+      robots: frontmatter.robots,
     },
   };
 

--- a/src/templates/docs/breadcrumb-stub.js
+++ b/src/templates/docs/breadcrumb-stub.js
@@ -1,6 +1,9 @@
+import { DocPageTitleGroup } from 'components/pages/doc-page/doc-page-title-group';
+import { styles as codeStyles } from 'components/shared/code';
 import { Heading } from 'components/shared/heading';
 import { SEO } from 'components/shared/seo';
 import { Breadcrumbs } from 'components/templates/doc-page/breadcrumbs';
+import { DocPageContent } from 'components/templates/doc-page/doc-page-content';
 import styles from 'components/templates/doc-page/doc-page.module.scss';
 import LocaleProvider from 'contexts/locale-provider';
 import { Link } from 'gatsby';
@@ -17,6 +20,7 @@ const BreadcrumbsStubPage = (props) => {
       breadcrumbs,
       navLinks,
       title,
+      remarkNode,
       directChildren,
       locale,
       translations = null,
@@ -40,34 +44,53 @@ const BreadcrumbsStubPage = (props) => {
       >
         <div className={`${styles.container}`}>
           <Breadcrumbs items={breadcrumbs} label={styles.breadcrumbsStub} />
-          <Heading className={styles.title}>{title}</Heading>
-          <ul className={styles.sectionList}>
-            {childrenToList(directChildren).map(
-              ({ meta, name }, i) =>
-                !meta.hideFromSidebar && (
-                  <li key={`bcl-${i}`}>
-                    {meta.redirect ? (
-                      <a
-                        href={meta.redirect}
-                        className={'link'}
-                        target={
-                          meta.redirectTarget ? meta.redirectTarget : '_self'
-                        }
-                      >
-                        {meta.title ? meta.title : name}
-                      </a>
-                    ) : (
-                      <Link
-                        to={`${meta.path || slugify(`/${name}`)}`}
-                        className={'link'}
-                      >
-                        {meta.title ? meta.title : name}
-                      </Link>
-                    )}
-                  </li>
-                ),
-            )}
-          </ul>
+          {remarkNode ? (
+            <>
+              <DocPageTitleGroup
+                title={remarkNode.frontmatter.title}
+                articleSrc={remarkNode.frontmatter.fileOrigin}
+                heading={remarkNode.frontmatter.heading}
+              />
+              <DocPageContent
+                label={codeStyles.codeContainer}
+                content={remarkNode.body}
+                version={version}
+              />
+            </>
+          ) : (
+            <>
+              <Heading className={styles.title}>{title}</Heading>
+              <ul className={styles.sectionList}>
+                {childrenToList(directChildren).map(
+                  ({ meta, name }, i) =>
+                    !meta.hideFromSidebar && (
+                      <li key={`bcl-${i}`}>
+                        {meta.redirect ? (
+                          <a
+                            href={meta.redirect}
+                            className={'link'}
+                            target={
+                              meta.redirectTarget
+                                ? meta.redirectTarget
+                                : '_self'
+                            }
+                          >
+                            {meta.title ? meta.title : name}
+                          </a>
+                        ) : (
+                          <Link
+                            to={`${meta.path || slugify(`/${name}`)}`}
+                            className={'link'}
+                          >
+                            {meta.title ? meta.title : name}
+                          </Link>
+                        )}
+                      </li>
+                    ),
+                )}
+              </ul>
+            </>
+          )}
         </div>
       </DocLayout>
     </LocaleProvider>

--- a/src/templates/docs/breadcrumb-stub.js
+++ b/src/templates/docs/breadcrumb-stub.js
@@ -99,11 +99,12 @@ const BreadcrumbsStubPage = (props) => {
 
 export default BreadcrumbsStubPage;
 
-export const Head = ({ pageContext: { title, version } }) => {
+export const Head = ({ pageContext: { title, version, remarkNode } }) => {
   const pageMetaData = {
     data: {
       title,
       description: ' ',
+      robots: remarkNode?.frontmatter.robots,
     },
   };
 


### PR DESCRIPTION
- [x] Add `robots` metatag to frontmatter
- [ ] Allow editing the content of the categories. The API section supports this option but not on the `Guides`. 

Editing the markdown content of the [Test Types category](https://mdr-ci.staging.k6.io/docs/refs/pull/1203/merge/test-types/) to showcase it does not work yet.