### PR TITLE
Fix community forum links after b4cc2d20

### DIFF
--- a/src/data/markdown/docs/05 Examples/01 Examples/24 distribute-workloads.md
+++ b/src/data/markdown/docs/05 Examples/01 Examples/24 distribute-workloads.md
@@ -155,5 +155,5 @@ export default function () {
 
 </CodeGroup>
 
-For a more sophisticated example of randomizing, read this [forum post](https://community.grafana.com/t/how-to-distribute-vus-across-different-scenarios-with-k6/49/17).
+For a more sophisticated example of randomizing, read this [forum post](https://community.grafana.com/t/how-to-distribute-vus-across-different-scenarios-with-k6/97698/17).
 

--- a/src/data/markdown/docs/20 jslib/01 jslib/03 k6chaijs.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/03 k6chaijs.md
@@ -73,7 +73,7 @@ If you are familiar with k6, the result is the same as using [check](/javascript
 
 ## Plugins
 
-It's possible to extend the default functionality with [Chai plugins](https://www.chaijs.com/plugins/).  To use a plugin or build a Chai version with plugins, follow the instructions in this [example](https://community.grafana.com/t/how-to-build-plugins-for-chaijs/5080/3).
+It's possible to extend the default functionality with [Chai plugins](https://www.chaijs.com/plugins/).  To use a plugin or build a Chai version with plugins, follow the instructions in this [example](https://community.grafana.com/t/how-to-build-plugins-for-chaijs/97010/3).
 
 ## Read more
 


### PR DESCRIPTION
The search and replace done there unfortunately breaks one of the links and links to a different thread for the other.