### PR TITLE
fix change vusInitalized example

### DIFF
--- a/src/data/markdown/docs/02 javascript api/06 k6-execution.md
+++ b/src/data/markdown/docs/02 javascript api/06 k6-execution.md
@@ -48,7 +48,7 @@ The instance object provides information associated with the load generator inst
 | iterationsInterrupted  | integer | The number of prematurely interrupted iterations in the current instance. |
 | iterationsCompleted    | integer | The number of completed iterations in the current instance. |
 | vusActive              | integer | The number of active VUs. |
-| vusInitialized         | integer | The number of currently initialized VUs. |
+| vusInitialized         | integer | The number of VUs which finished setup and are ready or running. If more VUs are required, more will be Initialized. |
 | currentTestRunDuration | float   | The time passed from the start of the current test run in milliseconds. |
 
 ### scenario


### PR DESCRIPTION
mention that the initialised VUs are ready or running, as they finished setup call, which is only run ones per creation of a VU.

Fixes grafana/k6-docs/issues#1302
https://github.com/grafana/k6-docs/issues/1302