### PR TITLE
fix: GRPC broken error link

### DIFF
--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 grpc/30 Stream/10-Stream-on.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 grpc/30 Stream/10-Stream-on.md
@@ -15,7 +15,7 @@ Possible events:
 | Event name | Description |
 | --------- | -------- |
 | data       | Emitted when the server sends data|
-| error    | Emitted when an error occurs. In case of the error, an [`Error`](/javascript-api/k6-experimental/grpc/stream/stream-error) object sends to the handler function.|
+| error    | Emitted when an error occurs. In case of the error, an [`Error`](/javascript-api/k6-experimental/grpc/stream/error/) object sends to the handler function.|
 | end      | Emitted when stream closes |
 
 


### PR DESCRIPTION
# What?

Fix broken link.

# Why?

https://github.com/grafana/k6-docs/actions/runs/5309238148/jobs/9609731039