### PR TITLE
Add deprecation warning for statsd output

### DIFF
--- a/src/components/shared/installation-instructions/installation-instructions.view.js
+++ b/src/components/shared/installation-instructions/installation-instructions.view.js
@@ -19,7 +19,7 @@ const InstallationInstructions = ({ extensionUrl }) => (
     <Blockquote>
       <p>
         To learn more about how to build custom k6 versions, check out{' '}
-        <a href="https://github.com/grafana/xk6">xk6</a>
+        <a href="https://github.com/grafana/xk6">xk6</a>.
       </p>
     </Blockquote>
   </>

--- a/src/data/markdown/translated-guides/en/04 Results output/200 Real-time/00 Amazon CloudWatch.md
+++ b/src/data/markdown/translated-guides/en/04 Results output/200 Real-time/00 Amazon CloudWatch.md
@@ -3,13 +3,25 @@ title: 'Amazon CloudWatch'
 excerpt: 'You can send k6 results output to Amazon CloudWatch and later visualize them.'
 ---
 
-k6 can send metrics data to [Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) through the [CloudWatch Agent](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Install-CloudWatch-Agent.html), which is effectively a StatsD integration. These metrics can then be visualized in dashboards.
+<Blockquote mod="warning" title="">
 
-This guide covers running the CloudWatch integration and visualizing the results:
+The built-in StatsD output has been deprecated on k6 v0.47.0. You can continue to use this feature by using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd), and this guide has been updated to include instructions for how to use it.
+
+For more information on the reason behind this change, you can follow [this issue](https://github.com/grafana/k6/issues/2982) in the k6 repository.
+
+</Blockquote>
+
+k6 can send metrics data to [Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) through the [CloudWatch Agent](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Install-CloudWatch-Agent.html) by using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd). These metrics can then be visualized in dashboards.
+
+This guide covers how to:
 
 - Run the CloudWatch agent
 - Run the k6 test
 - Visualize k6 metrics in Amazon CloudWatch
+
+## Before you begin
+
+To use the StatsD output option, you have to build a k6 binary using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd). For more details, refer to [StatsD](/results-output/real-time/statsd).
 
 ## Run the CloudWatch agent
 
@@ -60,18 +72,20 @@ We presume that you already have a machine that supports both running k6 and Clo
 
 ## Run the k6 test
 
-Once the agent is running, [install](/get-started/installation) k6 and [run](/get-started/running-k6) the test, so that the metrics gets sent to the agent with the following command:
+Once the agent is running, you can run your test with:
 
 <CodeGroup labels={[]}>
 
 
 ```bash
-$ K6_STATSD_ENABLE_TAGS=true k6 run --out statsd script.js
+$ K6_STATSD_ENABLE_TAGS=true k6 run --out output-statsd script.js
 ```
 
 </CodeGroup>
 
-Please look at [StatsD](/results-output/real-time/statsd) output page for configuration options.
+Make sure you're using the k6 binary you built with the xk6-output-statsd extension.
+
+You can look at the [StatsD](/results-output/real-time/statsd) output page for configuration options.
 
 ## Visualize k6 metrics in Amazon CloudWatch
 

--- a/src/data/markdown/translated-guides/en/04 Results output/200 Real-time/00 DataDog.md
+++ b/src/data/markdown/translated-guides/en/04 Results output/200 Real-time/00 DataDog.md
@@ -3,15 +3,25 @@ title: 'Datadog'
 excerpt: 'Send k6 output to Datadog to visualize load test results and correlate performance testing metrics in Datadog.'
 ---
 
-> ⚠️ &nbsp; For k6 Cloud tests, follow the [k6 Cloud instructions](/cloud/integrations/cloud-apm/datadog).
+<Blockquote mod="warning" title="">
+
+The built-in StatsD output has been deprecated on k6 v0.47.0. You can continue to use this feature by using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd), and this guide has been updated to include instructions for how to use it.
+
+For more information on the reason behind this change, you can follow [this issue](https://github.com/grafana/k6/issues/2982) in the k6 repository.
+
+</Blockquote>
 
 k6 can send metrics to [Datadog](https://www.datadoghq.com/). That allows visualizing and correlating performance testing metrics with other monitored metrics in Datadog.
 
-This article outlines the instructions of the Datadog integration:
+This guide covers how to:
 
 - Run the Datadog Agent
 - Run the k6 test
 - Visualize in Datadog
+
+## Before you begin
+
+To use the StatsD output option, you have to build a k6 binary using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd). For more details, refer to [StatsD](/results-output/real-time/statsd).
 
 ## Run the Datadog Agent
 
@@ -58,12 +68,14 @@ Once the Datadog Agent service is running, run the k6 test and send the metrics 
 <CodeGroup labels={[""]}>
 
 ```bash
-$ K6_STATSD_ENABLE_TAGS=true k6 run --out statsd script.js
+$ K6_STATSD_ENABLE_TAGS=true k6 run --out output-statsd script.js
 ```
 
 </CodeGroup>
 
-Please look at the [StatsD](/results-output/real-time/statsd) output page for configuration options.
+Make sure you're using the k6 binary you built with the xk6-output-statsd extension.
+
+You can look at the [StatsD](/results-output/real-time/statsd) output page for configuration options.
 
 ## Visualize in Datadog
 

--- a/src/data/markdown/translated-guides/en/04 Results output/200 Real-time/00 Netdata.md
+++ b/src/data/markdown/translated-guides/en/04 Results output/200 Real-time/00 Netdata.md
@@ -3,10 +3,23 @@ title: 'Netdata'
 excerpt: 'You can send k6 output to Netdata. With this integration, visualize test results with zero configuration, in seconds'
 ---
 
+<Blockquote mod="warning" title="">
+
+The built-in StatsD output has been deprecated on k6 v0.47.0. You can continue to use this feature by using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd), and this guide has been updated to include instructions for how to use it.
+
+For more information on the reason behind this change, you can follow [this issue](https://github.com/grafana/k6/issues/2982) in the k6 repository.
+
+</Blockquote>
+
 k6 can send performance testing metrics to [Netdata](https://netdata.cloud). This enables the user to start monitoring their k6 experiments right away, as Netdata is a monitoring tool with:
-- auto-configuration and auto-detection of data sources
-- automatic organization of metrics into **meaningful** charts and visualization
-- per-second metric granularity
+
+- Auto-configuration and auto-detection of data sources
+- Automatic organization of metrics into **meaningful** charts and visualization
+- Per-second metric granularity
+
+## Before you begin
+
+To use the StatsD output option, you have to build a k6 binary using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd). For more details, refer to [StatsD](/results-output/real-time/statsd).
 
 ## Run Netdata
 
@@ -24,8 +37,10 @@ Netdata runs a fully functional [StatsD](https://learn.netdata.cloud/docs/agent/
 ## Run the k6 test
 
 ```bash
-k6 run --out statsd script.js
+k6 run --out output-statsd script.js
 ```
+
+Make sure you're using the k6 binary you built with the xk6-output-statsd extension.
 
 **Caveat**: By default, Netdata binds the StatsD server to `localhost`. That means that if Netdata and k6 are in different hosts, you will need to edit the configuration file of Netdata.
 1. Visit [StatsD documentation](https://learn.netdata.cloud/docs/agent/collectors/statsd.plugin) for a reference on the configuration options. We are interested in `#bind to` option.

--- a/src/data/markdown/translated-guides/en/04 Results output/200 Real-time/00 Netdata.md
+++ b/src/data/markdown/translated-guides/en/04 Results output/200 Real-time/00 Netdata.md
@@ -32,7 +32,7 @@ Alternatively, you can read more about installing and running Netdata in their [
 
 ## Setup Netdata for K6
 
-Netdata runs a fully functional [StatsD](https://learn.netdata.cloud/docs/agent/collectors/statsd.plugin) server by default and we have included a default configuration file for k6 metrics. 
+Netdata runs a fully functional [StatsD](https://github.com/netdata/netdata/blob/master/collectors/statsd.plugin/README.md) server by default and we have included a default configuration file for k6 metrics. 
 
 ## Run the k6 test
 
@@ -43,12 +43,13 @@ k6 run --out output-statsd script.js
 Make sure you're using the k6 binary you built with the xk6-output-statsd extension.
 
 **Caveat**: By default, Netdata binds the StatsD server to `localhost`. That means that if Netdata and k6 are in different hosts, you will need to edit the configuration file of Netdata.
-1. Visit [StatsD documentation](https://learn.netdata.cloud/docs/agent/collectors/statsd.plugin) for a reference on the configuration options. We are interested in `#bind to` option.
+
+1. Visit the [StatsD documentation](https://github.com/netdata/netdata/blob/master/collectors/statsd.plugin/README.md) for a reference on the configuration options. We are interested in the `#bind to` option.
 2. Use `sudo ./edit-config netdata.conf` from inside the directory where Netdata stores its configuration files (e.g `/etc/netdata/`) and add `bind to=udp:0.0.0.0:8125`.
 
 ## Visualize in Netdata
 
-Netdata will automatically create charts for your application, as illustrated in the [documentation](https://learn.netdata.cloud/docs/agent/collectors/statsd.plugin/k6). 
+Netdata will automatically create charts for your application, as illustrated in the [documentation](https://github.com/netdata/netdata/blob/master/collectors/statsd.plugin/k6.md). 
 
 Simply head over to `localhost:19999` (assuming that you are running Netdata on the same machine) and find the k6 section. If you had opened Netdata before running the experiment, you will need to refresh the dashboard page.
 

--- a/src/data/markdown/translated-guides/en/04 Results output/200 Real-time/00 NewRelic.md
+++ b/src/data/markdown/translated-guides/en/04 Results output/200 Real-time/00 NewRelic.md
@@ -3,7 +3,13 @@ title: 'New Relic'
 excerpt: 'You can send k6 output to New Relic. With this integration visualize load test results and correlate them your New Relic telemetry data, create and share reports, and alert on k6 telemetry.'
 ---
 
-> ⚠️ &nbsp; For k6 Cloud tests, follow the [k6 Cloud instructions](/cloud/integrations/cloud-apm/new-relic).
+<Blockquote mod="warning" title="">
+
+The built-in StatsD output has been deprecated on k6 v0.47.0. You can continue to use this feature by using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd), and this guide has been updated to include instructions for how to use it.
+
+For more information on the reason behind this change, you can follow [this issue](https://github.com/grafana/k6/issues/2982) in the k6 repository.
+
+</Blockquote>
 
 k6 can send telemetry data to [New Relic](https://newrelic.com/) through the New Relic [StatsD integration](https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/statsd-monitoring-integration-version-2). Within New Relic you can find your k6 performance data alongside your real users data and server side performance. This data can be visualized in dashboards and shared with others, used to compare load impact with system performance, and alert on metrics too.
 
@@ -12,6 +18,10 @@ This guide covers running the New Relic integration:
 - Run the New Relic StatsD integration
 - Run the k6 test
 - Visualize k6 telemetry in New Relic
+
+## Before you begin
+
+To use the StatsD output option, you have to build a k6 binary using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd). For more details, refer to [StatsD](/results-output/real-time/statsd).
 
 ## Run the New Relic StatsD integration
 
@@ -66,12 +76,14 @@ Once the integration is running, run the k6 test and send the metrics to the int
 <CodeGroup labels={[""]}>
 
 ```bash
-$ K6_STATSD_ENABLE_TAGS=true k6 run --out statsd script.js
+$ K6_STATSD_ENABLE_TAGS=true k6 run --out output-statsd script.js
 ```
 
 </CodeGroup>
 
-Please look at the [StatsD](/results-output/real-time/statsd) output page for configuration options.
+Make sure you're using the k6 binary you built with the xk6-output-statsd extension.
+
+You can look at the [StatsD](/results-output/real-time/statsd) output page for configuration options.
 
 ## Visualisation in New Relic
 

--- a/src/data/markdown/translated-guides/en/04 Results output/200 Real-time/00 StatsD.md
+++ b/src/data/markdown/translated-guides/en/04 Results output/200 Real-time/00 StatsD.md
@@ -5,18 +5,26 @@ excerpt: 'k6 has a built-in output to a StatsD service.'
 
 <Blockquote mod="warning" title="">
 
-The built-in StatsD output has been deprecated on k6 v0.47.0. If you'd like to keep using this feature, you can use the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd).
+The built-in StatsD output has been deprecated on k6 v0.47.0. You can continue to use this feature by using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd), and this guide has been updated to include instructions for how to use it.
 
 For more information on the reason behind this change, you can follow [this issue](https://github.com/grafana/k6/issues/2982) in the k6 repository.
 
 </Blockquote>
 
-k6 can also push the metrics to a [StatsD](https://github.com/statsd/statsd) service like:
+k6 can push test metrics to a [StatsD](https://github.com/statsd/statsd) service by using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd).
+
+## Build the k6 version
+
+<InstallationInstructions extensionUrl="github.com/grafana/xk6-output-statsd"/>
+
+## Run the k6 test
+
+Using the k6 binary you built in the previous step, you can use the `--out output-statsd` option when running your tests to use this extension:
 
 <CodeGroup labels={["StatsD"]}>
 
 ```bash
-$ k6 run --out statsd script.js
+$ ./k6 run --out output-statsd script.js
 ```
 
 </CodeGroup>

--- a/src/data/markdown/translated-guides/en/04 Results output/200 Real-time/00 StatsD.md
+++ b/src/data/markdown/translated-guides/en/04 Results output/200 Real-time/00 StatsD.md
@@ -3,6 +3,14 @@ title: 'StatsD'
 excerpt: 'k6 has a built-in output to a StatsD service.'
 ---
 
+<Blockquote mod="warning" title="">
+
+The built-in StatsD output has been deprecated on k6 v0.47.0. If you'd like to keep using this feature, you can use the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd).
+
+For more information on the reason behind this change, you can follow [this issue](https://github.com/grafana/k6/issues/2982) in the k6 repository.
+
+</Blockquote>
+
 k6 can also push the metrics to a [StatsD](https://github.com/statsd/statsd) service like:
 
 <CodeGroup labels={["StatsD"]}>

--- a/src/data/markdown/translated-guides/es/01 Get started/04 Results Output.md
+++ b/src/data/markdown/translated-guides/es/01 Get started/04 Results Output.md
@@ -103,7 +103,7 @@ k6 puede enviar datos de resultados más granulares a diferentes salidas para in
 <CodeGroup labels={[]}>
 
 ```bash
-$ k6 run --out statsd script.js
+$ k6 run --out output-statsd script.js
 ```
 
 </CodeGroup>

--- a/src/data/markdown/translated-guides/es/01 Get started/04 Results Output.md
+++ b/src/data/markdown/translated-guides/es/01 Get started/04 Results Output.md
@@ -103,7 +103,9 @@ k6 puede enviar datos de resultados más granulares a diferentes salidas para in
 <CodeGroup labels={[]}>
 
 ```bash
-$ k6 run --out output-statsd script.js
+$ k6 run \
+--out json=test.json \
+--out influxdb=http://localhost:8086/k6
 ```
 
 </CodeGroup>

--- a/src/data/markdown/translated-guides/es/04 Results visualization/01 Amazon CloudWatch.md
+++ b/src/data/markdown/translated-guides/es/04 Results visualization/01 Amazon CloudWatch.md
@@ -64,7 +64,7 @@ Suponemos que ya tiene una máquina que soporta tanto la ejecución de k6 como d
 Una vez que el agente esté funcionando correctamente, [instale](/es/empezando/instalacion/) k6 y [ejecute](/es/empezando/ejecucion-de-k6/)  la prueba, para que las métricas sean enviadas al agente mediante el siguiente comando:
 
 ```bash
-$ k6 run --out statsd script.js
+$ k6 run --out output-statsd script.js
 ```
 
 Las siguientes opciones pueden ser configuradas como variables de entorno, dependiendo de la configuración del agente:

--- a/src/data/markdown/translated-guides/es/04 Results visualization/08 Netdata.md
+++ b/src/data/markdown/translated-guides/es/04 Results visualization/08 Netdata.md
@@ -24,7 +24,7 @@ Netdata runs a fully functional [StatsD](https://learn.netdata.cloud/docs/agent/
 ## Run the k6 test
 
 ```bash
-k6 run --out statsd script.js
+k6 run --out output-statsd script.js
 ```
 
 **Caveat**: By default, Netdata binds the StatsD server to `localhost`. That means that if Netdata and K6 are in different hosts, you will need to edit the configuration file of Netdata.

--- a/src/data/markdown/translated-guides/es/04 Results visualization/09 NewRelic.md
+++ b/src/data/markdown/translated-guides/es/04 Results visualization/09 NewRelic.md
@@ -52,7 +52,7 @@ Una vez que la integración esté lista, ejecute la prueba con k6 y envíe las m
 <CodeGroup labels={[""]}>
 
 ```bash
-$ k6 run --out statsd script.js
+$ k6 run --out output-statsd script.js
 ```
 
 </CodeGroup>

--- a/src/data/markdown/translated-guides/es/04 Results visualization/10 StatsD.md
+++ b/src/data/markdown/translated-guides/es/04 Results visualization/10 StatsD.md
@@ -8,7 +8,7 @@ k6 también puede mostrar las métricas con un servicio [StatsD](https://github.
 <CodeGroup labels={["StatsD"]}>
 
 ```bash
-$ k6 run --out statsd script.js
+$ k6 run --out output-statsd script.js
 ```
 
 </CodeGroup>


### PR DESCRIPTION
Related to https://github.com/grafana/k6/pull/3347, closes https://github.com/grafana/k6-docs/issues/1354.