### PR TITLE
Fix winget installation command

### DIFF
--- a/src/data/markdown/translated-guides/en/01 Get started/02 Installation.md
+++ b/src/data/markdown/translated-guides/en/01 Get started/02 Installation.md
@@ -45,7 +45,7 @@ choco install k6
 If you use the [Windows Package Manager](https://github.com/microsoft/winget-cli), install the official packages from the k6 manifests [(created by the community)](https://github.com/microsoft/winget-pkgs/tree/master/manifests/k/k6/k6):
 
 ```
-winget install k6
+winget install k6 --source winget
 ```
 
 Alternatively, you can download and run [the latest official installer](https://dl.k6.io/msi/k6-latest-amd64.msi).


### PR DESCRIPTION
Without specifying `--source winget` the `msstore` will be taken as source and your installation will fail:

<img width="430" alt="image" src="https://github.com/grafana/k6-docs/assets/469989/bfb864f0-54c4-4638-8c31-02cdcb7df1ce">

Changing the source to `winget` will make the installation work on Windows 11 using PowerShell:

<img width="540" alt="image" src="https://github.com/grafana/k6-docs/assets/469989/b664a8a6-8a28-4182-839d-4f837cc45a72">
