### PR TITLE
Remove non-existing arguments from aws' `SignatureV4.sign` and `SignatureV4.presign` methods

### DIFF
--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/00 SignatureV4.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/00 SignatureV4.md
@@ -68,6 +68,17 @@ export default function () {
             secretAccessKey: awsConfig.secretAccessKey,
             sessionToken: awsConfig.sessionToken,
         },
+
+        /**
+         * Whether the URI should be escaped or not.
+         */
+        uriEscapePath: false,
+
+        /**
+         * Whether or not the body's hash should be calculated and included
+         * in the request.
+         */
+        applyChecksum: false,
     })
 
     /**
@@ -105,17 +116,6 @@ export default function () {
              * The headers we will be sending in the request.
              */
             headers: {},
-
-            /**
-             * Whether the URI should be escaped or not.
-             */
-            uriEscapePath: false,
-
-            /**
-             * Whether or not the body's hash should be calculated and included
-             * in the request.
-             */
-            applyChecksum: false,
         },
 
         /**

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SignatureV4/00 presign().md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SignatureV4/00 presign().md
@@ -17,9 +17,6 @@ The first parameter of the `presign` method consists of an Object with the follo
 | hostname      | string                   | The hostname the request is sent to                                                                                                                                                                                                                                     |
 | path          | string                   | The path of the request                                                                                                                                                                                                                                                 |
 | headers       | Object                   | The headers of the HTTP request                                                                                                                                                                                                                                         |
-| uriEscapePath | boolean                  | Whether to uri-escape the request URI path as part of computing the canonical request string. This is required for every AWS service, except Amazon S3, as of late 2017.                                                                                                |
-| applyChecksum | boolean                  | Whether to calculate a checksum of the request body and include it as either a request header (when signing) or as a query string parameter (when pre-signing). This is required for AWS Glacier and Amazon S3 and optional for every other AWS service as of late 2017. |
-|               |                          |                                                                                                                                                                                                                                                                         |
 
 You can provide further options and override SignatureV4 options in the context of this specific request.
 To do this, pass a second parameter to the `presign` method, which is an Object with the following parameters.
@@ -75,6 +72,8 @@ export default function () {
             secretAccessKey: awsConfig.secretAccessKey,
             sessionToken: awsConfig.sessionToken,
         },
+        uriEscapePath: false,
+        applyChecksum: false,
     })
 
     // We can now use the signer to produce a pre-signed URL.
@@ -112,17 +111,6 @@ export default function () {
              * hash calculation, and communicate that value instead, as specified.
              */
             headers: { [AMZ_CONTENT_SHA256_HEADER]: 'UNSIGNED-PAYLOAD' },
-
-            /**
-             * Whether the URI should be escaped or not.
-             */
-            uriEscapePath: false,
-
-            /**
-             * Whether or not the body's hash should be calculated and included
-             * in the request.
-             */
-            applyChecksum: false,
         },
 
         /**

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SignatureV4/00 sign().md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SignatureV4/00 sign().md
@@ -17,8 +17,6 @@ The first parameter of the `sign` method consists of an Object with the followin
 | hostname      | string                   | The hostname the request is sent to                                                                                                                                                                                                                                     |
 | path          | string                   | The path of the request                                                                                                                                                                                                                                                 |
 | headers       | Object                   | The headers of the HTTP request                                                                                                                                                                                                                                         |
-| uriEscapePath | boolean                  | Whether to uri-escape the request URI path as part of computing the canonical request string. This is required for every AWS service, except Amazon S3, as of late 2017.                                                                                                |
-| applyChecksum | boolean                  | Whether to calculate a checksum of the request body and include it as either a request header (when signing) or as a query string parameter (when pre-signing). This is required for AWS Glacier and Amazon S3 and optional for every other AWS service as of late 2017. |
 | body (optional)         | string or ArrayBuffer    | The optional body of the HTTP request                                                                                                                                                                                                                                   |
 | query (optional) | `Object.<string, string \| Array.<string>>` | The optional query parameters of the HTTP request |
 
@@ -69,6 +67,8 @@ export default function () {
             secretAccessKey: awsConfig.secretAccessKey,
             sessionToken: awsConfig.sessionToken,
         },
+        uriEscapePath: false,
+        applyChecksum: false,
     })
 
     /**
@@ -106,17 +106,6 @@ export default function () {
              * The headers we will be sending in the request.
              */
             headers: {},
-
-            /**
-             * Whether the URI should be escaped or not.
-             */
-            uriEscapePath: false,
-
-            /**
-             * Whether or not the body's hash should be calculated and included
-             * in the request.
-             */
-            applyChecksum: false,
         },
 
         /**


### PR DESCRIPTION
As per k6-jslib-aws[#62](https://github.com/grafana/k6-jslib-aws/issues/62), this PR removes mentions of the `uriEscapePath` and `applyChecksum` parameters on the `SignatureV4.sign` and `SignatureV4.presign` methods, as those only exist and apply to the `SignatureV4` constructor instead. 