### PR TITLE
Add check for running in the root of the repository

### DIFF
--- a/scripts/apply-patch
+++ b/scripts/apply-patch
@@ -3,6 +3,7 @@
 function usage {
   cat <<EOF
 Apply the changes for directory SRC for commit COMMIT to directory DST.
+The script assumes it is run from the root of the repository.
 
 Usage:
   $0 <COMMIT> <SRC> <DST>
@@ -49,6 +50,14 @@ function path_components {
 
   echo "${n}"
 }
+
+GIT_ROOT="$(git rev-parse --show-toplevel)"
+if [[ "$(pwd)" != "${GIT_ROOT}" ]]; then
+  echo "ERROR: Script has not been run from the repository root ('${GIT_ROOT}')."
+  echo "Please change directory there and adjust argument paths to match the new working directory."
+
+  exit 1
+fi
 
 git diff "${COMMIT}" -- "${SRC}" > "${PATCH}"
 git apply -p "$(path_components "${SRC}")" --directory "${DST}" "${PATCH}"

--- a/scripts/apply-patch
+++ b/scripts/apply-patch
@@ -54,7 +54,7 @@ function path_components {
 GIT_ROOT="$(git rev-parse --show-toplevel)"
 if [[ "$(pwd)" != "${GIT_ROOT}" ]]; then
   echo "ERROR: Script has not been run from the repository root ('${GIT_ROOT}')."
-  echo "Please change directory there and adjust argument paths to match the new working directory."
+  echo "Please move to the root directory and re-run the script."
 
   exit 1
 fi


### PR DESCRIPTION
```console
$ ../scripts/apply-patch HEAD~ sources/next sources/v0.47.x
ERROR: Script has not been run from the repository root ('/Users/jdb/ext/grafana/k6-docs').
Please change directory there and adjust argument paths to match the new working directory.
```

Closes: #1435

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
