### PR TITLE
Delisting experimental modules from extensions listing

### DIFF
--- a/src/data/doc-extensions/extensions.json
+++ b/src/data/doc-extensions/extensions.json
@@ -46,21 +46,6 @@
       "cloudEnabled": false
     },
     {
-      "name": "xk6-websockets",
-      "description": "A WHATWG WebSockets API specification implementation for k6 that might replace k6/ws in the future.",
-      "url": "https://github.com/grafana/xk6-websockets",
-      "logo": "",
-      "author": {
-        "name": "",
-        "url": ""
-      },
-      "stars": "13",
-      "type": ["JavaScript"],
-      "categories": ["WebSockets"],
-      "tiers": ["Official"],
-      "cloudEnabled": true
-    },
-    {
       "name": "xk6-kafka",
       "description": "Load-test Apache Kafka. Includes support for Avro messages",
       "url": "https://github.com/mostafa/xk6-kafka",
@@ -118,36 +103,6 @@
       "stars": "46",
       "type": ["JavaScript"],
       "categories": ["Data"],
-      "tiers": ["Official"],
-      "cloudEnabled": false
-    },
-    {
-      "name": "xk6-redis",
-      "description": "Client for testing Redis",
-      "url": "https://github.com/grafana/xk6-redis",
-      "logo": "",
-      "author": {
-        "name": "",
-        "url": "https://github.com/grafana"
-      },
-      "stars": "13",
-      "type": ["JavaScript"],
-      "categories": ["Data"],
-      "tiers": ["Official"],
-      "cloudEnabled": true
-    },
-    {
-      "name": "xk6-distributed-tracing",
-      "description": "Distributed tracing",
-      "url": "https://github.com/grafana/xk6-distributed-tracing",
-      "logo": "",
-      "author": {
-        "name": "grafana",
-        "url": "https://github.com/grafana"
-      },
-      "stars": "58",
-      "type": ["Output"],
-      "categories": ["Observability"],
       "tiers": ["Official"],
       "cloudEnabled": false
     },
@@ -494,21 +449,6 @@
       "type": ["JavaScript"],
       "categories": ["Misc"],
       "tiers": ["Community"],
-      "cloudEnabled": false
-    },
-    {
-      "name": "xk6-output-prometheus-remote",
-      "description": "Export results to Prometheus remote write endpoints",
-      "url": "https://github.com/grafana/xk6-output-prometheus-remote",
-      "logo": "",
-      "author": {
-        "name": "",
-        "url": "https://github.com/grafana"
-      },
-      "stars": "92",
-      "type": ["Output"],
-      "categories": ["Reporting", "Observability"],
-      "tiers": ["Official"],
       "cloudEnabled": false
     },
     {

--- a/src/data/markdown/docs/07 extensions/02 Explanations/030-extension-graduation.md
+++ b/src/data/markdown/docs/07 extensions/02 Explanations/030-extension-graduation.md
@@ -28,6 +28,9 @@ Only Grafana-controlled extensions may progress beyond the _extension_ phase to 
 This phase is the first exposure to core k6. 
 The extension is still maintained outside the core of k6 but imported as a Go module, no longer requiring xk6.
 
+Once an extension is promoted as an _experimental module_, the extension will be removed from the [extension listing](/extensions/get-started/explore/).
+At this time, documentation for the functionality will be provided in [k6 API](/javascript-api/k6-experimental/) and [output](/results-output/real-time/) for _JavaScript_ and _Output_ extensions, respectively.
+
 There should be a reasonably high degree of quality and stability at this point.
 This phase makes the feature accessible to more users, which in turn gives k6 developers more chances to receive feedback.
 The key will be to achieve a balance between usability and stability.


### PR DESCRIPTION
Adding text and links to graduation process to locate pertinent documentation for delisted extensions.