### PR TITLE
Update broken link in xk6-disruptor docs

### DIFF
--- a/src/data/markdown/docs/40 xk6-disruptor/01 Get started.md
+++ b/src/data/markdown/docs/40 xk6-disruptor/01 Get started.md
@@ -5,7 +5,7 @@ excerpt: 'xk6-disruptor is an extension that adds fault injection capabilities t
 
 Inject faults into kubernetes-based applications with `xk6-disruptor`. Start here to learn the basics to use the disruptor:
 
-- [First steps](/javascript-api/xk6-disruptor/get-started/first-steps)
+- [First steps](/javascript-api/xk6-disruptor)
 
 - [Requirements](/javascript-api/xk6-disruptor/get-started/requirements)
 


### PR DESCRIPTION
That PR fixes the following issue: https://github.com/grafana/k6-docs/issues/1377