### PR TITLE
Remove iface option from disruptor API

### DIFF
--- a/src/data/markdown/docs/40 xk6-disruptor/03 API/02 PodDisruptor/02 injectGrpcFaults.md
+++ b/src/data/markdown/docs/40 xk6-disruptor/03 API/02 PodDisruptor/02 injectGrpcFaults.md
@@ -19,7 +19,6 @@ The injection of the fault is controlled by the following options:
 | Option    | Type   | Description |
 | --------- | ------ | -------- |
 | proxyPort | number | port the agent will use to listen for requests in the target pods ( default `8000`) |
-| iface     | string | network interface where the agent will capture the traffic ( default `eth0`) |
 
 
 ## Example

--- a/src/data/markdown/docs/40 xk6-disruptor/03 API/02 PodDisruptor/03 injectHTTPFaults.md
+++ b/src/data/markdown/docs/40 xk6-disruptor/03 API/02 PodDisruptor/03 injectHTTPFaults.md
@@ -19,7 +19,6 @@ The injection of the fault is controlled by the following options:
 | Option    | Type   | Description |
 | --------- | ------ | -------- |
 | proxyPort | number | port the agent will use to listen for requests in the target pods ( default `8000`) |
-| iface     | string | network interface where the agent will capture the traffic ( default `eth0`) |
 
 <Blockquote mod="note">
 

--- a/src/data/markdown/docs/40 xk6-disruptor/03 API/03 ServiceDisruptor/02 injectGrpcFaults.md
+++ b/src/data/markdown/docs/40 xk6-disruptor/03 API/03 ServiceDisruptor/02 injectGrpcFaults.md
@@ -18,7 +18,6 @@ The injection of the fault is controlled by the following options:
 | Option    | Type   | Description |
 | --------- | ------ | ------- |
 | proxyPort | number | port the agent will use to listen for requests in the target pods ( default `8000`) |
-| iface     | string | network interface where the agent will capture the traffic ( default `eth0`) |
 
 ## Example
 

--- a/src/data/markdown/docs/40 xk6-disruptor/03 API/03 ServiceDisruptor/03 injectHTTPFaults.md
+++ b/src/data/markdown/docs/40 xk6-disruptor/03 API/03 ServiceDisruptor/03 injectHTTPFaults.md
@@ -18,7 +18,6 @@ The injection of the fault is controlled by the following options:
 | Option    | Type   | Description |
 | --------- | ------ | ----------- |
 | proxyPort | number | port the agent will use to listen for requests in the target pods ( default `8000`) |
-| iface     | string | network interface where the agent will capture the traffic ( default `eth0`) |
 
 <Blockquote mod="note">
 


### PR DESCRIPTION
After the changes introduced in https://github.com/grafana/xk6-disruptor/pull/249 the `iface` option is no longer available. 