### PR TITLE
Fix example code in browser module context file

### DIFF
--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/context.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/context.md
@@ -43,7 +43,8 @@ export default function () {
   const context = browser.context(); // underlying live browserContext associated with browser
   const page2 = context.newPage(); // shares the browserContext with page1
 
-  page.close();
+  page1.close();
+  page2.close();
   context.close();
 }
 ```


### PR DESCRIPTION
This just ensures that the correct `page` is referenced during the cleanup steps.