### PR TITLE
Update 00 NewRelic.md

### DIFF
--- a/src/data/markdown/translated-guides/en/04 Results output/200 Real-time/00 NewRelic.md
+++ b/src/data/markdown/translated-guides/en/04 Results output/200 Real-time/00 NewRelic.md
@@ -33,7 +33,7 @@ Run the New Relic integration as a Docker container with this command:
 
 ```bash
 docker run --rm \
-  -d --restart unless-stopped \
+  -d \
   --name newrelic-statsd \
   -h $(hostname) \
   -e NR_ACCOUNT_ID=<NR-ACCOUNT-ID> \


### PR DESCRIPTION
Without removing the restart policy option, docker run gives error: "docker: Conflicting options: --restart and --rm"