### PR TITLE
fix JSON for run example test

### DIFF
--- a/src/data/markdown/translated-guides/en/07 Testing Guides/01 API load testing.md
+++ b/src/data/markdown/translated-guides/en/07 Testing Guides/01 API load testing.md
@@ -389,7 +389,7 @@ For example, consider a JSON file with a list of user info such as:
 {
 	"users": [
 	  { "username": "lorem", "surname": "ipsum" },
-	  { "username": "dolorem", "surname": "ipsum" },
+	  { "username": "dolorem", "surname": "ipsum" }
 	]
 }
 ```


### PR DESCRIPTION
Hello everyone!

### What  
Removed comma on the last line from JSON example. 
Follow link related: 
https://k6.io/docs/testing-guides/api-load-testing/#data-parameterization

### Why  
Because the format is incorrect and the test broken when running.  

Thanks!