### PR TITLE
Stop promoting k6/experimental/grpc

### DIFF
--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/grpc/_index.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/grpc/_index.md
@@ -7,7 +7,7 @@ weight: 02
 
 # grpc
 
-{{< docs/shared source="k6" lookup="experimental-module.md" version="<K6_VERSION>" >}}
+{{< docs/shared source="k6" lookup="experimental-grpc-module.md" version="<K6_VERSION>" >}}
 
 The `k6/experimental/grpc` module is an extension of the [`k6/net/grpc`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-net-grpc). It provides a [gRPC](https://grpc.io/) client for Remote Procedure Calls (RPC) over HTTP/2.
 

--- a/docs/sources/v0.47.x/shared/experimental-grpc-module.md
+++ b/docs/sources/v0.47.x/shared/experimental-grpc-module.md
@@ -1,0 +1,11 @@
+---
+title: Experimental grpc module admonition
+---
+
+{{% admonition type="caution" %}}
+
+Starting on k6 `v0.49`, the experimental module `k6/experimental/grpc` has been graduated, and its functionality is now available in the [`k6/net/grpc` module](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-net-grpc/). The `k6/experimental/grpc` is deprecated and will be removed in `v0.51.0`.
+
+To migrate your scripts, replace all `k6/experimental/grpc` imports with `k6/net/grpc`.
+
+{{% /admonition %}}

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/grpc/_index.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/grpc/_index.md
@@ -7,7 +7,7 @@ weight: 02
 
 # grpc
 
-{{< docs/shared source="k6" lookup="experimental-module.md" version="<K6_VERSION>" >}}
+{{< docs/shared source="k6" lookup="experimental-grpc-module.md" version="<K6_VERSION>" >}}
 
 The `k6/experimental/grpc` module is an extension of the [`k6/net/grpc`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-net-grpc). It provides a [gRPC](https://grpc.io/) client for Remote Procedure Calls (RPC) over HTTP/2.
 

--- a/docs/sources/v0.48.x/shared/experimental-grpc-module.md
+++ b/docs/sources/v0.48.x/shared/experimental-grpc-module.md
@@ -1,0 +1,11 @@
+---
+title: Experimental grpc module admonition
+---
+
+{{% admonition type="caution" %}}
+
+Starting on k6 `v0.49`, the experimental module `k6/experimental/grpc` has been graduated, and its functionality is now available in the [`k6/net/grpc` module](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-net-grpc/). The `k6/experimental/grpc` is deprecated and will be removed in `v0.51.0`.
+
+To migrate your scripts, replace all `k6/experimental/grpc` imports with `k6/net/grpc`.
+
+{{% /admonition %}}


### PR DESCRIPTION
<!-- 
Please make sure you have read the contribution guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md as well as the
the code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md before opening a PR.
-->

## What?

In k6 v0.49, we graduated the experimental gRPC module, and we're going to remove it. So this change warns customers (it's already part of the v0.49 see https://grafana.com/docs/k6/v0.49.x/javascript-api/k6-experimental/grpc/).

## Checklist

Please fill in this template:
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `make docs` command locally and verified that the changes look good.

Select one of these and delete the others:

If updating the documentation for the most recent release of k6: 
- [ ] I have made my changes in the `docs/sources/next` folder of the documentation.
- [ ] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.
- [ ] I have reflected my changes in the relevant (*e.g.*  when correcting a documentation error) folders of the previous k6 versions of the documentation.
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->

If updating the documentation for the next release of k6:
- [ ] I have made my changes in the `docs/sources/next` folder of the documentation.

## Related PR(s)/Issue(s)

https://github.com/grafana/k6-docs/pull/1472

<!-- Does it close an issue? -->
Closes #1473

<!-- Thanks for your contribution! 🙏🏼 -->