### PR TITLE
Do not use SYS_ADMIN Docker capability for k6 browser

### DIFF
--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser.md
@@ -87,10 +87,10 @@ $ k6 run script.js
 
 ```bash
 # WARNING!
-# Be aware that grafana/k6:master-with-browser launches Chrome browser setting 'no-sandbox'
-# argument. Use it only with trustworthy websites.
+# Be aware that grafana/k6:master-with-browser launches Chrome browser by setting the
+# 'no-sandbox' argument. Use it only with trustworthy websites.
 #
-# As an alternative, our recomendation is to use a Docker SECCOMP profile instead, and
+# As an alternative, our recommendation is to use a Docker SECCOMP profile instead, and
 # overwrite the Chrome arguments to not use 'no-sandbox' such as:
 # docker container run --rm -i -e K6_BROWSER_ARGS='' --security-opt seccomp=$(pwd)/chrome.json grafana/k6:master-with-browser run - <script.js
 #
@@ -152,10 +152,10 @@ $ K6_BROWSER_HEADLESS=false K6_BROWSER_ARGS='show-property-changed-rects' k6 run
 ```
 ```bash
 # WARNING!
-# Be aware that grafana/k6:master-with-browser launches Chrome browser setting 'no-sandbox'
-# argument. Use it only with trustworthy websites.
+# Be aware that grafana/k6:master-with-browser launches Chrome browser by setting the
+# 'no-sandbox' argument. Use it only with trustworthy websites.
 #
-# As an alternative, our recomendation is to use a Docker SECCOMP profile instead, and
+# As an alternative, our recommendation is to use a Docker SECCOMP profile instead, and
 # overwrite the Chrome arguments to not use 'no-sandbox' such as:
 # docker container run --rm -i -e K6_BROWSER_ARGS='' --security-opt seccomp=$(pwd)/chrome.json grafana/k6:master-with-browser run - <script.js
 #

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser.md
@@ -86,9 +86,17 @@ $ k6 run script.js
 ```
 
 ```bash
-# When using the `k6:master-with-browser` Docker image, you need to add `--cap-add=SYS_ADMIN`
-# to grant further system permissions on the host for the Docker container.
-docker run --rm -i --cap-add=SYS_ADMIN grafana/k6:master-with-browser run - <script.js
+# WARNING!
+# Be aware that grafana/k6:master-with-browser launches Chrome browser setting 'no-sandbox'
+# argument. Use it only with trustworthy websites.
+#
+# As an alternative, our recomendation is to use a Docker SECCOMP profile instead, and
+# overwrite the Chrome arguments to not use 'no-sandbox' such as:
+# docker container run --rm -i -e K6_BROWSER_ARGS='' --security-opt seccomp=$(pwd)/chrome.json grafana/k6:master-with-browser run - <script.js
+#
+# You can find an example of a hardened SECCOMP profile in:
+# https://raw.githubusercontent.com/jfrazelle/dotfiles/master/etc/docker/seccomp/chrome.json.
+docker run --rm -i grafana/k6:master-with-browser run - <script.js
 ```
 
 ```bash
@@ -143,9 +151,17 @@ The following command passes the [browser module options](#browser-module-option
 $ K6_BROWSER_HEADLESS=false K6_BROWSER_ARGS='show-property-changed-rects' k6 run script.js
 ```
 ```bash
-# When using the `k6:master-with-browser` Docker image, you need to add `--cap-add=SYS_ADMIN`
-# to grant further system permissions on the host for the Docker container.
-docker run --rm -i --cap-add=SYS_ADMIN -e K6_BROWSER_HEADLESS=false -e K6_BROWSER_ARGS='show-property-changed-rects' grafana/k6:master-with-browser run - <script.js
+# WARNING!
+# Be aware that grafana/k6:master-with-browser launches Chrome browser setting 'no-sandbox'
+# argument. Use it only with trustworthy websites.
+#
+# As an alternative, our recomendation is to use a Docker SECCOMP profile instead, and
+# overwrite the Chrome arguments to not use 'no-sandbox' such as:
+# docker container run --rm -i -e K6_BROWSER_ARGS='' --security-opt seccomp=$(pwd)/chrome.json grafana/k6:master-with-browser run - <script.js
+#
+# You can find an example of a hardened SECCOMP profile in:
+# https://raw.githubusercontent.com/jfrazelle/dotfiles/master/etc/docker/seccomp/chrome.json.
+docker run --rm -i -e K6_BROWSER_HEADLESS=false -e K6_BROWSER_ARGS='show-property-changed-rects' grafana/k6:master-with-browser run - <script.js
 ```
 
 ```bash

--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/01 browser.md
@@ -87,11 +87,11 @@ $ k6 run script.js
 
 ```bash
 # WARNING!
-# Be aware that grafana/k6:master-with-browser launches Chrome browser by setting the
-# 'no-sandbox' argument. Use it only with trustworthy websites.
+# The grafana/k6:master-with-browser image launches a Chrome browser by setting the
+# 'no-sandbox' argument. Only use it with trustworthy websites.
 #
-# As an alternative, our recommendation is to use a Docker SECCOMP profile instead, and
-# overwrite the Chrome arguments to not use 'no-sandbox' such as:
+# As an alternative, you can use a Docker SECCOMP profile instead, and overwrite the
+# Chrome arguments to not use 'no-sandbox' such as:
 # docker container run --rm -i -e K6_BROWSER_ARGS='' --security-opt seccomp=$(pwd)/chrome.json grafana/k6:master-with-browser run - <script.js
 #
 # You can find an example of a hardened SECCOMP profile in:
@@ -152,11 +152,11 @@ $ K6_BROWSER_HEADLESS=false K6_BROWSER_ARGS='show-property-changed-rects' k6 run
 ```
 ```bash
 # WARNING!
-# Be aware that grafana/k6:master-with-browser launches Chrome browser by setting the
-# 'no-sandbox' argument. Use it only with trustworthy websites.
+# The grafana/k6:master-with-browser image launches a Chrome browser by setting the
+# 'no-sandbox' argument. Only use it with trustworthy websites.
 #
-# As an alternative, our recommendation is to use a Docker SECCOMP profile instead, and
-# overwrite the Chrome arguments to not use 'no-sandbox' such as:
+# As an alternative, you can use a Docker SECCOMP profile instead, and overwrite the
+# Chrome arguments to not use 'no-sandbox' such as:
 # docker container run --rm -i -e K6_BROWSER_ARGS='' --security-opt seccomp=$(pwd)/chrome.json grafana/k6:master-with-browser run - <script.js
 #
 # You can find an example of a hardened SECCOMP profile in:

--- a/src/data/markdown/translated-guides/en/03 Using k6 browser/02 Running browser tests.md
+++ b/src/data/markdown/translated-guides/en/03 Using k6 browser/02 Running browser tests.md
@@ -81,11 +81,11 @@ $ k6 run script.js
 
 ```bash
 # WARNING!
-# Be aware that grafana/k6:master-with-browser launches Chrome browser by setting the
-# 'no-sandbox' argument. Use it only with trustworthy websites.
+# The grafana/k6:master-with-browser image launches a Chrome browser by setting the
+# 'no-sandbox' argument. Only use it with trustworthy websites.
 #
-# As an alternative, our recommendation is to use a Docker SECCOMP profile instead, and
-# overwrite the Chrome arguments to not use 'no-sandbox' such as:
+# As an alternative, you can use a Docker SECCOMP profile instead, and overwrite the
+# Chrome arguments to not use 'no-sandbox' such as:
 # docker container run --rm -i -e K6_BROWSER_ARGS='' --security-opt seccomp=$(pwd)/chrome.json grafana/k6:master-with-browser run - <script.js
 #
 # You can find an example of a hardened SECCOMP profile in:
@@ -113,11 +113,11 @@ $ K6_BROWSER_HEADLESS=false k6 run script.js
 
 ```bash
 # WARNING!
-# Be aware that grafana/k6:master-with-browser launches Chrome browser by setting the
-# 'no-sandbox' argument. Use it only with trustworthy websites.
+# The grafana/k6:master-with-browser image launches a Chrome browser by setting the
+# 'no-sandbox' argument. Only use it with trustworthy websites.
 #
-# As an alternative, our recommendation is to use a Docker SECCOMP profile instead, and
-# overwrite the Chrome arguments to not use 'no-sandbox' such as:
+# As an alternative, you can use a Docker SECCOMP profile instead, and overwrite the
+# Chrome arguments to not use 'no-sandbox' such as:
 # docker container run --rm -i -e K6_BROWSER_ARGS='' --security-opt seccomp=$(pwd)/chrome.json grafana/k6:master-with-browser run - <script.js
 #
 # You can find an example of a hardened SECCOMP profile in:

--- a/src/data/markdown/translated-guides/en/03 Using k6 browser/02 Running browser tests.md
+++ b/src/data/markdown/translated-guides/en/03 Using k6 browser/02 Running browser tests.md
@@ -80,9 +80,17 @@ $ k6 run script.js
 ```
 
 ```bash
-# When using the `k6:master-with-browser` Docker image, you need to add `--cap-add=SYS_ADMIN`
-# to grant further system permissions on the host for the Docker container.
-docker run --rm -i --cap-add=SYS_ADMIN grafana/k6:master-with-browser run - <script.js
+# WARNING!
+# Be aware that grafana/k6:master-with-browser launches Chrome browser setting 'no-sandbox'
+# argument. Use it only with trustworthy websites.
+#
+# As an alternative, our recomendation is to use a Docker SECCOMP profile instead, and
+# overwrite the Chrome arguments to not use 'no-sandbox' such as:
+# docker container run --rm -i -e K6_BROWSER_ARGS='' --security-opt seccomp=$(pwd)/chrome.json grafana/k6:master-with-browser run - <script.js
+#
+# You can find an example of a hardened SECCOMP profile in:
+# https://raw.githubusercontent.com/jfrazelle/dotfiles/master/etc/docker/seccomp/chrome.json.
+docker run --rm -i grafana/k6:master-with-browser run - <script.js
 ```
 
 ```bash
@@ -104,9 +112,17 @@ $ K6_BROWSER_HEADLESS=false k6 run script.js
 ```
 
 ```bash
-# When using the `k6:master-with-browser` Docker image, you need to add `--cap-add=SYS_ADMIN`
-# to grant further system permissions on the host for the Docker container.
-docker run --rm -i --cap-add=SYS_ADMIN -e K6_BROWSER_HEADLESS=false grafana/k6:master-with-browser run - <script.js
+# WARNING!
+# Be aware that grafana/k6:master-with-browser launches Chrome browser setting 'no-sandbox'
+# argument. Use it only with trustworthy websites.
+#
+# As an alternative, our recomendation is to use a Docker SECCOMP profile instead, and
+# overwrite the Chrome arguments to not use 'no-sandbox' such as:
+# docker container run --rm -i -e K6_BROWSER_ARGS='' --security-opt seccomp=$(pwd)/chrome.json grafana/k6:master-with-browser run - <script.js
+#
+# You can find an example of a hardened SECCOMP profile in:
+# https://raw.githubusercontent.com/jfrazelle/dotfiles/master/etc/docker/seccomp/chrome.json.
+docker run --rm -i -e K6_BROWSER_HEADLESS=false grafana/k6:master-with-browser run - <script.js
 ```
 
 ```bash

--- a/src/data/markdown/translated-guides/en/03 Using k6 browser/02 Running browser tests.md
+++ b/src/data/markdown/translated-guides/en/03 Using k6 browser/02 Running browser tests.md
@@ -81,10 +81,10 @@ $ k6 run script.js
 
 ```bash
 # WARNING!
-# Be aware that grafana/k6:master-with-browser launches Chrome browser setting 'no-sandbox'
-# argument. Use it only with trustworthy websites.
+# Be aware that grafana/k6:master-with-browser launches Chrome browser by setting the
+# 'no-sandbox' argument. Use it only with trustworthy websites.
 #
-# As an alternative, our recomendation is to use a Docker SECCOMP profile instead, and
+# As an alternative, our recommendation is to use a Docker SECCOMP profile instead, and
 # overwrite the Chrome arguments to not use 'no-sandbox' such as:
 # docker container run --rm -i -e K6_BROWSER_ARGS='' --security-opt seccomp=$(pwd)/chrome.json grafana/k6:master-with-browser run - <script.js
 #
@@ -113,10 +113,10 @@ $ K6_BROWSER_HEADLESS=false k6 run script.js
 
 ```bash
 # WARNING!
-# Be aware that grafana/k6:master-with-browser launches Chrome browser setting 'no-sandbox'
-# argument. Use it only with trustworthy websites.
+# Be aware that grafana/k6:master-with-browser launches Chrome browser by setting the
+# 'no-sandbox' argument. Use it only with trustworthy websites.
 #
-# As an alternative, our recomendation is to use a Docker SECCOMP profile instead, and
+# As an alternative, our recommendation is to use a Docker SECCOMP profile instead, and
 # overwrite the Chrome arguments to not use 'no-sandbox' such as:
 # docker container run --rm -i -e K6_BROWSER_ARGS='' --security-opt seccomp=$(pwd)/chrome.json grafana/k6:master-with-browser run - <script.js
 #

--- a/src/data/markdown/translated-guides/en/03 Using k6 browser/04 Migrating to k6 v0-46.md
+++ b/src/data/markdown/translated-guides/en/03 Using k6 browser/04 Migrating to k6 v0-46.md
@@ -139,10 +139,10 @@ $ K6_BROWSER_HEADLESS=false K6_BROWSER_TIMEOUT='60s' k6 run script.js
 
 ```bash
 # WARNING!
-# Be aware that grafana/k6:master-with-browser launches Chrome browser setting 'no-sandbox'
-# argument. Use it only with trustworthy websites.
+# Be aware that grafana/k6:master-with-browser launches Chrome browser by setting the
+# 'no-sandbox' argument. Use it only with trustworthy websites.
 #
-# As an alternative, our recomendation is to use a Docker SECCOMP profile instead, and
+# As an alternative, our recommendation is to use a Docker SECCOMP profile instead, and
 # overwrite the Chrome arguments to not use 'no-sandbox' such as:
 # docker container run --rm -i -e K6_BROWSER_ARGS='' --security-opt seccomp=$(pwd)/chrome.json grafana/k6:master-with-browser run - <script.js
 #

--- a/src/data/markdown/translated-guides/en/03 Using k6 browser/04 Migrating to k6 v0-46.md
+++ b/src/data/markdown/translated-guides/en/03 Using k6 browser/04 Migrating to k6 v0-46.md
@@ -139,11 +139,11 @@ $ K6_BROWSER_HEADLESS=false K6_BROWSER_TIMEOUT='60s' k6 run script.js
 
 ```bash
 # WARNING!
-# Be aware that grafana/k6:master-with-browser launches Chrome browser by setting the
-# 'no-sandbox' argument. Use it only with trustworthy websites.
+# The grafana/k6:master-with-browser image launches a Chrome browser by setting the
+# 'no-sandbox' argument. Only use it with trustworthy websites.
 #
-# As an alternative, our recommendation is to use a Docker SECCOMP profile instead, and
-# overwrite the Chrome arguments to not use 'no-sandbox' such as:
+# As an alternative, you can use a Docker SECCOMP profile instead, and overwrite the
+# Chrome arguments to not use 'no-sandbox' such as:
 # docker container run --rm -i -e K6_BROWSER_ARGS='' --security-opt seccomp=$(pwd)/chrome.json grafana/k6:master-with-browser run - <script.js
 #
 # You can find an example of a hardened SECCOMP profile in:

--- a/src/data/markdown/translated-guides/en/03 Using k6 browser/04 Migrating to k6 v0-46.md
+++ b/src/data/markdown/translated-guides/en/03 Using k6 browser/04 Migrating to k6 v0-46.md
@@ -138,9 +138,17 @@ $ K6_BROWSER_HEADLESS=false K6_BROWSER_TIMEOUT='60s' k6 run script.js
 ```
 
 ```bash
-# When using the `k6:master-with-browser` Docker image, you need to add `--cap-add=SYS_ADMIN`
-# to grant further system permissions on the host for the Docker container.
-docker run --rm -i --cap-add=SYS_ADMIN -e K6_BROWSER_HEADLESS=false -e K6_BROWSER_TIMEOUT='60s' grafana/k6:master-with-browser run - <script.js
+# WARNING!
+# Be aware that grafana/k6:master-with-browser launches Chrome browser setting 'no-sandbox'
+# argument. Use it only with trustworthy websites.
+#
+# As an alternative, our recomendation is to use a Docker SECCOMP profile instead, and
+# overwrite the Chrome arguments to not use 'no-sandbox' such as:
+# docker container run --rm -i -e K6_BROWSER_ARGS='' --security-opt seccomp=$(pwd)/chrome.json grafana/k6:master-with-browser run - <script.js
+#
+# You can find an example of a hardened SECCOMP profile in:
+# https://raw.githubusercontent.com/jfrazelle/dotfiles/master/etc/docker/seccomp/chrome.json.
+docker run --rm -i -e K6_BROWSER_HEADLESS=false -e K6_BROWSER_TIMEOUT='60s' grafana/k6:master-with-browser run - <script.js
 ```
 
 ```bash


### PR DESCRIPTION
Updates all k6 browser Docker examples, which uses the `grafana/k6:master-with-browser` image removing the usage of `SYS_ADMIN` Docker capability, which is now not needed because the Chrome `no-sandbox` argument is set by default. This change and its implications are mentioned in a comment along with the cmdline example and a recommendation to use a Docker SECCOMP profile instead, which provides better security at the cost of worse UX.