### PR TITLE
Add my xk6-read extension to extensions registry.

### DIFF
--- a/src/data/doc-extensions/extensions.json
+++ b/src/data/doc-extensions/extensions.json
@@ -1081,6 +1081,21 @@
       "categories": ["Misc"],
       "tiers": ["Community"],
       "cloudEnabled": false
+    },
+    {
+      "name": "xk6-read",
+      "description": "Read files and directories",
+      "url": "https://github.com/acuenca-facephi/xk6-read",
+      "logo": "",
+      "author": {
+        "name": "Adrián Cuenca",
+        "url": "https://github.com/acuenca-facephi"
+      },
+      "stars": "0",
+      "type": ["JavaScript"],
+      "categories": ["Misc"],
+      "tiers": ["Community"],
+      "cloudEnabled": false
     }
   ]
 }


### PR DESCRIPTION
xk6-read is an extension to read files and directories. 
I created it because in my use case I need to use thousands of different images during test execution, and k6 only can read files in the init stage. This force me to load all the images using a JSON file with an array of file paths and load in memory ALL the images.