### PR TITLE
Fix broken links

### DIFF
--- a/src/data/markdown/docs/05 Examples/01 Examples/24 distribute-workloads.md
+++ b/src/data/markdown/docs/05 Examples/01 Examples/24 distribute-workloads.md
@@ -155,5 +155,5 @@ export default function () {
 
 </CodeGroup>
 
-For a more sophisticated example of randomizing, read this [forum post](https://community.grafana.com/t/how-to-distribute-vus-across-different-scenarios-with-k6/97698/2).
+For a more sophisticated example of randomizing, read this [forum post](https://community.grafana.com/t/how-to-distribute-vus-across-different-scenarios-with-k6/97698/17).
 

--- a/src/data/markdown/docs/05 Examples/01 Examples/24 distribute-workloads.md
+++ b/src/data/markdown/docs/05 Examples/01 Examples/24 distribute-workloads.md
@@ -155,5 +155,5 @@ export default function () {
 
 </CodeGroup>
 
-For a more sophisticated example of randomizing, read this [forum post](https://community.grafana.com/t/how-to-distribute-vus-across-different-scenarios-with-k6/49/17).
+For a more sophisticated example of randomizing, read this [forum post](https://community.grafana.com/t/how-to-distribute-vus-across-different-scenarios-with-k6/97698/2).
 

--- a/src/data/markdown/docs/07 extensions/01 Get started/04 Create/01 JavaScript Extensions.md
+++ b/src/data/markdown/docs/07 extensions/01 Get started/04 Create/01 JavaScript Extensions.md
@@ -33,7 +33,7 @@ $ go install go.k6.io/xk6/cmd/xk6@latest
   ```
 
 1. In the directory, make a Go file for your JavaScript extension.
-  
+
   A simple JavaScript extension requires a struct that exposes methods called by the test script.
 
   <!-- TODO: A better trivial example? A coin flip perhaps? -->
@@ -340,7 +340,7 @@ INFO[0000] Active VUs: 2, Iteration: 2, VU ID: 2, VU ID from runtime: 2  source=
 - Use the registry's [`NewMetric`](https://pkg.go.dev/go.k6.io/k6/metrics#Registry.NewMetric) method to create
   custom metrics; to emit them, use [`metrics.PushIfNotDone()`](https://pkg.go.dev/go.k6.io/k6/metrics#PushIfNotDone).
 
-> Questions? Feel free to join the discussion on extensions in the [k6 Community Forum](https://community.grafana.com/c/extensions/).
+> Questions? Feel free to join the discussion on extensions in the [k6 Community Forum](https://community.grafana.com/c/grafana-k6/extensions/82).
 
 Next, create an [Output extension](/extensions/get-started/create/output-extensions/) to publish test metrics
 to a destination not already supported by k6.

--- a/src/data/markdown/docs/07 extensions/01 Get started/04 Create/02 Output Extensions.md
+++ b/src/data/markdown/docs/07 extensions/01 Get started/04 Create/02 Output Extensions.md
@@ -242,5 +242,5 @@ Your output should look something like this:
 - Use the [project template](https://github.com/grafana/xk6-output-template) as a starting point
   for your output extension.
 
-> Questions? Feel free to join the discussion on extensions in the [k6 Community Forum](https://community.grafana.com/c/extensions/).
+> Questions? Feel free to join the discussion on extensions in the [k6 Community Forum](https://community.grafana.com/c/grafana-k6/extensions/82).
 

--- a/src/data/markdown/docs/07 extensions/03 Guides/build-k6-using-docker.md
+++ b/src/data/markdown/docs/07 extensions/03 Guides/build-k6-using-docker.md
@@ -41,7 +41,7 @@ docker run --rm -e GOOS=windows -v "%cd%:/xk6" ^
 
 </CodeGroup>
 
-This creates a `k6` (or `k6.exe`) binary in the current working directory. 
+This creates a `k6` (or `k6.exe`) binary in the current working directory.
 
 To build the binary with concrete versions, see the example below (k6 `v0.45.1`, xk6-kafka `v0.19.1`, and xk6-output-influxdb `v0.4.1`):
 
@@ -84,7 +84,7 @@ The example command line may look a bit intimidating at first, but let's focus o
 docker run --rm -u "$(id -u):$(id -g)" -v "${PWD}:/xk6"
 ```
 
-This tells Docker to run a new container from an image. 
+This tells Docker to run a new container from an image.
 - `--rm` means the container will be destroyed once your build is completed.
 - `-u` specifies the user and group IDs of the account on the host machine. This is important for the `k6` file to have the same file permissions as the host user.
 - `-v` is required to mount the current working directory inside the container, so that the `k6` binary can be written to it.
@@ -168,5 +168,5 @@ k6.exe run my-script.js
 
 ## Encountering issues?
 
-If you're having issues, search the [k6 Community Forum](https://community.grafana.com/c/extensions/). 
+If you're having issues, search the [k6 Community Forum](https://community.grafana.com/c/grafana-k6/extensions/82).
 Someone may have had the same issue in the past.

--- a/src/data/markdown/translated-guides/en/07 Testing Guides/05 Running distributed tests.md
+++ b/src/data/markdown/translated-guides/en/07 Testing Guides/05 Running distributed tests.md
@@ -32,18 +32,21 @@ Using [kind](https://kind.sigs.k8s.io/) or [k3d](https://k3d.io/) are awesome op
 
 </Blockquote>
 
-- [1. Install the operator](#install-the-operator)
-- [2. Create a test script](#create-a-test-script)
-- [3. Adding test scripts](#add-test-scripts)
+- [Introducing k6-operator](#introducing-k6-operator)
+- [Get started with k6-operator](#get-started-with-k6-operator)
+- [1. Install the operator](#1-install-the-operator)
+- [2. Create a test script](#2-create-a-test-script)
+- [3. Add test scripts](#3-add-test-scripts)
   - [Add as a ConfigMap](#add-as-a-configmap)
-  - [Add within a PersistentVolume](#add-inside-a-persistentvolume)
-- [4. Create a custom resource](#create-a-custom-resource)
+  - [Add inside a PersistentVolume](#add-inside-a-persistentvolume)
+- [4. Create a custom resource](#4-create-a-custom-resource)
   - [Script in a ConfigMap](#script-in-a-configmap)
   - [Script in a PersistentVolume](#script-in-a-persistentvolume)
   - [Configure the environment](#configure-the-environment)
   - [Change command-line arguments](#change-command-line-arguments)
-- [5. Run your test](#run-your-test)
-- [6. When things go wrong](#when-things-go-wrong)
+- [5. Run your test](#5-run-your-test)
+- [6. When things go wrong](#6-when-things-go-wrong)
+- [See also](#see-also)
 
 ## 1. Install the operator
 The first step to running distributed tests in Kubernetes is to install the operator if not already installed in the cluster.
@@ -52,7 +55,7 @@ Installation commands must be run from the source directory.
 
 <Blockquote mod="note" title="Prerequisites">
 
-Besides privileged access to a Kubernetes cluster, installation will require that the system performing the installation has the following tools installed: 
+Besides privileged access to a Kubernetes cluster, installation will require that the system performing the installation has the following tools installed:
 - [Git](https://git-scm.com/downloads)
 - [Go](https://go.dev/doc/install)
 - [Kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)
@@ -216,7 +219,7 @@ spec:
 </CodeGroup>
 
 Recall when the script was [added as a ConfigMap](#add-as-a-configmap) for our configuration values.
-We created the ConfigMap named `my-test`. 
+We created the ConfigMap named `my-test`.
 The test script content was added to the map using the filename as the key-value, therefore the `file` value is `test.js`.
 
 The amount of `parallelism` is up to you; how many pods do you want to split the test amongst?
@@ -259,7 +262,7 @@ It is important that the `PersistentVolumeClaim` and `CustomResource` are create
 </Blockquote>
 
 ### Configure the environment
-Not everything should be included directly in your scripts. 
+Not everything should be included directly in your scripts.
 Well written scripts will allow for variability to support multiple scenarios and to avoid hard-coding values that tend to change.
 These could be anything from passwords to target urls, in addition to system options.
 
@@ -346,7 +349,7 @@ The test configuration is applied as in the following:
 kubectl apply -f /path/to/your/k6-resource.yaml
 ```
 
-After completing a test run, you need to clean up the test jobs created. 
+After completing a test run, you need to clean up the test jobs created.
 This is done by running the following command:
 
 ```shell
@@ -379,7 +382,7 @@ spec:
 ## 6. When things go wrong
 Sadly nothing works perfectly all the time, so knowing where you can go for help is important.
 
-Be sure to search the [k6-operator category in the community forum](https://community.grafana.com/c/k6-operator). 
+Be sure to search the [k6-operator category in the community forum](https://community.grafana.com/c/grafana-k6/k6-operator/73).
 k6 has a growing and helpful community of engineers working with k6-operator, so there's a good chance your issue has already been discussed and overcome.
 It's also in these forums where you'll be able to get help from members of the k6 development team.
 


### PR DESCRIPTION
I've fixed the few links I could fix myself, which lead to the check broken links action failing. An occurrence of it can be found [here](https://github.com/grafana/k6-docs/actions/runs/5855037923/job/15872214175).

I've only fixed some, as others I either had no clue where to point them instead, or couldn't actually find them with a search and replace in the code, or they fail because of `429` which we can't really avoid with the `linkinator` action, besides using the `retry` option, which we already do.