### PR TITLE
fix: correct req to get

### DIFF
--- a/src/data/markdown/translated-guides/en/06 Test Types/01 Smoke Testing.md
+++ b/src/data/markdown/translated-guides/en/06 Test Types/01 Smoke Testing.md
@@ -53,7 +53,7 @@ export const options = {
 };
 
 export default () => {
-  const urlRes = http.req('https://test-api.k6.io');
+  const urlRes = http.get('https://test-api.k6.io');
   sleep(1);
   // MORE STEPS
   // Here you can have more steps or complex script

--- a/src/data/markdown/translated-guides/en/06 Test Types/02 Load Testing.md
+++ b/src/data/markdown/translated-guides/en/06 Test Types/02 Load Testing.md
@@ -77,7 +77,7 @@ export const options = {
 };
 
 export default () => {
-  const urlRes = http.req('https://test-api.k6.io');
+  const urlRes = http.get('https://test-api.k6.io');
   sleep(1);
   // MORE STEPS
   // Here you can have more steps or complex script

--- a/src/data/markdown/translated-guides/en/06 Test Types/03 Stress testing.md
+++ b/src/data/markdown/translated-guides/en/06 Test Types/03 Stress testing.md
@@ -69,7 +69,7 @@ export const options = {
 };
 
 export default () => {
-  const urlRes = http.req('https://test-api.k6.io');
+  const urlRes = http.get('https://test-api.k6.io');
   sleep(1);
   // MORE STEPS
   // Here you can have more steps or complex script

--- a/src/data/markdown/translated-guides/en/06 Test Types/05 Soak Testing.md
+++ b/src/data/markdown/translated-guides/en/06 Test Types/05 Soak Testing.md
@@ -67,7 +67,7 @@ export const options = {
 };
 
 export default () => {
-  const urlRes = http.req('https://test-api.k6.io');
+  const urlRes = http.get('https://test-api.k6.io');
   sleep(1);
   // MORE STEPS
   // Here you can have more steps or complex script

--- a/src/data/markdown/translated-guides/en/06 Test Types/06-spike-testing.md
+++ b/src/data/markdown/translated-guides/en/06 Test Types/06-spike-testing.md
@@ -64,7 +64,7 @@ export const options = {
 };
 
 export default () => {
-  const urlRes = http.req('https://test-api.k6.io');
+  const urlRes = http.get('https://test-api.k6.io');
   sleep(1);
   // MORE STEPS
   // Add only the processes that will be on high demand

--- a/src/data/markdown/translated-guides/en/06 Test Types/07-breakpoint-testing.md
+++ b/src/data/markdown/translated-guides/en/06 Test Types/07-breakpoint-testing.md
@@ -83,7 +83,7 @@ export const options = {
 };
 
 export default () => {
-  const urlRes = http.req('https://test-api.k6.io');
+  const urlRes = http.get('https://test-api.k6.io');
   sleep(1);
   // MORE STEPS
   // Here you can have more steps or complex script


### PR DESCRIPTION
## Description

It seems that the method `req` has been updated to `request`. To make it easier for people to read the documentation, I have changed `req` to `get`.

