### PR TITLE
Document jslib-aws version v0.8.1

### DIFF
--- a/src/data/markdown/docs/05 Examples/01 Examples/02 http-authentication.md
+++ b/src/data/markdown/docs/05 Examples/01 Examples/02 http-authentication.md
@@ -118,7 +118,7 @@ Here's an example script to demonstrate how to sign a request to fetch an object
 
 ```javascript
 import http from 'k6/http';
-import { AWSConfig, SignatureV4 } from 'https://jslib.k6.io/aws/0.7.2/signature.js';
+import { AWSConfig, SignatureV4 } from 'https://jslib.k6.io/aws/0.8.1/signature.js';
 
 const awsConfig = new AWSConfig({
     region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/00 AwsConfig.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/00 AwsConfig.md
@@ -41,7 +41,7 @@ import exec from 'k6/execution';
 
 // Note that you AWSConfig is also included in the dedicated service
 // client bundles such as `s3.js` and `secrets-manager.js`
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.8.0/aws.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.8.1/aws.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/00 KMSClient.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/00 KMSClient.md
@@ -35,7 +35,7 @@ Both the dedicated `kms.js` jslib bundle and the all-encompassing `aws.js` bundl
 ```javascript
 import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.2/index.js';
 
-import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.8.0/kms.js';
+import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.8.1/kms.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/00 S3Client.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/00 S3Client.md
@@ -43,7 +43,7 @@ import { check } from 'k6';
 import exec from 'k6/execution';
 import http from 'k6/http';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.8.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.8.1/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,
@@ -103,7 +103,7 @@ export function handleSummary(data) {
 import crypto from 'k6/crypto';
 import exec from 'k6/execution';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.8.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.8.1/s3.js';
 
 const awsConfig = new AWSConfig({
     region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/00 S3Client.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/00 S3Client.md
@@ -13,17 +13,18 @@ S3Client is included in both the dedicated jslib `s3.js` bundle, and the `aws.js
 
 ### Methods
 
-| Function                                                                                                                                     | Description                                                  |
-| :------------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------|
-| [listBuckets()](/javascript-api/jslib/aws/s3client/s3client-listbuckets)                                                                     | List the buckets the authenticated user has access to        |
-| [listObjects(bucketName, [prefix])](/javascript-api/jslib/aws/s3client/s3client-listobjects/)                                                | List the objects contained in a bucket                       |
-| [getObject(bucketName, objectKey)](/javascript-api/jslib/aws/s3client/s3client-getobject/)                                                   | Download an object from a bucket                             |
-| [putObject(bucketName, objectKey, data)](/javascript-api/jslib/aws/s3client/s3client-putobject/)                                             | Upload an object to a bucket                                 |
-| [deleteObject(bucketName, objectKey)](/javascript-api/jslib/aws/s3client/s3client-deleteobject/)                                             | Delete an object from a bucket                               |
-| [createMultipartUpload(bucketName, objectKey)](/javascript-api/jslib/aws/s3client/s3client-createmultipartupload/)                           | Create a multipart upload for a given objectKey to a bucket  |
-| [uploadPart(bucketName, objectKey, uploadId, partNumber, data)](/javascript-api/jslib/aws/s3client/s3client-uploadpart/)                     | Upload a part in a multipart upload                          |
-| [completeMultipartUpload(bucketName, objectKey, uploadId, parts)](/javascript-api/jslib/aws/s3client/s3client-completemultipartupload/)      | Complete a previously assembled multipart upload             |
-| [abortMultipartUpload(bucketName, objectKey, uploadId)](/javascript-api/jslib/aws/s3client/s3client-abortmultipartupload/)                   | Abort a multipart upload                                     |
+| Function                                                                                                                                | Description                                                 |
+| :-------------------------------------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------- |
+| [listBuckets()](/javascript-api/jslib/aws/s3client/s3client-listbuckets)                                                                | List the buckets the authenticated user has access to       |
+| [listObjects(bucketName, [prefix])](/javascript-api/jslib/aws/s3client/s3client-listobjects/)                                           | List the objects contained in a bucket                      |
+| [getObject(bucketName, objectKey)](/javascript-api/jslib/aws/s3client/s3client-getobject/)                                              | Download an object from a bucket                            |
+| [putObject(bucketName, objectKey, data)](/javascript-api/jslib/aws/s3client/s3client-putobject/)                                        | Upload an object to a bucket                                |
+| [deleteObject(bucketName, objectKey)](/javascript-api/jslib/aws/s3client/s3client-deleteobject/)                                        | Delete an object from a bucket                              |
+| [copyObject(sourceBucket, sourceKey, destinationBucket, destinationKey)](/javascript-api/jslib/aws/s3client/s3client-copyobject/)       | Copy an object from one bucket to another                   |
+| [createMultipartUpload(bucketName, objectKey)](/javascript-api/jslib/aws/s3client/s3client-createmultipartupload/)                      | Create a multipart upload for a given objectKey to a bucket |
+| [uploadPart(bucketName, objectKey, uploadId, partNumber, data)](/javascript-api/jslib/aws/s3client/s3client-uploadpart/)                | Upload a part in a multipart upload                         |
+| [completeMultipartUpload(bucketName, objectKey, uploadId, parts)](/javascript-api/jslib/aws/s3client/s3client-completemultipartupload/) | Complete a previously assembled multipart upload            |
+| [abortMultipartUpload(bucketName, objectKey, uploadId)](/javascript-api/jslib/aws/s3client/s3client-abortmultipartupload/)              | Abort a multipart upload                                    |
 
 ### Throws
 

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/00 SQSClient.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/00 SQSClient.md
@@ -34,7 +34,7 @@ Both the dedicated `sqs.js` jslib bundle and the all-encompassing `aws.js` bundl
 ```javascript
 import exec from 'k6/execution'
 
-import { AWSConfig, SQSClient } from 'https://jslib.k6.io/aws/0.8.0/sqs.js'
+import { AWSConfig, SQSClient } from 'https://jslib.k6.io/aws/0.8.1/sqs.js'
 
 const awsConfig = new AWSConfig({
     region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/00 SecretsManagerClient.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/00 SecretsManagerClient.md
@@ -37,7 +37,7 @@ S3 Client methods will throw errors in case of failure.
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.8.0/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.8.1/secrets-manager.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/00 SignatureV4.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/00 SignatureV4.md
@@ -44,7 +44,7 @@ SignatureV4 methods throw errors on failure.
 ```javascript
 import http from 'k6/http.js'
 
-import { AWSConfig, SignatureV4 } from 'https://jslib.k6.io/aws/0.8.0/aws.js'
+import { AWSConfig, SignatureV4 } from 'https://jslib.k6.io/aws/0.8.1/aws.js'
 
 const awsConfig = new AWSConfig({
     region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/00 SystemsManagerClient.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/00 SystemsManagerClient.md
@@ -34,7 +34,7 @@ Both the dedicated `ssm.js` jslib bundle and the all-encompassing `aws.js` bundl
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SystemsManagerClient } from 'https://jslib.k6.io/aws/0.8.0/ssm.js';
+import { AWSConfig, SystemsManagerClient } from 'https://jslib.k6.io/aws/0.8.1/ssm.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/KMSClient/00 generateDataKey.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/KMSClient/00 generateDataKey.md
@@ -26,7 +26,7 @@ excerpt: 'KMSClient.generateDataKey generates a symmetric data key for use outsi
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.8.0/kms.js';
+import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.8.1/kms.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/KMSClient/00 listKeys.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/KMSClient/00 listKeys.md
@@ -19,7 +19,7 @@ excerpt: "KMSClient.listKeys lists all the KMS keys in the caller's AWS account 
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.8.0/kms.js';
+import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.8.1/kms.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/KMSClient/90 KMSDataKey.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/KMSClient/90 KMSDataKey.md
@@ -21,7 +21,7 @@ For instance, the [`generateDataKey`](/javascript-api/jslib/aws/kmsclient/kmscli
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.8.0/kms.js';
+import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.8.1/kms.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/KMSClient/90 KMSKey.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/KMSClient/90 KMSKey.md
@@ -18,7 +18,7 @@ excerpt: 'KMSKey is returned by the KMSClient.* methods that query KMS keys'
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.8.0/kms.js';
+import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.8.1/kms.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/00 abortMultipartUpload(bucketName, objectKey, uploadId).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/00 abortMultipartUpload(bucketName, objectKey, uploadId).md
@@ -17,7 +17,7 @@ excerpt: 'S3Client.abortMultipartUpload aborts a multipart upload to a bucket'
 <CodeGroup labels={[]}>
 
 ```javascript
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.8.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.8.1/s3.js';
 
 const awsConfig = new AWSConfig({
     region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/00 completeMultipartUpload(bucketName, objectKey, uploadId, parts).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/00 completeMultipartUpload(bucketName, objectKey, uploadId, parts).md
@@ -21,7 +21,7 @@ excerpt: 'S3Client.completeMultipartUpload uploads a multipart object to a bucke
 import crypto from 'k6/crypto';
 import exec from 'k6/execution';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.8.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.8.1/s3.js';
 
 const awsConfig = new AWSConfig({
     region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/00 copyObject.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/00 copyObject.md
@@ -1,0 +1,51 @@
+---
+title: 'S3Client.copyObject'
+description: 'S3Client.copyObject copies an object from a bucket to another'
+excerpt: 'S3Client.copyObject copies an object from a bucket to another'
+---
+
+`S3Client.copyObject` copies an object from one bucket to another.
+
+### Parameters
+
+| Parameter         | Type   | Description                                        |
+| :---------------- | :----- | :------------------------------------------------- |
+| sourceBucket      | string | Name of the bucket to copy the object from.        |
+| sourceKey         | string | Name of the object to copy from the source bucket. |
+| destinationBucket | string | Name of the bucket to copy the object to.          |
+| destinationKey    | string | Name of the destination object.                    |
+
+### Example
+
+<CodeGroup labels={[]}>
+
+```javascript
+import exec from 'k6/execution';
+
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.8.1/s3.js';
+
+
+const awsConfig = new AWSConfig({
+  region: __ENV.AWS_REGION,
+  accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+  secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+});
+
+const testFile = open('./bonjour.txt', 'r');
+const s3 = new S3Client(awsConfig);
+const testBucketName = 'test-jslib-aws';
+const testFileKey = 'bonjour.txt';
+const testDestinationBucketName = 'test-jslib-aws-destination';
+
+export default function () {
+    // Let's upload our test file to the bucket
+    s3.putObject(testBucketName, testFileKey, testFile);
+
+    // Let's create our destination bucket
+    s3.copyObject(testBucketName, testFileKey, testDestinationBucketName, testFileKey);
+}
+```
+
+_A k6 script that will copy an object from a source S3 bucket to a destination bucket_
+
+</CodeGroup>

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/00 createMultipartUpload(bucketName, objectKey).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/00 createMultipartUpload(bucketName, objectKey).md
@@ -22,7 +22,7 @@ excerpt: 'S3Client.createMultipartUpload creates a multipart upload to a bucket'
 <CodeGroup labels={[]}>
 
 ```javascript
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.8.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.8.1/s3.js';
 
 const awsConfig = new AWSConfig({
     region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/00 deleteObject(bucketName, objectKey).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/00 deleteObject(bucketName, objectKey).md
@@ -18,7 +18,7 @@ excerpt: 'S3Client.deleteObject deletes an object from a bucket'
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.8.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.8.1/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/00 getObject(bucketName, objectKey).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/00 getObject(bucketName, objectKey).md
@@ -24,7 +24,7 @@ excerpt: 'S3Client.getObject downloads an object from a bucket'
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.8.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.8.1/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/00 listBuckets().md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/00 listBuckets().md
@@ -19,7 +19,7 @@ excerpt: 'S3Client.listBuckets lists the buckets the authenticated user has acce
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.8.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.8.1/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/00 listObjects(bucketName, [prefix]).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/00 listObjects(bucketName, [prefix]).md
@@ -24,7 +24,7 @@ excerpt: 'S3Client.listObjects lists the objects contained in a bucket'
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.8.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.8.1/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/00 putObject(bucketName, objectKey, data).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/00 putObject(bucketName, objectKey, data).md
@@ -17,7 +17,7 @@ excerpt: 'S3Client.putObject uploads an object to a bucket'
 <CodeGroup labels={[]}>
 
 ```javascript
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.8.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.8.1/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/00 uploadPart(bucketName, objectKey, uploadId, partNumber, data) copy.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/00 uploadPart(bucketName, objectKey, uploadId, partNumber, data) copy.md
@@ -28,7 +28,7 @@ excerpt: 'S3Client.uploadPart a part in a multipart upload to a bucket'
 import crypto from 'k6/crypto';
 import exec from 'k6/execution';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.8.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.8.1/s3.js';
 
 const awsConfig = new AWSConfig({
     region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/90 Bucket.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/90 Bucket.md
@@ -16,7 +16,7 @@ Bucket is returned by the S3Client.* methods that query S3 buckets. Namely, `lis
 <CodeGroup labels={[]}>
 
 ```javascript
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.8.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.8.1/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/90 Object.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/90 Object.md
@@ -27,7 +27,7 @@ import {
   // listBuckets,
   AWSConfig,
   S3Client,
-} from 'https://jslib.k6.io/aws/0.8.0/s3.js';
+} from 'https://jslib.k6.io/aws/0.8.1/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/90 S3MultipartUpload.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/90 S3MultipartUpload.md
@@ -16,7 +16,7 @@ S3MultipartUpload is returned by the [`createMultipartUpload(bucketName, objectK
 <CodeGroup labels={[]}>
 
 ```javascript
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.8.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.8.1/s3.js';
 
 const awsConfig = new AWSConfig({
     region: __ENV.AWS_REGION,
@@ -31,7 +31,7 @@ const testBucketName = 'test-jslib-aws';
 const testFileKey = 'multipart.txt';
 
 export default function () {
-    // Initialize a multipart upload 
+    // Initialize a multipart upload
     const multipartUpload = s3.createMultipartUpload(testBucketName, testFileKey);
     console.log(multipartUpload.uploadId);
 

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/90 S3Part.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/90 S3Part.md
@@ -19,7 +19,7 @@ S3Part is returned by the [`uploadPart(bucketName, objectKey, uploadId, partNumb
 import crypto from 'k6/crypto';
 import exec from 'k6/execution';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.8.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.8.1/s3.js';
 
 const awsConfig = new AWSConfig({
     region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SQSClient/00 listQueues.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SQSClient/00 listQueues.md
@@ -25,7 +25,7 @@ excerpt: "SQSClient.listQueues retrieves a list of available Amazon SQS queues"
 ```javascript
 import exec from 'k6/execution'
 
-import { AWSConfig, SQSClient } from 'https://jslib.k6.io/aws/0.8.0/sqs.js'
+import { AWSConfig, SQSClient } from 'https://jslib.k6.io/aws/0.8.1/sqs.js'
 
 const awsConfig = new AWSConfig({
     region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SQSClient/00 sendMessage.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SQSClient/00 sendMessage.md
@@ -27,7 +27,7 @@ excerpt: "SQSClient.sendMessage sends a message to the specified Amazon SQS queu
 ```javascript
 import exec from 'k6/execution'
 
-import { AWSConfig, SQSClient } from 'https://jslib.k6.io/aws/0.8.0/sqs.js'
+import { AWSConfig, SQSClient } from 'https://jslib.k6.io/aws/0.8.1/sqs.js'
 
 const awsConfig = new AWSConfig({
     region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/00 createSecret(name, secretString, description, [versionID], [tags]).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/00 createSecret(name, secretString, description, [versionID], [tags]).md
@@ -19,7 +19,7 @@ excerpt: 'SecretsManagerClient.createSecret creates a new secret'
 <CodeGroup labels={[]}>
 
 ```javascript
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.8.0/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.8.1/secrets-manager.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/00 deleteSecret.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/00 deleteSecret.md
@@ -16,7 +16,7 @@ excerpt: 'SecretsManagerClient.deleteSecret deletes a secret'
 <CodeGroup labels={[]}>
 
 ```javascript
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.8.0/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.8.1/secrets-manager.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/00 getSecret(secretID).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/00 getSecret(secretID).md
@@ -23,7 +23,7 @@ excerpt: 'SecretsManagerClient.getSecret(secretID) downloads a secret from AWS s
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.8.0/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.8.1/secrets-manager.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/00 listSecrets().md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/00 listSecrets().md
@@ -19,7 +19,7 @@ excerpt: 'SecretsManagerClient.listSecrets lists the secrets the authenticated u
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.8.0/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.8.1/secrets-manager.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/00 putSecretValue(secretID, secretString, [versionID]).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/00 putSecretValue(secretID, secretString, [versionID]).md
@@ -20,7 +20,7 @@ excerpt: "SecretsManagerClient.putSecretValue updates an existing secret's value
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.8.0/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.8.1/secrets-manager.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/99 Secret.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/99 Secret.md
@@ -25,7 +25,7 @@ Secret is returned by the SecretsManagerClient.* methods that query secrets. Nam
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.8.0/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.8.1/secrets-manager.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SignatureV4/00 presign().md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SignatureV4/00 presign().md
@@ -55,7 +55,7 @@ import {
     SignatureV4,
     AMZ_CONTENT_SHA256_HEADER,
     UNSIGNED_PAYLOAD,
-} from 'https://jslib.k6.io/aws/0.8.0/kms.js'
+} from 'https://jslib.k6.io/aws/0.8.1/kms.js'
 
 const awsConfig = new AWSConfig({
     region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SignatureV4/00 sign().md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SignatureV4/00 sign().md
@@ -47,7 +47,7 @@ You can override SignatureV4 options in the context of this specific request. To
 ```javascript
 import http from 'k6/http.js'
 
-import { AWSConfig, SignatureV4 } from 'https://jslib.k6.io/aws/0.7.2/signature.js'
+import { AWSConfig, SignatureV4 } from 'https://jslib.k6.io/aws/0.8.1/signature.js'
 
 const awsConfig = new AWSConfig({
     region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SystemsManagerClient/00 getParameter.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SystemsManagerClient/00 getParameter.md
@@ -19,7 +19,7 @@ excerpt: "SystemsManagerClient.getParameter gets a Systems Manager parameter in 
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SystemsManagerClient } from 'https://jslib.k6.io/aws/0.8.0/ssm.js';
+import { AWSConfig, SystemsManagerClient } from 'https://jslib.k6.io/aws/0.8.1/ssm.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SystemsManagerClient/90 SystemsManagerParameter.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SystemsManagerClient/90 SystemsManagerParameter.md
@@ -25,7 +25,7 @@ excerpt: 'SystemsManagerParameter is returned by the SystemsManagerClient.* meth
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SystemsManagerClient } from 'https://jslib.k6.io/aws/0.8.0/ssm.js';
+import { AWSConfig, SystemsManagerClient } from 'https://jslib.k6.io/aws/0.8.1/ssm.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/04 deleteSecret(secretID, { recoveryWindow 30, noRecovery false}}).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/04 deleteSecret(secretID, { recoveryWindow 30, noRecovery false}}).md
@@ -16,7 +16,7 @@ excerpt: 'SecretsManagerClient.deleteSecret deletes a secret'
 <CodeGroup labels={[]}>
 
 ```javascript
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.8.0/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.8.1/secrets-manager.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/04 deleteSecret(secretID, {{ recoveryWindow 30, noRecovery false }}).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/04 deleteSecret(secretID, {{ recoveryWindow 30, noRecovery false }}).md
@@ -16,7 +16,7 @@ excerpt: 'SecretsManagerClient.deleteSecret deletes a secret'
 <CodeGroup labels={[]}>
 
 ```javascript
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.8.0/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.8.1/secrets-manager.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,


### PR DESCRIPTION
This Pull Request documents changes in the latest [jslib-aws version v0.8.1](https://github.com/grafana/k6-jslib-aws/releases/tag/v0.8.1).

Most notably it:
- bumps examples version to use `v0.8.1`.
- documents the new `S3Client.copyObject` operation.