### PR TITLE
fix: remove unnecessary sleep import and blank line

### DIFF
--- a/src/data/markdown/translated-guides/en/02 Using k6/14 Scenarios/01 Executors/05 constant-arrival-rate.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/14 Scenarios/01 Executors/05 constant-arrival-rate.md
@@ -58,7 +58,6 @@ It allocates 50 VUs for k6 to dynamically use as needed.
 
 ```javascript
 import http from 'k6/http';
-import { sleep } from 'k6';
 
 export const options = {
   discardResponseBodies: true,
@@ -77,7 +76,6 @@ export const options = {
 
       // Pre-allocate VUs
       preAllocatedVUs: 50,
-
     },
   },
 };

--- a/src/data/markdown/translated-guides/en/02 Using k6/14 Scenarios/01 Executors/06 ramping-arrival-rate.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/14 Scenarios/01 Executors/06 ramping-arrival-rate.md
@@ -77,7 +77,6 @@ export const options = {
       // Pre-allocate necessary VUs.
       preAllocatedVUs: 50,
 
-
       stages: [
         // Start 300 iterations per `timeUnit` for the first minute.
         { target: 300, duration: '1m' },


### PR DESCRIPTION
According to the document note, there is no need to use a sleep() function at the end of the VU code.

> Don't put sleep at the end of an iteration.
The arrival-rate executors already pace the iteration rate through the rate and timeUnit properties. So it's unnecessary to use a sleep() function at the end of the VU code.