### PR TITLE
Add apply-patch script to apply changes from a commit to a second directory

### DIFF
--- a/scripts/apply-patch
+++ b/scripts/apply-patch
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+function usage {
+  cat <<EOF
+Apply the changes for directory SRC for commit COMMIT to directory DST.
+
+Usage:
+  $0 [--commit] <COMMIT> <SRC> <DST>
+
+Examples:
+  $0 HEAD~ docs/sources/next docs/sources/v0.47.x
+EOF
+}
+
+TMPDIR=$(mktemp -d)
+
+if [[ $# -ne 3 ]]; then
+  usage
+  exit 1
+fi
+
+case "${@}" in
+  --help | -h)
+    usage
+    exit 0
+    ;;
+  *)
+esac
+
+COMMIT="$1"
+SRC="$2"
+DST="$3"
+
+PATCH="${TMPDIR}/diff.patch"
+
+# path_components returns the number of leading path components to strip from traditional diff paths.
+function path_components {
+  local p="$1"
+  local -i n=2
+
+  if [[ "${p}" =~ "/$" ]]; then
+    n=1
+  fi
+
+  while [[ "${p}" =~ "/" ]]; do
+    (( n++ ))
+    p="${p%/*}"
+  done
+
+  echo "${n}"
+}
+
+git diff "${COMMIT}" -- "${SRC}" > "${PATCH}"
+git apply -p "$(path_components "${SRC}")" --directory "${DST}" "${PATCH}"

--- a/scripts/apply-patch
+++ b/scripts/apply-patch
@@ -5,7 +5,7 @@ function usage {
 Apply the changes for directory SRC for commit COMMIT to directory DST.
 
 Usage:
-  $0 [--commit] <COMMIT> <SRC> <DST>
+  $0 <COMMIT> <SRC> <DST>
 
 Examples:
   $0 HEAD~ docs/sources/next docs/sources/v0.47.x


### PR DESCRIPTION
For example, to apply the changes made to the `docs/sources/next` directory in the previous commit to the `docs/sources/v0.47.x` directory.

```shell
$ ./scripts/apply-patch HEAD~ docs/sources/next docs/sources/v0.47.x
```

Closes https://github.com/grafana/technical-documentation/issues/836