### PR TITLE
Update `k6/ws` blockquote to refer the experimental module

### DIFF
--- a/src/components/shared/ws-blockquote/index.js
+++ b/src/components/shared/ws-blockquote/index.js
@@ -1,0 +1,3 @@
+import WsBlockquote from './ws-blockquote.view';
+
+export default WsBlockquote;

--- a/src/components/shared/ws-blockquote/ws-blockquote.view.js
+++ b/src/components/shared/ws-blockquote/ws-blockquote.view.js
@@ -1,0 +1,25 @@
+import Blockquote from 'components/shared/blockquote';
+import React from 'react';
+
+const WsBlockquote = () => (
+  <Blockquote mod="info">
+    <h4>A module with a better and standard API exists</h4>
+    <p>
+      The new{' '}
+      <a href="https://k6.io/docs/javascript-api/k6-experimental/websockets/">
+        k6/experimental/websockets API
+      </a>{' '}
+      partially implements the{' '}
+      <a href="https://websockets.spec.whatwg.org/">
+        WebSockets API living standard
+      </a>
+      .
+    </p>
+    <p>
+      When possible, we recommend using the new API. It uses a global event loop
+      for consistency with other k6 APIs and better performance.
+    </p>
+  </Blockquote>
+);
+
+export default WsBlockquote;

--- a/src/components/templates/doc-page/doc-page-content/doc-page-content.view.js
+++ b/src/components/templates/doc-page/doc-page-content/doc-page-content.view.js
@@ -18,6 +18,7 @@ import { Link } from 'components/shared/link';
 import TableWithNestedRows from 'components/shared/table-with-nested-rows';
 import TableWrapper from 'components/shared/table-wrapper';
 import Tooltip, { BNIT, BWIPT } from 'components/shared/tooltip';
+import WsBlockquote from 'components/shared/ws-blockquote';
 import React, { useRef } from 'react';
 
 import styles from './doc-page-content.module.scss';
@@ -41,6 +42,7 @@ const componentsForNativeReplacement = {
   BrowserWIP,
   ExperimentalBlockquote,
   BlockingAwsBlockquote,
+  WsBlockquote,
   InstallationInstructions,
   Tooltip,
   BNIT,

--- a/src/data/markdown/docs/02 javascript api/12 k6-ws.md
+++ b/src/data/markdown/docs/02 javascript api/12 k6-ws.md
@@ -2,15 +2,8 @@
 title: "k6/ws"
 excerpt: "k6 WebSocket API"
 ---
+<WsBlockquote />
 
-<Blockquote mod='info'>
-
-#### An extension with much better and standard API exists
-
-[xk6-websockets](https://github.com/grafana/xk6-websockets) implements [the WebSockets API living standard](https://websockets.spec.whatwg.org/). While the implementation isn't full, it uses a global event loop instead of local one.
-
-Currently, it's available as an experimental module [`k6/experimental/websockets`](/javascript-api/k6-experimental/websockets/). It is also likely that it will at some point become part of the core of k6.
-</Blockquote>
 
 The ws module provides a [WebSocket](https://en.wikipedia.org/wiki/WebSocket) client implementing the [WebSocket protocol](http://www.rfc-editor.org/rfc/rfc6455.txt).
 

--- a/src/data/markdown/docs/02 javascript api/12 k6-ws/10-connect- url- params- callback -.md
+++ b/src/data/markdown/docs/02 javascript api/12 k6-ws/10-connect- url- params- callback -.md
@@ -4,6 +4,8 @@ description: 'Create a WebSocket connection, and provides a Socket client to int
 excerpt: 'Create a WebSocket connection, and provides a Socket client to interact with the service.'
 ---
 
+<WsBlockquote />
+
 Initiate a WebSocket connection to a remote host.
 
 Calling connect will block the VU finalization until the WebSocket connection is closed. Instead of continuously looping the main function (`export default function() { ... }`) over an over, each VU will be halted listening to async events and executing their event handlers until the connection is closed.

--- a/src/data/markdown/docs/02 javascript api/12 k6-ws/20-Params.md
+++ b/src/data/markdown/docs/02 javascript api/12 k6-ws/20-Params.md
@@ -4,6 +4,8 @@ description: 'Used for setting various WebSocket request-specific parameters suc
 excerpt: 'Used for setting various WebSocket request-specific parameters such as headers, tags, etc.'
 ---
 
+<WsBlockquote />
+
 _Params_ is an object used by the WebSocket methods that generate WebSocket requests. _Params_ contains request-specific options like headers that should be inserted into the request.
 
 | Name                  | Type   | Description |

--- a/src/data/markdown/docs/02 javascript api/12 k6-ws/80 Socket.md
+++ b/src/data/markdown/docs/02 javascript api/12 k6-ws/80 Socket.md
@@ -3,6 +3,8 @@ title: 'Socket'
 excerpt: 'Socket is a WebSocket client to interact with a WebSocket connection.'
 ---
 
+<WsBlockquote />
+
 `Socket` is a WebSocket client to interact with a WebSocket connection. You can use it to listen various events happening on the WebSocket connection and send messages to the server. Additionally, you can use socket.setTimeout() and socket.setInterval() to execute code in the background, or repeatedly, while the WebSocket connection is open.
 
 | Method                                                                                                      | Description                                                                                                                                               |

--- a/src/data/markdown/docs/02 javascript api/12 k6-ws/80 Socket/Socket-close--.md
+++ b/src/data/markdown/docs/02 javascript api/12 k6-ws/80 Socket/Socket-close--.md
@@ -3,6 +3,8 @@ title: 'Socket.close([code])'
 excerpt: 'Close the WebSocket connection.'
 ---
 
+<WsBlockquote />
+
 Close the WebSocket connection.
 
 | Parameter       | Type     | Description                                  |

--- a/src/data/markdown/docs/02 javascript api/12 k6-ws/80 Socket/Socket-on-event- callback-.md
+++ b/src/data/markdown/docs/02 javascript api/12 k6-ws/80 Socket/Socket-on-event- callback-.md
@@ -3,6 +3,8 @@ title: 'Socket.on(event, callback)'
 excerpt: 'Set up callback functions for various events on the WebSocket connection.'
 ---
 
+<WsBlockquote />
+
 Set up callback functions for various events on the WebSocket connection. Multiple handlers can be defined for the same event.
 
 | Parameter | Type     | Description                                  |

--- a/src/data/markdown/docs/02 javascript api/12 k6-ws/80 Socket/Socket-ping--.md
+++ b/src/data/markdown/docs/02 javascript api/12 k6-ws/80 Socket/Socket-ping--.md
@@ -3,6 +3,8 @@ title: 'Socket.ping()'
 excerpt: 'Send a ping. Ping messages can be used to verify that the remote endpoint is responsive.'
 ---
 
+<WsBlockquote />
+
 Send a ping. Ping messages can be used to verify that the remote endpoint is responsive.
 
 ### Example

--- a/src/data/markdown/docs/02 javascript api/12 k6-ws/80 Socket/Socket-send-data-.md
+++ b/src/data/markdown/docs/02 javascript api/12 k6-ws/80 Socket/Socket-send-data-.md
@@ -3,6 +3,8 @@ title: 'Socket.send(data)'
 excerpt: 'Send a data string through the connection.'
 ---
 
+<WsBlockquote />
+
 Send a data string through the connection. 
 You can use `JSON.stringify` to convert a JSON or JavaScript values to a JSON string.
 

--- a/src/data/markdown/docs/02 javascript api/12 k6-ws/80 Socket/Socket-sendBinary.md
+++ b/src/data/markdown/docs/02 javascript api/12 k6-ws/80 Socket/Socket-sendBinary.md
@@ -3,6 +3,8 @@ title: 'Socket.sendBinary(data)'
 excerpt: 'Send binary data through the connection.'
 ---
 
+<WsBlockquote />
+
 Send binary data through the connection. 
 
 | Parameter | Type   | Description       |

--- a/src/data/markdown/docs/02 javascript api/12 k6-ws/80 Socket/Socket-setInterval-callback- interval-.md
+++ b/src/data/markdown/docs/02 javascript api/12 k6-ws/80 Socket/Socket-setInterval-callback- interval-.md
@@ -3,6 +3,8 @@ title: 'Socket.setInterval(callback, interval)'
 excerpt: 'Call a function repeatedly, while the WebSocket connection is open.'
 ---
 
+<WsBlockquote />
+
 Call a function repeatedly, while the WebSocket connection is open.
 
 | Parameter | Type     | Description                                                 |

--- a/src/data/markdown/docs/02 javascript api/12 k6-ws/80 Socket/Socket-setTimeout-callback- delay-.md
+++ b/src/data/markdown/docs/02 javascript api/12 k6-ws/80 Socket/Socket-setTimeout-callback- delay-.md
@@ -3,6 +3,8 @@ title: 'Socket.setTimeout(callback, delay)'
 excerpt: 'Call a function at a later time, if the WebSocket connection is still open then.'
 ---
 
+<WsBlockquote />
+
 Call a function at a later time, if the WebSocket connection is still open then.
 
 | Parameter | Type     | Description                                    |


### PR DESCRIPTION
As per https://github.com/grafana/k6-docs/pull/1224 discussion: 

![Screenshot 2023-06-16 at 12 05 18](https://github.com/grafana/k6-docs/assets/825430/6d6c0e05-5a89-491e-9e17-335b0f6ec2d6)
