### PR TITLE
chore: add instructions to release new JS API version to contributing

### DIFF
--- a/CONTRIBUTING/README.md
+++ b/CONTRIBUTING/README.md
@@ -122,7 +122,7 @@ Unless k6 OSS has a version upgrade, increment the version by 0.0.1. For example
 As the UI might change, refer to the GitHub [Managing releases](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) doc for the canonical instructions.
 
 Each release has a tag, which you can create either through the Github CLI or from https://github.com/grafana/k6-docs/releases.
-To upgrade through the UI,
+To upgrade through the UI:
 
 1. From the releases page, select **Draft a new Release**.
 ![DraftRelease1](../internal-images/DraftNewRelease.png)

--- a/CONTRIBUTING/javascript-api-version-release.md
+++ b/CONTRIBUTING/javascript-api-version-release.md
@@ -1,0 +1,37 @@
+# Update version for JavaScript API documentation
+
+The k6-docs project supports versioning for the JavaScript API section.
+
+## How it works
+
+`md` files for the latest version are located in `src/data/markdown/docs/02 javascript api` and page URLs have no version prefix.
+
+Other versions are located in `src/data/markdown/versioned-js-api` and URLs for versioned pages contain the version number (e.g. _https://k6.io/docs/javascript-api/v0-31/_, _https://k6.io/docs/javascript-api/v0-31/k6-crypto/createhash-algorithm/)_
+
+## How to add a new version
+
+Let's say the new version `v0.33` is released and we want to add docs for it and make it the new latest version.
+
+1. Make sure that `src/data/markdown/docs/02 javascript api` contains the `v0.32` docs you want to archive.
+2. Prepare for running `archive-js-api-version.sh`.
+
+- Add exec permission:  `chmod +x ./archive-js-api-version.sh`
+- Make sure you have installed the `archive-js-api-version.sh` dependencies.
+
+3. Run `npm run archive-version v0.32`.
+
+This script will:
+
+- Create a new folder inside `src/data/markdown/versioned-js-api` named `v0.32`.
+- Copy the contents of `src/data/markdown/docs/02 javascript api` to the new folder.
+- Replace internal links in `md` files for the JavaScript API section to point to `v0.32` pages.
+- If any Javascript API pages have custom `slug` set in the `frontmatter`, the value will also be updated to include version number.
+
+4. Go to `src/utils/versioning.js` and add `v0.32` to `SUPPORTED_VERSIONS`. Set `LATEST_VERSION = v0.33`.
+
+5. Clean the cache and test it.
+
+- `gatsby clean`
+- `npm start`
+
+6. Now, you can add the new docs for `v0.33` to `src/data/markdown/docs/02 javascript api` or merge open PRs for `v0.33`.


### PR DESCRIPTION
These instructions currently live in the [wiki](https://github.com/grafana/k6-docs/wiki/Add-version-for-Javascript-API-documentation) for this repo, I think we can move them to the CONTRIBUTING folder so they're easier to find in the future.