### PR TITLE
Add browser M1/M2 Macs Docker steps

### DIFF
--- a/docs/sources/next/using-k6-browser/running-browser-tests.md
+++ b/docs/sources/next/using-k6-browser/running-browser-tests.md
@@ -144,6 +144,30 @@ To run a simple local script:
 
    {{% /admonition %}}
 
+3. Optional Step: Running browser tests in Docker on M1/M2 Macs
+
+   1. Make sure you’re running [the latest Docker](https://docs.docker.com/engine/install/) version.
+
+   2. Update [Rosetta](https://en.wikipedia.org/wiki/Rosetta_(software)) and export an environment variable with the following:
+
+      ```bash
+       $ softwareupdate --install-rosetta
+       $ export DOCKER_DEFAULT_PLATFORM=linux/amd64
+       ```
+
+   3. Select VirtioFS in `Settings` > `General` > `VirtuoFS`.
+
+   4. Enable the Rosetta emulation in `Settings` > `Features in development` > `Use Rosetta for x86/amd64 emulation on Apple Silicon`.
+
+   5. Restart Docker.
+
+   6. Run the browser image with the following command (adds the `--platform` flag):
+
+      ```bash
+      $ docker run --rm -i --platform linux/amd64 -v $(pwd):/home/k6/screenshots -e K6_BROWSER_HEADLESS=false grafana/k6:master-with-browser run - <script.js
+      ```
+
+
 ## Interact with elements on your webpage
 
 You can use `page.locator()` and pass in the element's selector you want to find on the page. `page.locator()` will create and return a [Locator](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator) object, which you can later use to interact with the element.

--- a/docs/sources/next/using-k6-browser/running-browser-tests.md
+++ b/docs/sources/next/using-k6-browser/running-browser-tests.md
@@ -155,9 +155,9 @@ To run a simple local script:
        $ export DOCKER_DEFAULT_PLATFORM=linux/amd64
        ```
 
-   3. Select VirtuoFS in `Settings` > `General` > `VirtuoFS`.
+   3. Select VirtuoFS in **Settings** > **General** > **VirtuoFS**.
 
-   4. Enable the Rosetta emulation in `Settings` > `Features in development` > `Use Rosetta for x86/amd64 emulation on Apple Silicon`.
+   4. Enable the Rosetta emulation in **Settings** > **Features in development** > **Use Rosetta for x86/amd64 emulation on Apple Silicon**.
 
    5. Restart Docker.
 

--- a/docs/sources/next/using-k6-browser/running-browser-tests.md
+++ b/docs/sources/next/using-k6-browser/running-browser-tests.md
@@ -144,7 +144,7 @@ To run a simple local script:
 
    {{% /admonition %}}
 
-3. Optional Step: Running browser tests in Docker on M1/M2 Macs
+3. Optional step: running browser tests in Docker on M1/M2 Macs
 
    1. Make sure you’re running [the latest Docker](https://docs.docker.com/engine/install/) version.
 
@@ -155,7 +155,7 @@ To run a simple local script:
        $ export DOCKER_DEFAULT_PLATFORM=linux/amd64
        ```
 
-   3. Select VirtioFS in `Settings` > `General` > `VirtuoFS`.
+   3. Select VirtuoFS in `Settings` > `General` > `VirtuoFS`.
 
    4. Enable the Rosetta emulation in `Settings` > `Features in development` > `Use Rosetta for x86/amd64 emulation on Apple Silicon`.
 


### PR DESCRIPTION
## What?

- Running the browser with Docker on M1/M2 Macs requires additional steps.
- This PR adds the steps in the `Running browser tests` document as a 3rd optional step.

## Checklist

Please fill in this template:
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `make docs` command locally and verified that the changes look good.
- [x] I have made my changes in the `docs/sources/next` folder of the documentation.

## Related PR(s)/Issue(s)

Closes: #1317