### PR TITLE
Remove "post published URL to PR" action from pr-deploy

### DIFF
--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -128,20 +128,3 @@ jobs:
           AWS_REGION: 'eu-west-1'
           DISTRIBUTION: ${{ secrets.PR_CI_CLOUDFRONT_DISTRIBUTION_ID }}
           PATHS: '/docs/*'
-
-      - name: Post published URL to PR
-        # Run only if we did not skip the upload step and it's the first run for this PR.
-        if: steps.upload.outcome == 'success' && github.event.action == 'opened'
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.payload.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body:
-                "There's a version of the docs published here:\n\n" +
-                `${process.env.GATSBY_DEFAULT_DOC_URL}\n\n` +
-                'It will be deleted automatically in 30 days.',
-            })


### PR DESCRIPTION
Update the GH action to not post a comment with the preview URL, since it doesn't apply to the new Grafana docs.