### PR TITLE
Add browser launch options to the root page

### DIFF
--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser.md
@@ -196,7 +196,7 @@ Additionally if headless mode is set to `true` in [browser options](/javascript-
 | mute-audio | `true` | Mutes audio sent to the audio device so it is not audible during automated testing. |
 | blink-settings | primaryHoverType=2,availableHoverTypes=2,<br />primaryPointerType=4,availablePointerTypes=4 | Sets blink settings. Format is <name\>[=<value\>],<name\>[=<value\>],... The names are declared in [settings.json5](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/frame/settings.json5) from chromium project. For boolean type, use "true", "false", or omit '=<value\>' part to set to true. For enum type, use the int value of the enum value. |
 
-### Devices Example
+## Devices Example
 
 To emulate the browser behaviour on a mobile device and approximately measure the browser performance, you can import `devices` from `k6/experimental/browser`.
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser.md
@@ -9,7 +9,7 @@ The browser module APIs aim for rough compatibility with the [Playwright API for
 
 Note that because k6 does not run in NodeJS, the browser module APIs will slightly differ from their Playwright counterparts.
 
-You can find examples of using the browser module API in our [getting started guide](using-k6-browser).
+You can find examples of using [the browser module API](#browser-module-api) in our [getting started guide](using-k6-browser).
 
 <Blockquote mod="note" title="">
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser.md
@@ -9,6 +9,8 @@ The browser module APIs aim for rough compatibility with the [Playwright API for
 
 Note that because k6 does not run in NodeJS, the browser module APIs will slightly differ from their Playwright counterparts.
 
+You can find examples of using the browser module API in our [getting started guide](using-k6-browser).
+
 <Blockquote mod="note" title="">
 
 To work with the browser module, make sure you are using the latest [k6 version](https://github.com/grafana/k6/releases).
@@ -93,6 +95,86 @@ export default async function () {
 | [Touchscreen](/javascript-api/k6-experimental/browser/touchscreen/)                 | Used to simulate touch interactions with the associated [`Page`](/javascript-api/k6-experimental/browser/page/).                                                            |
 | [Worker](/javascript-api/k6-experimental/browser/worker/)                           | Represents a [WebWorker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API).                                                            |
 
+
+## Browser Module Options
+
+You can customize the behavior of the browser module by providing browser options as environment variables.
+
+| Environment Variable | Description |
+| -------------------- | ----------- |
+| K6_BROWSER_ARGS | Extra command line arguments to include when launching browser process. See [this link](https://peter.sh/experiments/chromium-command-line-switches/) for a list of Chromium arguments. Note that arguments should not start with `--` (see the [example](#example)). |
+| K6_BROWSER_DEBUG | All CDP messages and internal fine grained logs will be logged if set to `true`. |
+| K6_BROWSER_EXECUTABLE_PATH | Override search for browser executable in favor of specified absolute path. |
+| K6_BROWSER_HEADLESS | Show browser GUI or not. `true` by default. |
+| K6_BROWSER_IGNORE_DEFAULT_ARGS | Ignore any of the [default arguments](#default-arguments) included when launching a browser process. |
+| K6_BROWSER_TIMEOUT | Default timeout to use for various actions and navigation. `'30s'` if not set. |
+
+### Example
+
+<CodeGroup labels={["Bash", "Windows: CMD", "Windows: PowerShell"]} lineNumbers={[false]}>
+
+```bash
+$ K6_BROWSER_ARGS='show-property-changed-rects' k6 run script.js
+```
+
+```bash
+C:\k6> set "K6_BROWSER_ARGS='show-property-changed-rects' " && k6 run script.js
+```
+
+```bash
+PS C:\k6> $env:K6_BROWSER_ARGS='show-property-changed-rects' ; k6 run script.js
+```
+
+</CodeGroup>
+
+
+## Default arguments
+
+List of default arguments included when launching the browser process. You can pass one or more of the arguments to the `K6_BROWSER_IGNORE_DEFAULT_ARGS` environment variable when starting a test for the ones you want to ignore.
+
+<Blockquote mod="note">
+
+The starting '--' have been omitted from the argument names in these lists.
+
+</Blockquote>
+
+| Argument | Value  | Description                                            |
+|----------|--------|--------------------------------------------------------|
+| disable-background-networking | `true` | Disables several subsystems which run network requests in the background. This is used during network performance testing to avoid measurement noise. |
+| enable-features | NetworkService,<br />NetworkServiceInProcess | Comma-separated list of feature names to enable. |
+| disable-background-timer-throttling | `true` | Disables task throttling of timer tasks from background pages. |
+| disable-backgrounding-occluded-windows | `true` | Disables backgrounding renders for occluded windows. Done for tests to avoid nondeterministic behavior. |
+| disable-breakpad | `true` | Disables the crash reporting. |
+| disable-component-extensions<br />-with-background-pages | `true` | Disables default component extensions with background pages. Useful for performance tests where these pages may interfere with results. |
+| disable-default-apps | `true` | Disables the installation of default apps on the first run. This is used during automated testing. |
+| disable-dev-shm-usage | `true` | The /dev/shm partition is too small in certain VM environments, causing Chrome to fail or crash. This flag provides a work-around for this issue (a temporary directory will always be used to create anonymous shared memory files). |
+| disable-extensions | `true` | Disables extensions. |
+| disable-features | ImprovedCookieControls,<br />LazyFrameLoading,<br />GlobalMediaControls,<br />DestroyProfileOnBrowserClose,<br />MediaRouter,<br />AcceptCHFrame | Comma-separated list of feature names to disable. |
+| disable-hang-monitor | `true` | Suppresses hang monitor dialogs in renderer processes. This may allow slow unload handlers on a page to prevent the tab from closing, but the Task Manager can be used to terminate the offending process in this case. |
+| disable-ipc-flooding-protection | `true` | Disables the IPC flooding protection. It is activated by default. Some javascript functions can be used to flood the browser process with IPC. This protection limits the rate at which they can be used. |
+| disable-popup-blocking | `true` | Disables pop-up blocking. |
+| disable-prompt-on-repost | `true` | Usually, when the user attempts to navigate to a page that was the result of a post request, the browser prompts to make sure that's the intention of the user. This switch may be used to disable that check during automated testing.  |
+| disable-renderer-backgrounding | `true` | Prevents renderer process backgrounding when set. |
+| force-color-profile | `srgb` | Forces all monitors to be treated as though they have the specified color profile. Accepted values are "srgb" and "generic-rgb" (currently used by Mac layout tests) and "color-spin-gamma24" (used by layout tests). |
+| metrics-recording-only | `true` | Enables the recording of metrics reports but disables reporting. This executes all the code that a normal client would use for reporting, except the report is dropped rather than sent to the server. This is useful for finding issues in the metrics code during UI and performance tests. |
+| no-first-run | `true` | Skips the "First Run" tasks, whether or not it's the first run, and the "What's New" page. This does not drop the "First Run" sentinel and thus doesn't prevent "First Run" from occurring the next time Chromium is launched without this flag. It also does not update the last "What's New" milestone, so it does not prevent "What's New" from occurring the next time Chromium is launched without this flag. |
+| enable-automation | `true` | Enables indication that the browser is controlled by automation. |
+| password-store | `basic` | Specifies which encryption storage backend to use. The possible values are kwallet, kwallet5, gnome, gnome-keyring, gnome-libsecret, and basic. Any other value will lead to Chromium detecting the best backend automatically. |
+| use-mock-keychain | `true` | Uses mock keychain on Mac to prevent the blocking permissions dialog about: "Chrome wants to use your confidential information stored in your keychain." |
+| no-service-autorun | `true` | Disables the service process from adding itself as an autorun process. This does not delete existing autorun registrations, it just prevents the service from registering a new one. |
+| no-startup-window | `true` | Does not automatically open a browser window on startup (used when launching Chrome for the purpose of hosting background apps). |
+| no-default-browser-check | `true` | Disables the default browser check. Useful for UI/browser tests where we want to avoid having the default browser info-bar displayed. |
+| headless | `true`/`false` | Run in headless mode, i.e., without a UI or display server dependencies. Set by [launch options](/javascript-api/k6-experimental/browser/browsertype/launch/) (default true).  |
+| auto-open-devtools-for-tabs | `true`/`false` | This flag makes Chrome auto-open the DevTools window for each tab. It is intended to be used by developers and automation, not to require user interaction for opening DevTools. Set by [launch options](/javascript-api/k6-experimental/browser/browsertype/launch/) (default false). |
+| window-size | `800,600` | Sets the initial window size. Provided as string in the format "800,600". |
+
+Additionally if headless mode is set to `true` in [browser options](/javascript-api/k6-experimental/browser#browser_options), the following arguments are also set:
+
+| Argument   | Value  | Description                                            |
+|------------|--------|--------------------------------------------------------|
+| hide-scrollbars | `true` | Prevents creating scrollbars for web content. Useful for taking consistent screenshots. |
+| mute-audio | `true` | Mutes audio sent to the audio device so it is not audible during automated testing. |
+| blink-settings | primaryHoverType=2,availableHoverTypes=2,<br />primaryPointerType=4,availablePointerTypes=4 | Sets blink settings. Format is <name\>[=<value\>],<name\>[=<value\>],... The names are declared in [settings.json5](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/frame/settings.json5) from chromium project. For boolean type, use "true", "false", or omit '=<value\>' part to set to true. For enum type, use the int value of the enum value. |
 
 ### Devices Example
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser.md
@@ -9,7 +9,7 @@ The browser module APIs aim for rough compatibility with the [Playwright API for
 
 Note that because k6 does not run in NodeJS, the browser module APIs will slightly differ from their Playwright counterparts.
 
-You can find examples of using [the browser module API](#browser-module-api) in our [getting started guide](using-k6-browser).
+You can find examples of using [the browser module API](#browser-module-api) in our [getting started guide](/using-k6-browser).
 
 <Blockquote mod="note" title="">
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser.md
@@ -77,6 +77,25 @@ export default async function () {
 
 </CodeGroup>
 
+Then, run the test on your terminal with this command. The following command passes the [browser module options](#browser-module-options) as environment variables to launch a headful browser with custom arguments.
+
+<CodeGroup labels={["Bash", "Windows: CMD", "Windows: PowerShell"]} lineNumbers={[false]}>
+
+```bash
+$ K6_BROWSER_HEADLESS=false K6_BROWSER_ARGS='show-property-changed-rects' k6 run script.js
+```
+
+```bash
+C:\k6> set "K6_BROWSER_HEADLESS=false" && set "K6_BROWSER_ARGS='show-property-changed-rects' " && k6 run script.js
+```
+
+```bash
+PS C:\k6> $env:K6_BROWSER_HEADLESS="false" ; $env:K6_BROWSER_ARGS='show-property-changed-rects' ; k6 run script.js
+```
+
+</CodeGroup>
+
+
 
 ## Browser-level APIs
 
@@ -108,25 +127,6 @@ You can customize the behavior of the browser module by providing browser option
 | K6_BROWSER_HEADLESS | Show browser GUI or not. `true` by default. |
 | K6_BROWSER_IGNORE_DEFAULT_ARGS | Ignore any of the [default arguments](#default-arguments) included when launching a browser process. |
 | K6_BROWSER_TIMEOUT | Default timeout to use for various actions and navigation. `'30s'` if not set. |
-
-### Example
-
-<CodeGroup labels={["Bash", "Windows: CMD", "Windows: PowerShell"]} lineNumbers={[false]}>
-
-```bash
-$ K6_BROWSER_ARGS='show-property-changed-rects' k6 run script.js
-```
-
-```bash
-C:\k6> set "K6_BROWSER_ARGS='show-property-changed-rects' " && k6 run script.js
-```
-
-```bash
-PS C:\k6> $env:K6_BROWSER_ARGS='show-property-changed-rects' ; k6 run script.js
-```
-
-</CodeGroup>
-
 
 ## Default arguments
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser.md
@@ -77,23 +77,24 @@ export default async function () {
 
 </CodeGroup>
 
-Then, run the test on your terminal with this command. The following command passes the [browser module options](#browser-module-options) as environment variables to launch a headful browser with custom arguments.
+Then, you can run the test with this command. Also, see the [browser module options](/javascript-api/k6-experimental/browser/#browser-module-options) for customizing the browser module's behavior using environment variables.
 
 <CodeGroup labels={["Bash", "Windows: CMD", "Windows: PowerShell"]} lineNumbers={[false]}>
 
 ```bash
-$ K6_BROWSER_HEADLESS=false K6_BROWSER_ARGS='show-property-changed-rects' k6 run script.js
+$ k6 run script.js
 ```
 
 ```bash
-C:\k6> set "K6_BROWSER_HEADLESS=false" && set "K6_BROWSER_ARGS='show-property-changed-rects'" && k6 run script.js
+C:\k6> k6 run script.js
 ```
 
 ```bash
-PS C:\k6> $env:K6_BROWSER_HEADLESS="false" ; $env:K6_BROWSER_ARGS='show-property-changed-rects' ; k6 run script.js
+PS C:\k6> k6 run script.js
 ```
 
 </CodeGroup>
+
 
 
 
@@ -127,6 +128,25 @@ You can customize the behavior of the browser module by providing browser option
 | K6_BROWSER_HEADLESS | Show browser GUI or not. `true` by default. |
 | K6_BROWSER_IGNORE_DEFAULT_ARGS | Ignore any of the [default arguments](#default-arguments) included when launching a browser process. |
 | K6_BROWSER_TIMEOUT | Default timeout to use for various actions and navigation. `'30s'` if not set. |
+
+The following command passes the [browser module options](#browser-module-options) as environment variables to launch a headful browser with custom arguments.
+
+<CodeGroup labels={["Bash", "Windows: CMD", "Windows: PowerShell"]} lineNumbers={[false]}>
+
+```bash
+$ K6_BROWSER_HEADLESS=false K6_BROWSER_ARGS='show-property-changed-rects' k6 run script.js
+```
+
+```bash
+C:\k6> set "K6_BROWSER_HEADLESS=false" && set "K6_BROWSER_ARGS='show-property-changed-rects' " && k6 run script.js
+```
+
+```bash
+PS C:\k6> $env:K6_BROWSER_HEADLESS="false" ; $env:K6_BROWSER_ARGS='show-property-changed-rects' ; k6 run script.js
+```
+
+</CodeGroup>
+
 
 ## Default arguments
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser.md
@@ -86,7 +86,7 @@ $ K6_BROWSER_HEADLESS=false K6_BROWSER_ARGS='show-property-changed-rects' k6 run
 ```
 
 ```bash
-C:\k6> set "K6_BROWSER_HEADLESS=false" && set "K6_BROWSER_ARGS='show-property-changed-rects' " && k6 run script.js
+C:\k6> set "K6_BROWSER_HEADLESS=false" && set "K6_BROWSER_ARGS='show-property-changed-rects'" && k6 run script.js
 ```
 
 ```bash

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/10 Page/waitforfunction--options--.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/10 Page/waitforfunction--options--.md
@@ -31,6 +31,7 @@ Returns when the `pageFunction` returns a truthy value.
 
 ```javascript
 import { browser } from 'k6/experimental/browser';
+import { check } from 'k6';
 
 export const options = {
   scenarios: {

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/10 Page/waitforfunction--options--.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/10 Page/waitforfunction--options--.md
@@ -30,7 +30,6 @@ Returns when the `pageFunction` returns a truthy value.
 <!-- eslint-skip-->
 
 ```javascript
-import { check } from 'k6';
 import { browser } from 'k6/experimental/browser';
 
 export const options = {

--- a/src/data/markdown/translated-guides/en/03 Using k6 browser/02 Running browser tests.md
+++ b/src/data/markdown/translated-guides/en/03 Using k6 browser/02 Running browser tests.md
@@ -85,6 +85,23 @@ PS C:\k6> k6 run script.js
 
 </CodeGroup>
 
+You can also use [the browser module options](/javascript-api/k6-experimental/browser/#browser-module-options) to customize the launching of a browser process. For instance, you can start a headful browser using the previous test script with this command.
+
+<CodeGroup labels={["Bash", "Windows: CMD", "Windows: PowerShell"]} lineNumbers={[false]}>
+
+```bash
+$ K6_BROWSER_HEADLESS=false k6 run script.js
+```
+
+```bash
+C:\k6> set "K6_BROWSER_HEADLESS=false" && k6 run script.js
+```
+
+```bash
+PS C:\k6> $env:K6_BROWSER_HEADLESS=false ; k6 run script.js
+```
+
+</CodeGroup>
 
 
 ## Interact with elements on your webpage


### PR DESCRIPTION
I don't know the reason, but the preview/staging link doesn't update my latest changes. I'll rerun the CI jobs.

This doesn't show up ("You can find examples of ..." part):

<img width="892" alt="Screenshot 2023-06-13 at 14 33 00" src="https://github.com/grafana/k6-docs/assets/621232/13f41914-00ed-46a8-90cb-72a29fd8e8cc">

Closes: https://github.com/grafana/k6-docs/issues/1171.