### PR TITLE
Document new redis options

### DIFF
--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/_index.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/_index.md
@@ -7,7 +7,7 @@ weight: 10
 
 # Client
 
-`Client` is a [Redis](https://redis.io) client to interact with a Redis server, sentinel or cluster. It exposes a promise-based API, which users can interact with in an asynchronous manner.
+`Client` is a [Redis](https://redis.io) client to interact with a Redis server, sentinel, or cluster. It exposes a promise-based API, which users can interact with in an asynchronous manner.
 
 Though the API intends to be thorough and extensive, it does not expose the whole Redis API. Instead, the intent is to expose Redis for use cases most appropriate to k6.
 
@@ -15,10 +15,12 @@ Though the API intends to be thorough and extensive, it does not expose the whol
 
 ### Single-node server
 
-As shown in the above example, the simplest way to create a new `Client` instance that connects to a single Redis server is by passing a URL string.
+You can create a new `Client` instance that connects to a single Redis server by passing a URL string.
 It must be in the format:
 
-`redis[s]://[[username][:password]@][host][:port][/db-number]`
+```
+redis[s]://[[username][:password]@][host][:port][/db-number]
+```
 
 Here's an example of a URL string that connects to a Redis server running on localhost, on the default port (6379), and using the default database (0):
 
@@ -53,7 +55,7 @@ const client = new redis.Client({
 
 ### TLS
 
-A TLS connection can be established in a couple of ways.
+You can configure a TLS connection in a couple of ways.
 
 If the server has a certificate signed by a public Certificate Authority, you can use the `rediss` URL scheme:
 
@@ -87,7 +89,7 @@ const client = new redis.Client({
 
 {{< /code >}}
 
-Note that for self-signed certificates, k6's [**insecureSkipTLSVerify**](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference/#insecure-skip-tls-verify) option must be enabled (set to `true`).
+Note that for self-signed certificates, k6's [insecureSkipTLSVerify](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference/#insecure-skip-tls-verify) option must be enabled (set to `true`).
 
 #### TLS client authentication (mTLS)
 

--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/_index.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/_index.md
@@ -1,20 +1,198 @@
 ---
 title: 'Client'
-excerpt: 'Client is a Redis client to interact with a Redis server or cluster.'
+excerpt: 'Client is a Redis client to interact with a Redis server, cluster, or sentinel.'
 weight: 10
 weight: 10
 ---
 
 # Client
 
-`Client` is a Redis client to interact with a Redis server or cluster. It exposes a promise-based API, which users can interact with in an asynchronous manner.
+`Client` is a [Redis](https://redis.io) client to interact with a Redis server, sentinel or cluster. It exposes a promise-based API, which users can interact with in an asynchronous manner.
 
-Though the API intends to be thorough and extensive, it does not expose the whole Redis API.
-Instead, the intent is to expose Redis for use cases most appropriate to k6.
+Though the API intends to be thorough and extensive, it does not expose the whole Redis API. Instead, the intent is to expose Redis for use cases most appropriate to k6.
 
-Note that the `Client` is configured through the [`Options`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/redis/redis-options) object.
+## Usage
 
-## Example
+### Single-node server
+
+As shown in the above example, the simplest way to create a new `Client` instance that connects to a single Redis server is by passing a URL string.
+It must be in the format:
+
+`redis[s]://[[username][:password]@][host][:port][/db-number]`
+
+Here's an example of a URL string that connects to a Redis server running on localhost, on the default port (6379), and using the default database (0):
+
+{{< code >}}
+
+```javascript
+import redis from 'k6/experimental/redis';
+
+const client = new redis.Client('redis://localhost:6379');
+```
+
+{{< /code >}}
+
+A client can also be instantiated using an [options](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/redis/redis-options) object to support more complex use cases, and for more flexibility:
+
+{{< code >}}
+
+```javascript
+import redis from 'k6/experimental/redis';
+
+const client = new redis.Client({
+  socket: {
+    host: 'localhost',
+    port: 6379,
+  },
+  username: 'someusername',
+  password: 'somepassword',
+});
+```
+
+{{< /code >}}
+
+### TLS
+
+A TLS connection can be established in a couple of ways.
+
+If the server has a certificate signed by a public Certificate Authority, you can use the `rediss` URL scheme:
+
+{{< code >}}
+
+```javascript
+import redis from 'k6/experimental/redis';
+
+const client = new redis.Client('rediss://example.com');
+```
+
+{{< /code >}}
+
+Otherwise, you can supply your own self-signed certificate in PEM format using the [socket.tls](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/redis/redis-options#tls-configuration-options-tlsoptions) object:
+
+{{< code >}}
+
+```javascript
+import redis from 'k6/experimental/redis';
+
+const client = new redis.Client({
+  socket: {
+    host: 'localhost',
+    port: 6379,
+    tls: {
+      ca: [open('ca.crt')],
+    },
+  },
+});
+```
+
+{{< /code >}}
+
+Note that for self-signed certificates, k6's [**insecureSkipTLSVerify**](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference/#insecure-skip-tls-verify) option must be enabled (set to `true`).
+
+#### TLS client authentication (mTLS)
+
+You can also enable mTLS by setting two additional properties in the [socket.tls](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/redis/redis-options#tls-configuration-options-tlsoptions) object:
+
+{{< code >}}
+
+```javascript
+import redis from 'k6/experimental/redis';
+
+const client = new redis.Client({
+  socket: {
+    host: 'localhost',
+    port: 6379,
+    tls: {
+      ca: [open('ca.crt')],
+      cert: open('client.crt'), // client certificate
+      key: open('client.key'), // client private key
+    },
+  },
+});
+```
+
+{{< /code >}}
+
+### Cluster client
+
+You can connect to a cluster of Redis servers by using the [cluster](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/redis/redis-options#redis-cluster-options-clusteroptions) configuration property, and passing 2 or more node URLs:
+
+{{< code >}}
+
+```javascript
+import redis from 'k6/experimental/redis';
+
+const client = new redis.Client({
+  cluster: {
+    // Cluster options
+    maxRedirects: 3,
+    readOnly: true,
+    routeByLatency: true,
+    routeRandomly: true,
+    nodes: ['redis://host1:6379', 'redis://host2:6379'],
+  },
+});
+```
+
+{{< /code >}}
+
+Or the same as above, but passing [socket](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/redis/redis-options#socket-connection-options-socketoptions) objects to the nodes array instead of URLs:
+
+{{< code >}}
+
+```javascript
+import redis from 'k6/experimental/redis';
+
+const client = new redis.Client({
+  cluster: {
+    nodes: [
+      {
+        socket: {
+          host: 'host1',
+          port: 6379,
+        },
+      },
+      {
+        socket: {
+          host: 'host2',
+          port: 6379,
+        },
+      },
+    ],
+  },
+});
+```
+
+{{< /code >}}
+
+### Sentinel client
+
+A [Redis Sentinel](https://redis.io/docs/management/sentinel/) provides high availability features, as an alternative to a Redis cluster.
+
+You can connect to a sentinel instance by setting additional [options](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/redis/redis-options) in the object passed to the `Client` constructor:
+
+{{< code >}}
+
+```javascript
+import redis from 'k6/experimental/redis';
+
+const client = new redis.Client({
+  username: 'someusername',
+  password: 'somepassword',
+  socket: {
+    host: 'localhost',
+    port: 6379,
+  },
+  // Sentinel options
+  masterName: 'masterhost',
+  sentinelUsername: 'sentineluser',
+  sentinelPassword: 'sentinelpass',
+});
+```
+
+{{< /code >}}
+
+## Real world example
 
 {{< code >}}
 
@@ -42,15 +220,8 @@ export const options = {
   },
 };
 
-// Get the redis instance(s) address and password from the environment
-const redis_addrs = __ENV.REDIS_ADDRS || '';
-const redis_password = __ENV.REDIS_PASSWORD || '';
-
 // Instantiate a new redis client
-const redisClient = new redis.Client({
-  addrs: redis_addrs.split(',') || new Array('localhost:6379'), // in the form of 'host:port', separated by commas
-  password: redis_password,
-});
+const redisClient = new redis.Client(`redis://localhost:6379`);
 
 // Prepare an array of crocodile ids for later use
 // in the context of the measureUsingRedisData function.
@@ -111,10 +282,12 @@ export function handleSummary(data) {
 
 {{< /code >}}
 
-## key/value methods
+## API
 
-| Method                                                                                                                   | Redis command                                        | Description                                                                 |
-| :----------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------- | :-------------------------------------------------------------------------- |
+### Key value methods
+
+| Method                                                                                                                                  | Redis command                                        | Description                                                                 |
+| :-------------------------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------- | :-------------------------------------------------------------------------- |
 | [`Client.set(key, value, expiration)`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/redis/client/client-set) | **[SET](https://redis.io/commands/set)**             | Set `key` to hold `value`, with a time to live equal to `expiration`.       |
 | [`Client.get(key)`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/redis/client/client-get)                    | **[GET](https://redis.io/commands/get)**             | Get the value of `key`.                                                     |
 | [`Client.getSet(key, value)`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/redis/client/client-getset)       | **[GETSET](https://redis.io/commands/getset)**       | Atomically sets `key` to `value` and returns the old value stored at `key`. |
@@ -131,10 +304,10 @@ export function handleSummary(data) {
 | [`Client.ttl(key)`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/redis/client/client-ttl)                    | **[TTL](https://redis.io/commands/ttl)**             | Returns the remaining time to live of a key that has a timeout.             |
 | [`Client.persist(key)`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/redis/client/client-persist)            | **[PERSIST](https://redis.io/commands/persist)**     | Removes the existing timeout on key.                                        |
 
-## List methods
+### List methods
 
-| Method                                                                                                                   | Redis command                                  | Description                                                                     |
-| :----------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------- | :------------------------------------------------------------------------------ |
+| Method                                                                                                                                  | Redis command                                  | Description                                                                     |
+| :-------------------------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------- | :------------------------------------------------------------------------------ |
 | [`Client.lpush(key, values)`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/redis/client/client-lpush)        | **[LPSUH](https://redis.io/commands/lpush)**   | Inserts all the specified values at the head of the list stored at `key`.       |
 | [`Client.rpush(key, values)`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/redis/client/client-rpush)        | **[RPUSH](https://redis.io/commands/rpush)**   | Inserts all the specified values at the tail of the list stored at `key`.       |
 | [`Client.lpop(key)`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/redis/client/client-lpop)                  | **[LPOP](https://redis.io/commands/lpop)**     | Removes and returns the first element of the list stored at `key`.              |
@@ -145,10 +318,10 @@ export function handleSummary(data) {
 | [`Client.lrem(key, count, value)`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/redis/client/client-lrem)    | **[LREM](https://redis.io/commands/lrem)**     | Removes the first `count` occurrences of `value` from the list stored at `key`. |
 | [`Client.llen(key)`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/redis/client/client-llen)                  | **[LLEN](https://redis.io/commands/llen)**     | Returns the length of the list stored at `key`.                                 |
 
-## Hash methods
+### Hash methods
 
-| Method                                                                                                                          | Redis command                                    | Description                                                                                          |
-| :------------------------------------------------------------------------------------------------------------------------------ | :----------------------------------------------- | :--------------------------------------------------------------------------------------------------- |
+| Method                                                                                                                                         | Redis command                                    | Description                                                                                          |
+| :--------------------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------- | :--------------------------------------------------------------------------------------------------- |
 | [`Client.hset(key, field, value)`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/redis/client/client-hset)           | **[HSET](https://redis.io/commands/hset)**       | Sets the specified field in the hash stored at `key` to `value`.                                     |
 | [`Client.hsetnx(key, field, value)`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/redis/client/client-hsetnx)       | **[HSETNX](https://redis.io/commands/hsetnx)**   | Sets the specified field in the hash stored at `key` to `value`, only if `field` does not yet exist. |
 | [`Client.hget(key, field)`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/redis/client/client-hget)                  | **[HGET](https://redis.io/commands/hget)**       | Returns the value associated with `field` in the hash stored at `key`.                               |
@@ -159,10 +332,10 @@ export function handleSummary(data) {
 | [`Client.hlen(key)`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/redis/client/client-hlen)                         | **[HLEN](https://redis.io/commands/hlen)**       | Returns the number of fields in the hash stored at `key`.                                            |
 | [`Client.hincrby(key, field, increment)`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/redis/client/client-hincrby) | **[HINCRBY](https://redis.io/commands/hincrby)** | Increments the integer value of `field` in the hash stored at `key` by `increment`.                  |
 
-## Set methods
+### Set methods
 
-| Method                                                                                                                    | Redis command                                            | Description                                                              |
-| :------------------------------------------------------------------------------------------------------------------------ | :------------------------------------------------------- | :----------------------------------------------------------------------- |
+| Method                                                                                                                                   | Redis command                                            | Description                                                              |
+| :--------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------- | :----------------------------------------------------------------------- |
 | [`Client.sadd(key, members)`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/redis/client/client-sadd)          | **[SADD](https://redis.io/commands/sadd)**               | Adds the specified members to the set stored at `key`.                   |
 | [`Client.srem(key, members)`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/redis/client/client-srem)          | **[SREM](https://redis.io/commands/srem)**               | Removes the specified members from the set stored at `key`.              |
 | [`Client.sismember(key, member)`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/redis/client/client-sismember) | **[SISMEMBER](https://redis.io/commands/sismember)**     | Returns if member is a member of the set stored at `key`.                |
@@ -170,8 +343,8 @@ export function handleSummary(data) {
 | [`Client.srandmember(key)`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/redis/client/client-srandmember)     | **[SRANDMEMBER](https://redis.io/commands/srandmember)** | Returns a random element from the set value stored at `key`.             |
 | [`Client.spop(key)`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/redis/client/client-spop)                   | **[SPOP](https://redis.io/commands/spop)**               | Removes and returns a random element from the set value stored at `key`. |
 
-## miscellaneous
+### Miscellaneous
 
-| Method                                                                                                                          | Description                         |
-| :------------------------------------------------------------------------------------------------------------------------------ | :---------------------------------- |
+| Method                                                                                                                                         | Description                         |
+| :--------------------------------------------------------------------------------------------------------------------------------------------- | :---------------------------------- |
 | [`Client.sendCommand(command, args)`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/redis/client/client-sendcommand) | Send a command to the Redis server. |

--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/client-decr.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/client-decr.md
@@ -26,15 +26,8 @@ Decrements the number stored at `key` by one. If the key does not exist, it is s
 ```javascript
 import redis from 'k6/experimental/redis';
 
-// Get the redis instance(s) address and password from the environment
-const redis_addrs = __ENV.REDIS_ADDRS || '';
-const redis_password = __ENV.REDIS_PASSWORD || '';
-
 // Instantiate a new redis client
-const redisClient = new redis.Client({
-  addrs: redis_addrs.split(',') || new Array('localhost:6379'), // in the form of 'host:port', separated by commas
-  password: redis_password,
-});
+const redisClient = new redis.Client('redis://localhost:6379');
 
 export default async function () {
   await redisClient.set('mykey', 10, 0);

--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/client-decrby.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/client-decrby.md
@@ -27,15 +27,8 @@ Decrements the number stored at `key` by `decrement`. If the key does not exist,
 ```javascript
 import redis from 'k6/experimental/redis';
 
-// Get the redis instance(s) address and password from the environment
-const redis_addrs = __ENV.REDIS_ADDRS || '';
-const redis_password = __ENV.REDIS_PASSWORD || '';
-
 // Instantiate a new redis client
-const redisClient = new redis.Client({
-  addrs: redis_addrs.split(',') || new Array('localhost:6379'), // in the form of 'host:port', separated by commas
-  password: redis_password,
-});
+const redisClient = new redis.Client('redis://localhost:6379');
 
 export default async function () {
   await redisClient.set('mykey', 10, 0);

--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/client-del.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/client-del.md
@@ -26,15 +26,8 @@ Removes the specified keys. A key is ignored if it does not exist.
 ```javascript
 import redis from 'k6/experimental/redis';
 
-// Get the redis instance(s) address and password from the environment
-const redis_addrs = __ENV.REDIS_ADDRS || '';
-const redis_password = __ENV.REDIS_PASSWORD || '';
-
 // Instantiate a new redis client
-const redisClient = new redis.Client({
-  addrs: redis_addrs.split(',') || new Array('localhost:6379'), // in the form of 'host:port', separated by commas
-  password: redis_password,
-});
+const redisClient = new redis.Client('redis://localhost:6379');
 
 export default async function () {
   await redisClient.set('mykey', 'myvalue', 0);

--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/client-exists.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/client-exists.md
@@ -26,15 +26,8 @@ Returns the number of `key` arguments that exist. Note that if the same existing
 ```javascript
 import redis from 'k6/experimental/redis';
 
-// Get the redis instance(s) address and password from the environment
-const redis_addrs = __ENV.REDIS_ADDRS || '';
-const redis_password = __ENV.REDIS_PASSWORD || '';
-
 // Instantiate a new redis client
-const redisClient = new redis.Client({
-  addrs: redis_addrs.split(',') || new Array('localhost:6379'), // in the form of 'host:port', separated by commas
-  password: redis_password,
-});
+const redisClient = new redis.Client('redis://localhost:6379');
 
 export default async function () {
   let exists = await redisClient.exists('mykey');

--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/client-expire.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/client-expire.md
@@ -27,15 +27,8 @@ Sets a timeout on key, after which the key will automatically be deleted. Note t
 ```javascript
 import redis from 'k6/experimental/redis';
 
-// Get the redis instance(s) address and password from the environment
-const redis_addrs = __ENV.REDIS_ADDRS || '';
-const redis_password = __ENV.REDIS_PASSWORD || '';
-
 // Instantiate a new redis client
-const redisClient = new redis.Client({
-  addrs: redis_addrs.split(',') || new Array('localhost:6379'), // in the form of 'host:port', separated by commas
-  password: redis_password,
-});
+const redisClient = new redis.Client('redis://localhost:6379');
 
 export default async function () {
   await redisClient.set('mykey', 'myvalue', 10);

--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/client-get.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/client-get.md
@@ -26,15 +26,8 @@ Get the key's value.
 ```javascript
 import redis from 'k6/experimental/redis';
 
-// Get the redis instance(s) address and password from the environment
-const redis_addrs = __ENV.REDIS_ADDRS || '';
-const redis_password = __ENV.REDIS_PASSWORD || '';
-
 // Instantiate a new redis client
-const redisClient = new redis.Client({
-  addrs: redis_addrs.split(',') || new Array('localhost:6379'), // in the form of 'host:port', separated by commas
-  password: redis_password,
-});
+const redisClient = new redis.Client('redis://localhost:6379');
 
 export default async function () {
   await redisClient.set('mykey', 'myvalue', 0);

--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/client-getdel.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/client-getdel.md
@@ -26,15 +26,8 @@ Get the value of `key` and delete the key. This functionality is similar to `get
 ```javascript
 import redis from 'k6/experimental/redis';
 
-// Get the redis instance(s) address and password from the environment
-const redis_addrs = __ENV.REDIS_ADDRS || '';
-const redis_password = __ENV.REDIS_PASSWORD || '';
-
 // Instantiate a new redis client
-const redisClient = new redis.Client({
-  addrs: redis_addrs.split(',') || new Array('localhost:6379'), // in the form of 'host:port', separated by commas
-  password: redis_password,
-});
+const redisClient = new redis.Client('redis://localhost:6379');
 
 export default async function () {
   await redisClient.set('mykey', 'oldvalue', 0);

--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/client-getset.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/client-getset.md
@@ -27,15 +27,8 @@ Atomically sets `key` to `value` and returns the value previously stored at `key
 ```javascript
 import redis from 'k6/experimental/redis';
 
-// Get the redis instance(s) address and password from the environment
-const redis_addrs = __ENV.REDIS_ADDRS || '';
-const redis_password = __ENV.REDIS_PASSWORD || '';
-
 // Instantiate a new redis client
-const redisClient = new redis.Client({
-  addrs: redis_addrs.split(',') || new Array('localhost:6379'), // in the form of 'host:port', separated by commas
-  password: redis_password,
-});
+const redisClient = new redis.Client('redis://localhost:6379');
 
 export default async function () {
   await redisClient.set('mykey', 'oldvalue', 0);

--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/client-hdel.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/client-hdel.md
@@ -27,15 +27,8 @@ Deletes the specified fields from the hash stored at `key`. The number of fields
 ```javascript
 import redis from 'k6/experimental/redis';
 
-// Get the redis instance(s) address and password from the environment
-const redis_addrs = __ENV.REDIS_ADDRS || '';
-const redis_password = __ENV.REDIS_PASSWORD || '';
-
 // Instantiate a new redis client
-const redisClient = new redis.Client({
-  addrs: redis_addrs.split(',') || new Array('localhost:6379'), // in the form of 'host:port', separated by commas
-  password: redis_password,
-});
+const redisClient = new redis.Client('redis://localhost:6379');
 
 export default async function () {
   await redisClient.hset('myhash', 'myfield', 'myvalue');

--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/client-hget.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/client-hget.md
@@ -27,15 +27,8 @@ Returns the value associated with `field` in the hash stored at `key`.
 ```javascript
 import redis from 'k6/experimental/redis';
 
-// Get the redis instance(s) address and password from the environment
-const redis_addrs = __ENV.REDIS_ADDRS || '';
-const redis_password = __ENV.REDIS_PASSWORD || '';
-
 // Instantiate a new redis client
-const redisClient = new redis.Client({
-  addrs: redis_addrs.split(',') || new Array('localhost:6379'), // in the form of 'host:port', separated by commas
-  password: redis_password,
-});
+const redisClient = new redis.Client('redis://localhost:6379');
 
 export default async function () {
   await redisClient.hset('myhash', 'myfield', 'myvalue');

--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/client-hgetall.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/client-hgetall.md
@@ -26,15 +26,8 @@ Returns all fields and values of the hash stored at `key`.
 ```javascript
 import redis from 'k6/experimental/redis';
 
-// Get the redis instance(s) address and password from the environment
-const redis_addrs = __ENV.REDIS_ADDRS || '';
-const redis_password = __ENV.REDIS_PASSWORD || '';
-
 // Instantiate a new redis client
-const redisClient = new redis.Client({
-  addrs: redis_addrs.split(',') || new Array('localhost:6379'), // in the form of 'host:port', separated by commas
-  password: redis_password,
-});
+const redisClient = new redis.Client('redis://localhost:6379');
 
 export default async function () {
   await redisClient.hset('myhash', 'myfield', 'myvalue');

--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/client-hincrby.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/client-hincrby.md
@@ -28,15 +28,8 @@ Increments the integer value of `field` in the hash stored at `key` by `incremen
 ```javascript
 import redis from 'k6/experimental/redis';
 
-// Get the redis instance(s) address and password from the environment
-const redis_addrs = __ENV.REDIS_ADDRS || '';
-const redis_password = __ENV.REDIS_PASSWORD || '';
-
 // Instantiate a new redis client
-const redisClient = new redis.Client({
-  addrs: redis_addrs.split(',') || new Array('localhost:6379'), // in the form of 'host:port', separated by commas
-  password: redis_password,
-});
+const redisClient = new redis.Client('redis://localhost:6379');
 
 export default async function () {
   await redisClient.hset('myhash', 'myfield', 10);

--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/client-hkeys.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/client-hkeys.md
@@ -26,15 +26,8 @@ Returns all fields of the hash stored at `key`.
 ```javascript
 import redis from 'k6/experimental/redis';
 
-// Get the redis instance(s) address and password from the environment
-const redis_addrs = __ENV.REDIS_ADDRS || '';
-const redis_password = __ENV.REDIS_PASSWORD || '';
-
 // Instantiate a new redis client
-const redisClient = new redis.Client({
-  addrs: redis_addrs.split(',') || new Array('localhost:6379'), // in the form of 'host:port', separated by commas
-  password: redis_password,
-});
+const redisClient = new redis.Client('redis://localhost:6379');
 
 export default async function () {
   await redisClient.hset('myhash', 'myfield', 'myvalue');

--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/client-hlen.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/client-hlen.md
@@ -26,15 +26,8 @@ Returns the number of fields in the hash stored at `key`.
 ```javascript
 import redis from 'k6/experimental/redis';
 
-// Get the redis instance(s) address and password from the environment
-const redis_addrs = __ENV.REDIS_ADDRS || '';
-const redis_password = __ENV.REDIS_PASSWORD || '';
-
 // Instantiate a new redis client
-const redisClient = new redis.Client({
-  addrs: redis_addrs.split(',') || new Array('localhost:6379'), // in the form of 'host:port', separated by commas
-  password: redis_password,
-});
+const redisClient = new redis.Client('redis://localhost:6379');
 
 export default async function () {
   await redisClient.hset('myhash', 'myfield', 10);

--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/client-hset.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/client-hset.md
@@ -28,15 +28,8 @@ Sets the specified field in the hash stored at `key` to `value`. If the `key` do
 ```javascript
 import redis from 'k6/experimental/redis';
 
-// Get the redis instance(s) address and password from the environment
-const redis_addrs = __ENV.REDIS_ADDRS || '';
-const redis_password = __ENV.REDIS_PASSWORD || '';
-
 // Instantiate a new redis client
-const redisClient = new redis.Client({
-  addrs: redis_addrs.split(',') || new Array('localhost:6379'), // in the form of 'host:port', separated by commas
-  password: redis_password,
-});
+const redisClient = new redis.Client('redis://localhost:6379');
 
 export default async function () {
   await redisClient.hset('myhash', 'myfield', 'myvalue');

--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/client-hsetnx.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/client-hsetnx.md
@@ -28,15 +28,8 @@ Sets the specified field in the hash stored at `key` to `value`, only if `field`
 ```javascript
 import redis from 'k6/experimental/redis';
 
-// Get the redis instance(s) address and password from the environment
-const redis_addrs = __ENV.REDIS_ADDRS || '';
-const redis_password = __ENV.REDIS_PASSWORD || '';
-
 // Instantiate a new redis client
-const redisClient = new redis.Client({
-  addrs: redis_addrs.split(',') || new Array('localhost:6379'), // in the form of 'host:port', separated by commas
-  password: redis_password,
-});
+const redisClient = new redis.Client('redis://localhost:6379');
 
 export default async function () {
   await redisClient.hsetnx('myhash', 'myfield', 'myvalue');

--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/client-hvals.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/client-hvals.md
@@ -26,15 +26,8 @@ Returns all values of the hash stored at `key`.
 ```javascript
 import redis from 'k6/experimental/redis';
 
-// Get the redis instance(s) address and password from the environment
-const redis_addrs = __ENV.REDIS_ADDRS || '';
-const redis_password = __ENV.REDIS_PASSWORD || '';
-
 // Instantiate a new redis client
-const redisClient = new redis.Client({
-  addrs: redis_addrs.split(',') || new Array('localhost:6379'), // in the form of 'host:port', separated by commas
-  password: redis_password,
-});
+const redisClient = new redis.Client('redis://localhost:6379');
 
 export default async function () {
   await redisClient.hset('myhash', 'myfield', 'myvalue');

--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/client-incr.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/client-incr.md
@@ -26,15 +26,8 @@ Increments the number stored at `key` by one. If the key does not exist, it is s
 ```javascript
 import redis from 'k6/experimental/redis';
 
-// Get the redis instance(s) address and password from the environment
-const redis_addrs = __ENV.REDIS_ADDRS || '';
-const redis_password = __ENV.REDIS_PASSWORD || '';
-
 // Instantiate a new redis client
-const redisClient = new redis.Client({
-  addrs: redis_addrs.split(',') || new Array('localhost:6379'), // in the form of 'host:port', separated by commas
-  password: redis_password,
-});
+const redisClient = new redis.Client('redis://localhost:6379');
 
 export default async function () {
   await redisClient.set('mykey', 10, 0);

--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/client-incrby.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/client-incrby.md
@@ -27,15 +27,8 @@ Increments the number stored at `key` by `increment`. If the key does not exist,
 ```javascript
 import redis from 'k6/experimental/redis';
 
-// Get the redis instance(s) address and password from the environment
-const redis_addrs = __ENV.REDIS_ADDRS || '';
-const redis_password = __ENV.REDIS_PASSWORD || '';
-
 // Instantiate a new redis client
-const redisClient = new redis.Client({
-  addrs: redis_addrs.split(',') || new Array('localhost:6379'), // in the form of 'host:port', separated by commas
-  password: redis_password,
-});
+const redisClient = new redis.Client('redis://localhost:6379');
 
 export default async function () {
   await redisClient.set('mykey', 10, 0);

--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/client-lindex.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/client-lindex.md
@@ -26,15 +26,8 @@ Returns the specified element of the list stored at `key`. The index is zero-bas
 ```javascript
 import redis from 'k6/experimental/redis';
 
-// Get the redis instance(s) address and password from the environment
-const redis_addrs = __ENV.REDIS_ADDRS || '';
-const redis_password = __ENV.REDIS_PASSWORD || '';
-
 // Instantiate a new redis client
-const redisClient = new redis.Client({
-  addrs: redis_addrs.split(',') || new Array('localhost:6379'), // in the form of 'host:port', separated by commas
-  password: redis_password,
-});
+const redisClient = new redis.Client('redis://localhost:6379');
 
 export default async function () {
   await redisClient.rpush('mylist', 'first');

--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/client-llen.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/client-llen.md
@@ -26,15 +26,8 @@ Returns the length of the list stored at `key`. If `key` does not exist, it is i
 ```javascript
 import redis from 'k6/experimental/redis';
 
-// Get the redis instance(s) address and password from the environment
-const redis_addrs = __ENV.REDIS_ADDRS || '';
-const redis_password = __ENV.REDIS_PASSWORD || '';
-
 // Instantiate a new redis client
-const redisClient = new redis.Client({
-  addrs: redis_addrs.split(',') || new Array('localhost:6379'), // in the form of 'host:port', separated by commas
-  password: redis_password,
-});
+const redisClient = new redis.Client('redis://localhost:6379');
 
 export default function () {
   redisClient

--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/client-lpop.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/client-lpop.md
@@ -26,15 +26,8 @@ Removes and returns the first element of the list stored at `key`.
 ```javascript
 import redis from 'k6/experimental/redis';
 
-// Get the redis instance(s) address and password from the environment
-const redis_addrs = __ENV.REDIS_ADDRS || '';
-const redis_password = __ENV.REDIS_PASSWORD || '';
-
 // Instantiate a new redis client
-const redisClient = new redis.Client({
-  addrs: redis_addrs.split(',') || new Array('localhost:6379'), // in the form of 'host:port', separated by commas
-  password: redis_password,
-});
+const redisClient = new redis.Client('redis://localhost:6379');
 
 export default async function () {
   await redisClient.lpush('mylist', 'first');

--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/client-lpush.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/client-lpush.md
@@ -27,15 +27,8 @@ Inserts all the specified values at the head of the list stored at `key`. If `ke
 ```javascript
 import redis from 'k6/experimental/redis';
 
-// Get the redis instance(s) address and password from the environment
-const redis_addrs = __ENV.REDIS_ADDRS || '';
-const redis_password = __ENV.REDIS_PASSWORD || '';
-
 // Instantiate a new redis client
-const redisClient = new redis.Client({
-  addrs: redis_addrs.split(',') || new Array('localhost:6379'), // in the form of 'host:port', separated by commas
-  password: redis_password,
-});
+const redisClient = new redis.Client('redis://localhost:6379');
 
 export default async function () {
   await redisClient.lpush('mylist', 'first');

--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/client-lrange.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/client-lrange.md
@@ -28,15 +28,8 @@ Returns the specified elements of the list stored at `key`. The offsets start an
 ```javascript
 import redis from 'k6/experimental/redis';
 
-// Get the redis instance(s) address and password from the environment
-const redis_addrs = __ENV.REDIS_ADDRS || '';
-const redis_password = __ENV.REDIS_PASSWORD || '';
-
 // Instantiate a new redis client
-const redisClient = new redis.Client({
-  addrs: redis_addrs.split(',') || new Array('localhost:6379'), // in the form of 'host:port', separated by commas
-  password: redis_password,
-});
+const redisClient = new redis.Client('redis://localhost:6379');
 
 export default async function () {
   await redisClient.rpush('mylist', 'first');

--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/client-lrem.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/client-lrem.md
@@ -28,15 +28,8 @@ Removes the first `count` occurrences of `value` from the list stored at `key`. 
 ```javascript
 import redis from 'k6/experimental/redis';
 
-// Get the redis instance(s) address and password from the environment
-const redis_addrs = __ENV.REDIS_ADDRS || '';
-const redis_password = __ENV.REDIS_PASSWORD || '';
-
 // Instantiate a new redis client
-const redisClient = new redis.Client({
-  addrs: redis_addrs.split(',') || new Array('localhost:6379'), // in the form of 'host:port', separated by commas
-  password: redis_password,
-});
+const redisClient = new redis.Client('redis://localhost:6379');
 
 export default async function () {
   await redisClient.rpush('mylist', 'first');

--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/client-lset.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/client-lset.md
@@ -28,15 +28,8 @@ Sets the list element at `index` to `element`.
 ```javascript
 import redis from 'k6/experimental/redis';
 
-// Get the redis instance(s) address and password from the environment
-const redis_addrs = __ENV.REDIS_ADDRS || '';
-const redis_password = __ENV.REDIS_PASSWORD || '';
-
 // Instantiate a new redis client
-const redisClient = new redis.Client({
-  addrs: redis_addrs.split(',') || new Array('localhost:6379'), // in the form of 'host:port', separated by commas
-  password: redis_password,
-});
+const redisClient = new redis.Client('redis://localhost:6379');
 
 export default async function () {
   await redisClient.rpush('mylist', 'first');

--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/client-mget.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/client-mget.md
@@ -26,15 +26,8 @@ Returns the values of all specified keys.
 ```javascript
 import redis from 'k6/experimental/redis';
 
-// Get the redis instance(s) address and password from the environment
-const redis_addrs = __ENV.REDIS_ADDRS || '';
-const redis_password = __ENV.REDIS_PASSWORD || '';
-
 // Instantiate a new redis client
-const redisClient = new redis.Client({
-  addrs: redis_addrs.split(',') || new Array('localhost:6379'), // in the form of 'host:port', separated by commas
-  password: redis_password,
-});
+const redisClient = new redis.Client('redis://localhost:6379');
 
 export default async function () {
   await redisClient.set('first', 1, 0);

--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/client-persist.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/client-persist.md
@@ -26,15 +26,8 @@ Removes the existing timeout on `key`.
 ```javascript
 import redis from 'k6/experimental/redis';
 
-// Get the redis instance(s) address and password from the environment
-const redis_addrs = __ENV.REDIS_ADDRS || '';
-const redis_password = __ENV.REDIS_PASSWORD || '';
-
 // Instantiate a new redis client
-const redisClient = new redis.Client({
-  addrs: redis_addrs.split(',') || new Array('localhost:6379'), // in the form of 'host:port', separated by commas
-  password: redis_password,
-});
+const redisClient = new redis.Client('redis://localhost:6379');
 
 export default async function () {
   await redisClient.set('mykey', 'myvalue', 10);

--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/client-randomkey.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/client-randomkey.md
@@ -20,15 +20,8 @@ Returns a random key.
 ```javascript
 import redis from 'k6/experimental/redis';
 
-// Get the redis instance(s) address and password from the environment
-const redis_addrs = __ENV.REDIS_ADDRS || '';
-const redis_password = __ENV.REDIS_PASSWORD || '';
-
 // Instantiate a new redis client
-const redisClient = new redis.Client({
-  addrs: redis_addrs.split(',') || new Array('localhost:6379'), // in the form of 'host:port', separated by commas
-  password: redis_password,
-});
+const redisClient = new redis.Client('redis://localhost:6379');
 
 export default async function () {
   await redisClient.set('first', 1, 0);

--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/client-rpop.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/client-rpop.md
@@ -26,15 +26,8 @@ Removes and returns the last element of the list stored at `key`.
 ```javascript
 import redis from 'k6/experimental/redis';
 
-// Get the redis instance(s) address and password from the environment
-const redis_addrs = __ENV.REDIS_ADDRS || '';
-const redis_password = __ENV.REDIS_PASSWORD || '';
-
 // Instantiate a new redis client
-const redisClient = new redis.Client({
-  addrs: redis_addrs.split(',') || new Array('localhost:6379'), // in the form of 'host:port', separated by commas
-  password: redis_password,
-});
+const redisClient = new redis.Client('redis://localhost:6379');
 
 export default async function () {
   await redisClient.lpush('mylist', 'first');

--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/client-rpush.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/client-rpush.md
@@ -27,15 +27,8 @@ Inserts all the specified values at the tail of the list stored at `key`. If `ke
 ```javascript
 import redis from 'k6/experimental/redis';
 
-// Get the redis instance(s) address and password from the environment
-const redis_addrs = __ENV.REDIS_ADDRS || '';
-const redis_password = __ENV.REDIS_PASSWORD || '';
-
 // Instantiate a new redis client
-const redisClient = new redis.Client({
-  addrs: redis_addrs.split(',') || new Array('localhost:6379'), // in the form of 'host:port', separated by commas
-  password: redis_password,
-});
+const redisClient = new redis.Client('redis://localhost:6379');
 
 export default async function () {
   await redisClient.lpush('mylist', 'first');

--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/client-sadd.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/client-sadd.md
@@ -27,15 +27,8 @@ Adds the specified members to the set stored at `key`. Specified members that ar
 ```javascript
 import redis from 'k6/experimental/redis';
 
-// Get the redis instance(s) address and password from the environment
-const redis_addrs = __ENV.REDIS_ADDRS || '';
-const redis_password = __ENV.REDIS_PASSWORD || '';
-
 // Instantiate a new redis client
-const redisClient = new redis.Client({
-  addrs: redis_addrs.split(',') || new Array('localhost:6379'), // in the form of 'host:port', separated by commas
-  password: redis_password,
-});
+const redisClient = new redis.Client('redis://localhost:6379');
 
 export default async function () {
   await redisClient.sadd('myset', 'foo');

--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/client-sendcommand.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/client-sendcommand.md
@@ -27,15 +27,8 @@ In the event a Redis command you wish to use is not implemented yet, the `sendCo
 ```javascript
 import redis from 'k6/experimental/redis';
 
-// Get the redis instance(s) address and password from the environment
-const redis_addrs = __ENV.REDIS_ADDRS || '';
-const redis_password = __ENV.REDIS_PASSWORD || '';
-
 // Instantiate a new redis client
-const redisClient = new redis.Client({
-  addrs: redis_addrs.split(',') || new Array('localhost:6379'), // in the form of 'host:port', separated by commas
-  password: redis_password,
-});
+const redisClient = new redis.Client('redis://localhost:6379');
 
 export default async function () {
   const result = await redisClient.sendCommand('ECHO', 'Hello world');

--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/client-set.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/client-set.md
@@ -28,15 +28,8 @@ Set the value of a key, with a time to live equal to the expiration time paramet
 ```javascript
 import redis from 'k6/experimental/redis';
 
-// Get the redis instance(s) address and password from the environment
-const redis_addrs = __ENV.REDIS_ADDRS || '';
-const redis_password = __ENV.REDIS_PASSWORD || '';
-
 // Instantiate a new redis client
-const redisClient = new redis.Client({
-  addrs: redis_addrs.split(',') || new Array('localhost:6379'), // in the form of 'host:port', separated by commas
-  password: redis_password,
-});
+const redisClient = new redis.Client('redis://localhost:6379');
 
 export default async function () {
   await redisClient.set('mykey', 'myvalue', 0);

--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/client-sismember.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/client-sismember.md
@@ -27,15 +27,8 @@ Returns if member is a member of the set stored at `key`.
 ```javascript
 import redis from 'k6/experimental/redis';
 
-// Get the redis instance(s) address and password from the environment
-const redis_addrs = __ENV.REDIS_ADDRS || '';
-const redis_password = __ENV.REDIS_PASSWORD || '';
-
 // Instantiate a new redis client
-const redisClient = new redis.Client({
-  addrs: redis_addrs.split(',') || new Array('localhost:6379'), // in the form of 'host:port', separated by commas
-  password: redis_password,
-});
+const redisClient = new redis.Client('redis://localhost:6379');
 
 export default async function () {
   await redisClient.sadd('myset', 'foo');

--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/client-smembers.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/client-smembers.md
@@ -26,15 +26,8 @@ Returns all the members of the set values stored at `keys`.
 ```javascript
 import redis from 'k6/experimental/redis';
 
-// Get the redis instance(s) address and password from the environment
-const redis_addrs = __ENV.REDIS_ADDRS || '';
-const redis_password = __ENV.REDIS_PASSWORD || '';
-
 // Instantiate a new redis client
-const redisClient = new redis.Client({
-  addrs: redis_addrs.split(',') || new Array('localhost:6379'), // in the form of 'host:port', separated by commas
-  password: redis_password,
-});
+const redisClient = new redis.Client('redis://localhost:6379');
 
 export default async function () {
   await redisClient.sadd('myset', 'foo');

--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/client-spop.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/client-spop.md
@@ -26,15 +26,8 @@ Removes and returns a random element from the set value stored at `key`.
 ```javascript
 import redis from 'k6/experimental/redis';
 
-// Get the redis instance(s) address and password from the environment
-const redis_addrs = __ENV.REDIS_ADDRS || '';
-const redis_password = __ENV.REDIS_PASSWORD || '';
-
 // Instantiate a new redis client
-const redisClient = new redis.Client({
-  addrs: redis_addrs.split(',') || new Array('localhost:6379'), // in the form of 'host:port', separated by commas
-  password: redis_password,
-});
+const redisClient = new redis.Client('redis://localhost:6379');
 
 export default async function () {
   await redisClient.sadd('myset', 'foo');

--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/client-srandmember.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/client-srandmember.md
@@ -26,15 +26,8 @@ Returns a random element from the set value stored at `key`.
 ```javascript
 import redis from 'k6/experimental/redis';
 
-// Get the redis instance(s) address and password from the environment
-const redis_addrs = __ENV.REDIS_ADDRS || '';
-const redis_password = __ENV.REDIS_PASSWORD || '';
-
 // Instantiate a new redis client
-const redisClient = new redis.Client({
-  addrs: redis_addrs.split(',') || new Array('localhost:6379'), // in the form of 'host:port', separated by commas
-  password: redis_password,
-});
+const redisClient = new redis.Client('redis://localhost:6379');
 
 export default async function () {
   await redisClient.sadd('myset', 'foo');

--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/client-srem.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/client-srem.md
@@ -27,15 +27,8 @@ Removes the specified members from the set stored at `key`. Specified members th
 ```javascript
 import redis from 'k6/experimental/redis';
 
-// Get the redis instance(s) address and password from the environment
-const redis_addrs = __ENV.REDIS_ADDRS || '';
-const redis_password = __ENV.REDIS_PASSWORD || '';
-
 // Instantiate a new redis client
-const redisClient = new redis.Client({
-  addrs: redis_addrs.split(',') || new Array('localhost:6379'), // in the form of 'host:port', separated by commas
-  password: redis_password,
-});
+const redisClient = new redis.Client('redis://localhost:6379');
 
 export default async function () {
   await redisClient.sadd('myset', 'foo');

--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/client-ttl.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/client-ttl.md
@@ -26,15 +26,8 @@ Returns the remaining time to live of a key that has a timeout.
 ```javascript
 import redis from 'k6/experimental/redis';
 
-// Get the redis instance(s) address and password from the environment
-const redis_addrs = __ENV.REDIS_ADDRS || '';
-const redis_password = __ENV.REDIS_PASSWORD || '';
-
 // Instantiate a new redis client
-const redisClient = new redis.Client({
-  addrs: redis_addrs.split(',') || new Array('localhost:6379'), // in the form of 'host:port', separated by commas
-  password: redis_password,
-});
+const redisClient = new redis.Client('redis://localhost:6379');
 
 export default async function () {
   await redisClient.set('mykey', 'myvalue', 10);

--- a/docs/sources/next/javascript-api/k6-experimental/redis/redis-options.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/redis-options.md
@@ -6,15 +6,15 @@ weight: 20
 
 # Redis options
 
-You can configure the [Redis Client](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/redis/client) either by using a Redis connection URL as demonstrated in the [client documentation](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/redis/client#usage) or using an [Options](#options) object to access more advanced configuration.
+You can configure the [Redis Client](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/redis/client) by using a Redis connection URL as demonstrated in the [client documentation](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/redis/client#usage), or by using an [Options](#options) object to access more advanced configuration.
 
 ## Options
 
-Configuration for the overall Redis client, including authentication and connection settings.
+The configuration for the overall Redis client, including authentication and connection settings.
 
 | Option Name      | Type                                                               | Description                                                             |
 | ---------------- | ------------------------------------------------------------------ | ----------------------------------------------------------------------- |
-| socket           | [SocketOptions](#socket-connection-options-socketoptions)          | Configuration of connection socket used to connect to the redis server. |
+| socket           | [SocketOptions](#socket-connection-options)          | The configuration of the connection socket used to connect to the Redis server. |
 | username         | String (optional)                                                  | Username for client authentication.                                     |
 | password         | String (optional)                                                  | Password for client authentication.                                     |
 | clientName       | String (optional)                                                  | Name for the client connection.                                         |
@@ -22,7 +22,7 @@ Configuration for the overall Redis client, including authentication and connect
 | masterName       | String (optional)                                                  | Master instance name for Sentinel.                                      |
 | sentinelUsername | String (optional)                                                  | Username for Sentinel authentication.                                   |
 | sentinelPassword | String (optional)                                                  | Password for Sentinel authentication.                                   |
-| cluster          | [ClusterOptions](#redis-cluster-options-clusteroptions) (optional) | Configuration for Redis Cluster connections.                            |
+| cluster          | [ClusterOptions](#redis-cluster-options) (optional) | The configuration for Redis Cluster connections.                            |
 
 ### Socket Connection Options
 
@@ -32,16 +32,16 @@ Socket-level settings for connecting to a Redis server.
 | ------------------ | -------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
 | host               | String                                                         | IP address or hostname of the Redis server.                                            |
 | port               | Number (optional)                                              | Port number of the Redis server.                                                       |
-| tls                | [TLSOptions](#tls-configuration-options-tlsoptions) (optional) | Configuration for TLS/SSL.                                                             |
-| dialTimeout        | Number (optional, default is _5(seconds)_)                     | Timeout for establishing a connection, expressed in seconds.                           |
-| readTimeout        | Number (optional, default is _3(seconds)_)                     | Timeout for socket reads, expressed in seconds. A value of `-1` disables the timeout.  |
-| writeTimeout       | Number (optional, default is `readTimeout`)                    | Timeout for socket writes, expressed in seconds. A value of `-1` disables the timeout. |
-| poolSize           | Number (optional, default is _10 (per CPU)_)                   | Number of socket connections in the pool per CPU.                                      |
+| tls                | [TLSOptions](#tls-configuration-options) (optional) | The configuration for TLS/SSL.                                                             |
+| dialTimeout        | Number (optional, default is _5_ (seconds))                     | Timeout for establishing a connection, in seconds.                           |
+| readTimeout        | Number (optional, default is _3_ (seconds))                     | Timeout for socket reads, in seconds. A value of `-1` disables the timeout.  |
+| writeTimeout       | Number (optional, default is `readTimeout`)                    | Timeout for socket writes, in seconds. A value of `-1` disables the timeout. |
+| poolSize           | Number (optional, default is _10_ (per CPU))                   | Number of socket connections in the pool per CPU.                                      |
 | minIdleConns       | Number (optional)                                              | Minimum number of idle connections in the pool.                                        |
 | maxConnAge         | Number (optional, default is _0_ (no maximum idle time))       | Maximum idle time before closing a connection.                                         |
 | poolTimeout        | Number (optional, `readTimeout + 1`)                           | Timeout for acquiring a connection from the pool.                                      |
 | idleTimeout        | Number (optional, `readTimeout + 1`)                           | Timeout for idle connections in the pool.                                              |
-| idleCheckFrequency | Number (optional, default is _1 (minute)_)                     | Frequency of idle connection checks, in minutes. A value of `-1` disables the checks.  |
+| idleCheckFrequency | Number (optional, default is _1_ (minute))                     | Frequency of idle connection checks, in minutes. A value of `-1` disables the checks.  |
 
 #### TLS Configuration Options
 
@@ -63,4 +63,4 @@ Options for behavior in a Redis Cluster setup.
 | readOnly       | Boolean (optional)                                                      | Enables read-only mode for replicas.                                                        |
 | routeByLatency | Boolean (optional)                                                      | Route read commands by latency.                                                             |
 | routeRandomly  | Boolean (optional)                                                      | Random routing for read commands.                                                           |
-| nodes          | String[] or [SocketOptions](#socket-connection-options-socketoptions)[] | List of cluster nodes as URLs or [SocketOptions](#socket-connection-options-socketoptions). |
+| nodes          | String[] or [SocketOptions](#socket-connection-options)[] | List of cluster nodes as URLs or [SocketOptions](#socket-connection-options). |

--- a/docs/sources/next/javascript-api/k6-experimental/redis/redis-options.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/redis-options.md
@@ -1,55 +1,66 @@
 ---
-title: 'Redis options'
+title: 'Options'
 excerpt: 'Options allow to fine tune how a Redis client behaves and interacts with a Redis server or cluster.'
 weight: 20
 ---
 
 # Redis options
 
-You can configure the [Redis Client](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/redis/client) at construction time with the [Options](#options) object.
-We recommend passing the options to the constructor as an argument, then passing the most common options, such as the `addrs` and `password`, to the constructor from the environment.
-
-The following snippet provides an example:
-
-```javascript
-import redis from 'k6/experimental/redis';
-
-// Get the redis instance(s) address and password from the environment
-const redis_addrs = __ENV.REDIS_ADDRS || '';
-const redis_password = __ENV.REDIS_PASSWORD || '';
-
-// Instantiate a new redis client
-const redisClient = new redis.Client({
-  addrs: redis_addrs.split(',') || new Array('localhost:6379'), // in the form of 'host:port', separated by commas
-  password: redis_password,
-});
-
-export default function () {
-  // do something with the redis client
-}
-```
+You can configure the [Redis Client](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/redis/client) either by using a Redis connection URL as demonstrated in the [client documentation](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/redis/client#usage) or using an [Options](#options) object to access more advanced configuration.
 
 ## Options
 
-| Option name          | type              | default           | description                                                                                                                                                                                                                                      |
-| :------------------- | :---------------- | :---------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `addrs`              | string[]          |                   | Array of addresses in the 'host:port' defining which connect Redis to connect to. Supplying a single entry would connect the client to a single Redis instance. Supplying multiple entries would connect the client to a cluster/sentinel nodes. |
-| `db`                 | number (optional) | 0                 | The id of the database to be selected after connecting to the server. Only used when connecting to a single-node use.                                                                                                                            |
-| `username`           | string (optional) |                   | Username to authenticate the client connection with.                                                                                                                                                                                             |
-| `password`           | string (optional) |                   | Password to authenticate the client connection with.                                                                                                                                                                                             |
-| `sentinelUsername`   | string (optional) |                   | Username to authenticate the client connection with when connecting to a sentinel.                                                                                                                                                               |
-| `sentinelPassword`   | string (optional) |                   | Password to authenticate the client connection with when connecting to a sentinel.                                                                                                                                                               |
-| `masterName`         | string (optional) |                   | The name of the master to connect to when connecting to a Redis cluster.                                                                                                                                                                         |
-| `maxRetries`         | number (optional) | 0                 | The maximum number of retries to attempt when connecting to a Redis server before giving up.                                                                                                                                                     |
-| `minRetryBackoff`    | number (optional) | 8 (ms)            | The minimum amount of time to wait between retries when connecting to a Redis server.                                                                                                                                                            |
-| `maxRetryBackoff`    | number (optional) | 512 (ms)          | The maximum amount of time to wait between retries when connecting to a Redis server.                                                                                                                                                            |
-| `dialTimeout`        | number (optional) | 5 (seconds)       | The maximum amount of time to wait for a connection to a Redis server to be established.                                                                                                                                                         |
-| `readTimeout`        | number (optional) | 3 (seconds)       | The maximum amount of time to wait for socket reads to succeed. Use `-1` for no timeout.                                                                                                                                                         |
-| `writeTimeout`       | number (optional) | `readTimeout`     | The maximum amount of time to wait for a socket write to succeed. Use `-1` for no timeout.                                                                                                                                                       |
-| `poolSize`           | number (optional) | 10 (per CPU)      | The maximum number of socket connections to keep open in the connection pool.                                                                                                                                                                    |
-| `minIdleConns`       | number (optional) |                   | The minimum number of idle connections to keep open in the connection pool.                                                                                                                                                                      |
-| `maxIdleConns`       | number (optional) |                   | The maximum number of idle connections to keep open in the connection pool.                                                                                                                                                                      |
-| `maxConnAge`         | number (optional) | 0                 | The maximum amount of time a connection can be idle in the connection pool before being closed.                                                                                                                                                  |
-| `poolTimeout`        | number (optional) | `readTimeout + 1` | The maximum amount of time to wait for a connection to the Redis server to be returned from the pool.                                                                                                                                            |
-| `idleTimeout`        | number (optional) | `readTimeout + 1` | The maximum amount of time the client waits for a connection to become active before timing out.                                                                                                                                                 |
-| `idleCheckFrequency` | number (optional) | 1 (minute)        | The frequency at which the client checks for idle connections in the connection pool. Use `-1` to disable the checks.                                                                                                                            |
+Configuration for the overall Redis client, including authentication and connection settings.
+
+| Option Name      | Type                                                               | Description                                                             |
+| ---------------- | ------------------------------------------------------------------ | ----------------------------------------------------------------------- |
+| socket           | [SocketOptions](#socket-connection-options-socketoptions)          | Configuration of connection socket used to connect to the redis server. |
+| username         | String (optional)                                                  | Username for client authentication.                                     |
+| password         | String (optional)                                                  | Password for client authentication.                                     |
+| clientName       | String (optional)                                                  | Name for the client connection.                                         |
+| database         | Number (optional)                                                  | Database ID to select after connecting.                                 |
+| masterName       | String (optional)                                                  | Master instance name for Sentinel.                                      |
+| sentinelUsername | String (optional)                                                  | Username for Sentinel authentication.                                   |
+| sentinelPassword | String (optional)                                                  | Password for Sentinel authentication.                                   |
+| cluster          | [ClusterOptions](#redis-cluster-options-clusteroptions) (optional) | Configuration for Redis Cluster connections.                            |
+
+### Socket Connection Options
+
+Socket-level settings for connecting to a Redis server.
+
+| Option Name        | Type                                                           | Description                                                                            |
+| ------------------ | -------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| host               | String                                                         | IP address or hostname of the Redis server.                                            |
+| port               | Number (optional)                                              | Port number of the Redis server.                                                       |
+| tls                | [TLSOptions](#tls-configuration-options-tlsoptions) (optional) | Configuration for TLS/SSL.                                                             |
+| dialTimeout        | Number (optional, default is _5(seconds)_)                     | Timeout for establishing a connection, expressed in seconds.                           |
+| readTimeout        | Number (optional, default is _3(seconds)_)                     | Timeout for socket reads, expressed in seconds. A value of `-1` disables the timeout.  |
+| writeTimeout       | Number (optional, default is `readTimeout`)                    | Timeout for socket writes, expressed in seconds. A value of `-1` disables the timeout. |
+| poolSize           | Number (optional, default is _10 (per CPU)_)                   | Number of socket connections in the pool per CPU.                                      |
+| minIdleConns       | Number (optional)                                              | Minimum number of idle connections in the pool.                                        |
+| maxConnAge         | Number (optional, default is _0_ (no maximum idle time))       | Maximum idle time before closing a connection.                                         |
+| poolTimeout        | Number (optional, `readTimeout + 1`)                           | Timeout for acquiring a connection from the pool.                                      |
+| idleTimeout        | Number (optional, `readTimeout + 1`)                           | Timeout for idle connections in the pool.                                              |
+| idleCheckFrequency | Number (optional, default is _1 (minute)_)                     | Frequency of idle connection checks, in minutes. A value of `-1` disables the checks.  |
+
+#### TLS Configuration Options
+
+Options for establishing a secure TLS connection.
+
+| Option Name | Type                   | Description                                         |
+| ----------- | ---------------------- | --------------------------------------------------- |
+| ca          | ArrayBuffer[]          | Array of CA certificates.                           |
+| cert        | ArrayBuffer (optional) | Client certificate for mutual TLS.                  |
+| key         | ArrayBuffer (optional) | Private key associated with the client certificate. |
+
+### Redis Cluster Options
+
+Options for behavior in a Redis Cluster setup.
+
+| Option Name    | Type                                                                    | Description                                                                                 |
+| -------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| maxRedirects   | Number (optional, default is _3_ retries)                               | Maximum number of command redirects.                                                        |
+| readOnly       | Boolean (optional)                                                      | Enables read-only mode for replicas.                                                        |
+| routeByLatency | Boolean (optional)                                                      | Route read commands by latency.                                                             |
+| routeRandomly  | Boolean (optional)                                                      | Random routing for read commands.                                                           |
+| nodes          | String[] or [SocketOptions](#socket-connection-options-socketoptions)[] | List of cluster nodes as URLs or [SocketOptions](#socket-connection-options-socketoptions). |

--- a/docs/sources/next/javascript-api/k6-experimental/redis/redis-options.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/redis-options.md
@@ -1,6 +1,6 @@
 ---
 title: 'Options'
-excerpt: 'Options allow to fine tune how a Redis client behaves and interacts with a Redis server or cluster.'
+excerpt: 'Options allow you to fine-tune how a Redis client behaves and interacts with a Redis server or cluster.'
 weight: 20
 ---
 


### PR DESCRIPTION
k6 version 0.48 will introduce a breaking change in the way the `k6/experimental/redis` Client class is constructed.

This Pull Request documents the new API and its usage.

This is my first PR on the new version of the documentation, so 🤞🏻