### PR TITLE
Add xk6-input-prometheus

### DIFF
--- a/src/data/doc-extensions/extensions.json
+++ b/src/data/doc-extensions/extensions.json
@@ -1141,6 +1141,21 @@
       "categories": ["Observability"],
       "tiers": ["Community"],
       "cloudEnabled": false
+    },
+    {
+      "name": "xk6-input-prometheus",
+      "description": "Enables real-time input from prometheus",
+      "url": "https://github.com/JorTurFer/xk6-input-prometheus",
+      "logo": "",
+      "author": {
+        "name": "Jorge Turrado",
+        "url": "https://github.com/JorTurFer"
+      },
+      "stars": "0",
+      "type": ["JavaScript"],
+      "categories": ["Data"],
+      "tiers": ["Community"],
+      "cloudEnabled": false
     }
   ]
 }


### PR DESCRIPTION
Hi,
I have created an extension for reading metrics from prometheus. There are use cases where direct metrics aren't available during the tests and the tests case has to be evaluated thanks to indirect measurements.

Our use case for this extension is to measure [KEDA](keda.sh) lag during the load. To measure the operator processing lag, we can't use any direct metric from anywhere because things happen internally, but thanks to this extension, we can export the operator metrics to Grafana Cloud, and query the metrics from there during the test. This brings us the option to use thresholds using custom gauges populated from prometheus queries.

The repo isn't public yet but it'll be public soon (when we finish some pending stuff), so there you will be able to see how the extension works