### PR TITLE
Fix broken links in browser docs

### DIFF
--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser.md
@@ -115,7 +115,7 @@ PS C:\k6> k6 run script.js
 | [Keyboard](/javascript-api/k6-experimental/browser/keyboard/)                       | Used to simulate the keyboard interactions with the associated [`Page`](/javascript-api/k6-experimental/browser/page/).                                                     |
 | [Locator](/javascript-api/k6-experimental/browser/locator/)                         | The Locator API makes it easier to work with dynamically changing elements.                                                                                     |
 | [Mouse](/javascript-api/k6-experimental/browser/mouse/)                             | Used to simulate the mouse interactions with the associated [`Page`](/javascript-api/k6-experimental/browser/page/).                                                        |
-| [Page](/javascript-api/k6-experimental/browser/page/) <BWIPT />                     | Provides methods to interact with a single tab in a [`Browser`](/javascript-api/k6-experimental/browser/browser-class/).                                                          |
+| [Page](/javascript-api/k6-experimental/browser/page/) <BWIPT />                     | Provides methods to interact with a single tab in a browser.                                                          |
 | [Request](/javascript-api/k6-experimental/browser/request/) <BWIPT />               | Used to keep track of the request the [`Page`](/javascript-api/k6-experimental/browser/page/) makes.                                                                        |
 | [Response](/javascript-api/k6-experimental/browser/response/) <BWIPT />             | Represents the response received by the [`Page`](/javascript-api/k6-experimental/browser/page/).                                                                            |
 | [Touchscreen](/javascript-api/k6-experimental/browser/touchscreen/)                 | Used to simulate touch interactions with the associated [`Page`](/javascript-api/k6-experimental/browser/page/).                                                            |
@@ -195,7 +195,7 @@ The starting '--' have been omitted from the argument names in these lists.
 | no-service-autorun | `true` | Disables the service process from adding itself as an autorun process. This does not delete existing autorun registrations, it just prevents the service from registering a new one. |
 | no-startup-window | `true` | Does not automatically open a browser window on startup (used when launching Chrome for the purpose of hosting background apps). |
 | no-default-browser-check | `true` | Disables the default browser check. Useful for UI/browser tests where we want to avoid having the default browser info-bar displayed. |
-| headless | `true`/`false` | Run in headless mode, i.e., without a UI or display server dependencies. Set by [launch options](/javascript-api/k6-experimental/browser/browsertype/launch/) (default true).  |
+| headless | `true`/`false` | Run in headless mode, i.e., without a UI or display server dependencies. Set by `K6_BROWSER_HEADLESS` environment variable (default true).  |
 | auto-open-devtools-for-tabs | `true`/`false` | This flag makes Chrome auto-open the DevTools window for each tab. It is intended to be used by developers and automation, not to require user interaction for opening DevTools. Set by [launch options](/javascript-api/k6-experimental/browser/browsertype/launch/) (default false). |
 | window-size | `800,600` | Sets the initial window size. Provided as string in the format "800,600". |
 

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser.md
@@ -196,7 +196,6 @@ The starting '--' have been omitted from the argument names in these lists.
 | no-startup-window | `true` | Does not automatically open a browser window on startup (used when launching Chrome for the purpose of hosting background apps). |
 | no-default-browser-check | `true` | Disables the default browser check. Useful for UI/browser tests where we want to avoid having the default browser info-bar displayed. |
 | headless | `true`/`false` | Run in headless mode, i.e., without a UI or display server dependencies. Set by `K6_BROWSER_HEADLESS` environment variable (default true).  |
-| auto-open-devtools-for-tabs | `true`/`false` | This flag makes Chrome auto-open the DevTools window for each tab. It is intended to be used by developers and automation, not to require user interaction for opening DevTools. Set by [launch options](/javascript-api/k6-experimental/browser/browsertype/launch/) (default false). |
 | window-size | `800,600` | Sets the initial window size. Provided as string in the format "800,600". |
 
 Additionally if headless mode is set to `true` in [browser options](/javascript-api/k6-experimental/browser#browser_options), the following arguments are also set:


### PR DESCRIPTION
Fixes a couple of broken links present in browser API docs mistakenly introduced in https://github.com/grafana/k6-docs/pull/1208 and corresponding to `v1.0.2` changes.