### PR TITLE
Add an example of output in the cookiesForUrl documentation

### DIFF
--- a/src/data/markdown/docs/02 javascript api/09 k6-http/60 CookieJar/CookieJar-cookiesForUrl-url.md
+++ b/src/data/markdown/docs/02 javascript api/09 k6-http/60 CookieJar/CookieJar-cookiesForUrl-url.md
@@ -33,5 +33,12 @@ export default function () {
   });
 }
 ```
-
+Example return value from `cookiesForUrl`
+```
+{
+  "cookieName1": ["cookieValue1", "cookieValue2"],
+  "cookieName2": ["cookieValue3"],
+  "cookieName3": ["cookieValue4", "cookieValue5", "cookieValue6"]
+}
+```
 </CodeGroup>


### PR DESCRIPTION
There isn't really an example of what the output format would look like in cookiesForUrl. 

This PR adds an explicit example of what output from cookiesForUrl might look like. 