### PR TITLE
Fix broken links

### DIFF
--- a/src/data/markdown/docs/02 javascript api/02 k6/sleep- t -.md
+++ b/src/data/markdown/docs/02 javascript api/02 k6/sleep- t -.md
@@ -29,7 +29,7 @@ export default function () {
 
 </CodeGroup>
 
-Using the [k6-utils](/javascript-api/jslib/utils) library to specify a range between a minimum and maximum:
+Using the [k6-utils](https://k6.io/docs/javascript-api/jslib/utils) library to specify a range between a minimum and maximum:
 
 <CodeGroup labels={[]}>
 

--- a/src/data/markdown/docs/02 javascript api/alternative main modules/20 jslib.md
+++ b/src/data/markdown/docs/02 javascript api/alternative main modules/20 jslib.md
@@ -8,7 +8,7 @@ The [jslib.k6.io](https://jslib.k6.io/) is a collection of external JavaScript l
 
 | Library | Description |
 | -------- | ----------- |
-| [utils](/javascript-api/jslib/utils)  | Small utility functions useful in every day load testing |
+| [utils](https://k6.io/docs/javascript-api/jslib/utils)  | Small utility functions useful in every day load testing |
 | [expect](/javascript-api/jslib/expect)  | Micro-framework for writing tests in a style of Jest or ava.  |
 | [httpx](/javascript-api/jslib/httpx)  | Wrapper around the http that simplifies session handling |
 

--- a/src/data/markdown/versioned-js-api/v0.35/javascript api/alternative main modules/20 jslib.md
+++ b/src/data/markdown/versioned-js-api/v0.35/javascript api/alternative main modules/20 jslib.md
@@ -8,7 +8,7 @@ The [jslib.k6.io](https://jslib.k6.io/) is a collection of external JavaScript l
 
 | Library | Description |
 | -------- | ----------- |
-| [utils](/javascript-api/jslib/utils)  | Small utility functions useful in every day load testing |
+| [utils](https://k6.io/docs/javascript-api/jslib/utils)  | Small utility functions useful in every day load testing |
 | [expect](/javascript-api/jslib/expect)  | Micro-framework for writing tests in a style of Jest or ava.  |
 | [httpx](/javascript-api/jslib/httpx)  | Wrapper around the http that simplifies session handling |
 

--- a/src/data/markdown/versioned-js-api/v0.36/javascript api/alternative main modules/20 jslib.md
+++ b/src/data/markdown/versioned-js-api/v0.36/javascript api/alternative main modules/20 jslib.md
@@ -8,7 +8,7 @@ The [jslib.k6.io](https://jslib.k6.io/) is a collection of external JavaScript l
 
 | Library | Description |
 | -------- | ----------- |
-| [utils](/javascript-api/jslib/utils)  | Small utility functions useful in every day load testing |
+| [utils](https://k6.io/docs/javascript-api/jslib/utils)  | Small utility functions useful in every day load testing |
 | [expect](/javascript-api/jslib/expect)  | Micro-framework for writing tests in a style of Jest or ava.  |
 | [httpx](/javascript-api/jslib/httpx)  | Wrapper around the http that simplifies session handling |
 

--- a/src/data/markdown/versioned-js-api/v0.37/javascript api/02 k6/sleep- t -.md
+++ b/src/data/markdown/versioned-js-api/v0.37/javascript api/02 k6/sleep- t -.md
@@ -29,7 +29,7 @@ export default function () {
 
 </CodeGroup>
 
-Using the [k6-utils](/javascript-api/jslib/utils) library to specify a range between a minimum and maximum:
+Using the [k6-utils](https://k6.io/docs/javascript-api/jslib/utils) library to specify a range between a minimum and maximum:
 
 <CodeGroup labels={[]}>
 

--- a/src/data/markdown/versioned-js-api/v0.37/javascript api/alternative main modules/20 jslib.md
+++ b/src/data/markdown/versioned-js-api/v0.37/javascript api/alternative main modules/20 jslib.md
@@ -8,7 +8,7 @@ The [jslib.k6.io](https://jslib.k6.io/) is a collection of external JavaScript l
 
 | Library | Description |
 | -------- | ----------- |
-| [utils](/javascript-api/jslib/utils)  | Small utility functions useful in every day load testing |
+| [utils](https://k6.io/docs/javascript-api/jslib/utils)  | Small utility functions useful in every day load testing |
 | [expect](/javascript-api/jslib/expect)  | Micro-framework for writing tests in a style of Jest or ava.  |
 | [httpx](/javascript-api/jslib/httpx)  | Wrapper around the http that simplifies session handling |
 

--- a/src/data/markdown/versioned-js-api/v0.38/javascript api/02 k6/sleep- t -.md
+++ b/src/data/markdown/versioned-js-api/v0.38/javascript api/02 k6/sleep- t -.md
@@ -29,7 +29,7 @@ export default function () {
 
 </CodeGroup>
 
-Using the [k6-utils](/javascript-api/jslib/utils) library to specify a range between a minimum and maximum:
+Using the [k6-utils](https://k6.io/docs/javascript-api/jslib/utils) library to specify a range between a minimum and maximum:
 
 <CodeGroup labels={[]}>
 

--- a/src/data/markdown/versioned-js-api/v0.38/javascript api/alternative main modules/20 jslib.md
+++ b/src/data/markdown/versioned-js-api/v0.38/javascript api/alternative main modules/20 jslib.md
@@ -8,7 +8,7 @@ The [jslib.k6.io](https://jslib.k6.io/) is a collection of external JavaScript l
 
 | Library | Description |
 | -------- | ----------- |
-| [utils](/javascript-api/jslib/utils)  | Small utility functions useful in every day load testing |
+| [utils](https://k6.io/docs/javascript-api/jslib/utils)  | Small utility functions useful in every day load testing |
 | [expect](/javascript-api/jslib/expect)  | Micro-framework for writing tests in a style of Jest or ava.  |
 | [httpx](/javascript-api/jslib/httpx)  | Wrapper around the http that simplifies session handling |
 

--- a/src/data/markdown/versioned-js-api/v0.39/javascript api/02 k6/sleep- t -.md
+++ b/src/data/markdown/versioned-js-api/v0.39/javascript api/02 k6/sleep- t -.md
@@ -29,7 +29,7 @@ export default function () {
 
 </CodeGroup>
 
-Using the [k6-utils](/javascript-api/jslib/utils) library to specify a range between a minimum and maximum:
+Using the [k6-utils](https://k6.io/docs/javascript-api/jslib/utils) library to specify a range between a minimum and maximum:
 
 <CodeGroup labels={[]}>
 

--- a/src/data/markdown/versioned-js-api/v0.39/javascript api/alternative main modules/20 jslib.md
+++ b/src/data/markdown/versioned-js-api/v0.39/javascript api/alternative main modules/20 jslib.md
@@ -8,7 +8,7 @@ The [jslib.k6.io](https://jslib.k6.io/) is a collection of external JavaScript l
 
 | Library | Description |
 | -------- | ----------- |
-| [utils](/javascript-api/jslib/utils)  | Small utility functions useful in every day load testing |
+| [utils](https://k6.io/docs/javascript-api/jslib/utils)  | Small utility functions useful in every day load testing |
 | [expect](/javascript-api/jslib/expect)  | Micro-framework for writing tests in a style of Jest or ava.  |
 | [httpx](/javascript-api/jslib/httpx)  | Wrapper around the http that simplifies session handling |
 

--- a/src/data/markdown/versioned-js-api/v0.40/javascript api/02 k6/sleep- t -.md
+++ b/src/data/markdown/versioned-js-api/v0.40/javascript api/02 k6/sleep- t -.md
@@ -29,7 +29,7 @@ export default function () {
 
 </CodeGroup>
 
-Using the [k6-utils](/javascript-api/jslib/utils) library to specify a range between a minimum and maximum:
+Using the [k6-utils](https://k6.io/docs/javascript-api/jslib/utils) library to specify a range between a minimum and maximum:
 
 <CodeGroup labels={[]}>
 

--- a/src/data/markdown/versioned-js-api/v0.40/javascript api/alternative main modules/20 jslib.md
+++ b/src/data/markdown/versioned-js-api/v0.40/javascript api/alternative main modules/20 jslib.md
@@ -8,7 +8,7 @@ The [jslib.k6.io](https://jslib.k6.io/) is a collection of external JavaScript l
 
 | Library | Description |
 | -------- | ----------- |
-| [utils](/javascript-api/jslib/utils)  | Small utility functions useful in every day load testing |
+| [utils](https://k6.io/docs/javascript-api/jslib/utils)  | Small utility functions useful in every day load testing |
 | [expect](/javascript-api/jslib/expect)  | Micro-framework for writing tests in a style of Jest or ava.  |
 | [httpx](/javascript-api/jslib/httpx)  | Wrapper around the http that simplifies session handling |
 

--- a/src/data/markdown/versioned-js-api/v0.41/javascript api/02 k6/sleep- t -.md
+++ b/src/data/markdown/versioned-js-api/v0.41/javascript api/02 k6/sleep- t -.md
@@ -29,7 +29,7 @@ export default function () {
 
 </CodeGroup>
 
-Using the [k6-utils](/javascript-api/jslib/utils) library to specify a range between a minimum and maximum:
+Using the [k6-utils](https://k6.io/docs/javascript-api/jslib/utils) library to specify a range between a minimum and maximum:
 
 <CodeGroup labels={[]}>
 

--- a/src/data/markdown/versioned-js-api/v0.41/javascript api/alternative main modules/20 jslib.md
+++ b/src/data/markdown/versioned-js-api/v0.41/javascript api/alternative main modules/20 jslib.md
@@ -8,7 +8,7 @@ The [jslib.k6.io](https://jslib.k6.io/) is a collection of external JavaScript l
 
 | Library | Description |
 | -------- | ----------- |
-| [utils](/javascript-api/jslib/utils)  | Small utility functions useful in every day load testing |
+| [utils](https://k6.io/docs/javascript-api/jslib/utils)  | Small utility functions useful in every day load testing |
 | [expect](/javascript-api/jslib/expect)  | Micro-framework for writing tests in a style of Jest or ava.  |
 | [httpx](/javascript-api/jslib/httpx)  | Wrapper around the http that simplifies session handling |
 

--- a/src/data/markdown/versioned-js-api/v0.42/javascript api/02 k6/sleep- t -.md
+++ b/src/data/markdown/versioned-js-api/v0.42/javascript api/02 k6/sleep- t -.md
@@ -29,7 +29,7 @@ export default function () {
 
 </CodeGroup>
 
-Using the [k6-utils](/javascript-api/jslib/utils) library to specify a range between a minimum and maximum:
+Using the [k6-utils](https://k6.io/docs/javascript-api/jslib/utils) library to specify a range between a minimum and maximum:
 
 <CodeGroup labels={[]}>
 

--- a/src/data/markdown/versioned-js-api/v0.42/javascript api/alternative main modules/20 jslib.md
+++ b/src/data/markdown/versioned-js-api/v0.42/javascript api/alternative main modules/20 jslib.md
@@ -8,7 +8,7 @@ The [jslib.k6.io](https://jslib.k6.io/) is a collection of external JavaScript l
 
 | Library | Description |
 | -------- | ----------- |
-| [utils](/javascript-api/jslib/utils)  | Small utility functions useful in every day load testing |
+| [utils](https://k6.io/docs/javascript-api/jslib/utils)  | Small utility functions useful in every day load testing |
 | [expect](/javascript-api/jslib/expect)  | Micro-framework for writing tests in a style of Jest or ava.  |
 | [httpx](/javascript-api/jslib/httpx)  | Wrapper around the http that simplifies session handling |
 

--- a/src/data/markdown/versioned-js-api/v0.43/javascript api/02 k6/sleep- t -.md
+++ b/src/data/markdown/versioned-js-api/v0.43/javascript api/02 k6/sleep- t -.md
@@ -29,7 +29,7 @@ export default function () {
 
 </CodeGroup>
 
-Using the [k6-utils](/javascript-api/jslib/utils) library to specify a range between a minimum and maximum:
+Using the [k6-utils](https://k6.io/docs/javascript-api/jslib/utils) library to specify a range between a minimum and maximum:
 
 <CodeGroup labels={[]}>
 

--- a/src/data/markdown/versioned-js-api/v0.43/javascript api/alternative main modules/20 jslib.md
+++ b/src/data/markdown/versioned-js-api/v0.43/javascript api/alternative main modules/20 jslib.md
@@ -8,7 +8,7 @@ The [jslib.k6.io](https://jslib.k6.io/) is a collection of external JavaScript l
 
 | Library | Description |
 | -------- | ----------- |
-| [utils](/javascript-api/jslib/utils)  | Small utility functions useful in every day load testing |
+| [utils](https://k6.io/docs/javascript-api/jslib/utils)  | Small utility functions useful in every day load testing |
 | [expect](/javascript-api/jslib/expect)  | Micro-framework for writing tests in a style of Jest or ava.  |
 | [httpx](/javascript-api/jslib/httpx)  | Wrapper around the http that simplifies session handling |
 

--- a/src/data/markdown/versioned-js-api/v0.44/javascript api/02 k6/sleep- t -.md
+++ b/src/data/markdown/versioned-js-api/v0.44/javascript api/02 k6/sleep- t -.md
@@ -29,7 +29,7 @@ export default function () {
 
 </CodeGroup>
 
-Using the [k6-utils](/javascript-api/jslib/utils) library to specify a range between a minimum and maximum:
+Using the [k6-utils](https://k6.io/docs/javascript-api/jslib/utils/) library to specify a range between a minimum and maximum:
 
 <CodeGroup labels={[]}>
 

--- a/src/data/markdown/versioned-js-api/v0.44/javascript api/07 k6-experimental/01 browser/03 BrowserType/connect--options--.md
+++ b/src/data/markdown/versioned-js-api/v0.44/javascript api/07 k6-experimental/01 browser/03 BrowserType/connect--options--.md
@@ -16,7 +16,7 @@ Connects to an existing browser instance.
 
 | Type   | Description                                            |
 |--------|--------------------------------------------------------|
-| object | [Browser](/javascript-api/k6-browser/api/browser/) object |
+| object | [Browser](/javascript-api/k6-experimental/browser/browser-class) object |
 
 
 ## Example

--- a/src/data/markdown/versioned-js-api/v0.44/javascript api/alternative main modules/20 jslib.md
+++ b/src/data/markdown/versioned-js-api/v0.44/javascript api/alternative main modules/20 jslib.md
@@ -8,7 +8,7 @@ The [jslib.k6.io](https://jslib.k6.io/) is a collection of external JavaScript l
 
 | Library | Description |
 | -------- | ----------- |
-| [utils](/javascript-api/jslib/utils)  | Small utility functions useful in every day load testing |
+| [utils](https://k6.io/docs/javascript-api/jslib/utils)  | Small utility functions useful in every day load testing |
 | [expect](/javascript-api/jslib/expect)  | Micro-framework for writing tests in a style of Jest or ava.  |
 | [httpx](/javascript-api/jslib/httpx)  | Wrapper around the http that simplifies session handling |
 

--- a/src/data/markdown/versioned-js-api/v0.45/javascript api/02 k6/sleep- t -.md
+++ b/src/data/markdown/versioned-js-api/v0.45/javascript api/02 k6/sleep- t -.md
@@ -29,7 +29,7 @@ export default function () {
 
 </CodeGroup>
 
-Using the [k6-utils](/javascript-api/jslib/utils) library to specify a range between a minimum and maximum:
+Using the [k6-utils](https://k6.io/docs/javascript-api/jslib/utils) library to specify a range between a minimum and maximum:
 
 <CodeGroup labels={[]}>
 

--- a/src/data/markdown/versioned-js-api/v0.45/javascript api/07 k6-experimental/01 browser/03 BrowserType/connect--options--.md
+++ b/src/data/markdown/versioned-js-api/v0.45/javascript api/07 k6-experimental/01 browser/03 BrowserType/connect--options--.md
@@ -16,7 +16,7 @@ Connects to an existing browser instance.
 
 | Type   | Description                                            |
 |--------|--------------------------------------------------------|
-| object | [Browser](/javascript-api/k6-browser/api/browser/) object |
+| object | [Browser](/javascript-api/k6-experimental/browser/browser-class) object |
 
 
 ## Example

--- a/src/data/markdown/versioned-js-api/v0.45/javascript api/alternative main modules/20 jslib.md
+++ b/src/data/markdown/versioned-js-api/v0.45/javascript api/alternative main modules/20 jslib.md
@@ -8,7 +8,7 @@ The [jslib.k6.io](https://jslib.k6.io/) is a collection of external JavaScript l
 
 | Library | Description |
 | -------- | ----------- |
-| [utils](/javascript-api/jslib/utils)  | Small utility functions useful in every day load testing |
+| [utils](https://k6.io/docs/javascript-api/jslib/utils)  | Small utility functions useful in every day load testing |
 | [expect](/javascript-api/jslib/expect)  | Micro-framework for writing tests in a style of Jest or ava.  |
 | [httpx](/javascript-api/jslib/httpx)  | Wrapper around the http that simplifies session handling |
 


### PR DESCRIPTION
Fixes 4 broken links:

Source | Destination
-- | --
https://k6.io/docs/v0.45/javascript-api/k6-experimental/browser/browsertype/connect/ | https://k6.io/docs/v0.45/javascript-api/k6-browser/api/browser/
https://k6.io/docs/v0.44/javascript-api/k6-experimental/browser/browsertype/connect/ | https://k6.io/docs/v0.44/javascript-api/k6-browser/api/browser/
https://k6.io/docs/v0.44/javascript-api/k6/sleep/ ([source file](https://github.com/grafana/k6-docs/blob/main/src/data/markdown/versioned-js-api/v0.44/javascript%20api/02%20k6/sleep-%20t%20-.md)) | https://k6.io/docs/v0.44/javascript-api/jslib/utils
https://k6.io/docs/v0.43/javascript-api/k6/sleep/ | https://k6.io/docs/v0.43/javascript-api/jslib/utils

