### PR TITLE
Fix misleading gRPC connection params defaults

### DIFF
--- a/docs/sources/next/javascript-api/k6-experimental/grpc/client/client-connect-connect-address-params.md
+++ b/docs/sources/next/javascript-api/k6-experimental/grpc/client/client-connect-connect-address-params.md
@@ -26,8 +26,8 @@ See [Client.close()](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-
 | `ConnectParams.reflect`         | boolean         | Whether to use the [gRPC server reflection protocol](https://github.com/grpc/grpc/blob/master/doc/server-reflection.md) when connecting.                                            |
 | `ConnectParams.reflectMetadata` | object          | Object with key-value pairs representing custom metadata the user would like to add to the reflection request.                                                                      |
 | `ConnectParams.timeout`         | string / number | Connection timeout to use. Default timeout is `"60s"`. <br/> The type can also be a number, in which case k6 interprets it as milliseconds, e.g., `60000` is equivalent to `"60s"`. |
-| `ConnectParams.maxReceiveSize`  | number          | Sets the maximum message size in bytes the client can receive. Defaults to 0.                                                                                                       |
-| `ConnectParams.maxSendSize`     | number          | Sets the maximum message size in bytes the client can send. Defaults to 0.                                                                                                          |
+| `ConnectParams.maxReceiveSize`  | number          | Sets the maximum message size in bytes the client can receive. Defaults to `grpc-go` default, which is 4MB.                                                                         |
+| `ConnectParams.maxSendSize`     | number          | Sets the maximum message size in bytes the client can send. Defaults to `grpc-go` default, which is approximately 2GB.                                                              |
 | `ConnectParams.tls` (optional)  | object          | [TLS](#tls) settings of the connection. Defaults to `null`.                                                                                                                         |
 
 ## TLS

--- a/docs/sources/next/javascript-api/k6-net-grpc/client/client-connect-connect-address-params.md
+++ b/docs/sources/next/javascript-api/k6-net-grpc/client/client-connect-connect-address-params.md
@@ -24,8 +24,8 @@ See [Client.close()](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-
 | `ConnectParams.reflect`         | boolean         | Whether to use the [gRPC server reflection protocol](https://github.com/grpc/grpc/blob/master/doc/server-reflection.md) when connecting.                                            |
 | `ConnectParams.reflectMetadata` | object          | Object with key-value pairs representing custom metadata the user would like to add to the reflection request.                                                                      |
 | `ConnectParams.timeout`         | string / number | Connection timeout to use. Default timeout is `"60s"`. <br/> The type can also be a number, in which case k6 interprets it as milliseconds, e.g., `60000` is equivalent to `"60s"`. |
-| `ConnectParams.maxReceiveSize`  | number          | Sets the maximum message size in bytes the client can receive. Defaults to 0.                                                                                                       |
-| `ConnectParams.maxSendSize`     | number          | Sets the maximum message size in bytes the client can send. Defaults to 0.                                                                                                          |
+| `ConnectParams.maxReceiveSize`  | number          | Sets the maximum message size in bytes the client can receive. Defaults to `grpc-go` default, which is 4MB.                                                                         |
+| `ConnectParams.maxSendSize`     | number          | Sets the maximum message size in bytes the client can send. Defaults to `grpc-go` default, which is approximately 2GB.                                                              |
 | `ConnectParams.tls` (optional)  | object          | [TLS](#tls) settings of the connection. Defaults to `null`.                                                                                                                         |
 
 ## TLS

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/grpc/client/client-connect-connect-address-params.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/grpc/client/client-connect-connect-address-params.md
@@ -24,8 +24,8 @@ See [Client.close()](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-
 | `ConnectParams.reflect`         | boolean         | Whether to use the [gRPC server reflection protocol](https://github.com/grpc/grpc/blob/master/doc/server-reflection.md) when connecting.                                            |
 | `ConnectParams.reflectMetadata` | object          | Object with key-value pairs representing custom metadata the user would like to add to the reflection request.                                                                      |
 | `ConnectParams.timeout`         | string / number | Connection timeout to use. Default timeout is `"60s"`. <br/> The type can also be a number, in which case k6 interprets it as milliseconds, e.g., `60000` is equivalent to `"60s"`. |
-| `ConnectParams.maxReceiveSize`  | number          | Sets the maximum message size in bytes the client can receive. Defaults to 0.                                                                                                       |
-| `ConnectParams.maxSendSize`     | number          | Sets the maximum message size in bytes the client can send. Defaults to 0.                                                                                                          |
+| `ConnectParams.maxReceiveSize`  | number          | Sets the maximum message size in bytes the client can receive. Defaults to `grpc-go` default, which is 4MB.                                                                         |
+| `ConnectParams.maxSendSize`     | number          | Sets the maximum message size in bytes the client can send. Defaults to `grpc-go` default, which is approximately 2GB.                                                              |
 | `ConnectParams.tls` (optional)  | object          | [TLS](#tls) settings of the connection. Defaults to `null`.                                                                                                                         |
 
 ## TLS

--- a/docs/sources/v0.47.x/javascript-api/k6-net-grpc/client/client-connect-connect-address-params.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-net-grpc/client/client-connect-connect-address-params.md
@@ -24,8 +24,8 @@ See [Client.close()](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-
 | `ConnectParams.reflect`         | boolean         | Whether to use the [gRPC server reflection protocol](https://github.com/grpc/grpc/blob/master/doc/server-reflection.md) when connecting.                                            |
 | `ConnectParams.reflectMetadata` | object          | Object with key-value pairs representing custom metadata the user would like to add to the reflection request.                                                                      |
 | `ConnectParams.timeout`         | string / number | Connection timeout to use. Default timeout is `"60s"`. <br/> The type can also be a number, in which case k6 interprets it as milliseconds, e.g., `60000` is equivalent to `"60s"`. |
-| `ConnectParams.maxReceiveSize`  | number          | Sets the maximum message size in bytes the client can receive. Defaults to 0.                                                                                                       |
-| `ConnectParams.maxSendSize`     | number          | Sets the maximum message size in bytes the client can send. Defaults to 0.                                                                                                          |
+| `ConnectParams.maxReceiveSize`  | number          | Sets the maximum message size in bytes the client can receive. Defaults to `grpc-go` default, which is 4MB.                                                                         |
+| `ConnectParams.maxSendSize`     | number          | Sets the maximum message size in bytes the client can send. Defaults to `grpc-go` default, which is approximately 2GB.                                                              |
 | `ConnectParams.tls` (optional)  | object          | [TLS](#tls) settings of the connection. Defaults to `null`.                                                                                                                         |
 
 ## TLS

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/grpc/client/client-connect-connect-address-params.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/grpc/client/client-connect-connect-address-params.md
@@ -24,8 +24,8 @@ See [Client.close()](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-
 | `ConnectParams.reflect`         | boolean         | Whether to use the [gRPC server reflection protocol](https://github.com/grpc/grpc/blob/master/doc/server-reflection.md) when connecting.                                            |
 | `ConnectParams.reflectMetadata` | object          | Object with key-value pairs representing custom metadata the user would like to add to the reflection request.                                                                      |
 | `ConnectParams.timeout`         | string / number | Connection timeout to use. Default timeout is `"60s"`. <br/> The type can also be a number, in which case k6 interprets it as milliseconds, e.g., `60000` is equivalent to `"60s"`. |
-| `ConnectParams.maxReceiveSize`  | number          | Sets the maximum message size in bytes the client can receive. Defaults to 0.                                                                                                       |
-| `ConnectParams.maxSendSize`     | number          | Sets the maximum message size in bytes the client can send. Defaults to 0.                                                                                                          |
+| `ConnectParams.maxReceiveSize`  | number          | Sets the maximum message size in bytes the client can receive. Defaults to `grpc-go` default, which is 4MB.                                                                         |
+| `ConnectParams.maxSendSize`     | number          | Sets the maximum message size in bytes the client can send. Defaults to `grpc-go` default, which is approximately 2GB.                                                              |
 | `ConnectParams.tls` (optional)  | object          | [TLS](#tls) settings of the connection. Defaults to `null`.                                                                                                                         |
 
 ## TLS

--- a/docs/sources/v0.48.x/javascript-api/k6-net-grpc/client/client-connect-connect-address-params.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-net-grpc/client/client-connect-connect-address-params.md
@@ -24,8 +24,8 @@ See [Client.close()](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-
 | `ConnectParams.reflect`         | boolean         | Whether to use the [gRPC server reflection protocol](https://github.com/grpc/grpc/blob/master/doc/server-reflection.md) when connecting.                                            |
 | `ConnectParams.reflectMetadata` | object          | Object with key-value pairs representing custom metadata the user would like to add to the reflection request.                                                                      |
 | `ConnectParams.timeout`         | string / number | Connection timeout to use. Default timeout is `"60s"`. <br/> The type can also be a number, in which case k6 interprets it as milliseconds, e.g., `60000` is equivalent to `"60s"`. |
-| `ConnectParams.maxReceiveSize`  | number          | Sets the maximum message size in bytes the client can receive. Defaults to 0.                                                                                                       |
-| `ConnectParams.maxSendSize`     | number          | Sets the maximum message size in bytes the client can send. Defaults to 0.                                                                                                          |
+| `ConnectParams.maxReceiveSize`  | number          | Sets the maximum message size in bytes the client can receive. Defaults to `grpc-go` default, which is 4MB.                                                                         |
+| `ConnectParams.maxSendSize`     | number          | Sets the maximum message size in bytes the client can send. Defaults to `grpc-go` default, which is approximately 2GB.                                                              |
 | `ConnectParams.tls` (optional)  | object          | [TLS](#tls) settings of the connection. Defaults to `null`.                                                                                                                         |
 
 ## TLS

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/grpc/client/client-connect-connect-address-params.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/grpc/client/client-connect-connect-address-params.md
@@ -26,8 +26,8 @@ See [Client.close()](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-
 | `ConnectParams.reflect`         | boolean         | Whether to use the [gRPC server reflection protocol](https://github.com/grpc/grpc/blob/master/doc/server-reflection.md) when connecting.                                            |
 | `ConnectParams.reflectMetadata` | object          | Object with key-value pairs representing custom metadata the user would like to add to the reflection request.                                                                      |
 | `ConnectParams.timeout`         | string / number | Connection timeout to use. Default timeout is `"60s"`. <br/> The type can also be a number, in which case k6 interprets it as milliseconds, e.g., `60000` is equivalent to `"60s"`. |
-| `ConnectParams.maxReceiveSize`  | number          | Sets the maximum message size in bytes the client can receive. Defaults to 0.                                                                                                       |
-| `ConnectParams.maxSendSize`     | number          | Sets the maximum message size in bytes the client can send. Defaults to 0.                                                                                                          |
+| `ConnectParams.maxReceiveSize`  | number          | Sets the maximum message size in bytes the client can receive. Defaults to `grpc-go` default, which is 4MB.                                                                         |
+| `ConnectParams.maxSendSize`     | number          | Sets the maximum message size in bytes the client can send. Defaults to `grpc-go` default, which is approximately 2GB.                                                              |
 | `ConnectParams.tls` (optional)  | object          | [TLS](#tls) settings of the connection. Defaults to `null`.                                                                                                                         |
 
 ## TLS

--- a/docs/sources/v0.49.x/javascript-api/k6-net-grpc/client/client-connect-connect-address-params.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-net-grpc/client/client-connect-connect-address-params.md
@@ -24,8 +24,8 @@ See [Client.close()](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-
 | `ConnectParams.reflect`         | boolean         | Whether to use the [gRPC server reflection protocol](https://github.com/grpc/grpc/blob/master/doc/server-reflection.md) when connecting.                                            |
 | `ConnectParams.reflectMetadata` | object          | Object with key-value pairs representing custom metadata the user would like to add to the reflection request.                                                                      |
 | `ConnectParams.timeout`         | string / number | Connection timeout to use. Default timeout is `"60s"`. <br/> The type can also be a number, in which case k6 interprets it as milliseconds, e.g., `60000` is equivalent to `"60s"`. |
-| `ConnectParams.maxReceiveSize`  | number          | Sets the maximum message size in bytes the client can receive. Defaults to 0.                                                                                                       |
-| `ConnectParams.maxSendSize`     | number          | Sets the maximum message size in bytes the client can send. Defaults to 0.                                                                                                          |
+| `ConnectParams.maxReceiveSize`  | number          | Sets the maximum message size in bytes the client can receive. Defaults to `grpc-go` default, which is 4MB.                                                                         |
+| `ConnectParams.maxSendSize`     | number          | Sets the maximum message size in bytes the client can send. Defaults to `grpc-go` default, which is approximately 2GB.                                                              |
 | `ConnectParams.tls` (optional)  | object          | [TLS](#tls) settings of the connection. Defaults to `null`.                                                                                                                         |
 
 ## TLS


### PR DESCRIPTION
<!-- 
Please make sure you have read the contribution guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md as well as the
the code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md before opening a PR.
-->

## What?

This change fixes the misleading "Defaults" for the grpc's connection params.

* `MaxCallRecvMsgSize` https://github.com/grafana/k6/blob/master/vendor/google.golang.org/grpc/rpc_util.go#L334-L336
* `MaxCallSendMsgSize` https://github.com/grafana/k6/blob/master/vendor/google.golang.org/grpc/rpc_util.go#L358-L360

## Checklist

Please fill in this template:
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `make docs` command locally and verified that the changes look good.

Select one of these and delete the others:

If updating the documentation for the most recent release of k6: 
- [x] I have made my changes in the `docs/sources/next` folder of the documentation.
- [x] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.
- [x] I have reflected my changes in the relevant (*e.g.*  when correcting a documentation error) folders of the previous k6 versions of the documentation.
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->

If updating the documentation for the next release of k6:
- [x] I have made my changes in the `docs/sources/next` folder of the documentation.

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->
Closes #1434

<!-- Thanks for your contribution! 🙏🏼 -->