### PR TITLE
Remove spurious code in xk6-disruptor examples

### DIFF
--- a/src/data/markdown/docs/40 xk6-disruptor/01 Get started/01 Welcome.md
+++ b/src/data/markdown/docs/40 xk6-disruptor/01 Get started/01 Welcome.md
@@ -30,12 +30,6 @@ export default function () {
         select: { labels: { "app.kubernetes.io/name": "my-app" } },
     });
 
-    // Check that there is at least one target
-    const targets = disruptor.targets();
-    if (targets.length === 0) {
-        throw new Error("expected list to have one target");
-    }
-
     // Disrupt the targets by injecting HTTP faults into them for 30 seconds
     const fault = {
         averageDelay: 500,

--- a/src/data/markdown/docs/40 xk6-disruptor/03 API/02 PodDisruptor.md
+++ b/src/data/markdown/docs/40 xk6-disruptor/03 API/02 PodDisruptor.md
@@ -43,11 +43,6 @@ const fault = {
 
 export default function () {
   const disruptor = new PodDisruptor(selector);
-  const targets = disruptor.targets();
-  if (targets.length != 1) {
-    throw new Error('expected list to have one target');
-  }
-
   disruptor.injectHTTPFaults(fault, '30s');
 }
 ```

--- a/src/data/markdown/docs/40 xk6-disruptor/03 API/03 ServiceDisruptor.md
+++ b/src/data/markdown/docs/40 xk6-disruptor/03 API/03 ServiceDisruptor.md
@@ -33,11 +33,6 @@ const fault = {
 
 export default function () {
   const disruptor = new ServiceDisruptor('nginx', 'default');
-  const targets = disruptor.targets();
-  if (targets.length != 1) {
-    throw new Error('expected list to have one target');
-  }
-
   disruptor.injectHTTPFaults(fault, '30s');
 }
 ```


### PR DESCRIPTION
Remove from xk6-disruptor examples a validation of the number of targets that is confusing for users. 