### PR TITLE
Fix docs that fail after the fix in v0.45.1

### DIFF
--- a/src/data/markdown/docs/07 extensions/03 Guides/build-k6-using-docker.md
+++ b/src/data/markdown/docs/07 extensions/03 Guides/build-k6-using-docker.md
@@ -8,7 +8,7 @@ Using the [xk6 Docker image](https://hub.docker.com/r/grafana/xk6/) can simplify
 
 ## Building your first extension
 
-For example, to build a k6 latest version binary with the [`xk6-kafka`](https://github.com/mostafa/xk6-kafka) and [`xk6-output-influxdb`](https://github.com/grafana/xk6-output-influxdb) extensions, run one of the commands below, depending on your operating system:
+For example, to build a custom k6 binary with the latest versions of k6 and the [`xk6-kafka`](https://github.com/mostafa/xk6-kafka) and [`xk6-output-influxdb`](https://github.com/grafana/xk6-output-influxdb) extensions, run one of the commands below, depending on your operating system:
 
 <CodeGroup labels={["Linux", "Mac", "Windows PowerShell", "Windows"]}>
 

--- a/src/data/markdown/docs/07 extensions/03 Guides/build-k6-using-docker.md
+++ b/src/data/markdown/docs/07 extensions/03 Guides/build-k6-using-docker.md
@@ -13,35 +13,68 @@ For example, to build a k6 latest version binary with the [`xk6-kafka`](https://
 <CodeGroup labels={["Linux", "Mac", "Windows PowerShell", "Windows"]}>
 
 ```bash
-docker run --rm -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" grafana/xk6 build latest \
-  --with github.com/mostafa/xk6-kafka@v0.17.0 \
-  --with github.com/grafana/xk6-output-influxdb@v0.3.0
+docker run --rm -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" grafana/xk6 build \
+  --with github.com/mostafa/xk6-kafka \
+  --with github.com/grafana/xk6-output-influxdb
 ```
 
 ```bash
 docker run --rm -e GOOS=darwin -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" \
-  grafana/xk6 build latest \
-  --with github.com/mostafa/xk6-kafka@v0.17.0 \
-  --with github.com/grafana/xk6-output-influxdb@v0.3.0
+  grafana/xk6 build \
+  --with github.com/mostafa/xk6-kafka \
+  --with github.com/grafana/xk6-output-influxdb
 ```
 
 ```powershell
 docker run --rm -e GOOS=windows -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" `
-  grafana/xk6 build latest --output k6.exe `
-  --with github.com/mostafa/xk6-kafka@v0.17.0 `
-  --with github.com/grafana/xk6-output-influxdb@v0.3.0
+  grafana/xk6 build --output k6.exe `
+  --with github.com/mostafa/xk6-kafka `
+  --with github.com/grafana/xk6-output-influxdb
 ```
 
 ```batch
 docker run --rm -e GOOS=windows -v "%cd%:/xk6" ^
-  grafana/xk6 build latest --output k6.exe ^
-  --with github.com/mostafa/xk6-kafka@v0.17.0 ^
-  --with github.com/grafana/xk6-output-influxdb@v0.3.0
+  grafana/xk6 build --output k6.exe ^
+  --with github.com/mostafa/xk6-kafka ^
+  --with github.com/grafana/xk6-output-influxdb
 ```
 
 </CodeGroup>
 
-This creates a `k6` (or `k6.exe`) binary in the current working directory. Replace `latest` in the command above for a concrete version if needed, e.g. `v0.45.1`.
+This creates a `k6` (or `k6.exe`) binary in the current working directory. 
+
+To build the binary with concrete versions, see the example below (`k6` v0.45.1, `xk6-kafka` v0.19.1, and `xk6-output-influxdb` v0.4.1):
+
+<CodeGroup labels={["Linux", "Mac", "Windows PowerShell", "Windows"]}>
+
+```bash
+docker run --rm -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" grafana/xk6 build v0.45.1 \
+  --with github.com/mostafa/xk6-kafka@v0.19.1 \
+  --with github.com/grafana/xk6-output-influxdb@v0.4.1
+```
+
+```bash
+docker run --rm -e GOOS=darwin -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" \
+  grafana/xk6 build v0.45.1 \
+  --with github.com/mostafa/xk6-kafka@v0.19.1 \
+  --with github.com/grafana/xk6-output-influxdb@v0.4.1
+```
+
+```powershell
+docker run --rm -e GOOS=windows -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" `
+  grafana/xk6 build v0.45.1 --output k6.exe `
+  --with github.com/mostafa/xk6-kafka@v0.19.1 `
+  --with github.com/grafana/xk6-output-influxdb@v0.4.1
+```
+
+```batch
+docker run --rm -e GOOS=windows -v "%cd%:/xk6" ^
+  grafana/xk6 build v0.45.1 --output k6.exe ^
+  --with github.com/mostafa/xk6-kafka@v0.19.1 ^
+  --with github.com/grafana/xk6-output-influxdb@v0.4.1
+```
+
+</CodeGroup>
 
 ## Breaking down the command
 

--- a/src/data/markdown/docs/07 extensions/03 Guides/build-k6-using-docker.md
+++ b/src/data/markdown/docs/07 extensions/03 Guides/build-k6-using-docker.md
@@ -43,7 +43,7 @@ docker run --rm -e GOOS=windows -v "%cd%:/xk6" ^
 
 This creates a `k6` (or `k6.exe`) binary in the current working directory. 
 
-To build the binary with concrete versions, see the example below (`k6` v0.45.1, `xk6-kafka` v0.19.1, and `xk6-output-influxdb` v0.4.1):
+To build the binary with concrete versions, see the example below (k6 `v0.45.1`, xk6-kafka `v0.19.1`, and xk6-output-influxdb `v0.4.1`):
 
 <CodeGroup labels={["Linux", "Mac", "Windows PowerShell", "Windows"]}>
 

--- a/src/data/markdown/docs/07 extensions/03 Guides/build-k6-using-docker.md
+++ b/src/data/markdown/docs/07 extensions/03 Guides/build-k6-using-docker.md
@@ -8,40 +8,40 @@ Using the [xk6 Docker image](https://hub.docker.com/r/grafana/xk6/) can simplify
 
 ## Building your first extension
 
-For example, to build a k6 v0.43.1 binary with the [`xk6-kafka`](https://github.com/mostafa/xk6-kafka) and [`xk6-output-influxdb`](https://github.com/grafana/xk6-output-influxdb) extensions, run one of the commands below, depending on your operating system:
+For example, to build a k6 latest version binary with the [`xk6-kafka`](https://github.com/mostafa/xk6-kafka) and [`xk6-output-influxdb`](https://github.com/grafana/xk6-output-influxdb) extensions, run one of the commands below, depending on your operating system:
 
 <CodeGroup labels={["Linux", "Mac", "Windows PowerShell", "Windows"]}>
 
 ```bash
-docker run --rm -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" grafana/xk6 build v0.43.1 \
+docker run --rm -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" grafana/xk6 build latest \
   --with github.com/mostafa/xk6-kafka@v0.17.0 \
   --with github.com/grafana/xk6-output-influxdb@v0.3.0
 ```
 
 ```bash
 docker run --rm -e GOOS=darwin -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" \
-  grafana/xk6 build v0.43.1 \
+  grafana/xk6 build latest \
   --with github.com/mostafa/xk6-kafka@v0.17.0 \
   --with github.com/grafana/xk6-output-influxdb@v0.3.0
 ```
 
 ```powershell
 docker run --rm -e GOOS=windows -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" `
-  grafana/xk6 build v0.43.1 --output k6.exe `
+  grafana/xk6 build latest --output k6.exe `
   --with github.com/mostafa/xk6-kafka@v0.17.0 `
   --with github.com/grafana/xk6-output-influxdb@v0.3.0
 ```
 
 ```batch
 docker run --rm -e GOOS=windows -v "%cd%:/xk6" ^
-  grafana/xk6 build v0.43.1 --output k6.exe ^
+  grafana/xk6 build latest --output k6.exe ^
   --with github.com/mostafa/xk6-kafka@v0.17.0 ^
   --with github.com/grafana/xk6-output-influxdb@v0.3.0
 ```
 
 </CodeGroup>
 
-This creates a `k6` (or `k6.exe`) binary in the current working directory.
+This creates a `k6` (or `k6.exe`) binary in the current working directory. Replace `latest` in the command above for a concrete version if needed, e.g. `v0.45.1`.
 
 ## Breaking down the command
 


### PR DESCRIPTION
After the issue solved with https://github.com/grafana/k6/issues/3252, [the](https://k6.io/docs/extensions/guides/build-a-k6-binary-using-docker/#building-your-first-extension) was incorrect, as it was using `v0.43.1`. Reported in the forum https://community.grafana.com/t/error-installing-xk6-on-macos-both-using-go-directly-and-docker/100621/3 