### PR TITLE
Document gRPC's -bin metadata

### DIFF
--- a/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 grpc/20-Params.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-experimental/02 grpc/20-Params.md
@@ -8,7 +8,7 @@ excerpt: 'Params is an object used by the gRPC methods that generate RPC request
 
 | Name | Type | Description |
 |------|------|-------------|
-| `Params.metadata` | object | Object with key-value pairs representing custom metadata the user would like to add to the request. |
+| `Params.metadata` | object | Object with key-value pairs representing custom metadata the user would like to add to the request. Values of [keys ending with `-bin`](https://grpc.io/docs/what-is-grpc/core-concepts/#metadata) will be treated as binary data. |
 | `Params.tags` | object | Key-value pairs where the keys are names of tags and the values are tag values. Response time metrics generated as a result of the request will have these tags added to them, allowing the user to filter out those results specifically, when looking at results data. |
 | `Params.timeout` | string / number | Request timeout to use. Default timeout is 60 seconds (`"60s"`). <br/> The type can also be a number, in which case k6 interprets it as milliseconds, e.g., `60000` is equivalent to `"60s"`. |
 
@@ -29,7 +29,10 @@ export default function () {
     longitude: -747127767,
   };
   const params = {
-    metadata: { 'x-my-header': 'k6test' },
+    metadata: {
+      'x-my-header': 'k6test',
+      'x-my-header-bin': new Uint8Array([1, 2, 3]),
+    },
     tags: { k6test: 'yes' },
   };
   const response = client.invoke('main.RouteGuide/GetFeature', req, params);

--- a/src/data/markdown/docs/02 javascript api/11 k6-net-grpc/20-Params.md
+++ b/src/data/markdown/docs/02 javascript api/11 k6-net-grpc/20-Params.md
@@ -8,7 +8,7 @@ excerpt: 'Params is an object used by the gRPC methods that generate RPC request
 
 | Name | Type | Description |
 |------|------|-------------|
-| `Params.metadata` | object | Object with key-value pairs representing custom metadata the user would like to add to the request. |
+| `Params.metadata` | object | Object with key-value pairs representing custom metadata the user would like to add to the request. Values of [keys ending with `-bin`](https://grpc.io/docs/what-is-grpc/core-concepts/#metadata) will be treated as binary data. |
 | `Params.tags` | object | Key-value pairs where the keys are names of tags and the values are tag values. Response time metrics generated as a result of the request will have these tags added to them, allowing the user to filter out those results specifically, when looking at results data. |
 | `Params.timeout` | string / number | Request timeout to use. Default timeout is 60 seconds (`"60s"`). <br/> The type can also be a number, in which case k6 interprets it as milliseconds, e.g., `60000` is equivalent to `"60s"`. |
 
@@ -29,7 +29,10 @@ export default function () {
     longitude: -747127767,
   };
   const params = {
-    metadata: { 'x-my-header': 'k6test' },
+    metadata: {
+      'x-my-header': 'k6test',
+      'x-my-header-bin': new Uint8Array([1, 2, 3]),
+    },
     tags: { k6test: 'yes' },
   };
   const response = client.invoke('main.RouteGuide/GetFeature', req, params);


### PR DESCRIPTION
# What?

Document a special treatment of gRPC metadata's keys with `-bin` postfixes.

# Why?

This PR documents the feature implemented in:
* https://github.com/grafana/xk6-grpc/pull/46
* https://github.com/grafana/k6/pull/3234