### PR TITLE
Removes redundunt sentence

### DIFF
--- a/docs/sources/next/javascript-api/k6-net-grpc/stream/_index.md
+++ b/docs/sources/next/javascript-api/k6-net-grpc/stream/_index.md
@@ -8,12 +8,11 @@ weight: 30
 
 Using a gRPC client creates a stream. The client should be connected to the server (`client.connect` called) before creating a stream.
 
-| Method                                                                                                            | Description                                                     |
-| ----------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
-Using a gRPC client creates a stream.
-| [Stream.write(message)](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-net-grpc/stream/stream-write)  | Writes a message to the stream.                                 |
+| Method                                                                                                            | Description                                                      |
+| ----------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| [Stream.write(message)](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-net-grpc/stream/stream-write)  | Writes a message to the stream.                                  |
 | [Stream.on(event, handler)](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-net-grpc/stream/stream-on) | Sets up handler functions for various events on the gRPC stream. |
-| [Stream.end()](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-net-grpc/stream/stream-end)             | Signals to the server that the client has finished sending.     |
+| [Stream.end()](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-net-grpc/stream/stream-end)             | Signals to the server that the client has finished sending.      |
 
 ### Examples
 


### PR DESCRIPTION
<!-- 
Please make sure you have read the contribution guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md as well as the
the code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md before opening a PR.
-->

## What?

Fixes https://grafana.com/docs/k6/next/javascript-api/k6-net-grpc/stream/

![image](https://github.com/grafana/k6-docs/assets/5425600/9aba8356-244a-417b-a227-0f44e525543b)


## Checklist

Please fill in this template:
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `make docs` command locally and verified that the changes look good.

Select one of these and delete the others:

If updating the documentation for the most recent release of k6: 
- [ ] I have made my changes in the `docs/sources/next` folder of the documentation.
- [ ] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.
- [ ] I have reflected my changes in the relevant (*e.g.*  when correcting a documentation error) folders of the previous k6 versions of the documentation.
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->

If updating the documentation for the next release of k6:
- [x] I have made my changes in the `docs/sources/next` folder of the documentation.

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->
<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->