### PR TITLE
Clean artifact

### DIFF
--- a/docs/sources/v0.47.x/javascript-api/_index.md
+++ b/docs/sources/v0.47.x/javascript-api/_index.md
@@ -198,7 +198,7 @@ You can optionally [tag](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/tags-
 
 ## k6/net/grpc
 
-{{< docs/shared source="k6" lookup="grpc-module.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="grpc-module.md" version="<K6_VERSION>" >}}
 
 The `k6/net/grpc` module provides a [gRPC](https://grpc.io/) client for Remote Procedure Calls (RPC) over HTTP/2.
 

--- a/docs/sources/v0.47.x/javascript-api/jslib/aws/KMSClient/_index.md
+++ b/docs/sources/v0.47.x/javascript-api/jslib/aws/KMSClient/_index.md
@@ -8,7 +8,7 @@ weight: 00
 
 # KMSClient
 
-{{< docs/shared source="k6" lookup="blocking-aws-blockquote.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="blocking-aws-blockquote.md" version="<K6_VERSION>" >}}
 
 `KMSClient` interacts with the AWS Key Management Service.
 

--- a/docs/sources/v0.47.x/javascript-api/jslib/aws/S3Client/_index.md
+++ b/docs/sources/v0.47.x/javascript-api/jslib/aws/S3Client/_index.md
@@ -8,7 +8,7 @@ weight: 00
 
 # S3Client
 
-{{< docs/shared source="k6" lookup="blocking-aws-blockquote.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="blocking-aws-blockquote.md" version="<K6_VERSION>" >}}
 
 `S3Client` interacts with the AWS Simple Storage Service (S3).
 

--- a/docs/sources/v0.47.x/javascript-api/jslib/aws/SignatureV4/_index.md
+++ b/docs/sources/v0.47.x/javascript-api/jslib/aws/SignatureV4/_index.md
@@ -8,7 +8,7 @@ weight: 00
 
 # SignatureV4
 
-{{< docs/shared source="k6" lookup="blocking-aws-blockquote.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="blocking-aws-blockquote.md" version="<K6_VERSION>" >}}
 
 With SignatureV4, you can produce authenticated HTTP requests to AWS services. Namely, it lets you sign and pre-sign requests to AWS services using the [Signature V4](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html) algorithm. The `sign` operation produces a signed request with authorization information stored in its headers.
 The `presign` operation produces a pre-signed request with authorization information stored in its query string parameters.

--- a/docs/sources/v0.47.x/javascript-api/k6-crypto/_index.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-crypto/_index.md
@@ -6,7 +6,7 @@ weight: 03
 
 # k6/crypto
 
-{{< docs/shared source="k6" lookup="crypto-module.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="crypto-module.md" version="<K6_VERSION>" >}}
 
 The k6/crypto `module` provides common hashing functionality available in the GoLang [crypto](https://golang.org/pkg/crypto/) package.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-crypto/createhash.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-crypto/createhash.md
@@ -7,7 +7,7 @@ weight: 01
 
 # createHash( algorithm )
 
-{{< docs/shared source="k6" lookup="crypto-module.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="crypto-module.md" version="<K6_VERSION>" >}}
 
 Creates a hashing object that can then be fed with data repeatedly, and from which you can extract a hash digest whenever you want.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-crypto/createhmac.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-crypto/createhmac.md
@@ -7,7 +7,7 @@ weight: 02
 
 # createHMAC( algorithm, secret )
 
-{{< docs/shared source="k6" lookup="crypto-module.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="crypto-module.md" version="<K6_VERSION>" >}}
 
 Creates a HMAC hashing object that can then be fed with data repeatedly, and from which you can extract a signed hash digest whenever you want.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-crypto/hasher.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-crypto/hasher.md
@@ -7,7 +7,7 @@ weight: 80
 
 # Hasher
 
-{{< docs/shared source="k6" lookup="crypto-module.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="crypto-module.md" version="<K6_VERSION>" >}}
 
 This object is returned by [crypto.createHash()](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-crypto/createhash)
 and allows the user to successively add more string data to be hashed, and to extract digests along the way.

--- a/docs/sources/v0.47.x/javascript-api/k6-crypto/hmac.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-crypto/hmac.md
@@ -7,7 +7,7 @@ weight: 03
 
 # hmac( algorithm, secret, data, outputEncoding )
 
-{{< docs/shared source="k6" lookup="crypto-module.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="crypto-module.md" version="<K6_VERSION>" >}}
 
 Use [HMAC](https://en.wikipedia.org/wiki/Hash-based_message_authentication_code) to sign a piece of data using a shared secret.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-crypto/md4.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-crypto/md4.md
@@ -7,7 +7,7 @@ weight: 04
 
 # md4( input, outputEncoding )
 
-{{< docs/shared source="k6" lookup="crypto-module.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="crypto-module.md" version="<K6_VERSION>" >}}
 
 Use [md4](https://pkg.go.dev/golang.org/x/crypto/md4) to hash input data.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-crypto/md5.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-crypto/md5.md
@@ -7,7 +7,7 @@ weight: 05
 
 # md5( input, outputEncoding )
 
-{{< docs/shared source="k6" lookup="crypto-module.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="crypto-module.md" version="<K6_VERSION>" >}}
 
 Use [md5](https://golang.org/pkg/crypto/md5/) to hash input data.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-crypto/randombytes.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-crypto/randombytes.md
@@ -7,7 +7,7 @@ weight: 06
 
 # randomBytes( int )
 
-{{< docs/shared source="k6" lookup="crypto-module.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="crypto-module.md" version="<K6_VERSION>" >}}
 
 Return an ArrayBuffer object with a number of cryptographically random bytes. It will either return exactly the amount of bytes requested or will throw an exception if something went wrong.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-crypto/ripemd160.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-crypto/ripemd160.md
@@ -7,7 +7,7 @@ weight: 07
 
 # ripemd160( input, outputEncoding )
 
-{{< docs/shared source="k6" lookup="crypto-module.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="crypto-module.md" version="<K6_VERSION>" >}}
 
 Use [ripemd160](https://pkg.go.dev/golang.org/x/crypto/ripemd160) to hash input data.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-crypto/sha1.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-crypto/sha1.md
@@ -7,7 +7,7 @@ weight: 08
 
 # sha1( input, outputEncoding )
 
-{{< docs/shared source="k6" lookup="crypto-module.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="crypto-module.md" version="<K6_VERSION>" >}}
 
 Use [sha1](https://golang.org/pkg/crypto/sha1/) to hash input data.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-crypto/sha256.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-crypto/sha256.md
@@ -7,7 +7,7 @@ weight: 09
 
 # sha256( input, outputEncoding )
 
-{{< docs/shared source="k6" lookup="crypto-module.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="crypto-module.md" version="<K6_VERSION>" >}}
 
 Use [sha256](https://golang.org/pkg/crypto/sha256/) to hash input data.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-crypto/sha384.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-crypto/sha384.md
@@ -7,7 +7,7 @@ weight: 10
 
 # sha384( input, outputEncoding )
 
-{{< docs/shared source="k6" lookup="crypto-module.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="crypto-module.md" version="<K6_VERSION>" >}}
 
 Use [sha384](https://golang.org/pkg/crypto/sha512/) to hash input data.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-crypto/sha512.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-crypto/sha512.md
@@ -7,7 +7,7 @@ weight: 11
 
 # sha512( input, outputEncoding )
 
-{{< docs/shared source="k6" lookup="crypto-module.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="crypto-module.md" version="<K6_VERSION>" >}}
 
 Use [sha512](https://golang.org/pkg/crypto/sha512/) to hash input data.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-crypto/sha512_224.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-crypto/sha512_224.md
@@ -7,7 +7,7 @@ weight: 13
 
 # sha512_224( input, outputEncoding )
 
-{{< docs/shared source="k6" lookup="crypto-module.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="crypto-module.md" version="<K6_VERSION>" >}}
 
 Use [sha512_224](https://golang.org/pkg/crypto/sha512/) to hash input data.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-crypto/sha512_256.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-crypto/sha512_256.md
@@ -7,7 +7,7 @@ weight: 12
 
 # sha512_256( input, outputEncoding )
 
-{{< docs/shared source="k6" lookup="crypto-module.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="crypto-module.md" version="<K6_VERSION>" >}}
 
 Use [sha512_256](https://golang.org/pkg/crypto/sha512/) to hash input data.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/_index.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/_index.md
@@ -6,7 +6,7 @@ weight: 07
 
 # k6/experimental
 
-{{< docs/shared source="k6" lookup="experimental-module.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="experimental-module.md" version="<K6_VERSION>" >}}
 
 | Modules                                                                           | Description                                                                                                              |
 | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/_index.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/_index.md
@@ -6,7 +6,7 @@ weight: 01
 
 # browser
 
-{{< docs/shared source="k6" lookup="experimental-module.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="experimental-module.md" version="<K6_VERSION>" >}}
 
 The browser module APIs aim for rough compatibility with the [Playwright API for NodeJS](https://playwright.dev/docs/api/class-playwright).
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/console-message.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/console-message.md
@@ -6,7 +6,7 @@ weight: 03
 
 # ConsoleMessage
 
-{{< docs/shared source="k6" lookup="browser-module-wip.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="browser-module-wip.md" version="<K6_VERSION>" >}}
 
 ## Supported APIs
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/element-handle.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/element-handle.md
@@ -6,7 +6,7 @@ weight: 04
 
 # ElementHandle
 
-{{< docs/shared source="k6" lookup="browser-module-wip.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="browser-module-wip.md" version="<K6_VERSION>" >}}
 
 ## Supported APIs
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/frame.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/frame.md
@@ -6,7 +6,7 @@ weight: 05
 
 # Frame
 
-{{< docs/shared source="k6" lookup="browser-module-wip.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="browser-module-wip.md" version="<K6_VERSION>" >}}
 
 ## Supported APIs
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/js-handle.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/js-handle.md
@@ -6,7 +6,7 @@ weight: 06
 
 # JSHandle
 
-{{< docs/shared source="k6" lookup="browser-module-wip.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="browser-module-wip.md" version="<K6_VERSION>" >}}
 
 ## Supported APIs
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/keyboard.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/keyboard.md
@@ -6,7 +6,7 @@ weight: 07
 
 # Keyboard
 
-{{< docs/shared source="k6" lookup="browser-module-wip.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="browser-module-wip.md" version="<K6_VERSION>" >}}
 
 ## Supported APIs
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/mouse.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/mouse.md
@@ -6,7 +6,7 @@ weight: 09
 
 # Mouse
 
-{{< docs/shared source="k6" lookup="browser-module-wip.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="browser-module-wip.md" version="<K6_VERSION>" >}}
 
 ## Supported APIs
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/request/_index.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/request/_index.md
@@ -7,7 +7,7 @@ weight: 11
 
 # Request
 
-{{< docs/shared source="k6" lookup="browser-module-wip.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="browser-module-wip.md" version="<K6_VERSION>" >}}
 
 ## Supported APIs
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/response.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/response.md
@@ -6,7 +6,7 @@ weight: 12
 
 # Response
 
-{{< docs/shared source="k6" lookup="browser-module-wip.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="browser-module-wip.md" version="<K6_VERSION>" >}}
 
 ## Supported APIs
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/touchscreen.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/touchscreen.md
@@ -6,7 +6,7 @@ weight: 13
 
 # Touchscreen
 
-{{< docs/shared source="k6" lookup="browser-module-wip.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="browser-module-wip.md" version="<K6_VERSION>" >}}
 
 ## Supported APIs
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/worker.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/worker.md
@@ -6,7 +6,7 @@ weight: 14
 
 # Worker
 
-{{< docs/shared source="k6" lookup="browser-module-wip.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="browser-module-wip.md" version="<K6_VERSION>" >}}
 
 ## Supported APIs
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/grpc/_index.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/grpc/_index.md
@@ -7,7 +7,7 @@ weight: 02
 
 # grpc
 
-{{< docs/shared source="k6" lookup="experimental-module.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="experimental-module.md" version="<K6_VERSION>" >}}
 
 The `k6/experimental/grpc` module is an extension of the [`k6/net/grpc`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-net-grpc). It provides a [gRPC](https://grpc.io/) client for Remote Procedure Calls (RPC) over HTTP/2.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/redis/_index.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/redis/_index.md
@@ -7,7 +7,7 @@ weight: 02
 
 # redis
 
-{{< docs/shared source="k6" lookup="experimental-module.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="experimental-module.md" version="<K6_VERSION>" >}}
 
 The [Redis](https://redis.io/) module provides a client library that makes it possible to interact with Redis directly from a k6 script.
 With this module, you can:

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/timers.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/timers.md
@@ -6,7 +6,7 @@ weight: 03
 
 # timers
 
-{{< docs/shared source="k6" lookup="experimental-module.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="experimental-module.md" version="<K6_VERSION>" >}}
 
 This modules implements the commonly found in browsers:
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/tracing/_index.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/tracing/_index.md
@@ -7,7 +7,7 @@ weight: 04
 
 # tracing
 
-{{< docs/shared source="k6" lookup="experimental-module.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="experimental-module.md" version="<K6_VERSION>" >}}
 
 With this experimental module, you can _instrument_ HTTP requests so that they emit traces as the test runs.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/webcrypto/_index.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/webcrypto/_index.md
@@ -7,7 +7,7 @@ weight: 06
 
 # webcrypto
 
-{{< docs/shared source="k6" lookup="experimental-module.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="experimental-module.md" version="<K6_VERSION>" >}}
 
 With this experimental module, you can use the [WebCrypto API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API) in your k6 scripts. However, note that this API is not yet fully implemented and some algorithms and features might still be missing.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/websockets/_index.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/websockets/_index.md
@@ -7,7 +7,7 @@ weight: 05
 
 # websockets
 
-{{< docs/shared source="k6" lookup="experimental-module.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="experimental-module.md" version="<K6_VERSION>" >}}
 
 This experimental API implements the browser [WebSocket API](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) with additional k6-specific functionalities (cookies, tags, headers and so on).
 

--- a/docs/sources/v0.47.x/javascript-api/k6-net-grpc/_index.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-net-grpc/_index.md
@@ -6,7 +6,7 @@ weight: 11
 
 # k6/net/grpc
 
-{{< docs/shared source="k6" lookup="grpc-module.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="grpc-module.md" version="<K6_VERSION>" >}}
 
 The `k6/net/grpc` module provides a [gRPC](https://grpc.io/) client for Remote Procedure Calls (RPC) over HTTP/2.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-net-grpc/client/_index.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-net-grpc/client/_index.md
@@ -7,7 +7,7 @@ weight: 20
 
 # Client
 
-{{< docs/shared source="k6" lookup="grpc-module.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="grpc-module.md" version="<K6_VERSION>" >}}
 
 `Client` is a gRPC client that can interact with a gRPC server. Only unary RPCs are currently supported in this module.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-ws/_index.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-ws/_index.md
@@ -6,7 +6,7 @@ weight: 12
 
 # k6/ws
 
-{{< docs/shared source="k6" lookup="ws-module.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="ws-module.md" version="<K6_VERSION>" >}}
 
 The ws module provides a [WebSocket](https://en.wikipedia.org/wiki/WebSocket) client implementing the [WebSocket protocol](http://www.rfc-editor.org/rfc/rfc6455.txt).
 

--- a/docs/sources/v0.47.x/javascript-api/k6-ws/connect.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-ws/connect.md
@@ -7,7 +7,7 @@ weight: 10
 
 # connect( url, params, callback )
 
-{{< docs/shared source="k6" lookup="ws-module.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="ws-module.md" version="<K6_VERSION>" >}}
 
 Initiate a WebSocket connection to a remote host.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-ws/params.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-ws/params.md
@@ -7,7 +7,7 @@ weight: 20
 
 # Params
 
-{{< docs/shared source="k6" lookup="ws-module.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="ws-module.md" version="<K6_VERSION>" >}}
 
 _Params_ is an object used by the WebSocket methods that generate WebSocket requests. _Params_ contains request-specific options like headers that should be inserted into the request.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-ws/socket/_index.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-ws/socket/_index.md
@@ -7,7 +7,7 @@ weight: 80
 
 # Socket
 
-{{< docs/shared source="k6" lookup="ws-module.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="ws-module.md" version="<K6_VERSION>" >}}
 
 `Socket` is a WebSocket client to interact with a WebSocket connection. You can use it to listen various events happening on the WebSocket connection and send messages to the server. Additionally, you can use socket.setTimeout() and socket.setInterval() to execute code in the background, or repeatedly, while the WebSocket connection is open.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-ws/socket/socket-close.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-ws/socket/socket-close.md
@@ -5,7 +5,7 @@ excerpt: 'Close the WebSocket connection.'
 
 # Socket.close([code])
 
-{{< docs/shared source="k6" lookup="ws-module.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="ws-module.md" version="<K6_VERSION>" >}}
 
 Close the WebSocket connection.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-ws/socket/socket-on.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-ws/socket/socket-on.md
@@ -5,7 +5,7 @@ excerpt: 'Set up callback functions for various events on the WebSocket connecti
 
 # Socket.on(event, callback)
 
-{{< docs/shared source="k6" lookup="ws-module.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="ws-module.md" version="<K6_VERSION>" >}}
 
 Set up callback functions for various events on the WebSocket connection. Multiple handlers can be defined for the same event.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-ws/socket/socket-ping.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-ws/socket/socket-ping.md
@@ -5,7 +5,7 @@ excerpt: 'Send a ping. Ping messages can be used to verify that the remote endpo
 
 # Socket.ping()
 
-{{< docs/shared source="k6" lookup="ws-module.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="ws-module.md" version="<K6_VERSION>" >}}
 
 Send a ping. Ping messages can be used to verify that the remote endpoint is responsive.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-ws/socket/socket-send.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-ws/socket/socket-send.md
@@ -5,7 +5,7 @@ excerpt: 'Send a data string through the connection.'
 
 # Socket.send(data)
 
-{{< docs/shared source="k6" lookup="ws-module.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="ws-module.md" version="<K6_VERSION>" >}}
 
 Send a data string through the connection.
 You can use `JSON.stringify` to convert a JSON or JavaScript values to a JSON string.

--- a/docs/sources/v0.47.x/javascript-api/k6-ws/socket/socket-sendbinary.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-ws/socket/socket-sendbinary.md
@@ -5,7 +5,7 @@ excerpt: 'Send binary data through the connection.'
 
 # Socket.sendBinary(data)
 
-{{< docs/shared source="k6" lookup="ws-module.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="ws-module.md" version="<K6_VERSION>" >}}
 
 Send binary data through the connection.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-ws/socket/socket-setinterval.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-ws/socket/socket-setinterval.md
@@ -5,7 +5,7 @@ excerpt: 'Call a function repeatedly, while the WebSocket connection is open.'
 
 # Socket.setInterval(callback, interval)
 
-{{< docs/shared source="k6" lookup="ws-module.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="ws-module.md" version="<K6_VERSION>" >}}
 
 Call a function repeatedly, while the WebSocket connection is open.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-ws/socket/socket-settimeout.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-ws/socket/socket-settimeout.md
@@ -5,7 +5,7 @@ excerpt: 'Call a function at a later time, if the WebSocket connection is still 
 
 # Socket.setTimeout(callback, delay)
 
-{{< docs/shared source="k6" lookup="ws-module.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="ws-module.md" version="<K6_VERSION>" >}}
 
 Call a function at a later time, if the WebSocket connection is still open then.
 

--- a/docs/sources/v0.47.x/results-output/real-time/prometheus-remote-write.md
+++ b/docs/sources/v0.47.x/results-output/real-time/prometheus-remote-write.md
@@ -6,7 +6,7 @@ weight: 00
 
 # Prometheus remote write
 
-{{< docs/shared source="k6" lookup="experimental-module.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="experimental-module.md" version="<K6_VERSION>" >}}
 
 [Prometheus remote write](https://prometheus.io/docs/concepts/remote_write_spec/) is a protocol that makes it possible to reliably propagate data in real-time from a sender to a receiver.
 It has multiple compatible [implementations](https://prometheus.io/docs/concepts/remote_write_spec/#compatible-senders-and-receivers) and [storage integrations](https://prometheus.io/docs/prometheus/latest/storage/#remote-storage-integrations).

--- a/docs/sources/v0.47.x/using-k6-browser/_index.md
+++ b/docs/sources/v0.47.x/using-k6-browser/_index.md
@@ -8,7 +8,7 @@ weight: 03
 
 # Using k6 browser
 
-{{< docs/shared source="k6" lookup="experimental-module.md" version="<K6_VERSION>" >}} >}}
+{{< docs/shared source="k6" lookup="experimental-module.md" version="<K6_VERSION>" >}}
 
 The [Browser module](https://github.com/grafana/xk6-browser) brings browser automation and end-to-end web testing to k6 while supporting core k6 features. It adds browser-level APIs to interact with browsers and collect frontend performance metrics as part of your k6 tests.
 


### PR DESCRIPTION
# What?

It's removing an artifact that is presented on some pages.

![image](https://github.com/grafana/k6-docs/assets/5425600/9133bd39-bc8e-43c4-aa4d-86917190321b)


# Why?

It's probably left during the migration.