### PR TITLE
feat: add xk6-g0 extension

### DIFF
--- a/src/data/doc-extensions/extensions.json
+++ b/src/data/doc-extensions/extensions.json
@@ -1110,6 +1110,21 @@
       "categories": ["Misc"],
       "tiers": ["Community"],
       "cloudEnabled": false
+    },
+    {
+      "name": "xk6-g0",
+      "description": "Write k6 tests in golang",
+      "url": "https://github.com/szkiba/xk6-g0",
+      "logo": "",
+      "author": {
+        "name": "Iván Szkiba",
+        "url": "https://github.com/szkiba"
+      },
+      "stars": "0",
+      "type": ["JavaScript"],
+      "categories": ["Misc"],
+      "tiers": ["Community"],
+      "cloudEnabled": false
     }
   ]
 }


### PR DESCRIPTION
Please add [xk6-g0](https://github.com/szkiba/xk6-g0) extension.
The xk6-g0 extension allows writing k6 tests in the go language using yaegi interpreter.