### PR TITLE
disruptor/examples/http: fix backwards scenario startTimes

### DIFF
--- a/src/data/markdown/docs/40 xk6-disruptor/04 Examples/02 Inject HTTP faults into Pod.md
+++ b/src/data/markdown/docs/40 xk6-disruptor/04 Examples/02 Inject HTTP faults into Pod.md
@@ -93,7 +93,7 @@ This test defines two [scenarios](https://k6.io/docs/using-k6/scenarios) to be e
             preAllocatedVUs: 10,
             maxVUs: 100,
             exec: "default",
-            startTime: '0s',
+            startTime: "0s",
             duration: "30s",
         },
         disrupt: {
@@ -101,9 +101,9 @@ This test defines two [scenarios](https://k6.io/docs/using-k6/scenarios) to be e
             iterations: 1,
             vus: 1,
             exec: "disrupt",
-            startTime: "30s",
-        }
-     }
+            startTime: "0s",
+        },
+    }
  ```
 
  <Blockquote mod="note">
@@ -306,7 +306,7 @@ export const options = {
             preAllocatedVUs: 10,
             maxVUs: 100,
             exec: "default",
-            startTime: '0s',
+            startTime: "0s",
             duration: "30s",
         },
         disrupt: {


### PR DESCRIPTION
Current example would start the injeciton scenario immediately after the load scenario finishes, making injection noop.

Additionally I've surrounded the scenarios object with `export const options = {` so it's easier to copypaste.