### PR TITLE
Add xk6-webtransport extension to documentation

### DIFF
--- a/docs/sources/next/extensions/explore.md
+++ b/docs/sources/next/extensions/explore.md
@@ -335,6 +335,10 @@ Use the table to explore the many extensions. Questions? Feel free to join the d
         <h4>xk6-wamp</h4>
         <p>Add support for WAMP protocol</p>
     </a>
+    <a href="https://github.com/kelseyaubrecht/xk6-webtransport" target="_blank" class="nav-cards__item nav-cards__item--guide">
+        <h4>xk6-webtransport</h4>
+        <p>Add support for webtransport protocol</p>
+    </a>
     <a href="https://github.com/szkiba/xk6-yaml" target="_blank" class="nav-cards__item nav-cards__item--guide">
         <h4>xk6-yaml</h4>
         <p>Encode and decode YAML values</p>

--- a/docs/sources/v0.48.x/extensions/explore.md
+++ b/docs/sources/v0.48.x/extensions/explore.md
@@ -335,6 +335,10 @@ Use the table to explore the many extensions. Questions? Feel free to join the d
         <h4>xk6-wamp</h4>
         <p>Add support for WAMP protocol</p>
     </a>
+    <a href="https://github.com/kelseyaubrecht/xk6-webtransport" target="_blank" class="nav-cards__item nav-cards__item--guide">
+        <h4>xk6-webtransport</h4>
+        <p>Add support for webtransport protocol</p>
+    </a>
     <a href="https://github.com/szkiba/xk6-yaml" target="_blank" class="nav-cards__item nav-cards__item--guide">
         <h4>xk6-yaml</h4>
         <p>Encode and decode YAML values</p>

--- a/src/data/doc-extensions/extensions.json
+++ b/src/data/doc-extensions/extensions.json
@@ -1156,6 +1156,21 @@
       "categories": ["Misc"],
       "tiers": ["Community"],
       "cloudEnabled": false
+    },
+    {
+      "name": "xk6-webtransport",
+      "description": "Add support for webtransport protocol",
+      "url": "https://github.com/kelseyaubrecht/xk6-webtransport",
+      "logo": "",
+      "author": {
+        "name": "Kelsey Aubrecht",
+        "url": "https://github.com/kelseyaubrecht"
+      },
+      "stars": "1",
+      "type": ["JavaScript"],
+      "categories": ["Messaging, Protocol"],
+      "tiers": ["Community"],
+      "cloudEnabled": false
     }
   ]
 }


### PR DESCRIPTION
<!-- 
Please make sure you have read the contribution guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md as well as the
the code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md before opening a PR.
-->

## What?

New extension to enable the use of the webtransport protocol, using webtransport-go.

## Checklist

Please fill in this template:
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `make docs` command locally and verified that the changes look good.

Select one of these and delete the others:

If updating the documentation for the most recent release of k6: 
- [x] I have made my changes in the `docs/sources/next` folder of the documentation.
- [x] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.
- [ ] I have reflected my changes in the relevant (*e.g.*  when correcting a documentation error) folders of the previous k6 versions of the documentation.
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->

If updating the documentation for the next release of k6:
- [x] I have made my changes in the `docs/sources/next` folder of the documentation.

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->
<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->