### PR TITLE
chore: add link to release notes

### DIFF
--- a/docs/sources/next/misc/release-notes.md
+++ b/docs/sources/next/misc/release-notes.md
@@ -5,3 +5,5 @@ weight: 06
 ---
 
 # Release notes
+
+You can find the k6 release notes in the k6 GitHub repository on the [Releases page](https://github.com/grafana/k6/releases), and the "[release notes](https://github.com/grafana/k6/tree/master/release%20notes)" folder.

--- a/docs/sources/v0.47.x/misc/release-notes.md
+++ b/docs/sources/v0.47.x/misc/release-notes.md
@@ -1,7 +1,8 @@
 ---
 title: Release notes
-redirect: 'https://github.com/grafana/k6/releases'
 weight: 06
 ---
 
 # Release notes
+
+You can find the k6 release notes in the k6 GitHub repository on the [Releases page](https://github.com/grafana/k6/releases), and the "[release notes](https://github.com/grafana/k6/tree/master/release%20notes)" folder.

--- a/docs/sources/v0.48.x/misc/release-notes.md
+++ b/docs/sources/v0.48.x/misc/release-notes.md
@@ -1,7 +1,8 @@
 ---
 title: Release notes
-redirect: 'https://github.com/grafana/k6/releases'
 weight: 06
 ---
 
 # Release notes
+
+You can find the k6 release notes in the k6 GitHub repository on the [Releases page](https://github.com/grafana/k6/releases), and the "[release notes](https://github.com/grafana/k6/tree/master/release%20notes)" folder.


### PR DESCRIPTION
## What?

Update the Release notes page to include a link to the k6 repo Releases and release notes folder.

## Checklist

Please fill in this template:
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `make docs` command locally and verified that the changes look good.
- [x] I have made my changes in the `docs/sources/next` folder of the documentation.
- [x] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.
- [x] I have reflected my changes in the relevant (*e.g.*  when correcting a documentation error) folders of the previous k6 versions of the documentation.
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->