### PR TITLE
chore: fix broken links and bring changes from #1393

### DIFF
--- a/docs/sources/next/examples/oauth-authentication.md
+++ b/docs/sources/next/examples/oauth-authentication.md
@@ -61,6 +61,207 @@ export function authenticateUsingAzure(tenantId, clientId, clientSecret, scope, 
 
 {{< /code >}}
 
+### Azure B2C
+
+The following example shows how you can authenticate with Azure B2C using the [Client Credentials Flow](https://docs.microsoft.com/en-us/azure/active-directory-b2c/active-directory-b2c-reference-oauth-code#client-credentials-flow).
+
+This example is based on a JMeter example found at the [azure-ad-b2c/load-tests](https://github.com/azure-ad-b2c/load-tests) repository.
+
+To use this script, you need to:
+
+1. [Set up your own Azure B2C tenant](https://learn.microsoft.com/en-us/azure/active-directory-b2c/tutorial-create-tenant)
+   - Copy the tenant name, it will be used in your test script.
+1. [Register a web application](https://learn.microsoft.com/en-us/azure/active-directory-b2c/tutorial-register-applications?tabs=app-reg-ga)
+   - Register a single page application with the redirect URL of: https://jwt.ms. That's needed for the flow to receive a token.
+   - After the creation, you can get the Application (client) ID, and the Directory (tenant) ID. Copy both of them, they'll be used in your test script.
+1. [Create a user flow so that you can sign up and create a user](https://docs.microsoft.com/en-us/azure/active-directory-b2c/tutorial-create-user-flows)
+   - Create a new user, and copy the username and password. They'll be used in the test script.
+
+You can find the settings in the B2C settings in the Azure portal if you need to refer to them later on. Make sure to fill out all the variables for the `B2CGraphSettings` object, as well as replace `USERNAME` and `PASSWORD` in `export default function`.
+
+{{< code >}}
+
+```javascript
+import http from 'k6/http';
+import crypto from 'k6/crypto';
+import { randomString } from 'https://jslib.k6.io/k6-utils/1.2.0/index.js';
+
+const B2CGraphSettings = {
+  B2C: {
+    client_id: '', // Application ID in Azure
+    user_flow_name: '',
+    tenant_id: '', // Directory ID in Azure
+    tenant_name: '',
+    scope: 'openid',
+    redirect_url: 'https://jwt.ms',
+  },
+};
+
+/**
+ * Authenticate using OAuth against Azure B2C
+ * @function
+ * @param  {string} username - Username of the user to authenticate
+ * @param  {string} password
+ * @return {string} id_token
+ */
+export function GetB2cIdToken(username, password) {
+  const state = GetState();
+  SelfAsserted(state, username, password);
+  const code = CombinedSigninAndSignup(state);
+  return GetToken(code, state.codeVerifier);
+}
+
+/**
+ * @typedef {object} b2cStateProperties
+ * @property {string} csrfToken
+ * @property {string} stateProperty
+ * @property {string} codeVerifier
+ *
+ */
+
+/**
+ * Get the id token from Azure B2C
+ * @function
+ * @param {string} code
+ * @returns {string} id_token
+ */
+const GetToken = (code, codeVerifier) => {
+  const url =
+    `https://${B2CGraphSettings.B2C.tenant_name}.b2clogin.com/${B2CGraphSettings.B2C.tenant_id}` +
+    `/oauth2/v2.0/token` +
+    `?p=${B2CGraphSettings.B2C.user_flow_name}` +
+    `&client_id=${B2CGraphSettings.B2C.client_id}` +
+    `&grant_type=authorization_code` +
+    `&scope=${B2CGraphSettings.B2C.scope}` +
+    `&code=${code}` +
+    `&redirect_uri=${B2CGraphSettings.B2C.redirect_url}` +
+    `&code_verifier=${codeVerifier}`;
+
+  const response = http.post(url, '', {
+    tags: {
+      b2c_login: 'GetToken',
+    },
+  });
+
+  return JSON.parse(response.body).id_token;
+};
+
+/**
+ * Signs in the user using the CombinedSigninAndSignup policy
+ * extraqct B2C code from response
+ * @function
+ * @param {b2cStateProperties} state
+ * @returns {string} code
+ */
+const CombinedSigninAndSignup = (state) => {
+  const url =
+    `https://${B2CGraphSettings.B2C.tenant_name}.b2clogin.com/${B2CGraphSettings.B2C.tenant_name}.onmicrosoft.com` +
+    `/${B2CGraphSettings.B2C.user_flow_name}/api/CombinedSigninAndSignup/confirmed` +
+    `?csrf_token=${state.csrfToken}` +
+    `&rememberMe=false` +
+    `&tx=StateProperties=${state.stateProperty}` +
+    `&p=${B2CGraphSettings.B2C.user_flow_name}`;
+
+  const response = http.get(url, '', {
+    tags: {
+      b2c_login: 'CombinedSigninAndSignup',
+    },
+  });
+  const codeRegex = '.*code=([^"]*)';
+  return response.url.match(codeRegex)[1];
+};
+
+/**
+ * Signs in the user using the SelfAsserted policy
+ * @function
+ * @param {b2cStateProperties} state
+ * @param {string} username
+ * @param {string} password
+ */
+const SelfAsserted = (state, username, password) => {
+  const url =
+    `https://${B2CGraphSettings.B2C.tenant_name}.b2clogin.com/${B2CGraphSettings.B2C.tenant_id}` +
+    `/${B2CGraphSettings.B2C.user_flow_name}/SelfAsserted` +
+    `?tx=StateProperties=${state.stateProperty}` +
+    `&p=${B2CGraphSettings.B2C.user_flow_name}` +
+    `&request_type=RESPONSE` +
+    `&email=${username}` +
+    `&password=${password}`;
+
+  const params = {
+    headers: {
+      'X-CSRF-TOKEN': `${state.csrfToken}`,
+    },
+    tags: {
+      b2c_login: 'SelfAsserted',
+    },
+  };
+  http.post(url, '', params);
+};
+
+/**
+ * Calls the B2C login page to get the state property
+ * @function
+ * @returns {b2cStateProperties} b2cState
+ */
+const GetState = () => {
+  const nonce = randomString(50);
+  const challenge = crypto.sha256(nonce.toString(), 'base64rawurl');
+
+  const url =
+    `https://${B2CGraphSettings.B2C.tenant_name}.b2clogin.com` +
+    `/${B2CGraphSettings.B2C.tenant_id}/oauth2/v2.0/authorize?` +
+    `p=${B2CGraphSettings.B2C.user_flow_name}` +
+    `&client_id=${B2CGraphSettings.B2C.client_id}` +
+    `&nonce=${nonce}` +
+    `&redirect_uri=${B2CGraphSettings.B2C.redirect_url}` +
+    `&scope=${B2CGraphSettings.B2C.scope}` +
+    `&response_type=code` +
+    `&prompt=login` +
+    `&code_challenge_method=S256` +
+    `&code_challenge=${challenge}` +
+    `&response_mode=fragment`;
+
+  const response = http.get(url, '', {
+    tags: {
+      b2c_login: 'GetCookyAndState',
+    },
+  });
+
+  const vuJar = http.cookieJar();
+  const responseCookies = vuJar.cookiesForURL(response.url);
+
+  const b2cState = {};
+  b2cState.codeVerifier = nonce;
+  b2cState.csrfToken = responseCookies['x-ms-cpim-csrf'][0];
+  b2cState.stateProperty = response.body.match('.*StateProperties=([^"]*)')[1];
+  return b2cState;
+};
+
+/**
+ * Helper function to get the authorization header for a user
+ * @param {user} user
+ * @returns {object} httpsOptions
+ */
+export const GetAuthorizationHeaderForUser = (user) => {
+  const token = GetB2cIdToken(user.username, user.password);
+
+  return {
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': 'Bearer ' + token,
+    },
+  };
+};
+
+export default function () {
+  const token = GetB2cIdToken('USERNAME', 'PASSWORD');
+  console.log(token);
+}
+```
+
+{{< /code >}}
+
 ### Okta
 
 {{< code >}}
@@ -79,7 +280,14 @@ import encoding from 'k6/encoding';
  * @param  {string} scope - Space-separated list of scopes
  * @param  {string|object} resource - Either a resource ID (as string) or an object containing username and password
  */
-export function authenticateUsingOkta(oktaDomain, authServerId, clientId, clientSecret, scope, resource) {
+export function authenticateUsingOkta(
+  oktaDomain,
+  authServerId,
+  clientId,
+  clientSecret,
+  scope,
+  resource
+) {
   if (authServerId === 'undefined' || authServerId == '') {
     authServerId = 'default';
   }

--- a/docs/sources/next/get-started/resources.md
+++ b/docs/sources/next/get-started/resources.md
@@ -32,8 +32,6 @@ If you need a place to learn k6 and test your scripts, you can use these playgro
 
 - [pizza.grafana.fun](https://pizza.grafana.fun/). A simple demo webapp. [grafana/quickpizza](https://github.com/grafana/quickpizza)
 - [k6-http.grafana.fun](https://k6-http.grafana.fun). A simple HTTP Request & Response Service. [grafana/httpbin](https://github.com/grafana/httpbin)
-- [k6-php.grafana.fun](https://k6-php.grafana.fun). A simple PHP website. [grafana/test.k6.io](https://github.com/grafana/test.k6.io)
-- [test-api.k6.io](https://test-api.k6.io). A demo HTTP REST API with some WebSocket support. [grafana/test-api.k6.io](https://github.com/grafana/test-api.k6.io)
 - [grpcbin.test.k6.io](https://grpcbin.test.k6.io/). A simple gRPC Request & Response Service. [grafana/k6-grpcbin](https://github.com/grafana/k6-grpcbin)
 
 Note that these are shared testing environments - please avoid high-load tests. Alternatively, you can deploy and host them on your infrastructure and run the examples in the repository.

--- a/docs/sources/next/javascript-api/xk6-disruptor/faults/_index.md
+++ b/docs/sources/next/javascript-api/xk6-disruptor/faults/_index.md
@@ -1,14 +1,15 @@
 ---
 title: 'Faults'
 excerpt: 'xk6-disruptor: Fault Description'
-weight: 01
+weight: 100
 ---
 
 # Faults
 
 A fault is as an abnormal condition that affects a system component and which may lead to a failure.
 
-| Fault type                                                                           | Description                                 |
-| ------------------------------------------------------------------------------------ | ------------------------------------------- |
-| [gRPC Fault](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/faults/grpc) | Fault affecting gRPC requests from a target |
-| [HTTP Fault](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/faults/http) | Fault affecting HTTP requests from a target |
+| Fault type                                                                                                            | Description                                 |
+| --------------------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
+| [gRPC Fault](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/faults/grpc)                       | Fault affecting gRPC requests from a target |
+| [HTTP Fault](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/faults/http)                       | Fault affecting HTTP requests from a target |
+| [Pod Termination Fault](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/faults/pod-termination) | Fault terminating a number of target Pods   |

--- a/docs/sources/next/javascript-api/xk6-disruptor/faults/pod-termination.md
+++ b/docs/sources/next/javascript-api/xk6-disruptor/faults/pod-termination.md
@@ -1,0 +1,33 @@
+---
+title: 'Pod Termination'
+description: 'xk6-disruptor: Pod Termination Fault attributes'
+weight: 03
+---
+
+# Pod Termination
+
+A Pod Termination Fault allows terminating either a fixed number or a percentage of the pods that matching a selector or back a service.
+
+A Pod Termination fault is defined by the following attributes:
+
+| Attribute | Type                  | Description                                                                                                                                                                   |
+| --------- | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| count     | integer or percentage | the number of pods to be terminated. It can be specified as a integer number or as a percentage, for example `30%`, that defines the fraction of target pods to be terminated |
+
+{{% admonition type="note" %}}
+
+If the count is a percentage and there are no enough elements in the target pod list, the number is rounded up.
+For example '25%' of a list of 2 target pods will terminate one pod.
+If the list of target pods is not empty, at least one pod is always terminated.
+
+{{% /admonition %}}
+
+## Example
+
+This example defines a PorTermination fault that will terminate `30%` of target pods
+
+```javascript
+const fault = {
+  count: '30%',
+};
+```

--- a/docs/sources/next/javascript-api/xk6-disruptor/get-started/_index.md
+++ b/docs/sources/next/javascript-api/xk6-disruptor/get-started/_index.md
@@ -2,7 +2,6 @@
 title: 'Get started'
 excerpt: 'xk6-disruptor is an extension that adds fault injection capabilities to k6. Start here to learn the basics and how to use the disruptor'
 weight: 01
-weight: 01
 ---
 
 # Get started

--- a/docs/sources/next/javascript-api/xk6-disruptor/poddisruptor/_index.md
+++ b/docs/sources/next/javascript-api/xk6-disruptor/poddisruptor/_index.md
@@ -1,7 +1,7 @@
 ---
 title: 'PodDisruptor'
 excerpt: 'xk6-disruptor: PodDisruptor class'
-weight: 02
+weight: 200
 ---
 
 # PodDisruptor
@@ -12,11 +12,12 @@ To construct a `PodDisruptor`, use the [PodDisruptor() constructor](https://graf
 
 ## Methods
 
-| Method                                                                                                                      | Description                                                                                                    |
-| --------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| [PodDisruptor.injectGrpcFaults()](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/poddisruptor/injectgrpcfaults) | Inject [gRPC faults](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/faults/grpc) in the target Pods |
-| [PodDisruptor.injectHTTPFaults()](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/poddisruptor/injecthttpfaults) | Inject [HTTP faults](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/faults/http) in the target Pods |
-| PodDisruptor.targets()                                                                                                      | Returns the list of target Pods of the PodDisruptor                                                            |
+| Method                                                                                                                                 | Description                                                                                                                                         |
+| -------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [PodDisruptor.injectGrpcFaults()](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/poddisruptor/injectgrpcfaults) | Inject [gRPC faults](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/faults/grpc) in the target Pods                          |
+| [PodDisruptor.injectHTTPFaults()](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/poddisruptor/injecthttpfaults) | Inject [HTTP faults](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/faults/http) in the target Pods                          |
+| PodDisruptor.targets()                                                                                                                 | Returns the list of target Pods of the PodDisruptor                                                                                                 |
+| [PodDisruptor.terminatePods()](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/poddisruptor/terminate-pods)      | executes a [Pod Termination fault](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/faults/pod-termination) in the target Pods |
 
 ## Example
 
@@ -59,4 +60,4 @@ $ kubectl run nginx --image=nginx
 
 You can also use the [xk6-kubernetes](https://github.com/grafana/xk6-kubernetes) extension for creating these resources from your test script.
 
- {{% /admonition %}}
+{{% /admonition %}}

--- a/docs/sources/next/javascript-api/xk6-disruptor/poddisruptor/constructor.md
+++ b/docs/sources/next/javascript-api/xk6-disruptor/poddisruptor/constructor.md
@@ -1,7 +1,7 @@
 ---
 title: 'Constructor'
 excerpt: 'xk6-disruptor: PodDisruptor constructor'
-weight: 01
+weight: 100
 ---
 
 # Constructor

--- a/docs/sources/next/javascript-api/xk6-disruptor/poddisruptor/injectgrpcfaults.md
+++ b/docs/sources/next/javascript-api/xk6-disruptor/poddisruptor/injectgrpcfaults.md
@@ -1,18 +1,18 @@
 ---
 title: 'injectGrpcFaults()'
 excerpt: 'xk6-disruptor: PodDisruptor.injectGrpcFaults method'
-weight: 02
+weight: 200
 ---
 
 # injectGrpcFaults()
 
 injectGrpcFaults injects gRPC faults in the requests served by a target Pod.
 
-| Parameter          | Type   | Description                                                                                                            |
-| ------------------ | ------ | ---------------------------------------------------------------------------------------------------------------------- |
+| Parameter          | Type   | Description                                                                                                                        |
+| ------------------ | ------ | ---------------------------------------------------------------------------------------------------------------------------------- |
 | fault              | object | description of the [gRPC faults](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/faults/grpc) to be injected |
-| duration           | string | duration of the disruption                                                                                             |
-| options (optional) | object | [options](#options) that control the injection of the fault                                                            |
+| duration           | string | duration of the disruption                                                                                                         |
+| options (optional) | object | [options](#options) that control the injection of the fault                                                                        |
 
 ## options
 

--- a/docs/sources/next/javascript-api/xk6-disruptor/poddisruptor/injecthttpfaults.md
+++ b/docs/sources/next/javascript-api/xk6-disruptor/poddisruptor/injecthttpfaults.md
@@ -1,18 +1,18 @@
 ---
 title: 'injectHTTPFaults()'
 excerpt: 'xk6-disruptor: PodDisruptor.injectHTTPFaults method'
-weight: 03
+weight: 300
 ---
 
 # injectHTTPFaults()
 
 injectHTTPFaults injects HTTP faults in the requests served by a target Pod.
 
-| Parameter          | Type   | Description                                                                                                            |
-| ------------------ | ------ | ---------------------------------------------------------------------------------------------------------------------- |
+| Parameter          | Type   | Description                                                                                                                        |
+| ------------------ | ------ | ---------------------------------------------------------------------------------------------------------------------------------- |
 | fault              | object | description of the [http faults](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/faults/http) to be injected |
-| duration           | string | duration of the disruption                                                                                             |
-| options (optional) | object | [options](#options) that control the injection of the fault                                                            |
+| duration           | string | duration of the disruption                                                                                                         |
+| options (optional) | object | [options](#options) that control the injection of the fault                                                                        |
 
 ## options
 
@@ -30,7 +30,7 @@ WARN\[0035\] Request Failed error="read tcp 172.18.0.1:43564->172.18.255.200:80:
 
 This is normal and means that one request was "in transit" at the time the faults were injected, causing the request to fail from a network connection reset.
 
- {{% /admonition %}}
+{{% /admonition %}}
 
 ## Example
 

--- a/docs/sources/next/javascript-api/xk6-disruptor/poddisruptor/terminate-pods.md
+++ b/docs/sources/next/javascript-api/xk6-disruptor/poddisruptor/terminate-pods.md
@@ -1,0 +1,24 @@
+---
+title: 'terminatePods()'
+description: 'xk6-disruptor: PodDisruptor.terminatePods method'
+weight: 400
+---
+
+# terminatePods()
+
+`terminatePods` terminates a number of the pods matching the selector configured in the PodDisruptor.
+
+| Parameter | Type   | Description                                                                                                                              |
+| --------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| fault     | object | description of the [Pod Termination fault](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/faults/pod-termination) |
+
+## Example
+
+<!-- eslint-skip -->
+
+```javascript
+const fault = {
+  count: 2,
+};
+disruptor.terminatePods(fault);
+```

--- a/docs/sources/next/javascript-api/xk6-disruptor/servicedisruptor/_index.md
+++ b/docs/sources/next/javascript-api/xk6-disruptor/servicedisruptor/_index.md
@@ -1,7 +1,7 @@
 ---
 title: 'ServiceDisruptor'
 excerpt: 'xk6-disruptor: ServiceDisruptor class'
-weight: 03
+weight: 300
 ---
 
 # ServiceDisruptor
@@ -12,10 +12,12 @@ To construct a `ServiceDisruptor`, use the [ServiceDisruptor() constructor](http
 
 ## Methods
 
-| Method                                                                                                                              | Description                                                                                                     |
-| ----------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| [ServiceDisruptor.injectGrpcFaults()](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/servicedisruptor/injectgrpcfaults) | Inject [gRPC faults](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/faults/grpc) in the target Pods  |
-| [ServiceDisruptor.injectHTTPFaults()](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/servicedisruptor/injecthttpfaults) | Inject [HTTTP faults](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/faults/http) in the target Pods |
+| Method                                                                                                                                         | Description                                                                                                                                         |
+| ---------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [ServiceDisruptor.injectGrpcFaults()](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/servicedisruptor/injectgrpcfaults) | Inject [gRPC faults](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/faults/grpc) in the target Pods                          |
+| [ServiceDisruptor.injectHTTPFaults()](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/servicedisruptor/injecthttpfaults) | Inject [HTTTP faults](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/faults/http) in the target Pods                         |
+| ServiceDisruptor.targets()                                                                                                                     | Returns the list of target Pods of the ServiceDisruptor                                                                                             |
+| [ServiceDisruptor.terminatePods()](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/servicedisruptor/terminate-pods)      | executes a [Pod Termination fault](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/faults/pod-termination) in the target Pods |
 
 ## Example
 
@@ -50,4 +52,4 @@ You can test this script by creating first a pod running nginx and exposing it a
 
 You can also use the [xk6-kubernetes](https://github.com/grafana/xk6-kubernetes) extension for creating these resources from your test script.
 
- {{% /admonition %}}
+{{% /admonition %}}

--- a/docs/sources/next/javascript-api/xk6-disruptor/servicedisruptor/constructor.md
+++ b/docs/sources/next/javascript-api/xk6-disruptor/servicedisruptor/constructor.md
@@ -1,7 +1,7 @@
 ---
 title: 'Constructor'
 excerpt: 'xk6-disruptor: ServiceDisruptor constructor'
-weight: 01
+weight: 100
 ---
 
 # Constructor

--- a/docs/sources/next/javascript-api/xk6-disruptor/servicedisruptor/injectgrpcfaults.md
+++ b/docs/sources/next/javascript-api/xk6-disruptor/servicedisruptor/injectgrpcfaults.md
@@ -1,18 +1,18 @@
 ---
 title: 'injectGrpcFaults'
 excerpt: 'xk6-disruptor: ServiceDisruptor.injectGrpcFaults method'
-weight: 02
+weight: 200
 ---
 
 # injectGrpcFaults
 
 injectGrpcFaults injects gRPC faults in the requests served by a target Service.
 
-| Parameters         | Type   | Description                                                                                                            |
-| ------------------ | ------ | ---------------------------------------------------------------------------------------------------------------------- |
+| Parameters         | Type   | Description                                                                                                                        |
+| ------------------ | ------ | ---------------------------------------------------------------------------------------------------------------------------------- |
 | fault              | object | description of the [gRPC faults](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/faults/grpc) to be injected |
-| duration           | string | duration of the disruption                                                                                             |
-| options (optional) | object | [options](#options) that control the injection of the fault                                                            |
+| duration           | string | duration of the disruption                                                                                                         |
+| options (optional) | object | [options](#options) that control the injection of the fault                                                                        |
 
 ## Options
 

--- a/docs/sources/next/javascript-api/xk6-disruptor/servicedisruptor/injecthttpfaults.md
+++ b/docs/sources/next/javascript-api/xk6-disruptor/servicedisruptor/injecthttpfaults.md
@@ -1,18 +1,18 @@
 ---
 title: 'injectHTTPFaults'
 excerpt: 'xk6-disruptor: ServiceDisruptor.injectHTTPFaults method'
-weight: 03
+weight: 300
 ---
 
 # injectHTTPFaults
 
 injectHTTPFaults injects HTTP faults in the requests served by a target Service.
 
-| Parameters         | Type   | Description                                                                                                            |
-| ------------------ | ------ | ---------------------------------------------------------------------------------------------------------------------- |
+| Parameters         | Type   | Description                                                                                                                        |
+| ------------------ | ------ | ---------------------------------------------------------------------------------------------------------------------------------- |
 | fault              | object | description of the [http faults](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/faults/http) to be injected |
-| duration           | string | duration of the disruption                                                                                             |
-| options (optional) | object | [options](#options) that control the injection of the fault                                                            |
+| duration           | string | duration of the disruption                                                                                                         |
+| options (optional) | object | [options](#options) that control the injection of the fault                                                                        |
 
 ## Options
 
@@ -30,7 +30,7 @@ WARN\[0035\] Request Failed error="read tcp 172.18.0.1:43564->172.18.255.200:80:
 
 This is normal and means that one request was "in transit" at the time the faults were injected causing the request to fail due to a network connection reset.
 
- {{% /admonition %}}
+{{% /admonition %}}
 
 ## Example
 

--- a/docs/sources/next/javascript-api/xk6-disruptor/servicedisruptor/terminate-pods.md
+++ b/docs/sources/next/javascript-api/xk6-disruptor/servicedisruptor/terminate-pods.md
@@ -1,0 +1,24 @@
+---
+title: 'terminatePods()'
+description: 'xk6-disruptor: ServiceDisruptor.terminatePods method'
+weight: 400
+---
+
+# terminatePods()
+
+`terminatePods` terminates a number of pods that belong to the service specified in the ServiceDisruptor.
+
+| Parameter | Type   | Description                                                                                                                              |
+| --------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| fault     | object | description of the [Pod Termination fault](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/faults/pod-termination) |
+
+## Example
+
+<!-- eslint-skip -->
+
+```javascript
+const fault = {
+  count: 2,
+};
+disruptor.terminatePods(fault);
+```

--- a/docs/sources/next/results-output/end-of-test/custom-summary.md
+++ b/docs/sources/next/results-output/end-of-test/custom-summary.md
@@ -72,7 +72,7 @@ They determine where k6 displays or saves the content:
 
 The value of a key can have a type of either `string` or [`ArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer).
 
-You can return mutiple summary outputs in a script.
+You can return multiple summary outputs in a script.
 As an example, this `return` statement sends a report to standard output and writes the `data` object to a JSON file.
 
 {{< code >}}

--- a/docs/sources/next/using-k6/scenarios/executors/shared-iterations.md
+++ b/docs/sources/next/using-k6/scenarios/executors/shared-iterations.md
@@ -9,7 +9,7 @@ weight: 01
 The `shared-iterations` executor shares iterations between the number of VUs.
 The test ends once k6 executes all iterations.
 
-For a shortcut to this executor, use the [vus](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#vus) and [iterations](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#iterations) options.
+For a shortcut to this executor, use the [`vus`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#vus) and [`iterations`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#iterations) options.
 
 {{% admonition type="note" %}}
 
@@ -18,7 +18,7 @@ VU that executes faster will complete more iterations than slower VUs.
 
 To guarantee that every VU completes a specific, fixed number of iterations, [use the per-VU iterations executor](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/scenarios/executors/per-vu-iterations).
 
- {{% /admonition %}}
+{{% /admonition %}}
 
 ## Options
 

--- a/docs/sources/v0.47.x/get-started/resources.md
+++ b/docs/sources/v0.47.x/get-started/resources.md
@@ -32,8 +32,6 @@ If you need a place to learn k6 and test your scripts, you can use these playgro
 
 - [pizza.grafana.fun](https://pizza.grafana.fun/). A simple demo webapp. [grafana/quickpizza](https://github.com/grafana/quickpizza)
 - [k6-http.grafana.fun](https://k6-http.grafana.fun). A simple HTTP Request & Response Service. [grafana/httpbin](https://github.com/grafana/httpbin)
-- [k6-php.grafana.fun](https://k6-php.grafana.fun). A simple PHP website. [grafana/test.k6.io](https://github.com/grafana/test.k6.io)
-- [test-api.k6.io](https://test-api.k6.io). A demo HTTP REST API with some WebSocket support. [grafana/test-api.k6.io](https://github.com/grafana/test-api.k6.io)
 - [grpcbin.test.k6.io](https://grpcbin.test.k6.io/). A simple gRPC Request & Response Service. [grafana/k6-grpcbin](https://github.com/grafana/k6-grpcbin)
 
 Note that these are shared testing environments - please avoid high-load tests. Alternatively, you can deploy and host them on your infrastructure and run the examples in the repository.

--- a/docs/sources/v0.48.x/examples/oauth-authentication.md
+++ b/docs/sources/v0.48.x/examples/oauth-authentication.md
@@ -61,6 +61,207 @@ export function authenticateUsingAzure(tenantId, clientId, clientSecret, scope, 
 
 {{< /code >}}
 
+### Azure B2C
+
+The following example shows how you can authenticate with Azure B2C using the [Client Credentials Flow](https://docs.microsoft.com/en-us/azure/active-directory-b2c/active-directory-b2c-reference-oauth-code#client-credentials-flow).
+
+This example is based on a JMeter example found at the [azure-ad-b2c/load-tests](https://github.com/azure-ad-b2c/load-tests) repository.
+
+To use this script, you need to:
+
+1. [Set up your own Azure B2C tenant](https://learn.microsoft.com/en-us/azure/active-directory-b2c/tutorial-create-tenant)
+   - Copy the tenant name, it will be used in your test script.
+1. [Register a web application](https://learn.microsoft.com/en-us/azure/active-directory-b2c/tutorial-register-applications?tabs=app-reg-ga)
+   - Register a single page application with the redirect URL of: https://jwt.ms. That's needed for the flow to receive a token.
+   - After the creation, you can get the Application (client) ID, and the Directory (tenant) ID. Copy both of them, they'll be used in your test script.
+1. [Create a user flow so that you can sign up and create a user](https://docs.microsoft.com/en-us/azure/active-directory-b2c/tutorial-create-user-flows)
+   - Create a new user, and copy the username and password. They'll be used in the test script.
+
+You can find the settings in the B2C settings in the Azure portal if you need to refer to them later on. Make sure to fill out all the variables for the `B2CGraphSettings` object, as well as replace `USERNAME` and `PASSWORD` in `export default function`.
+
+{{< code >}}
+
+```javascript
+import http from 'k6/http';
+import crypto from 'k6/crypto';
+import { randomString } from 'https://jslib.k6.io/k6-utils/1.2.0/index.js';
+
+const B2CGraphSettings = {
+  B2C: {
+    client_id: '', // Application ID in Azure
+    user_flow_name: '',
+    tenant_id: '', // Directory ID in Azure
+    tenant_name: '',
+    scope: 'openid',
+    redirect_url: 'https://jwt.ms',
+  },
+};
+
+/**
+ * Authenticate using OAuth against Azure B2C
+ * @function
+ * @param  {string} username - Username of the user to authenticate
+ * @param  {string} password
+ * @return {string} id_token
+ */
+export function GetB2cIdToken(username, password) {
+  const state = GetState();
+  SelfAsserted(state, username, password);
+  const code = CombinedSigninAndSignup(state);
+  return GetToken(code, state.codeVerifier);
+}
+
+/**
+ * @typedef {object} b2cStateProperties
+ * @property {string} csrfToken
+ * @property {string} stateProperty
+ * @property {string} codeVerifier
+ *
+ */
+
+/**
+ * Get the id token from Azure B2C
+ * @function
+ * @param {string} code
+ * @returns {string} id_token
+ */
+const GetToken = (code, codeVerifier) => {
+  const url =
+    `https://${B2CGraphSettings.B2C.tenant_name}.b2clogin.com/${B2CGraphSettings.B2C.tenant_id}` +
+    `/oauth2/v2.0/token` +
+    `?p=${B2CGraphSettings.B2C.user_flow_name}` +
+    `&client_id=${B2CGraphSettings.B2C.client_id}` +
+    `&grant_type=authorization_code` +
+    `&scope=${B2CGraphSettings.B2C.scope}` +
+    `&code=${code}` +
+    `&redirect_uri=${B2CGraphSettings.B2C.redirect_url}` +
+    `&code_verifier=${codeVerifier}`;
+
+  const response = http.post(url, '', {
+    tags: {
+      b2c_login: 'GetToken',
+    },
+  });
+
+  return JSON.parse(response.body).id_token;
+};
+
+/**
+ * Signs in the user using the CombinedSigninAndSignup policy
+ * extraqct B2C code from response
+ * @function
+ * @param {b2cStateProperties} state
+ * @returns {string} code
+ */
+const CombinedSigninAndSignup = (state) => {
+  const url =
+    `https://${B2CGraphSettings.B2C.tenant_name}.b2clogin.com/${B2CGraphSettings.B2C.tenant_name}.onmicrosoft.com` +
+    `/${B2CGraphSettings.B2C.user_flow_name}/api/CombinedSigninAndSignup/confirmed` +
+    `?csrf_token=${state.csrfToken}` +
+    `&rememberMe=false` +
+    `&tx=StateProperties=${state.stateProperty}` +
+    `&p=${B2CGraphSettings.B2C.user_flow_name}`;
+
+  const response = http.get(url, '', {
+    tags: {
+      b2c_login: 'CombinedSigninAndSignup',
+    },
+  });
+  const codeRegex = '.*code=([^"]*)';
+  return response.url.match(codeRegex)[1];
+};
+
+/**
+ * Signs in the user using the SelfAsserted policy
+ * @function
+ * @param {b2cStateProperties} state
+ * @param {string} username
+ * @param {string} password
+ */
+const SelfAsserted = (state, username, password) => {
+  const url =
+    `https://${B2CGraphSettings.B2C.tenant_name}.b2clogin.com/${B2CGraphSettings.B2C.tenant_id}` +
+    `/${B2CGraphSettings.B2C.user_flow_name}/SelfAsserted` +
+    `?tx=StateProperties=${state.stateProperty}` +
+    `&p=${B2CGraphSettings.B2C.user_flow_name}` +
+    `&request_type=RESPONSE` +
+    `&email=${username}` +
+    `&password=${password}`;
+
+  const params = {
+    headers: {
+      'X-CSRF-TOKEN': `${state.csrfToken}`,
+    },
+    tags: {
+      b2c_login: 'SelfAsserted',
+    },
+  };
+  http.post(url, '', params);
+};
+
+/**
+ * Calls the B2C login page to get the state property
+ * @function
+ * @returns {b2cStateProperties} b2cState
+ */
+const GetState = () => {
+  const nonce = randomString(50);
+  const challenge = crypto.sha256(nonce.toString(), 'base64rawurl');
+
+  const url =
+    `https://${B2CGraphSettings.B2C.tenant_name}.b2clogin.com` +
+    `/${B2CGraphSettings.B2C.tenant_id}/oauth2/v2.0/authorize?` +
+    `p=${B2CGraphSettings.B2C.user_flow_name}` +
+    `&client_id=${B2CGraphSettings.B2C.client_id}` +
+    `&nonce=${nonce}` +
+    `&redirect_uri=${B2CGraphSettings.B2C.redirect_url}` +
+    `&scope=${B2CGraphSettings.B2C.scope}` +
+    `&response_type=code` +
+    `&prompt=login` +
+    `&code_challenge_method=S256` +
+    `&code_challenge=${challenge}` +
+    `&response_mode=fragment`;
+
+  const response = http.get(url, '', {
+    tags: {
+      b2c_login: 'GetCookyAndState',
+    },
+  });
+
+  const vuJar = http.cookieJar();
+  const responseCookies = vuJar.cookiesForURL(response.url);
+
+  const b2cState = {};
+  b2cState.codeVerifier = nonce;
+  b2cState.csrfToken = responseCookies['x-ms-cpim-csrf'][0];
+  b2cState.stateProperty = response.body.match('.*StateProperties=([^"]*)')[1];
+  return b2cState;
+};
+
+/**
+ * Helper function to get the authorization header for a user
+ * @param {user} user
+ * @returns {object} httpsOptions
+ */
+export const GetAuthorizationHeaderForUser = (user) => {
+  const token = GetB2cIdToken(user.username, user.password);
+
+  return {
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': 'Bearer ' + token,
+    },
+  };
+};
+
+export default function () {
+  const token = GetB2cIdToken('USERNAME', 'PASSWORD');
+  console.log(token);
+}
+```
+
+{{< /code >}}
+
 ### Okta
 
 {{< code >}}
@@ -79,7 +280,14 @@ import encoding from 'k6/encoding';
  * @param  {string} scope - Space-separated list of scopes
  * @param  {string|object} resource - Either a resource ID (as string) or an object containing username and password
  */
-export function authenticateUsingOkta(oktaDomain, authServerId, clientId, clientSecret, scope, resource) {
+export function authenticateUsingOkta(
+  oktaDomain,
+  authServerId,
+  clientId,
+  clientSecret,
+  scope,
+  resource
+) {
   if (authServerId === 'undefined' || authServerId == '') {
     authServerId = 'default';
   }

--- a/docs/sources/v0.48.x/get-started/resources.md
+++ b/docs/sources/v0.48.x/get-started/resources.md
@@ -32,8 +32,6 @@ If you need a place to learn k6 and test your scripts, you can use these playgro
 
 - [pizza.grafana.fun](https://pizza.grafana.fun/). A simple demo webapp. [grafana/quickpizza](https://github.com/grafana/quickpizza)
 - [k6-http.grafana.fun](https://k6-http.grafana.fun). A simple HTTP Request & Response Service. [grafana/httpbin](https://github.com/grafana/httpbin)
-- [k6-php.grafana.fun](https://k6-php.grafana.fun). A simple PHP website. [grafana/test.k6.io](https://github.com/grafana/test.k6.io)
-- [test-api.k6.io](https://test-api.k6.io). A demo HTTP REST API with some WebSocket support. [grafana/test-api.k6.io](https://github.com/grafana/test-api.k6.io)
 - [grpcbin.test.k6.io](https://grpcbin.test.k6.io/). A simple gRPC Request & Response Service. [grafana/k6-grpcbin](https://github.com/grafana/k6-grpcbin)
 
 Note that these are shared testing environments - please avoid high-load tests. Alternatively, you can deploy and host them on your infrastructure and run the examples in the repository.

--- a/docs/sources/v0.48.x/javascript-api/xk6-disruptor/faults/_index.md
+++ b/docs/sources/v0.48.x/javascript-api/xk6-disruptor/faults/_index.md
@@ -1,14 +1,15 @@
 ---
 title: 'Faults'
 excerpt: 'xk6-disruptor: Fault Description'
-weight: 01
+weight: 100
 ---
 
 # Faults
 
 A fault is as an abnormal condition that affects a system component and which may lead to a failure.
 
-| Fault type                                                                           | Description                                 |
-| ------------------------------------------------------------------------------------ | ------------------------------------------- |
-| [gRPC Fault](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/faults/grpc) | Fault affecting gRPC requests from a target |
-| [HTTP Fault](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/faults/http) | Fault affecting HTTP requests from a target |
+| Fault type                                                                                                            | Description                                 |
+| --------------------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
+| [gRPC Fault](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/faults/grpc)                       | Fault affecting gRPC requests from a target |
+| [HTTP Fault](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/faults/http)                       | Fault affecting HTTP requests from a target |
+| [Pod Termination Fault](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/faults/pod-termination) | Fault terminating a number of target Pods   |

--- a/docs/sources/v0.48.x/javascript-api/xk6-disruptor/faults/pod-termination.md
+++ b/docs/sources/v0.48.x/javascript-api/xk6-disruptor/faults/pod-termination.md
@@ -1,0 +1,33 @@
+---
+title: 'Pod Termination'
+description: 'xk6-disruptor: Pod Termination Fault attributes'
+weight: 03
+---
+
+# Pod Termination
+
+A Pod Termination Fault allows terminating either a fixed number or a percentage of the pods that matching a selector or back a service.
+
+A Pod Termination fault is defined by the following attributes:
+
+| Attribute | Type                  | Description                                                                                                                                                                   |
+| --------- | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| count     | integer or percentage | the number of pods to be terminated. It can be specified as a integer number or as a percentage, for example `30%`, that defines the fraction of target pods to be terminated |
+
+{{% admonition type="note" %}}
+
+If the count is a percentage and there are no enough elements in the target pod list, the number is rounded up.
+For example '25%' of a list of 2 target pods will terminate one pod.
+If the list of target pods is not empty, at least one pod is always terminated.
+
+{{% /admonition %}}
+
+## Example
+
+This example defines a PorTermination fault that will terminate `30%` of target pods
+
+```javascript
+const fault = {
+  count: '30%',
+};
+```

--- a/docs/sources/v0.48.x/javascript-api/xk6-disruptor/get-started/_index.md
+++ b/docs/sources/v0.48.x/javascript-api/xk6-disruptor/get-started/_index.md
@@ -2,7 +2,6 @@
 title: 'Get started'
 excerpt: 'xk6-disruptor is an extension that adds fault injection capabilities to k6. Start here to learn the basics and how to use the disruptor'
 weight: 01
-weight: 01
 ---
 
 # Get started

--- a/docs/sources/v0.48.x/javascript-api/xk6-disruptor/poddisruptor/_index.md
+++ b/docs/sources/v0.48.x/javascript-api/xk6-disruptor/poddisruptor/_index.md
@@ -1,7 +1,7 @@
 ---
 title: 'PodDisruptor'
 excerpt: 'xk6-disruptor: PodDisruptor class'
-weight: 02
+weight: 200
 ---
 
 # PodDisruptor
@@ -12,11 +12,12 @@ To construct a `PodDisruptor`, use the [PodDisruptor() constructor](https://graf
 
 ## Methods
 
-| Method                                                                                                                      | Description                                                                                                    |
-| --------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| [PodDisruptor.injectGrpcFaults()](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/poddisruptor/injectgrpcfaults) | Inject [gRPC faults](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/faults/grpc) in the target Pods |
-| [PodDisruptor.injectHTTPFaults()](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/poddisruptor/injecthttpfaults) | Inject [HTTP faults](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/faults/http) in the target Pods |
-| PodDisruptor.targets()                                                                                                      | Returns the list of target Pods of the PodDisruptor                                                            |
+| Method                                                                                                                                 | Description                                                                                                                                         |
+| -------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [PodDisruptor.injectGrpcFaults()](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/poddisruptor/injectgrpcfaults) | Inject [gRPC faults](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/faults/grpc) in the target Pods                          |
+| [PodDisruptor.injectHTTPFaults()](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/poddisruptor/injecthttpfaults) | Inject [HTTP faults](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/faults/http) in the target Pods                          |
+| PodDisruptor.targets()                                                                                                                 | Returns the list of target Pods of the PodDisruptor                                                                                                 |
+| [PodDisruptor.terminatePods()](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/poddisruptor/terminate-pods)      | executes a [Pod Termination fault](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/faults/pod-termination) in the target Pods |
 
 ## Example
 
@@ -59,4 +60,4 @@ $ kubectl run nginx --image=nginx
 
 You can also use the [xk6-kubernetes](https://github.com/grafana/xk6-kubernetes) extension for creating these resources from your test script.
 
- {{% /admonition %}}
+{{% /admonition %}}

--- a/docs/sources/v0.48.x/javascript-api/xk6-disruptor/poddisruptor/constructor.md
+++ b/docs/sources/v0.48.x/javascript-api/xk6-disruptor/poddisruptor/constructor.md
@@ -1,7 +1,7 @@
 ---
 title: 'Constructor'
 excerpt: 'xk6-disruptor: PodDisruptor constructor'
-weight: 01
+weight: 100
 ---
 
 # Constructor

--- a/docs/sources/v0.48.x/javascript-api/xk6-disruptor/poddisruptor/injectgrpcfaults.md
+++ b/docs/sources/v0.48.x/javascript-api/xk6-disruptor/poddisruptor/injectgrpcfaults.md
@@ -1,18 +1,18 @@
 ---
 title: 'injectGrpcFaults()'
 excerpt: 'xk6-disruptor: PodDisruptor.injectGrpcFaults method'
-weight: 02
+weight: 200
 ---
 
 # injectGrpcFaults()
 
 injectGrpcFaults injects gRPC faults in the requests served by a target Pod.
 
-| Parameter          | Type   | Description                                                                                                            |
-| ------------------ | ------ | ---------------------------------------------------------------------------------------------------------------------- |
+| Parameter          | Type   | Description                                                                                                                        |
+| ------------------ | ------ | ---------------------------------------------------------------------------------------------------------------------------------- |
 | fault              | object | description of the [gRPC faults](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/faults/grpc) to be injected |
-| duration           | string | duration of the disruption                                                                                             |
-| options (optional) | object | [options](#options) that control the injection of the fault                                                            |
+| duration           | string | duration of the disruption                                                                                                         |
+| options (optional) | object | [options](#options) that control the injection of the fault                                                                        |
 
 ## options
 

--- a/docs/sources/v0.48.x/javascript-api/xk6-disruptor/poddisruptor/injecthttpfaults.md
+++ b/docs/sources/v0.48.x/javascript-api/xk6-disruptor/poddisruptor/injecthttpfaults.md
@@ -1,18 +1,18 @@
 ---
 title: 'injectHTTPFaults()'
 excerpt: 'xk6-disruptor: PodDisruptor.injectHTTPFaults method'
-weight: 03
+weight: 300
 ---
 
 # injectHTTPFaults()
 
 injectHTTPFaults injects HTTP faults in the requests served by a target Pod.
 
-| Parameter          | Type   | Description                                                                                                            |
-| ------------------ | ------ | ---------------------------------------------------------------------------------------------------------------------- |
+| Parameter          | Type   | Description                                                                                                                        |
+| ------------------ | ------ | ---------------------------------------------------------------------------------------------------------------------------------- |
 | fault              | object | description of the [http faults](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/faults/http) to be injected |
-| duration           | string | duration of the disruption                                                                                             |
-| options (optional) | object | [options](#options) that control the injection of the fault                                                            |
+| duration           | string | duration of the disruption                                                                                                         |
+| options (optional) | object | [options](#options) that control the injection of the fault                                                                        |
 
 ## options
 
@@ -30,7 +30,7 @@ WARN\[0035\] Request Failed error="read tcp 172.18.0.1:43564->172.18.255.200:80:
 
 This is normal and means that one request was "in transit" at the time the faults were injected, causing the request to fail from a network connection reset.
 
- {{% /admonition %}}
+{{% /admonition %}}
 
 ## Example
 

--- a/docs/sources/v0.48.x/javascript-api/xk6-disruptor/poddisruptor/terminate-pods.md
+++ b/docs/sources/v0.48.x/javascript-api/xk6-disruptor/poddisruptor/terminate-pods.md
@@ -1,0 +1,24 @@
+---
+title: 'terminatePods()'
+description: 'xk6-disruptor: PodDisruptor.terminatePods method'
+weight: 400
+---
+
+# terminatePods()
+
+`terminatePods` terminates a number of the pods matching the selector configured in the PodDisruptor.
+
+| Parameter | Type   | Description                                                                                                                              |
+| --------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| fault     | object | description of the [Pod Termination fault](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/faults/pod-termination) |
+
+## Example
+
+<!-- eslint-skip -->
+
+```javascript
+const fault = {
+  count: 2,
+};
+disruptor.terminatePods(fault);
+```

--- a/docs/sources/v0.48.x/javascript-api/xk6-disruptor/servicedisruptor/_index.md
+++ b/docs/sources/v0.48.x/javascript-api/xk6-disruptor/servicedisruptor/_index.md
@@ -1,7 +1,7 @@
 ---
 title: 'ServiceDisruptor'
 excerpt: 'xk6-disruptor: ServiceDisruptor class'
-weight: 03
+weight: 300
 ---
 
 # ServiceDisruptor
@@ -12,10 +12,12 @@ To construct a `ServiceDisruptor`, use the [ServiceDisruptor() constructor](http
 
 ## Methods
 
-| Method                                                                                                                              | Description                                                                                                     |
-| ----------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| [ServiceDisruptor.injectGrpcFaults()](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/servicedisruptor/injectgrpcfaults) | Inject [gRPC faults](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/faults/grpc) in the target Pods  |
-| [ServiceDisruptor.injectHTTPFaults()](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/servicedisruptor/injecthttpfaults) | Inject [HTTTP faults](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/faults/http) in the target Pods |
+| Method                                                                                                                                         | Description                                                                                                                                         |
+| ---------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [ServiceDisruptor.injectGrpcFaults()](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/servicedisruptor/injectgrpcfaults) | Inject [gRPC faults](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/faults/grpc) in the target Pods                          |
+| [ServiceDisruptor.injectHTTPFaults()](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/servicedisruptor/injecthttpfaults) | Inject [HTTTP faults](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/faults/http) in the target Pods                         |
+| ServiceDisruptor.targets()                                                                                                                     | Returns the list of target Pods of the ServiceDisruptor                                                                                             |
+| [ServiceDisruptor.terminatePods()](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/servicedisruptor/terminate-pods)      | executes a [Pod Termination fault](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/faults/pod-termination) in the target Pods |
 
 ## Example
 
@@ -50,4 +52,4 @@ You can test this script by creating first a pod running nginx and exposing it a
 
 You can also use the [xk6-kubernetes](https://github.com/grafana/xk6-kubernetes) extension for creating these resources from your test script.
 
- {{% /admonition %}}
+{{% /admonition %}}

--- a/docs/sources/v0.48.x/javascript-api/xk6-disruptor/servicedisruptor/constructor.md
+++ b/docs/sources/v0.48.x/javascript-api/xk6-disruptor/servicedisruptor/constructor.md
@@ -1,7 +1,7 @@
 ---
 title: 'Constructor'
 excerpt: 'xk6-disruptor: ServiceDisruptor constructor'
-weight: 01
+weight: 100
 ---
 
 # Constructor

--- a/docs/sources/v0.48.x/javascript-api/xk6-disruptor/servicedisruptor/injectgrpcfaults.md
+++ b/docs/sources/v0.48.x/javascript-api/xk6-disruptor/servicedisruptor/injectgrpcfaults.md
@@ -1,18 +1,18 @@
 ---
 title: 'injectGrpcFaults'
 excerpt: 'xk6-disruptor: ServiceDisruptor.injectGrpcFaults method'
-weight: 02
+weight: 200
 ---
 
 # injectGrpcFaults
 
 injectGrpcFaults injects gRPC faults in the requests served by a target Service.
 
-| Parameters         | Type   | Description                                                                                                            |
-| ------------------ | ------ | ---------------------------------------------------------------------------------------------------------------------- |
+| Parameters         | Type   | Description                                                                                                                        |
+| ------------------ | ------ | ---------------------------------------------------------------------------------------------------------------------------------- |
 | fault              | object | description of the [gRPC faults](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/faults/grpc) to be injected |
-| duration           | string | duration of the disruption                                                                                             |
-| options (optional) | object | [options](#options) that control the injection of the fault                                                            |
+| duration           | string | duration of the disruption                                                                                                         |
+| options (optional) | object | [options](#options) that control the injection of the fault                                                                        |
 
 ## Options
 

--- a/docs/sources/v0.48.x/javascript-api/xk6-disruptor/servicedisruptor/injecthttpfaults.md
+++ b/docs/sources/v0.48.x/javascript-api/xk6-disruptor/servicedisruptor/injecthttpfaults.md
@@ -1,18 +1,18 @@
 ---
 title: 'injectHTTPFaults'
 excerpt: 'xk6-disruptor: ServiceDisruptor.injectHTTPFaults method'
-weight: 03
+weight: 300
 ---
 
 # injectHTTPFaults
 
 injectHTTPFaults injects HTTP faults in the requests served by a target Service.
 
-| Parameters         | Type   | Description                                                                                                            |
-| ------------------ | ------ | ---------------------------------------------------------------------------------------------------------------------- |
+| Parameters         | Type   | Description                                                                                                                        |
+| ------------------ | ------ | ---------------------------------------------------------------------------------------------------------------------------------- |
 | fault              | object | description of the [http faults](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/faults/http) to be injected |
-| duration           | string | duration of the disruption                                                                                             |
-| options (optional) | object | [options](#options) that control the injection of the fault                                                            |
+| duration           | string | duration of the disruption                                                                                                         |
+| options (optional) | object | [options](#options) that control the injection of the fault                                                                        |
 
 ## Options
 
@@ -30,7 +30,7 @@ WARN\[0035\] Request Failed error="read tcp 172.18.0.1:43564->172.18.255.200:80:
 
 This is normal and means that one request was "in transit" at the time the faults were injected causing the request to fail due to a network connection reset.
 
- {{% /admonition %}}
+{{% /admonition %}}
 
 ## Example
 

--- a/docs/sources/v0.48.x/javascript-api/xk6-disruptor/servicedisruptor/terminate-pods.md
+++ b/docs/sources/v0.48.x/javascript-api/xk6-disruptor/servicedisruptor/terminate-pods.md
@@ -1,0 +1,24 @@
+---
+title: 'terminatePods()'
+description: 'xk6-disruptor: ServiceDisruptor.terminatePods method'
+weight: 400
+---
+
+# terminatePods()
+
+`terminatePods` terminates a number of pods that belong to the service specified in the ServiceDisruptor.
+
+| Parameter | Type   | Description                                                                                                                              |
+| --------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| fault     | object | description of the [Pod Termination fault](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor/faults/pod-termination) |
+
+## Example
+
+<!-- eslint-skip -->
+
+```javascript
+const fault = {
+  count: 2,
+};
+disruptor.terminatePods(fault);
+```

--- a/docs/sources/v0.48.x/results-output/end-of-test/custom-summary.md
+++ b/docs/sources/v0.48.x/results-output/end-of-test/custom-summary.md
@@ -72,7 +72,7 @@ They determine where k6 displays or saves the content:
 
 The value of a key can have a type of either `string` or [`ArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer).
 
-You can return mutiple summary outputs in a script.
+You can return multiple summary outputs in a script.
 As an example, this `return` statement sends a report to standard output and writes the `data` object to a JSON file.
 
 {{< code >}}

--- a/docs/sources/v0.48.x/using-k6/scenarios/executors/shared-iterations.md
+++ b/docs/sources/v0.48.x/using-k6/scenarios/executors/shared-iterations.md
@@ -9,7 +9,7 @@ weight: 01
 The `shared-iterations` executor shares iterations between the number of VUs.
 The test ends once k6 executes all iterations.
 
-For a shortcut to this executor, use the [vus](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#vus) and [iterations](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#iterations) options.
+For a shortcut to this executor, use the [`vus`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#vus) and [`iterations`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#iterations) options.
 
 {{% admonition type="note" %}}
 
@@ -18,7 +18,7 @@ VU that executes faster will complete more iterations than slower VUs.
 
 To guarantee that every VU completes a specific, fixed number of iterations, [use the per-VU iterations executor](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/scenarios/executors/per-vu-iterations).
 
- {{% /admonition %}}
+{{% /admonition %}}
 
 ## Options
 

--- a/src/data/markdown/translated-guides/en/01 Get started/05 resources.md
+++ b/src/data/markdown/translated-guides/en/01 Get started/05 resources.md
@@ -30,8 +30,6 @@ If you need a place to learn k6 and test your scripts, you can use these playgro
 
 - [pizza.grafana.fun](https://pizza.grafana.fun/). A simple demo webapp. [grafana/quickpizza](https://github.com/grafana/quickpizza)
 - [k6-http.grafana.fun](https://k6-http.grafana.fun). A simple HTTP Request & Response Service. [grafana/httpbin](https://github.com/grafana/httpbin)
-- [k6-php.grafana.fun](https://k6-php.grafana.fun). A simple PHP website. [grafana/test.k6.io](https://github.com/grafana/test.k6.io)
-- [test-api.k6.io](https://test-api.k6.io). A demo HTTP REST API with some WebSocket support. [grafana/test-api.k6.io](https://github.com/grafana/test-api.k6.io)
 - [grpcbin.test.k6.io](https://grpcbin.test.k6.io/). A simple gRPC Request & Response Service. [grafana/k6-grpcbin](https://github.com/grafana/k6-grpcbin)
 
 Note that these are shared testing environments - please avoid high-load tests. Alternatively, you can deploy and host them on your infrastructure and run the examples in the repository.
@@ -43,4 +41,3 @@ Note that these are shared testing environments - please avoid high-load tests. 
 - [The browser recorder](/test-authoring/create-tests-from-recordings/using-the-browser-recorder/). Make test scripts from browser sessions.
 - [k6 TypeScript template](https://github.com/grafana/k6-template-typescript)
 - [Integrations](/integrations/)
-


### PR DESCRIPTION
<!-- 
Please make sure you have read the contribution guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md as well as the
the code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md before opening a PR.
-->

## What?

<!-- A description of the changes this PR brings to the documentation. -->

This PR fixes a few broken links by adding the content from PR #1393 that didn't get ported to the `next` folder. It brings in any files and updates from that PR to the `next` and `v0.48.x.` folders.

It also removes a few links from test services that we are not hosting anymore.

## Checklist

Please fill in this template:
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `make docs` command locally and verified that the changes look good.

Select one of these and delete the others:

If updating the documentation for the most recent release of k6: 
- [x] I have made my changes in the `docs/sources/next` folder of the documentation.
- [x] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.
- [x] I have reflected my changes in the relevant (*e.g.*  when correcting a documentation error) folders of the previous k6 versions of the documentation.
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->

## Related PR(s)/Issue(s)

#1393 