### PR TITLE
Update results output to highlight cloud option

### DIFF
--- a/docs/sources/next/results-output/real-time/_index.md
+++ b/docs/sources/next/results-output/real-time/_index.md
@@ -2,13 +2,12 @@
 title: Real time
 excerpt: Send your time-series k6 metrics to multiple file formats and services
 weight: 200
-weight: 200
 ---
 
 # Real time
 
 Besides the [end-of-test summary](https://grafana.com/docs/k6/<K6_VERSION>/results-output/end-of-test), you can also view metrics as granular data points.
-k6 can stream the metrics in real time and either:
+k6 can stream the metrics in real-time and either:
 
 - Write output to a file
 - Send output to an external service.
@@ -17,22 +16,19 @@ k6 can stream the metrics in real time and either:
 
 Currently, k6 supports writing to the following file formats:
 
-<Glossary>
-
 - [CSV](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/csv)
 - [JSON](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/json)
 
-</Glossary>
-
 ## Stream to service {#service}
 
-You can also stream real-time metrics to the following services:
+You can also stream real-time metrics to:
 
-<Glossary>
+- [Grafana Cloud k6](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/cloud)
+
+As well as the following third-party services:
 
 - [Amazon CloudWatch](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/amazon-cloudwatch)
 - [Apache Kafka](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/apache-kafka)
-- [Cloud](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/cloud)
 - [Datadog](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/datadog)
 - [Dynatrace](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/dynatrace)
 - [Elasticsearch](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/elasticsearch)
@@ -45,9 +41,11 @@ You can also stream real-time metrics to the following services:
 - [StatsD](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/statsd)
 - [Other alternative with a custom output extension](https://grafana.com/docs/k6/<K6_VERSION>/extensions/create/output-extensions)
 
-</Glossary>
+{{% admonition type="note" %}}
 
-> This list applies to local tests, not to [cloud tests](https://grafana.com/docs/grafana-cloud/k6/).
+This list applies to local tests, not to [cloud tests](https://grafana.com/docs/grafana-cloud/k6/).
+
+{{% /admonition %}}
 
 ## Read more
 

--- a/docs/sources/next/results-output/real-time/cloud.md
+++ b/docs/sources/next/results-output/real-time/cloud.md
@@ -1,10 +1,10 @@
 ---
-title: 'Cloud'
+title: 'Grafana Cloud k6'
 excerpt: 'When streaming the results to the cloud, the machine - where you execute the k6 CLI command - runs the test and uploads the results to the cloud. Then, you will be able to visualize and analyze the results on the web app in real-time.'
 weight: 00
 ---
 
-# Cloud
+# Grafana Cloud k6
 
 Besides [running cloud tests](https://grafana.com/docs/k6/<K6_VERSION>/get-started/running-k6#execution-modes), you can also run a test locally and stream the results to [Grafana Cloud k6](https://grafana.com/docs/grafana-cloud/k6/get-started/run-cloud-tests-from-the-cli/#run-locally-and-stream-to-the-cloud).
 

--- a/docs/sources/v0.47.x/results-output/real-time/_index.md
+++ b/docs/sources/v0.47.x/results-output/real-time/_index.md
@@ -2,13 +2,12 @@
 title: Real time
 excerpt: Send your time-series k6 metrics to multiple file formats and services
 weight: 200
-weight: 200
 ---
 
 # Real time
 
 Besides the [end-of-test summary](https://grafana.com/docs/k6/<K6_VERSION>/results-output/end-of-test), you can also view metrics as granular data points.
-k6 can stream the metrics in real time and either:
+k6 can stream the metrics in real-time and either:
 
 - Write output to a file
 - Send output to an external service.
@@ -17,22 +16,19 @@ k6 can stream the metrics in real time and either:
 
 Currently, k6 supports writing to the following file formats:
 
-<Glossary>
-
 - [CSV](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/csv)
 - [JSON](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/json)
 
-</Glossary>
-
 ## Stream to service {#service}
 
-You can also stream real-time metrics to the following services:
+You can also stream real-time metrics to:
 
-<Glossary>
+- [Grafana Cloud k6](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/cloud)
+
+As well as the following third-party services:
 
 - [Amazon CloudWatch](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/amazon-cloudwatch)
 - [Apache Kafka](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/apache-kafka)
-- [Cloud](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/cloud)
 - [Datadog](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/datadog)
 - [Dynatrace](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/dynatrace)
 - [Elasticsearch](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/elasticsearch)
@@ -45,9 +41,11 @@ You can also stream real-time metrics to the following services:
 - [StatsD](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/statsd)
 - [Other alternative with a custom output extension](https://grafana.com/docs/k6/<K6_VERSION>/extensions/create/output-extensions)
 
-</Glossary>
+{{% admonition type="note" %}}
 
-> This list applies to local tests, not to [cloud tests](https://grafana.com/docs/grafana-cloud/k6/).
+This list applies to local tests, not to [cloud tests](https://grafana.com/docs/grafana-cloud/k6/).
+
+{{% /admonition %}}
 
 ## Read more
 

--- a/docs/sources/v0.47.x/results-output/real-time/cloud.md
+++ b/docs/sources/v0.47.x/results-output/real-time/cloud.md
@@ -1,10 +1,10 @@
 ---
-title: 'Cloud'
+title: 'Grafana Cloud k6'
 excerpt: 'When streaming the results to the cloud, the machine - where you execute the k6 CLI command - runs the test and uploads the results to the cloud. Then, you will be able to visualize and analyze the results on the web app in real-time.'
 weight: 00
 ---
 
-# Cloud
+# Grafana Cloud k6
 
 Besides [running cloud tests](https://grafana.com/docs/k6/<K6_VERSION>/get-started/running-k6#execution-modes), you can also run a test locally and stream the results to [Grafana Cloud k6](https://grafana.com/docs/grafana-cloud/k6/get-started/run-cloud-tests-from-the-cli/#run-locally-and-stream-to-the-cloud).
 


### PR DESCRIPTION
- Mention Grafana Cloud option separately from 3rd-party services
- Rename "Cloud" to "Grafana Cloud k6"