### PR TITLE
Fix browser imports in examples

### DIFF
--- a/docs/sources/next/javascript-api/k6-experimental/browser/locator/dispatchevent.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/locator/dispatchevent.md
@@ -9,11 +9,11 @@ Dispatches HTML DOM event types e.g. `'click'`.
 
 <TableWithNestedRows>
 
-| Parameter       | Type   | Defaults | Description                                                                                                                                                                                                                                                   |
-| --------------- | ------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| type            | string | `''`     | DOM event type e.g. `'click'`.                                                                                                                                                                                                                                |
-| eventInit       | object | `null`   | Optional event specific properties. See [eventInit](#eventinit) for more details.                                                                                                                                                                             |
-| options         | object | `null`   |                                                                                                                                                                                                                                                               |
+| Parameter       | Type   | Defaults | Description                                                                                                                                                                                                                                                                                                                                   |
+| --------------- | ------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| type            | string | `''`     | DOM event type e.g. `'click'`.                                                                                                                                                                                                                                                                                                                |
+| eventInit       | object | `null`   | Optional event specific properties. See [eventInit](#eventinit) for more details.                                                                                                                                                                                                                                                             |
+| options         | object | `null`   |                                                                                                                                                                                                                                                                                                                                               |
 | options.timeout | number | `30000`  | Maximum time in milliseconds. Pass `0` to disable the timeout. Default is overridden by the `setDefaultTimeout` option on [BrowserContext](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext/) or [Page](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/page/). |
 
 </TableWithNestedRows>
@@ -35,15 +35,16 @@ Since eventInit is event-specific, please refer to the events documentation for 
 {{< code >}}
 
 ```javascript
-import { chromium } from 'k6/experimental/browser';
+import { browser } from 'k6/experimental/browser';
 
 export default async function () {
-  const browser = chromium.launch();
   const page = browser.newPage();
 
   await page.goto('https://test.k6.io/browser.php');
   const button = page.locator('#counter-button');
   button.dispatchEvent('click');
+
+  page.close();
 }
 ```
 

--- a/docs/sources/next/testing-guides/load-testing-websites.md
+++ b/docs/sources/next/testing-guides/load-testing-websites.md
@@ -190,11 +190,10 @@ The following is an example of a browser-based load testing script in k6 using t
 <!-- eslint-skip -->
 
 ```javascript
-import { chromium } from 'k6/experimental/browser';
+import { browser } from 'k6/experimental/browser';
 import { sleep } from 'k6';
 
 export default async function () {
-  const browser = chromium.launch({ headless: false });
   const page = browser.newPage();
 
   // 01. Go to the homepage
@@ -217,7 +216,6 @@ export default async function () {
     sleep(1);
   } finally {
     page.close();
-    browser.close();
   }
 }
 ```

--- a/docs/sources/next/using-k6-browser/recommended-practices/page-object-model-pattern.md
+++ b/docs/sources/next/using-k6-browser/recommended-practices/page-object-model-pattern.md
@@ -73,14 +73,13 @@ You can import the `Homepage` class within your test class and invoke the method
 {{< code >}}
 
 ```javascript
-import { chromium } from 'k6/experimental/browser';
+import { browser } from 'k6/experimental/browser';
 import { expect } from 'https://jslib.k6.io/k6chaijs/4.3.4.0/index.js';
 
 import { Homepage } from '../pages/homepage.js';
 import { bookingData } from '../data/booking-data.js';
 
 export default async function () {
-  const browser = chromium.launch();
   const page = browser.newPage();
 
   const { name } = bookingData;
@@ -92,7 +91,6 @@ export default async function () {
   expect(homepage.getVerificationMessage()).to.contain(name);
 
   page.close();
-  browser.close();
 }
 ```
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/locator/dispatchevent.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/locator/dispatchevent.md
@@ -9,11 +9,11 @@ Dispatches HTML DOM event types e.g. `'click'`.
 
 <TableWithNestedRows>
 
-| Parameter       | Type   | Defaults | Description                                                                                                                                                                                                                                                   |
-| --------------- | ------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| type            | string | `''`     | DOM event type e.g. `'click'`.                                                                                                                                                                                                                                |
-| eventInit       | object | `null`   | Optional event specific properties. See [eventInit](#eventinit) for more details.                                                                                                                                                                             |
-| options         | object | `null`   |                                                                                                                                                                                                                                                               |
+| Parameter       | Type   | Defaults | Description                                                                                                                                                                                                                                                                                                                                   |
+| --------------- | ------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| type            | string | `''`     | DOM event type e.g. `'click'`.                                                                                                                                                                                                                                                                                                                |
+| eventInit       | object | `null`   | Optional event specific properties. See [eventInit](#eventinit) for more details.                                                                                                                                                                                                                                                             |
+| options         | object | `null`   |                                                                                                                                                                                                                                                                                                                                               |
 | options.timeout | number | `30000`  | Maximum time in milliseconds. Pass `0` to disable the timeout. Default is overridden by the `setDefaultTimeout` option on [BrowserContext](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext/) or [Page](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/page/). |
 
 </TableWithNestedRows>
@@ -35,15 +35,16 @@ Since eventInit is event-specific, please refer to the events documentation for 
 {{< code >}}
 
 ```javascript
-import { chromium } from 'k6/experimental/browser';
+import { browser } from 'k6/experimental/browser';
 
 export default async function () {
-  const browser = chromium.launch();
   const page = browser.newPage();
 
   await page.goto('https://test.k6.io/browser.php');
   const button = page.locator('#counter-button');
   button.dispatchEvent('click');
+
+  page.close();
 }
 ```
 

--- a/docs/sources/v0.47.x/testing-guides/load-testing-websites.md
+++ b/docs/sources/v0.47.x/testing-guides/load-testing-websites.md
@@ -190,11 +190,10 @@ The following is an example of a browser-based load testing script in k6 using t
 <!-- eslint-skip -->
 
 ```javascript
-import { chromium } from 'k6/experimental/browser';
+import { browser } from 'k6/experimental/browser';
 import { sleep } from 'k6';
 
 export default async function () {
-  const browser = chromium.launch({ headless: false });
   const page = browser.newPage();
 
   // 01. Go to the homepage
@@ -217,7 +216,6 @@ export default async function () {
     sleep(1);
   } finally {
     page.close();
-    browser.close();
   }
 }
 ```

--- a/docs/sources/v0.47.x/using-k6-browser/recommended-practices/page-object-model-pattern.md
+++ b/docs/sources/v0.47.x/using-k6-browser/recommended-practices/page-object-model-pattern.md
@@ -73,14 +73,13 @@ You can import the `Homepage` class within your test class and invoke the method
 {{< code >}}
 
 ```javascript
-import { chromium } from 'k6/experimental/browser';
+import { browser } from 'k6/experimental/browser';
 import { expect } from 'https://jslib.k6.io/k6chaijs/4.3.4.0/index.js';
 
 import { Homepage } from '../pages/homepage.js';
 import { bookingData } from '../data/booking-data.js';
 
 export default async function () {
-  const browser = chromium.launch();
   const page = browser.newPage();
 
   const { name } = bookingData;
@@ -92,7 +91,6 @@ export default async function () {
   expect(homepage.getVerificationMessage()).to.contain(name);
 
   page.close();
-  browser.close();
 }
 ```
 

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/locator/dispatchevent.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/locator/dispatchevent.md
@@ -9,11 +9,11 @@ Dispatches HTML DOM event types e.g. `'click'`.
 
 <TableWithNestedRows>
 
-| Parameter       | Type   | Defaults | Description                                                                                                                                                                                                                                                   |
-| --------------- | ------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| type            | string | `''`     | DOM event type e.g. `'click'`.                                                                                                                                                                                                                                |
-| eventInit       | object | `null`   | Optional event specific properties. See [eventInit](#eventinit) for more details.                                                                                                                                                                             |
-| options         | object | `null`   |                                                                                                                                                                                                                                                               |
+| Parameter       | Type   | Defaults | Description                                                                                                                                                                                                                                                                                                                                   |
+| --------------- | ------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| type            | string | `''`     | DOM event type e.g. `'click'`.                                                                                                                                                                                                                                                                                                                |
+| eventInit       | object | `null`   | Optional event specific properties. See [eventInit](#eventinit) for more details.                                                                                                                                                                                                                                                             |
+| options         | object | `null`   |                                                                                                                                                                                                                                                                                                                                               |
 | options.timeout | number | `30000`  | Maximum time in milliseconds. Pass `0` to disable the timeout. Default is overridden by the `setDefaultTimeout` option on [BrowserContext](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext/) or [Page](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/page/). |
 
 </TableWithNestedRows>
@@ -35,15 +35,16 @@ Since eventInit is event-specific, please refer to the events documentation for 
 {{< code >}}
 
 ```javascript
-import { chromium } from 'k6/experimental/browser';
+import { browser } from 'k6/experimental/browser';
 
 export default async function () {
-  const browser = chromium.launch();
   const page = browser.newPage();
 
   await page.goto('https://test.k6.io/browser.php');
   const button = page.locator('#counter-button');
   button.dispatchEvent('click');
+
+  page.close();
 }
 ```
 

--- a/docs/sources/v0.48.x/testing-guides/load-testing-websites.md
+++ b/docs/sources/v0.48.x/testing-guides/load-testing-websites.md
@@ -190,11 +190,10 @@ The following is an example of a browser-based load testing script in k6 using t
 <!-- eslint-skip -->
 
 ```javascript
-import { chromium } from 'k6/experimental/browser';
+import { browser } from 'k6/experimental/browser';
 import { sleep } from 'k6';
 
 export default async function () {
-  const browser = chromium.launch({ headless: false });
   const page = browser.newPage();
 
   // 01. Go to the homepage
@@ -217,7 +216,6 @@ export default async function () {
     sleep(1);
   } finally {
     page.close();
-    browser.close();
   }
 }
 ```

--- a/docs/sources/v0.48.x/using-k6-browser/recommended-practices/page-object-model-pattern.md
+++ b/docs/sources/v0.48.x/using-k6-browser/recommended-practices/page-object-model-pattern.md
@@ -73,14 +73,13 @@ You can import the `Homepage` class within your test class and invoke the method
 {{< code >}}
 
 ```javascript
-import { chromium } from 'k6/experimental/browser';
+import { browser } from 'k6/experimental/browser';
 import { expect } from 'https://jslib.k6.io/k6chaijs/4.3.4.0/index.js';
 
 import { Homepage } from '../pages/homepage.js';
 import { bookingData } from '../data/booking-data.js';
 
 export default async function () {
-  const browser = chromium.launch();
   const page = browser.newPage();
 
   const { name } = bookingData;
@@ -92,7 +91,6 @@ export default async function () {
   expect(homepage.getVerificationMessage()).to.contain(name);
 
   page.close();
-  browser.close();
 }
 ```
 


### PR DESCRIPTION
<!-- 
Please make sure you have read the contribution guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md as well as the
the code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md before opening a PR.
-->

## What?

This fixes a few browser imports in the browser module examples from:

```js
import { chromium } from 'k6/experimental/browser';
```

to:

```js
import { browser } from 'k6/experimental/browser';
```

## Checklist

Please fill in this template:
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `make docs` command locally and verified that the changes look good.

Select one of these and delete the others:

If updating the documentation for the most recent release of k6: 
- [x] I have made my changes in the `docs/sources/next` folder of the documentation.
- [x] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.
- [x] I have reflected my changes in the relevant (*e.g.*  when correcting a documentation error) folders of the previous k6 versions of the documentation.
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->

If updating the documentation for the next release of k6:
- [ ] I have made my changes in the `docs/sources/next` folder of the documentation.

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->
<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->