### PR TITLE
Examples: fix `jslib` link

### DIFF
--- a/docs/sources/next/examples/url-query-parameters.md
+++ b/docs/sources/next/examples/url-query-parameters.md
@@ -6,7 +6,7 @@ weight: 21
 
 # URLs with query parameters
 
-How to use **URL** and **URLSearchParams** imported from [jslib.k6.io](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/modules#the-jslib-repository) to construct URLs with/without query parameters.
+How to use **URL** and **URLSearchParams** imported from [jslib.k6.io](https://jslib.k6.io/) to construct URLs with/without query parameters.
 
 ## URL
 

--- a/docs/sources/v0.47.x/examples/url-query-parameters.md
+++ b/docs/sources/v0.47.x/examples/url-query-parameters.md
@@ -6,7 +6,7 @@ weight: 21
 
 # URLs with query parameters
 
-How to use **URL** and **URLSearchParams** imported from [jslib.k6.io](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/modules#the-jslib-repository) to construct URLs with/without query parameters.
+How to use **URL** and **URLSearchParams** imported from [jslib.k6.io](https://jslib.k6.io/) to construct URLs with/without query parameters.
 
 ## URL
 

--- a/docs/sources/v0.48.x/examples/url-query-parameters.md
+++ b/docs/sources/v0.48.x/examples/url-query-parameters.md
@@ -6,7 +6,7 @@ weight: 21
 
 # URLs with query parameters
 
-How to use **URL** and **URLSearchParams** imported from [jslib.k6.io](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/modules#the-jslib-repository) to construct URLs with/without query parameters.
+How to use **URL** and **URLSearchParams** imported from [jslib.k6.io](https://jslib.k6.io/) to construct URLs with/without query parameters.
 
 ## URL
 

--- a/docs/sources/v0.49.x/examples/url-query-parameters.md
+++ b/docs/sources/v0.49.x/examples/url-query-parameters.md
@@ -6,7 +6,7 @@ weight: 21
 
 # URLs with query parameters
 
-How to use **URL** and **URLSearchParams** imported from [jslib.k6.io](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/modules#the-jslib-repository) to construct URLs with/without query parameters.
+How to use **URL** and **URLSearchParams** imported from [jslib.k6.io](https://jslib.k6.io/) to construct URLs with/without query parameters.
 
 ## URL
 


### PR DESCRIPTION
Examples: fix `jslib` link