### PR TITLE
Report when broken links fails

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -132,7 +132,6 @@ jobs:
     name: "Checks broken links"
     runs-on: ubuntu-latest
     needs: [build-deploy-staging]
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v3
       - uses: JustinBeckwith/linkinator-action@v1


### PR DESCRIPTION
Previously even if this fails the user who merged/pushed to main will get no notification.

Given that this is the last action it won't prevent anything else running