### PR TITLE
Update Custom Metrics / Performance Measure with Trend param isTime == true

### DIFF
--- a/docs/sources/next/using-k6-browser/metrics.md
+++ b/docs/sources/next/using-k6-browser/metrics.md
@@ -166,5 +166,5 @@ After you run the test, you should see a similar output as the one below.
 ```bash
   iteration_duration..........: avg=1.06s    min=1.06s    med=1.06s    max=1.06s    p(90)=1.06s    p(95)=1.06s
   iterations..................: 1      0.70866/s
-  total_action_time.............: avg=295.3s    min=295.3s    med=295.3s    max=295.3s    p(90)=295.3s    p(95)=295.3s
+  total_action_time.............: avg=295.3ms    min=295.3ms    med=295.3ms    max=295.3ms    p(90)=295.3ms    p(95)=295.3ms
 ```

--- a/docs/sources/next/using-k6-browser/metrics.md
+++ b/docs/sources/next/using-k6-browser/metrics.md
@@ -124,7 +124,7 @@ export const options = {
   },
 };
 
-const myTrend = new Trend('total_action_time');
+const myTrend = new Trend('total_action_time',true);
 
 export default async function () {
   const page = browser.newPage();
@@ -152,7 +152,7 @@ export default async function () {
       JSON.parse(JSON.stringify(window.performance.getEntriesByName('total-action-time')))[0].duration
     );
 
-    myTrend.add(total_action_time);
+    myTrend.add(totalActionTime);
   } finally {
     page.close();
   }
@@ -166,5 +166,5 @@ After you run the test, you should see a similar output as the one below.
 ```bash
   iteration_duration..........: avg=1.06s    min=1.06s    med=1.06s    max=1.06s    p(90)=1.06s    p(95)=1.06s
   iterations..................: 1      0.70866/s
-  total_action_time.............: avg=295.3    min=295.3    med=295.3    max=295.3    p(90)=295.3    p(95)=295.3
+  total_action_time.............: avg=295.3s    min=295.3s    med=295.3s    max=295.3s    p(90)=295.3s    p(95)=295.3s
 ```

--- a/docs/sources/v0.47.x/using-k6-browser/metrics.md
+++ b/docs/sources/v0.47.x/using-k6-browser/metrics.md
@@ -166,5 +166,5 @@ After you run the test, you should see a similar output as the one below.
 ```bash
   iteration_duration..........: avg=1.06s    min=1.06s    med=1.06s    max=1.06s    p(90)=1.06s    p(95)=1.06s
   iterations..................: 1      0.70866/s
-  total_action_time.............: avg=295.3s    min=295.3s    med=295.3s    max=295.3s    p(90)=295.3s    p(95)=295.3s
+  total_action_time.............: avg=295.3ms    min=295.3ms    med=295.3ms    max=295.3ms    p(90)=295.3ms    p(95)=295.3ms
 ```

--- a/docs/sources/v0.47.x/using-k6-browser/metrics.md
+++ b/docs/sources/v0.47.x/using-k6-browser/metrics.md
@@ -124,7 +124,7 @@ export const options = {
   },
 };
 
-const myTrend = new Trend('total_action_time');
+const myTrend = new Trend('total_action_time',true);
 
 export default async function () {
   const page = browser.newPage();
@@ -152,7 +152,7 @@ export default async function () {
       JSON.parse(JSON.stringify(window.performance.getEntriesByName('total-action-time')))[0].duration
     );
 
-    myTrend.add(total_action_time);
+    myTrend.add(totalActionTime);
   } finally {
     page.close();
   }
@@ -166,5 +166,5 @@ After you run the test, you should see a similar output as the one below.
 ```bash
   iteration_duration..........: avg=1.06s    min=1.06s    med=1.06s    max=1.06s    p(90)=1.06s    p(95)=1.06s
   iterations..................: 1      0.70866/s
-  total_action_time.............: avg=295.3    min=295.3    med=295.3    max=295.3    p(90)=295.3    p(95)=295.3
+  total_action_time.............: avg=295.3s    min=295.3s    med=295.3s    max=295.3s    p(90)=295.3s    p(95)=295.3s
 ```


### PR DESCRIPTION
Add isTime == true param to Trends
Fixed value being added to the myTrend trend too


<!-- 
Please make sure you have read the contribution guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md as well as the
the code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md before opening a PR.
-->

## What?

1. The documentation isn't declaring the trend metric as a time based trend metric

Documentation shows 

`const myTrend = new Trend('total_action_time');`

and not

`const myTrend = new Trend('total_action_time',true);`

2. Passed correct value to the add method of Trend 

Documentation shows

`    myTrend.add(total_action_time);
`

should be

`    myTrend.add(totalActionTime);
`

4.  The results that has a missing s has been added, it's supposed to be a time based metric

Documentation shows

```
  iteration_duration..........: avg=1.06s    min=1.06s    med=1.06s    max=1.06s    p(90)=1.06s    p(95)=1.06s
  iterations..................: 1      0.70866/s
  total_action_time.............: avg=295.3    min=295.3    med=295.3    max=295.3    p(90)=295.3    p(95)=295.3
```

and not

```
  iteration_duration..........: avg=1.06s    min=1.06s    med=1.06s    max=1.06s    p(90)=1.06s    p(95)=1.06s
  iterations..................: 1      0.70866/s
  total_action_time.............: avg=295.3s    min=295.3s    med=295.3s    max=295.3s    p(90)=295.3s    p(95)=295.3s
```


<!-- A description of the changes this PR brings to the documentation. -->

## Checklist

Please fill in this template:
- [x] I have used a meaningful title for the PR.
- [X] I have described the changes I've made in the "What?" section above.
- [X] I have performed a self-review of my changes.
- [x] I have run the `make docs` command locally and verified that the changes look good.

Select one of these and delete the others:

If updating the documentation for the most recent release of k6: 
- [x]  I have made my changes in the docs/sources/v{most_recent_release} folder of the documentation.


If updating the documentation for the next release of k6:
- [X] I have made my changes in the `docs/sources/next` folder of the documentation.

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->
<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->