### PR TITLE
Fix condition in secrets filter

### DIFF
--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/00 getSecret(secretID).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/00 getSecret(secretID).md
@@ -38,7 +38,7 @@ export default function () {
   // List the secrets the AWS authentication configuration
   // gives us access to.
   const secrets = secretsManager.listSecrets();
-  if (!secrets.filter((s) => s.name === testSecretName).length == 0) {
+  if (secrets.filter((s) => s.name === testSecretName).length == 0) {
     exec.test.abort('test secret not found');
   }
 

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/00 listSecrets().md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/00 listSecrets().md
@@ -34,7 +34,7 @@ export default function () {
   // List the secrets the AWS authentication configuration
   // gives us access to, and verify the test secret exists.
   const secrets = secretsManager.listSecrets();
-  if (!secrets.filter((s) => s.name === testSecretName).length == 0) {
+  if (secrets.filter((s) => s.name === testSecretName).length == 0) {
     exec.test.abort('test secret not found');
   }
 

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/99 Secret.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/99 Secret.md
@@ -42,7 +42,7 @@ export default function () {
   const secrets = secretsManager.listSecrets();
 
   // If our test secret does not exist, abort the execution.
-  if (!secrets.filter((s) => s.name === testSecretName).length == 0) {
+  if (secrets.filter((s) => s.name === testSecretName).length == 0) {
     exec.test.abort('test secret not found');
   }
 


### PR DESCRIPTION
The example code filtered by the name of the wanted secret, then checked if there is no matching entry, before proceeding. It should be the other way around, when the result is `length == 0`, we have no secret found, hence we abort.