### PR TITLE
chore: add DOCS_IMAGE to variables.mk

### DIFF
--- a/docs/variables.mk
+++ b/docs/variables.mk
@@ -7,3 +7,4 @@
 # This overrides the default behavior of assuming the repository directory is the same as the project name.
 PROJECTS := k6:UNVERSIONED:$(notdir $(basename $(shell git rev-parse --show-toplevel)))
 export WEBSITE_MOUNTS := true
+export DOCS_IMAGE := grafana/docs-base:2024-01-30


### PR DESCRIPTION
## What?

Add `DOCS_IMAGE` variable to `variables.mk` file to set the default Docker image to use when running the `make docs` command.

## Checklist

Please fill in this template:
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `make docs` command locally and verified that the changes look good.