### PR TITLE
Add links to the `k6 data collection pipeline` blog in `Read more` sections

### DIFF
--- a/docs/sources/next/results-output/_index.md
+++ b/docs/sources/next/results-output/_index.md
@@ -23,3 +23,4 @@ If you stream your metrics, you can either write them to a file, like JSON, or s
 - [Web dashboard](https://grafana.com/docs/k6/<K6_VERSION>/results-output/web-dashboard)
 - [Ways to visualize k6 results](https://k6.io/blog/ways-to-visualize-k6-results/)
 - [Build an output extension](https://grafana.com/docs/k6/<K6_VERSION>/extensions/create/output-extensions)
+- [k6 data collection pipeline](https://grafana.com/blog/2023/08/10/understanding-grafana-k6-a-simple-guide-to-the-load-testing-tool/)

--- a/docs/sources/next/results-output/real-time/_index.md
+++ b/docs/sources/next/results-output/real-time/_index.md
@@ -50,3 +50,4 @@ This list applies to local tests, not to [cloud tests](https://grafana.com/docs/
 ## Read more
 
 - [Ways to visualize k6 results](https://k6.io/blog/ways-to-visualize-k6-results/)
+- [k6 data collection pipeline](https://grafana.com/blog/2023/08/10/understanding-grafana-k6-a-simple-guide-to-the-load-testing-tool/)

--- a/docs/sources/v0.47.x/results-output/_index.md
+++ b/docs/sources/v0.47.x/results-output/_index.md
@@ -22,3 +22,4 @@ If you stream your metrics, you can either write them to a file, like JSON, or s
 - [Real time results](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time)
 - [Ways to visualize k6 results](https://k6.io/blog/ways-to-visualize-k6-results/)
 - [Build an output extension](https://grafana.com/docs/k6/<K6_VERSION>/extensions/create/output-extensions)
+- [k6 data collection pipeline](https://grafana.com/blog/2023/08/10/understanding-grafana-k6-a-simple-guide-to-the-load-testing-tool/)

--- a/docs/sources/v0.47.x/results-output/real-time/_index.md
+++ b/docs/sources/v0.47.x/results-output/real-time/_index.md
@@ -50,3 +50,4 @@ This list applies to local tests, not to [cloud tests](https://grafana.com/docs/
 ## Read more
 
 - [Ways to visualize k6 results](https://k6.io/blog/ways-to-visualize-k6-results/)
+- [k6 data collection pipeline](https://grafana.com/blog/2023/08/10/understanding-grafana-k6-a-simple-guide-to-the-load-testing-tool/)

--- a/docs/sources/v0.48.x/results-output/_index.md
+++ b/docs/sources/v0.48.x/results-output/_index.md
@@ -22,3 +22,4 @@ If you stream your metrics, you can either write them to a file, like JSON, or s
 - [Real time results](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time)
 - [Ways to visualize k6 results](https://k6.io/blog/ways-to-visualize-k6-results/)
 - [Build an output extension](https://grafana.com/docs/k6/<K6_VERSION>/extensions/create/output-extensions)
+- [k6 data collection pipeline](https://grafana.com/blog/2023/08/10/understanding-grafana-k6-a-simple-guide-to-the-load-testing-tool/)

--- a/docs/sources/v0.48.x/results-output/real-time/_index.md
+++ b/docs/sources/v0.48.x/results-output/real-time/_index.md
@@ -50,3 +50,4 @@ This list applies to local tests, not to [cloud tests](https://grafana.com/docs/
 ## Read more
 
 - [Ways to visualize k6 results](https://k6.io/blog/ways-to-visualize-k6-results/)
+- [k6 data collection pipeline](https://grafana.com/blog/2023/08/10/understanding-grafana-k6-a-simple-guide-to-the-load-testing-tool/)

--- a/docs/sources/v0.49.x/results-output/_index.md
+++ b/docs/sources/v0.49.x/results-output/_index.md
@@ -23,3 +23,4 @@ If you stream your metrics, you can either write them to a file, like JSON, or s
 - [Web dashboard](https://grafana.com/docs/k6/<K6_VERSION>/results-output/web-dashboard)
 - [Ways to visualize k6 results](https://k6.io/blog/ways-to-visualize-k6-results/)
 - [Build an output extension](https://grafana.com/docs/k6/<K6_VERSION>/extensions/create/output-extensions)
+- [k6 data collection pipeline](https://grafana.com/blog/2023/08/10/understanding-grafana-k6-a-simple-guide-to-the-load-testing-tool/)

--- a/docs/sources/v0.49.x/results-output/real-time/_index.md
+++ b/docs/sources/v0.49.x/results-output/real-time/_index.md
@@ -50,3 +50,4 @@ This list applies to local tests, not to [cloud tests](https://grafana.com/docs/
 ## Read more
 
 - [Ways to visualize k6 results](https://k6.io/blog/ways-to-visualize-k6-results/)
+- [k6 data collection pipeline](https://grafana.com/blog/2023/08/10/understanding-grafana-k6-a-simple-guide-to-the-load-testing-tool/)


### PR DESCRIPTION

Add links to the [k6 data collection pipeline blog](https://grafana.com/blog/2023/08/10/understanding-grafana-k6-a-simple-guide-to-the-load-testing-tool) in the `Read more` sections of the Results output docs

## Checklist

Please fill in this template:
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `make docs` command locally and verified that the changes look good.

## Related PR(s)/Issue(s)

[Issue: Explain the k6 architecture](https://github.com/grafana/k6-docs/issues/148)

