### PR TITLE
chore: remove noindex from Grafana docs

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -11,7 +11,6 @@ cascade:
   labels:
     products:
       - oss
-  noindex: true
   breadcrumb_start: 4
   search_section: Grafana k6
   search_type: doc

--- a/docs/sources/next/examples/_index.md
+++ b/docs/sources/next/examples/_index.md
@@ -1,6 +1,7 @@
 ---
-weight: 11
 title: Examples
+weight: 11
+noindex: true
 ---
 
 # Examples

--- a/docs/sources/next/testing-guides/api-load-testing.md
+++ b/docs/sources/next/testing-guides/api-load-testing.md
@@ -3,6 +3,7 @@ title: 'API load testing'
 head_title: 'Intro to API Load Testing: The k6 Guide'
 excerpt: 'Load testing APIs has many facets. This guide introduces you to performance testing and provides best practices to load test your APIs with k6.'
 weight: 01
+noindex: true
 ---
 
 # API load testing
@@ -106,7 +107,7 @@ But, even in this case, sleep can help you avoid overworking the load generator,
 
 When testing the API against normal, human-run workflows, add sleep as in a normal test.
 
- {{% /admonition %}}
+{{% /admonition %}}
 
 ### Virtual users
 

--- a/docs/sources/next/testing-guides/load-testing-websites.md
+++ b/docs/sources/next/testing-guides/load-testing-websites.md
@@ -3,6 +3,7 @@ title: 'Load testing websites'
 head_title: 'How to Load Test a Website: The k6 Guide'
 excerpt: 'Do you know how many users your site can handle? This guide answers the WHY and WHEN you should load test your website and gives you the best practices for load testing websites or web apps with k6. Let’s get started.'
 weight: 03
+noindex: true
 ---
 
 # Load testing websites
@@ -206,7 +207,9 @@ export default async function () {
     sleep(4);
 
     // 02. View products
-    const element = page.locator('a[class="woocommerce-LoopProduct-link woocommerce-loop-product__link"]');
+    const element = page.locator(
+      'a[class="woocommerce-LoopProduct-link woocommerce-loop-product__link"]'
+    );
     await element.click();
     page.waitForSelector('button[name="add-to-cart"]');
     page.screenshot({ path: 'screenshots/02_view-product.png' });
@@ -341,6 +344,5 @@ Load testing websites can be complex due to the number of viable testing approac
 - [Browser testing with k6 browser](https://grafana.com/docs/k6/<K6_VERSION>/using-k6-browser/)
 - [Load test types](https://grafana.com/docs/k6/<K6_VERSION>/testing-guides/test-types/)
 - [Session recording guide](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-authoring/create-tests-from-recordings/)
-- [Determining concurrent users in your load tests]
-(https://k6.io/blog/monthly-visits-concurrent-users)
+- [Determining concurrent users in your load tests](https://k6.io/blog/monthly-visits-concurrent-users)
 - [Data correlation in your test script](https://grafana.com/docs/k6/<K6_VERSION>/examples/correlation-and-dynamic-data)

--- a/docs/sources/next/testing-guides/test-types/_index.md
+++ b/docs/sources/next/testing-guides/test-types/_index.md
@@ -2,6 +2,8 @@
 title: 'Load test types'
 excerpt: 'A series of conceptual articles explaining the different types of load tests. Learn about planning, running, and interpreting different tests for different performance goals.'
 weight: -10
+cascade:
+  noindex: true
 ---
 
 # Load test types
@@ -38,14 +40,14 @@ The main types are as follows. Each type has its own article outlining its essen
 
 In k6 scripts, configure the load configuration using [`options`](https://grafana.com/docs/k6/<K6_VERSION>/get-started/running-k6#using-options) or [`scenarios`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/scenarios). This separates workload configuration from iteration logic.
 
- {{% /admonition %}}
+{{% /admonition %}}
 
 ## Test-type cheat sheet
 
 The following table provides some broad comparisons.
 
-| Type                                                                  | VUs/Throughput        | Duration                   | When?                                                                                                              |
-| --------------------------------------------------------------------- | --------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Type                                                                                                | VUs/Throughput        | Duration                   | When?                                                                                                              |
+| --------------------------------------------------------------------------------------------------- | --------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------ |
 | [Smoke](https://grafana.com/docs/k6/<K6_VERSION>/testing-guides/test-types/smoke-testing)           | Low                   | Short (seconds or minutes) | When the relevant system or application code changes. It checks functional logic, baseline metrics, and deviations |
 | [Load](https://grafana.com/docs/k6/<K6_VERSION>/testing-guides/test-types/load-testing)             | Average production    | Mid (5-60 minutes)         | Often to check system maintains performance with average use                                                       |
 | [Stress](https://grafana.com/docs/k6/<K6_VERSION>/testing-guides/test-types/stress-testing)         | High (above average)  | Mid (5-60 minutes)         | When system may receive above-average loads to check how it manages                                                |

--- a/docs/sources/v0.47.x/examples/_index.md
+++ b/docs/sources/v0.47.x/examples/_index.md
@@ -1,6 +1,7 @@
 ---
-weight: 11
 title: Examples
+weight: 11
+noindex: true
 ---
 
 # Examples

--- a/docs/sources/v0.47.x/testing-guides/api-load-testing.md
+++ b/docs/sources/v0.47.x/testing-guides/api-load-testing.md
@@ -3,6 +3,7 @@ title: 'API load testing'
 head_title: 'Intro to API Load Testing: The k6 Guide'
 excerpt: 'Load testing APIs has many facets. This guide introduces you to performance testing and provides best practices to load test your APIs with k6.'
 weight: 01
+noindex: true
 ---
 
 # API load testing
@@ -106,7 +107,7 @@ But, even in this case, sleep can help you avoid overworking the load generator,
 
 When testing the API against normal, human-run workflows, add sleep as in a normal test.
 
- {{% /admonition %}}
+{{% /admonition %}}
 
 ### Virtual users
 

--- a/docs/sources/v0.47.x/testing-guides/load-testing-websites.md
+++ b/docs/sources/v0.47.x/testing-guides/load-testing-websites.md
@@ -3,6 +3,7 @@ title: 'Load testing websites'
 head_title: 'How to Load Test a Website: The k6 Guide'
 excerpt: 'Do you know how many users your site can handle? This guide answers the WHY and WHEN you should load test your website and gives you the best practices for load testing websites or web apps with k6. Let’s get started.'
 weight: 03
+noindex: true
 ---
 
 # Load testing websites
@@ -206,7 +207,9 @@ export default async function () {
     sleep(4);
 
     // 02. View products
-    const element = page.locator('a[class="woocommerce-LoopProduct-link woocommerce-loop-product__link"]');
+    const element = page.locator(
+      'a[class="woocommerce-LoopProduct-link woocommerce-loop-product__link"]'
+    );
     await element.click();
     page.waitForSelector('button[name="add-to-cart"]');
     page.screenshot({ path: 'screenshots/02_view-product.png' });
@@ -341,6 +344,5 @@ Load testing websites can be complex due to the number of viable testing approac
 - [Browser testing with k6 browser](https://grafana.com/docs/k6/<K6_VERSION>/using-k6-browser/)
 - [Load test types](https://grafana.com/docs/k6/<K6_VERSION>/testing-guides/test-types/)
 - [Session recording guide](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-authoring/create-tests-from-recordings/)
-- [Determining concurrent users in your load tests]
-(https://k6.io/blog/monthly-visits-concurrent-users)
+- [Determining concurrent users in your load tests](https://k6.io/blog/monthly-visits-concurrent-users)
 - [Data correlation in your test script](https://grafana.com/docs/k6/<K6_VERSION>/examples/correlation-and-dynamic-data)

--- a/docs/sources/v0.47.x/testing-guides/test-types/_index.md
+++ b/docs/sources/v0.47.x/testing-guides/test-types/_index.md
@@ -2,6 +2,8 @@
 title: 'Load test types'
 excerpt: 'A series of conceptual articles explaining the different types of load tests. Learn about planning, running, and interpreting different tests for different performance goals.'
 weight: -10
+cascade:
+  noindex: true
 ---
 
 # Load test types
@@ -38,14 +40,14 @@ The main types are as follows. Each type has its own article outlining its essen
 
 In k6 scripts, configure the load configuration using [`options`](https://grafana.com/docs/k6/<K6_VERSION>/get-started/running-k6#using-options) or [`scenarios`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/scenarios). This separates workload configuration from iteration logic.
 
- {{% /admonition %}}
+{{% /admonition %}}
 
 ## Test-type cheat sheet
 
 The following table provides some broad comparisons.
 
-| Type                                                                  | VUs/Throughput        | Duration                   | When?                                                                                                              |
-| --------------------------------------------------------------------- | --------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Type                                                                                                | VUs/Throughput        | Duration                   | When?                                                                                                              |
+| --------------------------------------------------------------------------------------------------- | --------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------ |
 | [Smoke](https://grafana.com/docs/k6/<K6_VERSION>/testing-guides/test-types/smoke-testing)           | Low                   | Short (seconds or minutes) | When the relevant system or application code changes. It checks functional logic, baseline metrics, and deviations |
 | [Load](https://grafana.com/docs/k6/<K6_VERSION>/testing-guides/test-types/load-testing)             | Average production    | Mid (5-60 minutes)         | Often to check system maintains performance with average use                                                       |
 | [Stress](https://grafana.com/docs/k6/<K6_VERSION>/testing-guides/test-types/stress-testing)         | High (above average)  | Mid (5-60 minutes)         | When system may receive above-average loads to check how it manages                                                |

--- a/docs/sources/v0.48.x/examples/_index.md
+++ b/docs/sources/v0.48.x/examples/_index.md
@@ -1,6 +1,7 @@
 ---
-weight: 11
 title: Examples
+weight: 11
+noindex: true
 ---
 
 # Examples

--- a/docs/sources/v0.48.x/testing-guides/api-load-testing.md
+++ b/docs/sources/v0.48.x/testing-guides/api-load-testing.md
@@ -3,6 +3,7 @@ title: 'API load testing'
 head_title: 'Intro to API Load Testing: The k6 Guide'
 excerpt: 'Load testing APIs has many facets. This guide introduces you to performance testing and provides best practices to load test your APIs with k6.'
 weight: 01
+noindex: true
 ---
 
 # API load testing
@@ -106,7 +107,7 @@ But, even in this case, sleep can help you avoid overworking the load generator,
 
 When testing the API against normal, human-run workflows, add sleep as in a normal test.
 
- {{% /admonition %}}
+{{% /admonition %}}
 
 ### Virtual users
 

--- a/docs/sources/v0.48.x/testing-guides/load-testing-websites.md
+++ b/docs/sources/v0.48.x/testing-guides/load-testing-websites.md
@@ -3,6 +3,7 @@ title: 'Load testing websites'
 head_title: 'How to Load Test a Website: The k6 Guide'
 excerpt: 'Do you know how many users your site can handle? This guide answers the WHY and WHEN you should load test your website and gives you the best practices for load testing websites or web apps with k6. Let’s get started.'
 weight: 03
+noindex: true
 ---
 
 # Load testing websites
@@ -206,7 +207,9 @@ export default async function () {
     sleep(4);
 
     // 02. View products
-    const element = page.locator('a[class="woocommerce-LoopProduct-link woocommerce-loop-product__link"]');
+    const element = page.locator(
+      'a[class="woocommerce-LoopProduct-link woocommerce-loop-product__link"]'
+    );
     await element.click();
     page.waitForSelector('button[name="add-to-cart"]');
     page.screenshot({ path: 'screenshots/02_view-product.png' });
@@ -341,6 +344,5 @@ Load testing websites can be complex due to the number of viable testing approac
 - [Browser testing with k6 browser](https://grafana.com/docs/k6/<K6_VERSION>/using-k6-browser/)
 - [Load test types](https://grafana.com/docs/k6/<K6_VERSION>/testing-guides/test-types/)
 - [Session recording guide](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-authoring/create-tests-from-recordings/)
-- [Determining concurrent users in your load tests]
-(https://k6.io/blog/monthly-visits-concurrent-users)
+- [Determining concurrent users in your load tests](https://k6.io/blog/monthly-visits-concurrent-users)
 - [Data correlation in your test script](https://grafana.com/docs/k6/<K6_VERSION>/examples/correlation-and-dynamic-data)

--- a/docs/sources/v0.48.x/testing-guides/test-types/_index.md
+++ b/docs/sources/v0.48.x/testing-guides/test-types/_index.md
@@ -2,6 +2,8 @@
 title: 'Load test types'
 excerpt: 'A series of conceptual articles explaining the different types of load tests. Learn about planning, running, and interpreting different tests for different performance goals.'
 weight: -10
+cascade:
+  noindex: true
 ---
 
 # Load test types
@@ -38,14 +40,14 @@ The main types are as follows. Each type has its own article outlining its essen
 
 In k6 scripts, configure the load configuration using [`options`](https://grafana.com/docs/k6/<K6_VERSION>/get-started/running-k6#using-options) or [`scenarios`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/scenarios). This separates workload configuration from iteration logic.
 
- {{% /admonition %}}
+{{% /admonition %}}
 
 ## Test-type cheat sheet
 
 The following table provides some broad comparisons.
 
-| Type                                                                  | VUs/Throughput        | Duration                   | When?                                                                                                              |
-| --------------------------------------------------------------------- | --------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Type                                                                                                | VUs/Throughput        | Duration                   | When?                                                                                                              |
+| --------------------------------------------------------------------------------------------------- | --------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------ |
 | [Smoke](https://grafana.com/docs/k6/<K6_VERSION>/testing-guides/test-types/smoke-testing)           | Low                   | Short (seconds or minutes) | When the relevant system or application code changes. It checks functional logic, baseline metrics, and deviations |
 | [Load](https://grafana.com/docs/k6/<K6_VERSION>/testing-guides/test-types/load-testing)             | Average production    | Mid (5-60 minutes)         | Often to check system maintains performance with average use                                                       |
 | [Stress](https://grafana.com/docs/k6/<K6_VERSION>/testing-guides/test-types/stress-testing)         | High (above average)  | Mid (5-60 minutes)         | When system may receive above-average loads to check how it manages                                                |


### PR DESCRIPTION
<!-- 
Please make sure you have read the contribution guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md as well as the
the code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md before opening a PR.
-->

## What?

Remove the `noindex` property from the Grafana version of the docs, now that the latest version of the k6 docs (v0.48.x) is the latest available version.