### PR TITLE
Add ESLint config to docs/sources

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,12 +1,11 @@
 .cache/
 public/
 node_modules/
-docs/sources/
 docs/sources/get-started/run-cloud-tests-from-the-CLI.md
 docs/sources/get-started/run-your-first-tests.md
 CONTRIBUTING_FILE_FORMAT.md
 src/data/markdown/docs/40 xk6-disruptor/01 Get started/01 First steps.md
-src/data/markdown/docs/40 xk6-disruptor/01 Get started/04 Expose  Your Application.md
+src/data/markdown/docs/40 xk6-disruptor/01 Get started/04 Expose Your Application.md
 src/data/markdown/docs/40 xk6-disruptor/04 Examples/01 Inject Grpc faults into Service.md
 src/data/markdown/docs/40 xk6-disruptor/04 Examples/02 Inject HTTP faults into Pod.md
 src/data/markdown/docs/05 Examples/02 Tutorials/01 Get started with k6/100 Test-for-functional-behavior.md

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,5 +1,9 @@
 {
+  "docs/sources/**/*.md": [
+    "prettier --parser markdown --write",
+    "eslint -c ./docs/sources/.eslintrc.js --fix"
+  ],
   "*.{js,jsx,css,scss}": "prettier --write",
   "*.{js,jsx}": "eslint --fix",
-  "*.{md,mdx}": "eslint -c ./src/data/markdown/.eslintrc.js --fix"
+  "src/data/markdown/**/*.{md,mdx}": "eslint -c ./src/data/markdown/.eslintrc.js --fix"
 }

--- a/docs/sources/.eslintrc.js
+++ b/docs/sources/.eslintrc.js
@@ -1,0 +1,44 @@
+module.exports = {
+  root: true,
+  env: {
+    es2017: true,
+    commonjs: true,
+  },
+  parserOptions: {
+    ecmaVersion: '2017',
+    sourceType: 'module',
+  },
+  extends: ['plugin:mdx/recommended', 'plugin:prettier/recommended'],
+  plugins: ['markdown'],
+  overrides: [
+    {
+      // Enable the Markdown processor for all .md files.
+      files: ['**/*.md'],
+      processor: 'markdown/markdown',
+    },
+    {
+      // Customize the configuration ESLint uses for ```js, ```javascript
+      files: ['**/*.md/*.js', '**/*.md/*.javascript'],
+      rules: {
+        'no-undef': 'error',
+        'no-else-return': 'error',
+        'no-extra-boolean-cast': 'error',
+        'no-duplicate-case': 'error',
+        'no-const-assign': 'error',
+        'no-dupe-args': 'error',
+        'no-dupe-else-if': 'error',
+        'no-var': 'error',
+        'use-isnan': 'error',
+        'func-style': ['error', 'declaration', { allowArrowFunctions: true }],
+        'prefer-const': 'error',
+      },
+    },
+  ],
+  globals: {
+    console: 'readonly',
+    __VU: 'readonly',
+    __ENV: 'readonly',
+    __ITER: 'readonly',
+    open: 'readonly',
+  },
+};

--- a/docs/sources/.prettierrc
+++ b/docs/sources/.prettierrc
@@ -1,0 +1,14 @@
+{
+  "singleQuote": true,
+  "quoteProps": "consistent",
+  "trailingComma": "es5",
+  "printWidth": 100,
+  "overrides": [
+    {
+      "files": ["**/*.md"],
+      "options": {
+        "parser": "babel"
+      }
+    }
+  ]
+}

--- a/src/data/markdown/docs/40 xk6-disruptor/01 Get started/04 Expose  Your Application.md
+++ b/src/data/markdown/docs/40 xk6-disruptor/01 Get started/04 Expose  Your Application.md
@@ -29,7 +29,10 @@ Until this issue is solved in `kubectl`, tests using port forwarding to access a
 
 The simplest way to accomplish this is to ensure the scenario that executes the load (#2) starts after the scenario that injects the faults (#1):
 
+<CodeGroup labels={["port forwarding options"]}>
+
 ```javascript
+export const options = {
     scenarios: {
         disrupt: {   // #1 inject faults
             executor: 'shared-iterations',
@@ -47,8 +50,11 @@ The simplest way to accomplish this is to ensure the scenario that executes the 
             startTime: '20s',  // give time for the agents to be installed
             duration: "30s",
         }
-     }
- ```
+    }
+}
+```
+
+</CodeGroup>
 
 ## As a LoadBalancer service
 


### PR DESCRIPTION
# What

This Pull Request reintroduces the Prettier and ESLint configurations previously utilized in our Gatsby-based documentation site. 

It reinstates the effective workflow combining [husky](https://github.com/typicode/husky) and [lint-staged](https://github.com/lint-staged/lint-staged), specifically designed to ensure that JavaScript code blocks within markdown files adhere to our code quality standards.

# Impact

Post-merge, any changes to the `docs/sources` folder will be automatically vetted. 

Commits containing JavaScript code blocks that don't meet our Prettier and ESLint standards will be flagged, ensuring continuous adherence to our code quality benchmarks.