### PR TITLE
Update references to jslib-aws to v0.10.0

### DIFF
--- a/src/data/markdown/docs/05 Examples/01 Examples/02 http-authentication.md
+++ b/src/data/markdown/docs/05 Examples/01 Examples/02 http-authentication.md
@@ -118,7 +118,7 @@ Here's an example script to demonstrate how to sign a request to fetch an object
 
 ```javascript
 import http from 'k6/http';
-import { AWSConfig, SignatureV4 } from 'https://jslib.k6.io/aws/0.9.0/signature.js';
+import { AWSConfig, SignatureV4 } from 'https://jslib.k6.io/aws/0.10.0/signature.js';
 
 const awsConfig = new AWSConfig({
     region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/00 AwsConfig.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/00 AwsConfig.md
@@ -41,7 +41,7 @@ import exec from 'k6/execution';
 
 // Note that you AWSConfig is also included in the dedicated service
 // client bundles such as `s3.js` and `secrets-manager.js`
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.9.0/aws.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.10.0/aws.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/00 KMSClient.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/00 KMSClient.md
@@ -36,7 +36,7 @@ Both the dedicated `kms.js` jslib bundle and the all-encompassing `aws.js` bundl
 ```javascript
 import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.2/index.js';
 
-import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.9.0/kms.js';
+import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.10.0/kms.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/00 S3Client.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/00 S3Client.md
@@ -46,7 +46,7 @@ import { check } from 'k6';
 import exec from 'k6/execution';
 import http from 'k6/http';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.9.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.10.0/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,
@@ -108,7 +108,7 @@ export async function handleSummary(data) {
 import crypto from 'k6/crypto';
 import exec from 'k6/execution';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.9.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.10.0/s3.js';
 
 const awsConfig = new AWSConfig({
     region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/00 SQSClient.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/00 SQSClient.md
@@ -34,7 +34,7 @@ With it, the user can send messages to specified queues and list available queue
 ```javascript
 import exec from 'k6/execution'
 
-import { AWSConfig, SQSClient } from 'https://jslib.k6.io/aws/0.9.0/sqs.js'
+import { AWSConfig, SQSClient } from 'https://jslib.k6.io/aws/0.10.0/sqs.js'
 
 const awsConfig = new AWSConfig({
     region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/00 SecretsManagerClient.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/00 SecretsManagerClient.md
@@ -37,7 +37,7 @@ S3 Client methods will throw errors in case of failure.
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.9.0/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.10.0/secrets-manager.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/00 SignatureV4.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/00 SignatureV4.md
@@ -46,7 +46,7 @@ SignatureV4 methods throw errors on failure.
 ```javascript
 import http from 'k6/http'
 
-import { AWSConfig, SignatureV4 } from 'https://jslib.k6.io/aws/0.9.0/aws.js'
+import { AWSConfig, SignatureV4 } from 'https://jslib.k6.io/aws/0.10.0/aws.js'
 
 const awsConfig = new AWSConfig({
     region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/00 SystemsManagerClient.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/00 SystemsManagerClient.md
@@ -33,7 +33,7 @@ Both the dedicated `ssm.js` jslib bundle and the all-encompassing `aws.js` bundl
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SystemsManagerClient } from 'https://jslib.k6.io/aws/0.9.0/ssm.js';
+import { AWSConfig, SystemsManagerClient } from 'https://jslib.k6.io/aws/0.10.0/ssm.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/KMSClient/00 generateDataKey.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/KMSClient/00 generateDataKey.md
@@ -26,7 +26,7 @@ excerpt: 'KMSClient.generateDataKey generates a symmetric data key for use outsi
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.9.0/kms.js';
+import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.10.0/kms.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/KMSClient/00 listKeys.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/KMSClient/00 listKeys.md
@@ -19,7 +19,7 @@ excerpt: "KMSClient.listKeys lists all the KMS keys in the caller's AWS account 
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.9.0/kms.js';
+import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.10.0/kms.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/KMSClient/90 KMSDataKey.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/KMSClient/90 KMSDataKey.md
@@ -21,7 +21,7 @@ For instance, the [`generateDataKey`](/javascript-api/jslib/aws/kmsclient/kmscli
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.9.0/kms.js';
+import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.10.0/kms.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/KMSClient/90 KMSKey.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/KMSClient/90 KMSKey.md
@@ -18,7 +18,7 @@ excerpt: 'KMSKey is returned by the KMSClient.* methods that query KMS keys'
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.9.0/kms.js';
+import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.10.0/kms.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/00 abortMultipartUpload(bucketName, objectKey, uploadId).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/00 abortMultipartUpload(bucketName, objectKey, uploadId).md
@@ -25,7 +25,7 @@ excerpt: 'S3Client.abortMultipartUpload aborts a multipart upload to a bucket'
 <CodeGroup labels={[]}>
 
 ```javascript
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.9.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.10.0/s3.js';
 
 const awsConfig = new AWSConfig({
     region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/00 completeMultipartUpload(bucketName, objectKey, uploadId, parts).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/00 completeMultipartUpload(bucketName, objectKey, uploadId, parts).md
@@ -29,7 +29,7 @@ excerpt: 'S3Client.completeMultipartUpload uploads a multipart object to a bucke
 import crypto from 'k6/crypto';
 import exec from 'k6/execution';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.9.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.10.0/s3.js';
 
 const awsConfig = new AWSConfig({
     region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/00 copyObject.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/00 copyObject.md
@@ -28,7 +28,7 @@ excerpt: 'S3Client.copyObject copies an object from a bucket to another'
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.9.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.10.0/s3.js';
 
 
 const awsConfig = new AWSConfig({

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/00 createMultipartUpload(bucketName, objectKey).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/00 createMultipartUpload(bucketName, objectKey).md
@@ -22,7 +22,7 @@ excerpt: 'S3Client.createMultipartUpload creates a multipart upload to a bucket'
 <CodeGroup labels={[]}>
 
 ```javascript
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.9.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.10.0/s3.js';
 
 const awsConfig = new AWSConfig({
     region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/00 deleteObject(bucketName, objectKey).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/00 deleteObject(bucketName, objectKey).md
@@ -26,7 +26,7 @@ excerpt: 'S3Client.deleteObject deletes an object from a bucket'
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.9.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.10.0/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/00 getObject(bucketName, objectKey).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/00 getObject(bucketName, objectKey).md
@@ -26,7 +26,7 @@ excerpt: 'S3Client.getObject downloads an object from a bucket'
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.9.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.10.0/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/00 listBuckets().md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/00 listBuckets().md
@@ -19,7 +19,7 @@ excerpt: 'S3Client.listBuckets lists the buckets the authenticated user has acce
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.9.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.10.0/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/00 listObjects(bucketName, [prefix]).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/00 listObjects(bucketName, [prefix]).md
@@ -26,7 +26,7 @@ excerpt: 'S3Client.listObjects lists the objects contained in a bucket'
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.9.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.10.0/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/00 putObject(bucketName, objectKey, data).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/00 putObject(bucketName, objectKey, data).md
@@ -25,7 +25,7 @@ excerpt: 'S3Client.putObject uploads an object to a bucket'
 <CodeGroup labels={[]}>
 
 ```javascript
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.9.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.10.0/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/00 uploadPart(bucketName, objectKey, uploadId, partNumber, data) copy.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/00 uploadPart(bucketName, objectKey, uploadId, partNumber, data) copy.md
@@ -28,7 +28,7 @@ excerpt: 'S3Client.uploadPart a part in a multipart upload to a bucket'
 import crypto from 'k6/crypto';
 import exec from 'k6/execution';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.9.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.10.0/s3.js';
 
 const awsConfig = new AWSConfig({
     region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/90 Bucket.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/90 Bucket.md
@@ -16,7 +16,7 @@ Bucket is returned by the S3Client.* methods that query S3 buckets. Namely, `lis
 <CodeGroup labels={[]}>
 
 ```javascript
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.9.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.10.0/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/90 Object.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/90 Object.md
@@ -27,7 +27,7 @@ import {
   // listBuckets,
   AWSConfig,
   S3Client,
-} from 'https://jslib.k6.io/aws/0.9.0/s3.js';
+} from 'https://jslib.k6.io/aws/0.10.0/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/90 S3MultipartUpload.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/90 S3MultipartUpload.md
@@ -16,7 +16,7 @@ S3MultipartUpload is returned by the [`createMultipartUpload(bucketName, objectK
 <CodeGroup labels={[]}>
 
 ```javascript
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.9.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.10.0/s3.js';
 
 const awsConfig = new AWSConfig({
     region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/90 S3Part.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/S3Client/90 S3Part.md
@@ -19,7 +19,7 @@ S3Part is returned by the [`uploadPart(bucketName, objectKey, uploadId, partNumb
 import crypto from 'k6/crypto';
 import exec from 'k6/execution';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.9.0/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.10.0/s3.js';
 
 const awsConfig = new AWSConfig({
     region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SQSClient/00 listQueues.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SQSClient/00 listQueues.md
@@ -25,7 +25,7 @@ excerpt: "SQSClient.listQueues retrieves a list of available Amazon SQS queues"
 ```javascript
 import exec from 'k6/execution'
 
-import { AWSConfig, SQSClient } from 'https://jslib.k6.io/aws/0.9.0/sqs.js'
+import { AWSConfig, SQSClient } from 'https://jslib.k6.io/aws/0.10.0/sqs.js'
 
 const awsConfig = new AWSConfig({
     region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SQSClient/00 sendMessage.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SQSClient/00 sendMessage.md
@@ -27,7 +27,7 @@ excerpt: "SQSClient.sendMessage sends a message to the specified Amazon SQS queu
 ```javascript
 import exec from 'k6/execution'
 
-import { AWSConfig, SQSClient } from 'https://jslib.k6.io/aws/0.9.0/sqs.js'
+import { AWSConfig, SQSClient } from 'https://jslib.k6.io/aws/0.10.0/sqs.js'
 
 const awsConfig = new AWSConfig({
     region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/00 createSecret(name, secretString, description, [versionID], [tags]).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/00 createSecret(name, secretString, description, [versionID], [tags]).md
@@ -27,7 +27,7 @@ excerpt: 'SecretsManagerClient.createSecret creates a new secret'
 <CodeGroup labels={[]}>
 
 ```javascript
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.9.0/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.10.0/secrets-manager.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/00 deleteSecret.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/00 deleteSecret.md
@@ -24,7 +24,7 @@ excerpt: 'SecretsManagerClient.deleteSecret deletes a secret'
 <CodeGroup labels={[]}>
 
 ```javascript
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.9.0/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.10.0/secrets-manager.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/00 getSecret(secretID).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/00 getSecret(secretID).md
@@ -23,7 +23,7 @@ excerpt: 'SecretsManagerClient.getSecret(secretID) downloads a secret from AWS s
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.9.0/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.10.0/secrets-manager.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/00 listSecrets().md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/00 listSecrets().md
@@ -19,7 +19,7 @@ excerpt: 'SecretsManagerClient.listSecrets lists the secrets the authenticated u
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.9.0/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.10.0/secrets-manager.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/00 putSecretValue(secretID, secretString, [versionID]).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/00 putSecretValue(secretID, secretString, [versionID]).md
@@ -26,7 +26,7 @@ excerpt: "SecretsManagerClient.putSecretValue updates an existing secret's value
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.9.0/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.10.0/secrets-manager.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/99 Secret.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SecretsManagerClient/99 Secret.md
@@ -25,7 +25,7 @@ Secret is returned by the SecretsManagerClient.* methods that query secrets. Nam
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.9.0/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.10.0/secrets-manager.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SignatureV4/00 presign().md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SignatureV4/00 presign().md
@@ -52,7 +52,7 @@ import {
     SignatureV4,
     AMZ_CONTENT_SHA256_HEADER,
     UNSIGNED_PAYLOAD,
-} from 'https://jslib.k6.io/aws/0.9.0/kms.js'
+} from 'https://jslib.k6.io/aws/0.10.0/kms.js'
 
 const awsConfig = new AWSConfig({
     region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SignatureV4/00 sign().md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SignatureV4/00 sign().md
@@ -45,7 +45,7 @@ You can override SignatureV4 options in the context of this specific request. To
 ```javascript
 import http from 'k6/http'
 
-import { AWSConfig, SignatureV4 } from 'https://jslib.k6.io/aws/0.9.0/signature.js'
+import { AWSConfig, SignatureV4 } from 'https://jslib.k6.io/aws/0.10.0/signature.js'
 
 const awsConfig = new AWSConfig({
     region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SystemsManagerClient/00 getParameter.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SystemsManagerClient/00 getParameter.md
@@ -19,7 +19,7 @@ excerpt: "SystemsManagerClient.getParameter gets a Systems Manager parameter in 
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SystemsManagerClient } from 'https://jslib.k6.io/aws/0.9.0/ssm.js';
+import { AWSConfig, SystemsManagerClient } from 'https://jslib.k6.io/aws/0.10.0/ssm.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SystemsManagerClient/90 SystemsManagerParameter.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/SystemsManagerClient/90 SystemsManagerParameter.md
@@ -25,7 +25,7 @@ excerpt: 'SystemsManagerParameter is returned by the SystemsManagerClient.* meth
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SystemsManagerClient } from 'https://jslib.k6.io/aws/0.9.0/ssm.js';
+import { AWSConfig, SystemsManagerClient } from 'https://jslib.k6.io/aws/0.10.0/ssm.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/04 deleteSecret(secretID, { recoveryWindow 30, noRecovery false}}).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/04 deleteSecret(secretID, { recoveryWindow 30, noRecovery false}}).md
@@ -16,7 +16,7 @@ excerpt: 'SecretsManagerClient.deleteSecret deletes a secret'
 <CodeGroup labels={[]}>
 
 ```javascript
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.9.0/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.10.0/secrets-manager.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/04 deleteSecret(secretID, {{ recoveryWindow 30, noRecovery false }}).md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/05 aws/SecretsManagerClient/04 deleteSecret(secretID, {{ recoveryWindow 30, noRecovery false }}).md
@@ -16,7 +16,7 @@ excerpt: 'SecretsManagerClient.deleteSecret deletes a secret'
 <CodeGroup labels={[]}>
 
 ```javascript
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.9.0/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.10.0/secrets-manager.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,


### PR DESCRIPTION
We have recently released aws v0.10.0, this PR updates the documentation imports to reflect that 👍🏻 