### PR TITLE
chore: add minimum test duration for report to display graphs

### DIFF
--- a/docs/sources/next/results-output/web-dashboard/_index.md
+++ b/docs/sources/next/results-output/web-dashboard/_index.md
@@ -39,9 +39,9 @@ By default, the web dashboard is available on localhost port `5665`. You can cha
 
 {{% admonition type="note" %}}
 
-The k6 process waits to exit as long as there is at least one open browser window for the dashboard extension. In this way, the report can be downloaded, for example, even after the test has been completed.
+The k6 process waits to exit as long as there's at least one open browser window for the dashboard extension.
 
-In certain environments, it is not allowed that the k6 process does not exit after the test run (_e.g_ CI/CD pipeline). In this case, it is advisable to disable the HTTP port (with the `-1` value of port parameter).
+In certain environments, such as a CI/CD pipeline, the k6 process has to exit after the test run completes. In that case, it's advisable to disable the HTTP port by setting it to `-1`.
 
 {{% /admonition %}}
 
@@ -64,6 +64,8 @@ To automatically generate a report from the command line once the test finishes 
 ```shell
 K6_WEB_DASHBOARD=true K6_WEB_DASHBOARD_EXPORT=html-report.html k6 run script.js
 ```
+
+The report only includes graphs if the test duration is over thirty seconds.
 
 ## Dashboard options
 


### PR DESCRIPTION
## What?

Add the minimum test duration required for graphs to be displayed in the report generated by the web dashboard feature.

## Checklist

Please fill in this template:
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `make docs` command locally and verified that the changes look good.

If updating the documentation for the most recent release of k6: 
- [ ] I have made my changes in the `docs/sources/next` folder of the documentation.
- [ ] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.
- [ ] I have reflected my changes in the relevant (*e.g.*  when correcting a documentation error) folders of the previous k6 versions of the documentation.
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->

If updating the documentation for the next release of k6:
- [ ] I have made my changes in the `docs/sources/next` folder of the documentation.

## Related PR(s)/Issue(s)

Closes #1499.