### PR TITLE
Fix the browser examples which work with check

### DIFF
--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/04-element-handle.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/04-element-handle.md
@@ -82,7 +82,7 @@ export default async function () {
 
     await Promise.all([page.waitForNavigation(), submitButton.click()]);
     check(page, {
-      'header': page => page.locator('h2').textContent() == 'Welcome, admin!',
+      'header': p => p.locator('h2').textContent() == 'Welcome, admin!',
     });
   } finally {
     page.close();

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/04-element-handle.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/04-element-handle.md
@@ -82,7 +82,7 @@ export default async function () {
 
     await Promise.all([page.waitForNavigation(), submitButton.click()]);
     check(page, {
-      header: page.locator('h2').textContent() == 'Welcome, admin!',
+      'header': page => page.locator('h2').textContent() == 'Welcome, admin!',
     });
   } finally {
     page.close();

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/10 Page/waitforloadstate--options--.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/10 Page/waitforloadstate--options--.md
@@ -71,7 +71,7 @@ export default async function () {
     page.waitForLoadState(); // waits for the default `load` event
 
     check(page, {
-      header: page.locator('h2').textContent() == 'Welcome, admin!',
+      'header': page => page.locator('h2').textContent() == 'Welcome, admin!',
     });
   } finally {
     page.close();

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/10 Page/waitforloadstate--options--.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/10 Page/waitforloadstate--options--.md
@@ -71,7 +71,7 @@ export default async function () {
     page.waitForLoadState(); // waits for the default `load` event
 
     check(page, {
-      'header': page => page.locator('h2').textContent() == 'Welcome, admin!',
+      'header': p => p.locator('h2').textContent() == 'Welcome, admin!',
     });
   } finally {
     page.close();

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/10 Page/waitfornavigation--options--.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/10 Page/waitfornavigation--options--.md
@@ -71,7 +71,7 @@ export default async function () {
     await Promise.all([page.waitForNavigation(), submitButton.click()])
 
     check(page, {
-      header: page.locator('h2').textContent() == 'Welcome, admin!',
+      'header': page => page.locator('h2').textContent() == 'Welcome, admin!',
     });
   } finally {
     page.close();

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/10 Page/waitfornavigation--options--.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser/10 Page/waitfornavigation--options--.md
@@ -71,7 +71,7 @@ export default async function () {
     await Promise.all([page.waitForNavigation(), submitButton.click()])
 
     check(page, {
-      'header': page => page.locator('h2').textContent() == 'Welcome, admin!',
+      'header': p => p.locator('h2').textContent() == 'Welcome, admin!',
     });
   } finally {
     page.close();

--- a/src/data/markdown/translated-guides/en/03 Using k6 browser/01 Overview.md
+++ b/src/data/markdown/translated-guides/en/03 Using k6 browser/01 Overview.md
@@ -65,7 +65,7 @@ export default async function () {
     await Promise.all([page.waitForNavigation(), submitButton.click()]);
 
     check(page, {
-      'header': page => page.locator('h2').textContent() == 'Welcome, admin!',
+      'header': p => p.locator('h2').textContent() == 'Welcome, admin!',
     });
   } finally {
     page.close();

--- a/src/data/markdown/translated-guides/en/03 Using k6 browser/01 Overview.md
+++ b/src/data/markdown/translated-guides/en/03 Using k6 browser/01 Overview.md
@@ -65,7 +65,7 @@ export default async function () {
     await Promise.all([page.waitForNavigation(), submitButton.click()]);
 
     check(page, {
-      header: page.locator('h2').textContent() == 'Welcome, admin!',
+      'header': page => page.locator('h2').textContent() == 'Welcome, admin!',
     });
   } finally {
     page.close();

--- a/src/data/markdown/translated-guides/en/03 Using k6 browser/02 Running browser tests.md
+++ b/src/data/markdown/translated-guides/en/03 Using k6 browser/02 Running browser tests.md
@@ -225,7 +225,7 @@ export default async function () {
     await Promise.all([page.waitForNavigation(), submitButton.click()]);
 
     check(page, {
-      'header': page => page.locator('h2').textContent() == 'Welcome, admin!',
+      'header': p => p.locator('h2').textContent() == 'Welcome, admin!',
     });
   } finally {
     page.close();

--- a/src/data/markdown/translated-guides/en/03 Using k6 browser/02 Running browser tests.md
+++ b/src/data/markdown/translated-guides/en/03 Using k6 browser/02 Running browser tests.md
@@ -225,7 +225,7 @@ export default async function () {
     await Promise.all([page.waitForNavigation(), submitButton.click()]);
 
     check(page, {
-      header: page.locator('h2').textContent() == 'Welcome, admin!',
+      'header': page => page.locator('h2').textContent() == 'Welcome, admin!',
     });
   } finally {
     page.close();

--- a/src/data/markdown/versioned-js-api/v0.43/javascript api/07 k6-experimental/01 browser/04-element-handle.md
+++ b/src/data/markdown/versioned-js-api/v0.43/javascript api/07 k6-experimental/01 browser/04-element-handle.md
@@ -73,7 +73,7 @@ export default async function () {
 
     await Promise.all([page.waitForNavigation(), page.locator('input[type="submit"]').click()]);
     check(page, {
-      header: page.locator('h2').textContent() == 'Welcome, admin!',
+      'header': page => page.locator('h2').textContent() == 'Welcome, admin!',
     });
   } finally {
     page.close();

--- a/src/data/markdown/versioned-js-api/v0.43/javascript api/07 k6-experimental/01 browser/04-element-handle.md
+++ b/src/data/markdown/versioned-js-api/v0.43/javascript api/07 k6-experimental/01 browser/04-element-handle.md
@@ -73,7 +73,7 @@ export default async function () {
 
     await Promise.all([page.waitForNavigation(), page.locator('input[type="submit"]').click()]);
     check(page, {
-      'header': page => page.locator('h2').textContent() == 'Welcome, admin!',
+      'header': p => p.locator('h2').textContent() == 'Welcome, admin!',
     });
   } finally {
     page.close();

--- a/src/data/markdown/versioned-js-api/v0.43/javascript api/07 k6-experimental/01 browser/10-page.md
+++ b/src/data/markdown/versioned-js-api/v0.43/javascript api/07 k6-experimental/01 browser/10-page.md
@@ -95,7 +95,7 @@ export default async function () {
 
     await Promise.all([page.waitForNavigation(), page.locator('input[type="submit"]').click()]);
     check(page, {
-      'header': page => page.locator('h2').textContent() == 'Welcome, admin!',
+      'header': p => p.locator('h2').textContent() == 'Welcome, admin!',
     });
   } finally {
     page.close();

--- a/src/data/markdown/versioned-js-api/v0.43/javascript api/07 k6-experimental/01 browser/10-page.md
+++ b/src/data/markdown/versioned-js-api/v0.43/javascript api/07 k6-experimental/01 browser/10-page.md
@@ -95,7 +95,7 @@ export default async function () {
 
     await Promise.all([page.waitForNavigation(), page.locator('input[type="submit"]').click()]);
     check(page, {
-      header: page.locator('h2').textContent() == 'Welcome, admin!',
+      'header': page => page.locator('h2').textContent() == 'Welcome, admin!',
     });
   } finally {
     page.close();

--- a/src/data/markdown/versioned-js-api/v0.44/javascript api/07 k6-experimental/01 browser/04-element-handle.md
+++ b/src/data/markdown/versioned-js-api/v0.44/javascript api/07 k6-experimental/01 browser/04-element-handle.md
@@ -74,7 +74,7 @@ export default async function () {
 
     await Promise.all([page.waitForNavigation(), submitButton.click()]);
     check(page, {
-      'header': page => page.locator('h2').textContent() == 'Welcome, admin!',
+      'header': p => p.locator('h2').textContent() == 'Welcome, admin!',
     });
   } finally {
     page.close();

--- a/src/data/markdown/versioned-js-api/v0.44/javascript api/07 k6-experimental/01 browser/04-element-handle.md
+++ b/src/data/markdown/versioned-js-api/v0.44/javascript api/07 k6-experimental/01 browser/04-element-handle.md
@@ -74,7 +74,7 @@ export default async function () {
 
     await Promise.all([page.waitForNavigation(), submitButton.click()]);
     check(page, {
-      header: page.locator('h2').textContent() == 'Welcome, admin!',
+      'header': page => page.locator('h2').textContent() == 'Welcome, admin!',
     });
   } finally {
     page.close();

--- a/src/data/markdown/versioned-js-api/v0.44/javascript api/07 k6-experimental/01 browser/10 Page/waitforloadstate--options--.md
+++ b/src/data/markdown/versioned-js-api/v0.44/javascript api/07 k6-experimental/01 browser/10 Page/waitforloadstate--options--.md
@@ -59,7 +59,7 @@ export default async function () {
     page.waitForLoadState(); // waits for the default `load` event
 
     check(page, {
-      'header': page => page.locator('h2').textContent() == 'Welcome, admin!',
+      'header': p => p.locator('h2').textContent() == 'Welcome, admin!',
     });
   } finally {
     page.close();

--- a/src/data/markdown/versioned-js-api/v0.44/javascript api/07 k6-experimental/01 browser/10 Page/waitforloadstate--options--.md
+++ b/src/data/markdown/versioned-js-api/v0.44/javascript api/07 k6-experimental/01 browser/10 Page/waitforloadstate--options--.md
@@ -59,7 +59,7 @@ export default async function () {
     page.waitForLoadState(); // waits for the default `load` event
 
     check(page, {
-      header: page.locator('h2').textContent() == 'Welcome, admin!',
+      'header': page => page.locator('h2').textContent() == 'Welcome, admin!',
     });
   } finally {
     page.close();

--- a/src/data/markdown/versioned-js-api/v0.44/javascript api/07 k6-experimental/01 browser/10 Page/waitfornavigation--options--.md
+++ b/src/data/markdown/versioned-js-api/v0.44/javascript api/07 k6-experimental/01 browser/10 Page/waitfornavigation--options--.md
@@ -59,7 +59,7 @@ export default async function () {
     await Promise.all([page.waitForNavigation(), submitButton.click()])
 
     check(page, {
-      'header': page => page.locator('h2').textContent() == 'Welcome, admin!',
+      'header': p => p.locator('h2').textContent() == 'Welcome, admin!',
     });
   } finally {
     page.close();

--- a/src/data/markdown/versioned-js-api/v0.44/javascript api/07 k6-experimental/01 browser/10 Page/waitfornavigation--options--.md
+++ b/src/data/markdown/versioned-js-api/v0.44/javascript api/07 k6-experimental/01 browser/10 Page/waitfornavigation--options--.md
@@ -59,7 +59,7 @@ export default async function () {
     await Promise.all([page.waitForNavigation(), submitButton.click()])
 
     check(page, {
-      header: page.locator('h2').textContent() == 'Welcome, admin!',
+      'header': page => page.locator('h2').textContent() == 'Welcome, admin!',
     });
   } finally {
     page.close();

--- a/src/data/markdown/versioned-js-api/v0.45/javascript api/07 k6-experimental/01 browser/04-element-handle.md
+++ b/src/data/markdown/versioned-js-api/v0.45/javascript api/07 k6-experimental/01 browser/04-element-handle.md
@@ -74,7 +74,7 @@ export default async function () {
 
     await Promise.all([page.waitForNavigation(), submitButton.click()]);
     check(page, {
-      'header': page => page.locator('h2').textContent() == 'Welcome, admin!',
+      'header': p => p.locator('h2').textContent() == 'Welcome, admin!',
     });
   } finally {
     page.close();

--- a/src/data/markdown/versioned-js-api/v0.45/javascript api/07 k6-experimental/01 browser/04-element-handle.md
+++ b/src/data/markdown/versioned-js-api/v0.45/javascript api/07 k6-experimental/01 browser/04-element-handle.md
@@ -74,7 +74,7 @@ export default async function () {
 
     await Promise.all([page.waitForNavigation(), submitButton.click()]);
     check(page, {
-      header: page.locator('h2').textContent() == 'Welcome, admin!',
+      'header': page => page.locator('h2').textContent() == 'Welcome, admin!',
     });
   } finally {
     page.close();

--- a/src/data/markdown/versioned-js-api/v0.45/javascript api/07 k6-experimental/01 browser/10 Page/waitforloadstate--options--.md
+++ b/src/data/markdown/versioned-js-api/v0.45/javascript api/07 k6-experimental/01 browser/10 Page/waitforloadstate--options--.md
@@ -59,7 +59,7 @@ export default async function () {
     page.waitForLoadState(); // waits for the default `load` event
 
     check(page, {
-      'header': page => page.locator('h2').textContent() == 'Welcome, admin!',
+      'header': p => p.locator('h2').textContent() == 'Welcome, admin!',
     });
   } finally {
     page.close();

--- a/src/data/markdown/versioned-js-api/v0.45/javascript api/07 k6-experimental/01 browser/10 Page/waitforloadstate--options--.md
+++ b/src/data/markdown/versioned-js-api/v0.45/javascript api/07 k6-experimental/01 browser/10 Page/waitforloadstate--options--.md
@@ -59,7 +59,7 @@ export default async function () {
     page.waitForLoadState(); // waits for the default `load` event
 
     check(page, {
-      header: page.locator('h2').textContent() == 'Welcome, admin!',
+      'header': page => page.locator('h2').textContent() == 'Welcome, admin!',
     });
   } finally {
     page.close();

--- a/src/data/markdown/versioned-js-api/v0.45/javascript api/07 k6-experimental/01 browser/10 Page/waitfornavigation--options--.md
+++ b/src/data/markdown/versioned-js-api/v0.45/javascript api/07 k6-experimental/01 browser/10 Page/waitfornavigation--options--.md
@@ -59,7 +59,7 @@ export default async function () {
     await Promise.all([page.waitForNavigation(), submitButton.click()])
 
     check(page, {
-      'header': page => page.locator('h2').textContent() == 'Welcome, admin!',
+      'header': p => p.locator('h2').textContent() == 'Welcome, admin!',
     });
   } finally {
     page.close();

--- a/src/data/markdown/versioned-js-api/v0.45/javascript api/07 k6-experimental/01 browser/10 Page/waitfornavigation--options--.md
+++ b/src/data/markdown/versioned-js-api/v0.45/javascript api/07 k6-experimental/01 browser/10 Page/waitfornavigation--options--.md
@@ -59,7 +59,7 @@ export default async function () {
     await Promise.all([page.waitForNavigation(), submitButton.click()])
 
     check(page, {
-      header: page.locator('h2').textContent() == 'Welcome, admin!',
+      'header': page => page.locator('h2').textContent() == 'Welcome, admin!',
     });
   } finally {
     page.close();


### PR DESCRIPTION
`check` expects a function that returns a `boolean`. There is enough of a difference in what the k6 type definitions expect vs how the example k6 browser tests work with `check`. If a user works with the example browser tests as documented along with the type definitions then they will find an error in the example code. This commit fix those examples so that users will not see that error.

Before:
<img width="555" alt="Screenshot 2023-08-31 at 14 48 04" src="https://github.com/grafana/k6-docs/assets/1112428/403ae270-58d4-48c2-b661-4814380c5e3d">

