### PR TITLE
Fix overlapping banner on JS versioned API index page

### DIFF
--- a/src/components/pages/doc-javascript-api/doc-javascript-api.module.scss
+++ b/src/components/pages/doc-javascript-api/doc-javascript-api.module.scss
@@ -20,7 +20,7 @@
 }
 
 .info {
-  margin-top: 165px;
+  margin-top: 165px !important;
 
   @include lg-down {
     margin-top: 205px;


### PR DESCRIPTION
Before:

<img width="940" alt="Screenshot 2023-11-13 at 2 28 42 PM" src="https://github.com/grafana/k6-docs/assets/446316/1136c563-43f7-491c-9feb-fc29dbc915d5">

After:

<img width="851" alt="Screenshot 2023-11-13 at 2 28 49 PM" src="https://github.com/grafana/k6-docs/assets/446316/88a7c939-7974-4697-9db9-95b5c8331b36">

