### PR TITLE
Add xk6-nostr

### DIFF
--- a/src/data/doc-extensions/extensions.json
+++ b/src/data/doc-extensions/extensions.json
@@ -1141,6 +1141,21 @@
       "categories": ["Data"],
       "tiers": ["Community"],
       "cloudEnabled": false
+    },
+    {
+      "name": "xk6-nostr",
+      "description": "Interact with Nostr relays",
+      "url": "https://github.com/akiomik/xk6-nostr",
+      "logo": "",
+      "author": {
+        "name": "Akiomi Kamakura",
+        "url": "https://github.com/nostr"
+      },
+      "stars": "2",
+      "type": ["JavaScript"],
+      "categories": ["Messaging", "Protocol"],
+      "tiers": ["Community"],
+      "cloudEnabled": false
     }
   ]
 }

--- a/src/data/doc-extensions/extensions.json
+++ b/src/data/doc-extensions/extensions.json
@@ -1149,7 +1149,7 @@
       "logo": "",
       "author": {
         "name": "Akiomi Kamakura",
-        "url": "https://github.com/nostr"
+        "url": "https://github.com/akiomik"
       },
       "stars": "2",
       "type": ["JavaScript"],


### PR DESCRIPTION
Hi, I created an extension to interact with Nostr relays.
This extension is useful for relay load testing.

- https://github.com/akiomik/xk6-nostr

NOTE: Nostr is a protocol that mainly designed for distributed social media. Nostr uses websockets for communication between clients and servers (relays).

ref:

- http://nostr.com
- https://en.wikipedia.org/wiki/Nostr