### PR TITLE
chore: remove linkinator GitHub Action

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -128,25 +128,3 @@ jobs:
         run: aws --version
       - name: Deploy
         run: npm run deploy
-  linkinator:
-    name: "Checks broken links"
-    runs-on: ubuntu-latest
-    needs: [build-deploy-staging]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: JustinBeckwith/linkinator-action@225a937c02e8c0916755289a02594a9105a3cbd8 # latest commit with node 20 support
-        with:
-          paths: ${{ env.GATSBY_DEFAULT_DOC_URL }}
-          concurrency: 50
-          recurse: true
-          retry: true
-          skip: ".*(\\.js|\\.css)$"
-          linksToSkip: >-
-            localhost,
-            https://linkedin.com,
-            googleapis.com,
-            https://www.linkedin.com/company/k6io,
-            https://staging.k6.io/slack,
-            https://twitter.com/k6_io
-          verbosity: "ERROR"
-          markdown: false


### PR DESCRIPTION
## What?

Remove the linkinator GitHub Action from the staging workflow. Because the staging workflow is still running based on the legacy Gatsby build, it's been giving us false positives.

On the Grafana side, the team runs a check on all the links and the technical writer gets notified when a link is broken. But once we have a staging environment for the Grafana version of the docs, we can re-enable this.

## Checklist

Please fill in this template:
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `make docs` command locally and verified that the changes look good.