### PR TITLE
chore: remove null return value from page.$$ docs

### DIFF
--- a/docs/sources/next/javascript-api/k6-experimental/browser/page/doubledollar.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/page/doubledollar.md
@@ -16,9 +16,9 @@ The method finds all elements matching the specified selector within the page. I
 
 ### Returns
 
-| Type                                                                                                                      | Description                                                                                    |
-| ------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| null \| [ElementHandle](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/elementhandle/)[] | Returns an array of `ElementHandle` when multiple elements are found. Else, it returns `null`. |
+| Type                                                                                                              | Description                       |
+| ----------------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| [ElementHandle](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/elementhandle/)[] | Returns an `ElementHandle` array. |
 
 ### Example
 

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/doubledollar.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/doubledollar.md
@@ -16,9 +16,9 @@ The method finds all elements matching the specified selector within the page. I
 
 ### Returns
 
-| Type                                                                                                                      | Description                                                                                    |
-| ------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| null \| [ElementHandle](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/elementhandle/)[] | Returns an array of `ElementHandle` when multiple elements are found. Else, it returns `null`. |
+| Type                                                                                                              | Description                       |
+| ----------------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| [ElementHandle](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/elementhandle/)[] | Returns an `ElementHandle` array. |
 
 ### Example
 


### PR DESCRIPTION
## What?

The browser module `page.$$` method returns an empty array when it can't find any elements, not a `null` value.

## Checklist

Please fill in this template:
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `make docs` command locally and verified that the changes look good.
- [x] I have made my changes in the `docs/sources/next` folder of the documentation.
- [x] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.
- [x] I have reflected my changes in the relevant (*e.g.*  when correcting a documentation error) folders of the previous k6 versions of the documentation.
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->