### PR TITLE
Add setInputFiles local file example

### DIFF
--- a/docs/sources/next/javascript-api/k6-experimental/browser/elementhandle/setinputfiles.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/elementhandle/setinputfiles.md
@@ -44,7 +44,7 @@ export default async function () {
   const page = browser.newPage();
 
   // In this example we create a simple web page with an upload input field.
-  // Usually you would use page.goto to navigate to a page with an file input field.
+  // Usually, you would use page.goto to navigate to a page with a file input field.
   page.setContent(`
     <html>
       <head></head>
@@ -104,7 +104,7 @@ export default async function () {
   const page = browser.newPage();
 
   // In this example we create a simple web page with an upload input field.
-  // Usually you would use page.goto to navigate to a page with an file input field.
+  // Usually, you would use page.goto to navigate to a page with a file input field.
   page.setContent(`
     <html>
       <head></head>

--- a/docs/sources/next/javascript-api/k6-experimental/browser/elementhandle/setinputfiles.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/elementhandle/setinputfiles.md
@@ -43,30 +43,32 @@ export const options = {
 export default async function () {
   const page = browser.newPage();
 
-  // In this example we create a simple web page with an upload input field.
-  // Usually, you would use page.goto to navigate to a page with a file input field.
-  page.setContent(`
-    <html>
-      <head></head>
-      <body>
-          <!-- Simple file upload form -->
-          <form method="POST" action="/upload" enctype="multipart/form-data">
-              <input type="file" id="upload" multiple />
-              <input type="submit" value="Send" />
-          </form>
-      </body>
-    </html>`);
+  try {
+    // In this example we create a simple web page with an upload input field.
+    // Usually, you would use page.goto to navigate to a page with a file input field.
+    page.setContent(`
+      <html>
+        <head></head>
+        <body>
+            <!-- Simple file upload form -->
+            <form method="POST" action="/upload" enctype="multipart/form-data">
+                <input type="file" id="upload" multiple />
+                <input type="submit" value="Send" />
+            </form>
+        </body>
+      </html>`);
 
-  const eh = page.$('input[id="upload"]');
+    const eh = page.$('input[id="upload"]');
 
-  // The file is set to the input element with the id "upload".
-  eh.setInputFiles({
-    name: 'file.txt',
-    mimetype: 'text/plain',
-    buffer: encoding.b64encode('hello world'),
-  });
-
-  page.close();
+    // The file is set to the input element with the id "upload".
+    eh.setInputFiles({
+      name: 'file.txt',
+      mimetype: 'text/plain',
+      buffer: encoding.b64encode('hello world'),
+    });
+  } finally {
+    page.close();
+  }
 }
 ```
 
@@ -103,33 +105,35 @@ let file;
 export default async function () {
   const page = browser.newPage();
 
-  // In this example we create a simple web page with an upload input field.
-  // Usually, you would use page.goto to navigate to a page with a file input field.
-  page.setContent(`
-    <html>
-      <head></head>
-      <body>
-          <!-- Simple file upload form -->
-          <form method="POST" action="/upload" enctype="multipart/form-data">
-              <input type="file" id="upload" multiple />
-              <input type="submit" value="Send" />
-          </form>
-      </body>
-    </html>`);
+  try {
+    // In this example we create a simple web page with an upload input field.
+    // Usually, you would use page.goto to navigate to a page with a file input field.
+    page.setContent(`
+      <html>
+        <head></head>
+        <body>
+            <!-- Simple file upload form -->
+            <form method="POST" action="/upload" enctype="multipart/form-data">
+                <input type="file" id="upload" multiple />
+                <input type="submit" value="Send" />
+            </form>
+        </body>
+      </html>`);
 
-  const eh = page.$('input[id="upload"]');
+    const eh = page.$('input[id="upload"]');
 
-  // Read the whole file content into a buffer.
-  const buffer = await readAll(file);
+    // Read the whole file content into a buffer.
+    const buffer = await readAll(file);
 
-  // The file is set to the input element with the id "upload".
-  eh.setInputFiles({
-    name: 'file.txt',
-    mimetype: 'text/plain',
-    buffer: encoding.b64encode(buffer),
-  });
-
-  page.close();
+    // The file is set to the input element with the id "upload".
+    eh.setInputFiles({
+      name: 'file.txt',
+      mimetype: 'text/plain',
+      buffer: encoding.b64encode(buffer),
+    });
+  } finally {
+    page.close();
+  }
 }
 
 // readAll will read the whole of the file from the local filesystem into a

--- a/docs/sources/next/javascript-api/k6-experimental/browser/elementhandle/setinputfiles.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/elementhandle/setinputfiles.md
@@ -11,15 +11,15 @@ To work with local files on the file system, use the [experimental fs module](ht
 
 | Parameter           | Type        | Default | Description                                                                                                                                                                                                                                                                                                                                   |
 | ------------------- | ----------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| file                | object      | `null`  | This is a required parameter.                                                                                                                                                                                                                                                                                                                |
-| file.name           | string      | `''`    | The name of the file. For example, `file.txt`.                                                                                                                                                                                                                                                                                                         |
-| file.mimeType       | string      | `''`    | The type of the file content. For example, `text/plain`.                                                                                                                                                                                                                                                                                               |
+| file                | object      | `null`  | This is a required parameter.                                                                                                                                                                                                                                                                                                                 |
+| file.name           | string      | `''`    | The name of the file. For example, `file.txt`.                                                                                                                                                                                                                                                                                                |
+| file.mimeType       | string      | `''`    | The type of the file content. For example, `text/plain`.                                                                                                                                                                                                                                                                                      |
 | file.buffer         | ArrayBuffer | `[]`    | Base64 encoded content of the file.                                                                                                                                                                                                                                                                                                           |
 | options             | object      | `null`  | This is an optional parameter.                                                                                                                                                                                                                                                                                                                |
 | options.noWaitAfter | boolean     | `false` | If set to `true` and a navigation occurs from performing this action, it will not wait for it to complete.                                                                                                                                                                                                                                    |
 | options.timeout     | number      | `30000` | Maximum time in milliseconds. Pass `0` to disable the timeout. Default is overridden by the `setDefaultTimeout` option on [BrowserContext](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext/) or [Page](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/page/). |
 
-### Example
+### Inline File Example
 
 {{< code >}}
 
@@ -44,6 +44,7 @@ export default async function () {
   const page = browser.newPage();
 
   // In this example we create a simple web page with an upload input field.
+  // Usually you would use page.goto to navigate to a page with an file input field.
   page.setContent(`
     <html>
       <head></head>
@@ -66,6 +67,83 @@ export default async function () {
   });
 
   page.close();
+}
+```
+
+{{< /code >}}
+
+### Local File Example
+
+{{< code >}}
+
+```javascript
+import { browser } from 'k6/experimental/browser';
+import encoding from 'k6/encoding';
+import { open } from 'k6/experimental/fs';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+          type: 'chromium',
+        },
+      },
+    },
+  },
+};
+
+// Declare the location of the file on the local filesystem.
+let file;
+(async function () {
+  file = await open('/abs/path/to/file.txt');
+})();
+
+export default async function () {
+  const page = browser.newPage();
+
+  // In this example we create a simple web page with an upload input field.
+  // Usually you would use page.goto to navigate to a page with an file input field.
+  page.setContent(`
+    <html>
+      <head></head>
+      <body>
+          <!-- Simple file upload form -->
+          <form method="POST" action="/upload" enctype="multipart/form-data">
+              <input type="file" id="upload" multiple />
+              <input type="submit" value="Send" />
+          </form>
+      </body>
+    </html>`);
+
+  const eh = page.$('input[id="upload"]');
+
+  // Read the whole file content into a buffer.
+  const buffer = await readAll(file);
+
+  // The file is set to the input element with the id "upload".
+  eh.setInputFiles({
+    name: 'file.txt',
+    mimetype: 'text/plain',
+    buffer: encoding.b64encode(buffer),
+  });
+
+  page.close();
+}
+
+// readAll will read the whole of the file from the local filesystem into a
+// buffer.
+async function readAll(file) {
+  const fileInfo = await file.stat();
+  const buffer = new Uint8Array(fileInfo.size);
+
+  const bytesRead = await file.read(buffer);
+  if (bytesRead !== fileInfo.size) {
+    throw new Error('unexpected number of bytes read');
+  }
+
+  return buffer;
 }
 ```
 

--- a/docs/sources/next/javascript-api/k6-experimental/browser/frame/setinputfiles.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/frame/setinputfiles.md
@@ -44,30 +44,32 @@ export const options = {
 export default async function () {
   const page = browser.newPage();
 
-  // In this example we create a simple web page with an upload input field.
-  // Usually, you would use page.goto to navigate to a page with a file input field.
-  page.setContent(`
-    <html>
-      <head></head>
-      <body>
-          <!-- Simple file upload form -->
-          <form method="POST" action="/upload" enctype="multipart/form-data">
-              <input type="file" id="upload" multiple />
-              <input type="submit" value="Send" />
-          </form>
-      </body>
-    </html>`);
+  try {
+    // In this example we create a simple web page with an upload input field.
+    // Usually, you would use page.goto to navigate to a page with a file input field.
+    page.setContent(`
+      <html>
+        <head></head>
+        <body>
+            <!-- Simple file upload form -->
+            <form method="POST" action="/upload" enctype="multipart/form-data">
+                <input type="file" id="upload" multiple />
+                <input type="submit" value="Send" />
+            </form>
+        </body>
+      </html>`);
 
-  const frame = page.mainFrame();
+    const frame = page.mainFrame();
 
-  // The file is set to the input element with the id "upload".
-  frame.setInputFiles('input[id="upload"]', {
-    name: 'file.txt',
-    mimetype: 'text/plain',
-    buffer: encoding.b64encode('hello world'),
-  });
-
-  page.close();
+    // The file is set to the input element with the id "upload".
+    frame.setInputFiles('input[id="upload"]', {
+      name: 'file.txt',
+      mimetype: 'text/plain',
+      buffer: encoding.b64encode('hello world'),
+    });
+  } finally {
+    page.close();
+  }
 }
 ```
 
@@ -104,33 +106,35 @@ let file;
 export default async function () {
   const page = browser.newPage();
 
-  // In this example we create a simple web page with an upload input field.
-  // Usually, you would use page.goto to navigate to a page with a file input field.
-  page.setContent(`
-    <html>
-      <head></head>
-      <body>
-          <!-- Simple file upload form -->
-          <form method="POST" action="/upload" enctype="multipart/form-data">
-              <input type="file" id="upload" multiple />
-              <input type="submit" value="Send" />
-          </form>
-      </body>
-    </html>`);
+  try {
+    // In this example we create a simple web page with an upload input field.
+    // Usually, you would use page.goto to navigate to a page with a file input field.
+    page.setContent(`
+      <html>
+        <head></head>
+        <body>
+            <!-- Simple file upload form -->
+            <form method="POST" action="/upload" enctype="multipart/form-data">
+                <input type="file" id="upload" multiple />
+                <input type="submit" value="Send" />
+            </form>
+        </body>
+      </html>`);
 
-  const frame = page.mainFrame();
+    const frame = page.mainFrame();
 
-  // Read the whole file content into a buffer.
-  const buffer = await readAll(file);
+    // Read the whole file content into a buffer.
+    const buffer = await readAll(file);
 
-  // The file is set to the input element with the id "upload".
-  frame.setInputFiles({
-    name: 'file.txt',
-    mimetype: 'text/plain',
-    buffer: encoding.b64encode(buffer),
-  });
-
-  page.close();
+    // The file is set to the input element with the id "upload".
+    frame.setInputFiles({
+      name: 'file.txt',
+      mimetype: 'text/plain',
+      buffer: encoding.b64encode(buffer),
+    });
+  } finally {
+    page.close();
+  }
 }
 
 // readAll will read the whole of the file from the local filesystem into a

--- a/docs/sources/next/javascript-api/k6-experimental/browser/frame/setinputfiles.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/frame/setinputfiles.md
@@ -45,7 +45,7 @@ export default async function () {
   const page = browser.newPage();
 
   // In this example we create a simple web page with an upload input field.
-  // Usually you would use page.goto to navigate to a page with an file input field.
+  // Usually, you would use page.goto to navigate to a page with a file input field.
   page.setContent(`
     <html>
       <head></head>
@@ -105,7 +105,7 @@ export default async function () {
   const page = browser.newPage();
 
   // In this example we create a simple web page with an upload input field.
-  // Usually you would use page.goto to navigate to a page with an file input field.
+  // Usually, you would use page.goto to navigate to a page with a file input field.
   page.setContent(`
     <html>
       <head></head>

--- a/docs/sources/next/javascript-api/k6-experimental/browser/frame/setinputfiles.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/frame/setinputfiles.md
@@ -12,15 +12,15 @@ To work with local files on the file system, use the [experimental fs module](ht
 | Parameter           | Type        | Default | Description                                                                                                                                                                                                                                                                                                                                   |
 | ------------------- | ----------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | selector            | string      | `''`    | A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.                                                                                                                                                                                                                          |
-| file                | object      | `null`  | This is a required parameter.                                                                                                                                                                                                                                                                                                                |
-| file.name           | string      | `''`    | The name of the file. For example, `file.txt`.                                                                                                                                                                                                                                                                                                         |
-| file.mimeType       | string      | `''`    | The type of the file content. For example, `text/plain`.                                                                                                                                                                                                                                                                                               |
+| file                | object      | `null`  | This is a required parameter.                                                                                                                                                                                                                                                                                                                 |
+| file.name           | string      | `''`    | The name of the file. For example, `file.txt`.                                                                                                                                                                                                                                                                                                |
+| file.mimeType       | string      | `''`    | The type of the file content. For example, `text/plain`.                                                                                                                                                                                                                                                                                      |
 | file.buffer         | ArrayBuffer | `[]`    | Base64 encoded content of the file.                                                                                                                                                                                                                                                                                                           |
 | options             | object      | `null`  | This is an optional parameter.                                                                                                                                                                                                                                                                                                                |
 | options.noWaitAfter | boolean     | `false` | If set to `true` and a navigation occurs from performing this action, it will not wait for it to complete.                                                                                                                                                                                                                                    |
 | options.timeout     | number      | `30000` | Maximum time in milliseconds. Pass `0` to disable the timeout. Default is overridden by the `setDefaultTimeout` option on [BrowserContext](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext/) or [Page](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/page/). |
 
-### Example
+### Inline File Example
 
 {{< code >}}
 
@@ -45,6 +45,7 @@ export default async function () {
   const page = browser.newPage();
 
   // In this example we create a simple web page with an upload input field.
+  // Usually you would use page.goto to navigate to a page with an file input field.
   page.setContent(`
     <html>
       <head></head>
@@ -67,6 +68,83 @@ export default async function () {
   });
 
   page.close();
+}
+```
+
+{{< /code >}}
+
+### Local File Example
+
+{{< code >}}
+
+```javascript
+import { browser } from 'k6/experimental/browser';
+import encoding from 'k6/encoding';
+import { open } from 'k6/experimental/fs';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+          type: 'chromium',
+        },
+      },
+    },
+  },
+};
+
+// Declare the location of the file on the local filesystem.
+let file;
+(async function () {
+  file = await open('/abs/path/to/file.txt');
+})();
+
+export default async function () {
+  const page = browser.newPage();
+
+  // In this example we create a simple web page with an upload input field.
+  // Usually you would use page.goto to navigate to a page with an file input field.
+  page.setContent(`
+    <html>
+      <head></head>
+      <body>
+          <!-- Simple file upload form -->
+          <form method="POST" action="/upload" enctype="multipart/form-data">
+              <input type="file" id="upload" multiple />
+              <input type="submit" value="Send" />
+          </form>
+      </body>
+    </html>`);
+
+  const frame = page.mainFrame();
+
+  // Read the whole file content into a buffer.
+  const buffer = await readAll(file);
+
+  // The file is set to the input element with the id "upload".
+  frame.setInputFiles({
+    name: 'file.txt',
+    mimetype: 'text/plain',
+    buffer: encoding.b64encode(buffer),
+  });
+
+  page.close();
+}
+
+// readAll will read the whole of the file from the local filesystem into a
+// buffer.
+async function readAll(file) {
+  const fileInfo = await file.stat();
+  const buffer = new Uint8Array(fileInfo.size);
+
+  const bytesRead = await file.read(buffer);
+  if (bytesRead !== fileInfo.size) {
+    throw new Error('unexpected number of bytes read');
+  }
+
+  return buffer;
 }
 ```
 

--- a/docs/sources/next/javascript-api/k6-experimental/browser/page/setinputfiles.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/page/setinputfiles.md
@@ -12,15 +12,15 @@ To work with local files on the file system, use the [experimental fs module](ht
 | Parameter           | Type        | Default | Description                                                                                                                                                                                                                                                                                                                                   |
 | ------------------- | ----------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | selector            | string      | `''`    | A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.                                                                                                                                                                                                                          |
-| file                | object      | `null`  | This is a required parameter.                                                                                                                                                                                                                                                                                                                |
-| file.name           | string      | `''`    | The name of the file. For example, `file.txt`.                                                                                                                                                                                                                                                                                                         |
-| file.mimeType       | string      | `''`    | The type of the file content. For example, `text/plain`.                                                                                                                                                                                                                                                                                               |
+| file                | object      | `null`  | This is a required parameter.                                                                                                                                                                                                                                                                                                                 |
+| file.name           | string      | `''`    | The name of the file. For example, `file.txt`.                                                                                                                                                                                                                                                                                                |
+| file.mimeType       | string      | `''`    | The type of the file content. For example, `text/plain`.                                                                                                                                                                                                                                                                                      |
 | file.buffer         | ArrayBuffer | `[]`    | Base64 encoded content of the file.                                                                                                                                                                                                                                                                                                           |
 | options             | object      | `null`  | This is an optional parameter.                                                                                                                                                                                                                                                                                                                |
 | options.noWaitAfter | boolean     | `false` | If set to `true` and a navigation occurs from performing this action, it will not wait for it to complete.                                                                                                                                                                                                                                    |
 | options.timeout     | number      | `30000` | Maximum time in milliseconds. Pass `0` to disable the timeout. Default is overridden by the `setDefaultTimeout` option on [BrowserContext](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext/) or [Page](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/page/). |
 
-### Example
+### Inline File Example
 
 {{< code >}}
 
@@ -45,6 +45,7 @@ export default async function () {
   const page = browser.newPage();
 
   // In this example we create a simple web page with an upload input field.
+  // Usually you would use page.goto to navigate to a page with an file input field.
   page.setContent(`
     <html>
       <head></head>
@@ -65,6 +66,81 @@ export default async function () {
   });
 
   page.close();
+}
+```
+
+{{< /code >}}
+
+### Local File Example
+
+{{< code >}}
+
+```javascript
+import { browser } from 'k6/experimental/browser';
+import encoding from 'k6/encoding';
+import { open } from 'k6/experimental/fs';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+          type: 'chromium',
+        },
+      },
+    },
+  },
+};
+
+// Declare the location of the file on the local filesystem.
+let file;
+(async function () {
+  file = await open('/abs/path/to/file.txt');
+})();
+
+export default async function () {
+  const page = browser.newPage();
+
+  // In this example we create a simple web page with an upload input field.
+  // Usually you would use page.goto to navigate to a page with an file input field.
+  page.setContent(`
+    <html>
+      <head></head>
+      <body>
+          <!-- Simple file upload form -->
+          <form method="POST" action="/upload" enctype="multipart/form-data">
+              <input type="file" id="upload" multiple />
+              <input type="submit" value="Send" />
+          </form>
+      </body>
+    </html>`);
+
+  // Read the whole file content into a buffer.
+  const buffer = await readAll(file);
+
+  // The file is set to the input element with the id "upload".
+  page.setInputFiles({
+    name: 'file.txt',
+    mimetype: 'text/plain',
+    buffer: encoding.b64encode(buffer),
+  });
+
+  page.close();
+}
+
+// readAll will read the whole of the file from the local filesystem into a
+// buffer.
+async function readAll(file) {
+  const fileInfo = await file.stat();
+  const buffer = new Uint8Array(fileInfo.size);
+
+  const bytesRead = await file.read(buffer);
+  if (bytesRead !== fileInfo.size) {
+    throw new Error('unexpected number of bytes read');
+  }
+
+  return buffer;
 }
 ```
 

--- a/docs/sources/next/javascript-api/k6-experimental/browser/page/setinputfiles.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/page/setinputfiles.md
@@ -44,28 +44,30 @@ export const options = {
 export default async function () {
   const page = browser.newPage();
 
-  // In this example we create a simple web page with an upload input field.
-  // Usually, you would use page.goto to navigate to a page with a file input field.
-  page.setContent(`
-    <html>
-      <head></head>
-      <body>
-          <!-- Simple file upload form -->
-          <form method="POST" action="/upload" enctype="multipart/form-data">
-              <input type="file" id="upload" multiple />
-              <input type="submit" value="Send" />
-          </form>
-      </body>
-    </html>`);
+  try {
+    // In this example we create a simple web page with an upload input field.
+    // Usually, you would use page.goto to navigate to a page with a file input field.
+    page.setContent(`
+      <html>
+        <head></head>
+        <body>
+            <!-- Simple file upload form -->
+            <form method="POST" action="/upload" enctype="multipart/form-data">
+                <input type="file" id="upload" multiple />
+                <input type="submit" value="Send" />
+            </form>
+        </body>
+      </html>`);
 
-  // The file is set to the input element with the id "upload".
-  page.setInputFiles('input[id="upload"]', {
-    name: 'file.txt',
-    mimetype: 'text/plain',
-    buffer: encoding.b64encode('hello world'),
-  });
-
-  page.close();
+    // The file is set to the input element with the id "upload".
+    page.setInputFiles('input[id="upload"]', {
+      name: 'file.txt',
+      mimetype: 'text/plain',
+      buffer: encoding.b64encode('hello world'),
+    });
+  } finally {
+    page.close();
+  }
 }
 ```
 
@@ -102,31 +104,33 @@ let file;
 export default async function () {
   const page = browser.newPage();
 
-  // In this example we create a simple web page with an upload input field.
-  // Usually, you would use page.goto to navigate to a page with a file input field.
-  page.setContent(`
-    <html>
-      <head></head>
-      <body>
-          <!-- Simple file upload form -->
-          <form method="POST" action="/upload" enctype="multipart/form-data">
-              <input type="file" id="upload" multiple />
-              <input type="submit" value="Send" />
-          </form>
-      </body>
-    </html>`);
+  try {
+    // In this example we create a simple web page with an upload input field.
+    // Usually, you would use page.goto to navigate to a page with a file input field.
+    page.setContent(`
+      <html>
+        <head></head>
+        <body>
+            <!-- Simple file upload form -->
+            <form method="POST" action="/upload" enctype="multipart/form-data">
+                <input type="file" id="upload" multiple />
+                <input type="submit" value="Send" />
+            </form>
+        </body>
+      </html>`);
 
-  // Read the whole file content into a buffer.
-  const buffer = await readAll(file);
+    // Read the whole file content into a buffer.
+    const buffer = await readAll(file);
 
-  // The file is set to the input element with the id "upload".
-  page.setInputFiles({
-    name: 'file.txt',
-    mimetype: 'text/plain',
-    buffer: encoding.b64encode(buffer),
-  });
-
-  page.close();
+    // The file is set to the input element with the id "upload".
+    page.setInputFiles({
+      name: 'file.txt',
+      mimetype: 'text/plain',
+      buffer: encoding.b64encode(buffer),
+    });
+  } finally {
+    page.close();
+  }
 }
 
 // readAll will read the whole of the file from the local filesystem into a

--- a/docs/sources/next/javascript-api/k6-experimental/browser/page/setinputfiles.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/page/setinputfiles.md
@@ -45,7 +45,7 @@ export default async function () {
   const page = browser.newPage();
 
   // In this example we create a simple web page with an upload input field.
-  // Usually you would use page.goto to navigate to a page with an file input field.
+  // Usually, you would use page.goto to navigate to a page with a file input field.
   page.setContent(`
     <html>
       <head></head>
@@ -103,7 +103,7 @@ export default async function () {
   const page = browser.newPage();
 
   // In this example we create a simple web page with an upload input field.
-  // Usually you would use page.goto to navigate to a page with an file input field.
+  // Usually, you would use page.goto to navigate to a page with a file input field.
   page.setContent(`
     <html>
       <head></head>

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/elementhandle/setinputfiles.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/elementhandle/setinputfiles.md
@@ -44,7 +44,7 @@ export default async function () {
   const page = browser.newPage();
 
   // In this example we create a simple web page with an upload input field.
-  // Usually you would use page.goto to navigate to a page with an file input field.
+  // Usually, you would use page.goto to navigate to a page with a file input field.
   page.setContent(`
     <html>
       <head></head>
@@ -104,7 +104,7 @@ export default async function () {
   const page = browser.newPage();
 
   // In this example we create a simple web page with an upload input field.
-  // Usually you would use page.goto to navigate to a page with an file input field.
+  // Usually, you would use page.goto to navigate to a page with a file input field.
   page.setContent(`
     <html>
       <head></head>

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/elementhandle/setinputfiles.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/elementhandle/setinputfiles.md
@@ -19,7 +19,7 @@ To work with local files on the file system, use the [experimental fs module](ht
 | options.noWaitAfter | boolean     | `false` | If set to `true` and a navigation occurs from performing this action, it will not wait for it to complete.                                                                                                                                                                                                                                    |
 | options.timeout     | number      | `30000` | Maximum time in milliseconds. Pass `0` to disable the timeout. Default is overridden by the `setDefaultTimeout` option on [BrowserContext](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext/) or [Page](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/page/). |
 
-### Example
+### Inline File Example
 
 {{< code >}}
 
@@ -44,6 +44,7 @@ export default async function () {
   const page = browser.newPage();
 
   // In this example we create a simple web page with an upload input field.
+  // Usually you would use page.goto to navigate to a page with an file input field.
   page.setContent(`
     <html>
       <head></head>
@@ -66,6 +67,83 @@ export default async function () {
   });
 
   page.close();
+}
+```
+
+{{< /code >}}
+
+### Local File Example
+
+{{< code >}}
+
+```javascript
+import { browser } from 'k6/experimental/browser';
+import encoding from 'k6/encoding';
+import { open } from 'k6/experimental/fs';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+          type: 'chromium',
+        },
+      },
+    },
+  },
+};
+
+// Declare the location of the file on the local filesystem.
+let file;
+(async function () {
+  file = await open('/abs/path/to/file.txt');
+})();
+
+export default async function () {
+  const page = browser.newPage();
+
+  // In this example we create a simple web page with an upload input field.
+  // Usually you would use page.goto to navigate to a page with an file input field.
+  page.setContent(`
+    <html>
+      <head></head>
+      <body>
+          <!-- Simple file upload form -->
+          <form method="POST" action="/upload" enctype="multipart/form-data">
+              <input type="file" id="upload" multiple />
+              <input type="submit" value="Send" />
+          </form>
+      </body>
+    </html>`);
+
+  const eh = page.$('input[id="upload"]');
+
+  // Read the whole file content into a buffer.
+  const buffer = await readAll(file);
+
+  // The file is set to the input element with the id "upload".
+  eh.setInputFiles({
+    name: 'file.txt',
+    mimetype: 'text/plain',
+    buffer: encoding.b64encode(buffer),
+  });
+
+  page.close();
+}
+
+// readAll will read the whole of the file from the local filesystem into a
+// buffer.
+async function readAll(file) {
+  const fileInfo = await file.stat();
+  const buffer = new Uint8Array(fileInfo.size);
+
+  const bytesRead = await file.read(buffer);
+  if (bytesRead !== fileInfo.size) {
+    throw new Error('unexpected number of bytes read');
+  }
+
+  return buffer;
 }
 ```
 

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/elementhandle/setinputfiles.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/elementhandle/setinputfiles.md
@@ -43,30 +43,32 @@ export const options = {
 export default async function () {
   const page = browser.newPage();
 
-  // In this example we create a simple web page with an upload input field.
-  // Usually, you would use page.goto to navigate to a page with a file input field.
-  page.setContent(`
-    <html>
-      <head></head>
-      <body>
-          <!-- Simple file upload form -->
-          <form method="POST" action="/upload" enctype="multipart/form-data">
-              <input type="file" id="upload" multiple />
-              <input type="submit" value="Send" />
-          </form>
-      </body>
-    </html>`);
+  try {
+    // In this example we create a simple web page with an upload input field.
+    // Usually, you would use page.goto to navigate to a page with a file input field.
+    page.setContent(`
+      <html>
+        <head></head>
+        <body>
+            <!-- Simple file upload form -->
+            <form method="POST" action="/upload" enctype="multipart/form-data">
+                <input type="file" id="upload" multiple />
+                <input type="submit" value="Send" />
+            </form>
+        </body>
+      </html>`);
 
-  const eh = page.$('input[id="upload"]');
+    const eh = page.$('input[id="upload"]');
 
-  // The file is set to the input element with the id "upload".
-  eh.setInputFiles({
-    name: 'file.txt',
-    mimetype: 'text/plain',
-    buffer: encoding.b64encode('hello world'),
-  });
-
-  page.close();
+    // The file is set to the input element with the id "upload".
+    eh.setInputFiles({
+      name: 'file.txt',
+      mimetype: 'text/plain',
+      buffer: encoding.b64encode('hello world'),
+    });
+  } finally {
+    page.close();
+  }
 }
 ```
 
@@ -103,33 +105,35 @@ let file;
 export default async function () {
   const page = browser.newPage();
 
-  // In this example we create a simple web page with an upload input field.
-  // Usually, you would use page.goto to navigate to a page with a file input field.
-  page.setContent(`
-    <html>
-      <head></head>
-      <body>
-          <!-- Simple file upload form -->
-          <form method="POST" action="/upload" enctype="multipart/form-data">
-              <input type="file" id="upload" multiple />
-              <input type="submit" value="Send" />
-          </form>
-      </body>
-    </html>`);
+  try {
+    // In this example we create a simple web page with an upload input field.
+    // Usually, you would use page.goto to navigate to a page with a file input field.
+    page.setContent(`
+      <html>
+        <head></head>
+        <body>
+            <!-- Simple file upload form -->
+            <form method="POST" action="/upload" enctype="multipart/form-data">
+                <input type="file" id="upload" multiple />
+                <input type="submit" value="Send" />
+            </form>
+        </body>
+      </html>`);
 
-  const eh = page.$('input[id="upload"]');
+    const eh = page.$('input[id="upload"]');
 
-  // Read the whole file content into a buffer.
-  const buffer = await readAll(file);
+    // Read the whole file content into a buffer.
+    const buffer = await readAll(file);
 
-  // The file is set to the input element with the id "upload".
-  eh.setInputFiles({
-    name: 'file.txt',
-    mimetype: 'text/plain',
-    buffer: encoding.b64encode(buffer),
-  });
-
-  page.close();
+    // The file is set to the input element with the id "upload".
+    eh.setInputFiles({
+      name: 'file.txt',
+      mimetype: 'text/plain',
+      buffer: encoding.b64encode(buffer),
+    });
+  } finally {
+    page.close();
+  }
 }
 
 // readAll will read the whole of the file from the local filesystem into a

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/frame/setinputfiles.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/frame/setinputfiles.md
@@ -20,7 +20,7 @@ To work with local files on the file system, use the [experimental fs module](ht
 | options.noWaitAfter | boolean     | `false` | If set to `true` and a navigation occurs from performing this action, it will not wait for it to complete.                                                                                                                                                                                                                                    |
 | options.timeout     | number      | `30000` | Maximum time in milliseconds. Pass `0` to disable the timeout. Default is overridden by the `setDefaultTimeout` option on [BrowserContext](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext/) or [Page](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/page/). |
 
-### Example
+### Inline File Example
 
 {{< code >}}
 
@@ -45,6 +45,7 @@ export default async function () {
   const page = browser.newPage();
 
   // In this example we create a simple web page with an upload input field.
+  // Usually you would use page.goto to navigate to a page with an file input field.
   page.setContent(`
     <html>
       <head></head>
@@ -67,6 +68,83 @@ export default async function () {
   });
 
   page.close();
+}
+```
+
+{{< /code >}}
+
+### Local File Example
+
+{{< code >}}
+
+```javascript
+import { browser } from 'k6/experimental/browser';
+import encoding from 'k6/encoding';
+import { open } from 'k6/experimental/fs';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+          type: 'chromium',
+        },
+      },
+    },
+  },
+};
+
+// Declare the location of the file on the local filesystem.
+let file;
+(async function () {
+  file = await open('/abs/path/to/file.txt');
+})();
+
+export default async function () {
+  const page = browser.newPage();
+
+  // In this example we create a simple web page with an upload input field.
+  // Usually you would use page.goto to navigate to a page with an file input field.
+  page.setContent(`
+    <html>
+      <head></head>
+      <body>
+          <!-- Simple file upload form -->
+          <form method="POST" action="/upload" enctype="multipart/form-data">
+              <input type="file" id="upload" multiple />
+              <input type="submit" value="Send" />
+          </form>
+      </body>
+    </html>`);
+
+  const frame = page.mainFrame();
+
+  // Read the whole file content into a buffer.
+  const buffer = await readAll(file);
+
+  // The file is set to the input element with the id "upload".
+  frame.setInputFiles({
+    name: 'file.txt',
+    mimetype: 'text/plain',
+    buffer: encoding.b64encode(buffer),
+  });
+
+  page.close();
+}
+
+// readAll will read the whole of the file from the local filesystem into a
+// buffer.
+async function readAll(file) {
+  const fileInfo = await file.stat();
+  const buffer = new Uint8Array(fileInfo.size);
+
+  const bytesRead = await file.read(buffer);
+  if (bytesRead !== fileInfo.size) {
+    throw new Error('unexpected number of bytes read');
+  }
+
+  return buffer;
 }
 ```
 

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/frame/setinputfiles.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/frame/setinputfiles.md
@@ -44,30 +44,32 @@ export const options = {
 export default async function () {
   const page = browser.newPage();
 
-  // In this example we create a simple web page with an upload input field.
-  // Usually, you would use page.goto to navigate to a page with a file input field.
-  page.setContent(`
-    <html>
-      <head></head>
-      <body>
-          <!-- Simple file upload form -->
-          <form method="POST" action="/upload" enctype="multipart/form-data">
-              <input type="file" id="upload" multiple />
-              <input type="submit" value="Send" />
-          </form>
-      </body>
-    </html>`);
+  try {
+    // In this example we create a simple web page with an upload input field.
+    // Usually, you would use page.goto to navigate to a page with a file input field.
+    page.setContent(`
+      <html>
+        <head></head>
+        <body>
+            <!-- Simple file upload form -->
+            <form method="POST" action="/upload" enctype="multipart/form-data">
+                <input type="file" id="upload" multiple />
+                <input type="submit" value="Send" />
+            </form>
+        </body>
+      </html>`);
 
-  const frame = page.mainFrame();
+    const frame = page.mainFrame();
 
-  // The file is set to the input element with the id "upload".
-  frame.setInputFiles('input[id="upload"]', {
-    name: 'file.txt',
-    mimetype: 'text/plain',
-    buffer: encoding.b64encode('hello world'),
-  });
-
-  page.close();
+    // The file is set to the input element with the id "upload".
+    frame.setInputFiles('input[id="upload"]', {
+      name: 'file.txt',
+      mimetype: 'text/plain',
+      buffer: encoding.b64encode('hello world'),
+    });
+  } finally {
+    page.close();
+  }
 }
 ```
 
@@ -104,33 +106,35 @@ let file;
 export default async function () {
   const page = browser.newPage();
 
-  // In this example we create a simple web page with an upload input field.
-  // Usually, you would use page.goto to navigate to a page with a file input field.
-  page.setContent(`
-    <html>
-      <head></head>
-      <body>
-          <!-- Simple file upload form -->
-          <form method="POST" action="/upload" enctype="multipart/form-data">
-              <input type="file" id="upload" multiple />
-              <input type="submit" value="Send" />
-          </form>
-      </body>
-    </html>`);
+  try {
+    // In this example we create a simple web page with an upload input field.
+    // Usually, you would use page.goto to navigate to a page with a file input field.
+    page.setContent(`
+      <html>
+        <head></head>
+        <body>
+            <!-- Simple file upload form -->
+            <form method="POST" action="/upload" enctype="multipart/form-data">
+                <input type="file" id="upload" multiple />
+                <input type="submit" value="Send" />
+            </form>
+        </body>
+      </html>`);
 
-  const frame = page.mainFrame();
+    const frame = page.mainFrame();
 
-  // Read the whole file content into a buffer.
-  const buffer = await readAll(file);
+    // Read the whole file content into a buffer.
+    const buffer = await readAll(file);
 
-  // The file is set to the input element with the id "upload".
-  frame.setInputFiles({
-    name: 'file.txt',
-    mimetype: 'text/plain',
-    buffer: encoding.b64encode(buffer),
-  });
-
-  page.close();
+    // The file is set to the input element with the id "upload".
+    frame.setInputFiles({
+      name: 'file.txt',
+      mimetype: 'text/plain',
+      buffer: encoding.b64encode(buffer),
+    });
+  } finally {
+    page.close();
+  }
 }
 
 // readAll will read the whole of the file from the local filesystem into a

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/frame/setinputfiles.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/frame/setinputfiles.md
@@ -45,7 +45,7 @@ export default async function () {
   const page = browser.newPage();
 
   // In this example we create a simple web page with an upload input field.
-  // Usually you would use page.goto to navigate to a page with an file input field.
+  // Usually, you would use page.goto to navigate to a page with a file input field.
   page.setContent(`
     <html>
       <head></head>
@@ -105,7 +105,7 @@ export default async function () {
   const page = browser.newPage();
 
   // In this example we create a simple web page with an upload input field.
-  // Usually you would use page.goto to navigate to a page with an file input field.
+  // Usually, you would use page.goto to navigate to a page with a file input field.
   page.setContent(`
     <html>
       <head></head>

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/setinputfiles.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/setinputfiles.md
@@ -20,7 +20,7 @@ To work with local files on the file system, use the [experimental fs module](ht
 | options.noWaitAfter | boolean     | `false` | If set to `true` and a navigation occurs from performing this action, it will not wait for it to complete.                                                                                                                                                                                                                                    |
 | options.timeout     | number      | `30000` | Maximum time in milliseconds. Pass `0` to disable the timeout. Default is overridden by the `setDefaultTimeout` option on [BrowserContext](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext/) or [Page](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/page/). |
 
-### Example
+### Inline File Example
 
 {{< code >}}
 
@@ -45,6 +45,7 @@ export default async function () {
   const page = browser.newPage();
 
   // In this example we create a simple web page with an upload input field.
+  // Usually you would use page.goto to navigate to a page with an file input field.
   page.setContent(`
     <html>
       <head></head>
@@ -65,6 +66,81 @@ export default async function () {
   });
 
   page.close();
+}
+```
+
+{{< /code >}}
+
+### Local File Example
+
+{{< code >}}
+
+```javascript
+import { browser } from 'k6/experimental/browser';
+import encoding from 'k6/encoding';
+import { open } from 'k6/experimental/fs';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+          type: 'chromium',
+        },
+      },
+    },
+  },
+};
+
+// Declare the location of the file on the local filesystem.
+let file;
+(async function () {
+  file = await open('/abs/path/to/file.txt');
+})();
+
+export default async function () {
+  const page = browser.newPage();
+
+  // In this example we create a simple web page with an upload input field.
+  // Usually you would use page.goto to navigate to a page with an file input field.
+  page.setContent(`
+    <html>
+      <head></head>
+      <body>
+          <!-- Simple file upload form -->
+          <form method="POST" action="/upload" enctype="multipart/form-data">
+              <input type="file" id="upload" multiple />
+              <input type="submit" value="Send" />
+          </form>
+      </body>
+    </html>`);
+
+  // Read the whole file content into a buffer.
+  const buffer = await readAll(file);
+
+  // The file is set to the input element with the id "upload".
+  page.setInputFiles({
+    name: 'file.txt',
+    mimetype: 'text/plain',
+    buffer: encoding.b64encode(buffer),
+  });
+
+  page.close();
+}
+
+// readAll will read the whole of the file from the local filesystem into a
+// buffer.
+async function readAll(file) {
+  const fileInfo = await file.stat();
+  const buffer = new Uint8Array(fileInfo.size);
+
+  const bytesRead = await file.read(buffer);
+  if (bytesRead !== fileInfo.size) {
+    throw new Error('unexpected number of bytes read');
+  }
+
+  return buffer;
 }
 ```
 

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/setinputfiles.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/setinputfiles.md
@@ -44,28 +44,30 @@ export const options = {
 export default async function () {
   const page = browser.newPage();
 
-  // In this example we create a simple web page with an upload input field.
-  // Usually, you would use page.goto to navigate to a page with a file input field.
-  page.setContent(`
-    <html>
-      <head></head>
-      <body>
-          <!-- Simple file upload form -->
-          <form method="POST" action="/upload" enctype="multipart/form-data">
-              <input type="file" id="upload" multiple />
-              <input type="submit" value="Send" />
-          </form>
-      </body>
-    </html>`);
+  try {
+    // In this example we create a simple web page with an upload input field.
+    // Usually, you would use page.goto to navigate to a page with a file input field.
+    page.setContent(`
+      <html>
+        <head></head>
+        <body>
+            <!-- Simple file upload form -->
+            <form method="POST" action="/upload" enctype="multipart/form-data">
+                <input type="file" id="upload" multiple />
+                <input type="submit" value="Send" />
+            </form>
+        </body>
+      </html>`);
 
-  // The file is set to the input element with the id "upload".
-  page.setInputFiles('input[id="upload"]', {
-    name: 'file.txt',
-    mimetype: 'text/plain',
-    buffer: encoding.b64encode('hello world'),
-  });
-
-  page.close();
+    // The file is set to the input element with the id "upload".
+    page.setInputFiles('input[id="upload"]', {
+      name: 'file.txt',
+      mimetype: 'text/plain',
+      buffer: encoding.b64encode('hello world'),
+    });
+  } finally {
+    page.close();
+  }
 }
 ```
 
@@ -102,31 +104,33 @@ let file;
 export default async function () {
   const page = browser.newPage();
 
-  // In this example we create a simple web page with an upload input field.
-  // Usually, you would use page.goto to navigate to a page with a file input field.
-  page.setContent(`
-    <html>
-      <head></head>
-      <body>
-          <!-- Simple file upload form -->
-          <form method="POST" action="/upload" enctype="multipart/form-data">
-              <input type="file" id="upload" multiple />
-              <input type="submit" value="Send" />
-          </form>
-      </body>
-    </html>`);
+  try {
+    // In this example we create a simple web page with an upload input field.
+    // Usually, you would use page.goto to navigate to a page with a file input field.
+    page.setContent(`
+      <html>
+        <head></head>
+        <body>
+            <!-- Simple file upload form -->
+            <form method="POST" action="/upload" enctype="multipart/form-data">
+                <input type="file" id="upload" multiple />
+                <input type="submit" value="Send" />
+            </form>
+        </body>
+      </html>`);
 
-  // Read the whole file content into a buffer.
-  const buffer = await readAll(file);
+    // Read the whole file content into a buffer.
+    const buffer = await readAll(file);
 
-  // The file is set to the input element with the id "upload".
-  page.setInputFiles({
-    name: 'file.txt',
-    mimetype: 'text/plain',
-    buffer: encoding.b64encode(buffer),
-  });
-
-  page.close();
+    // The file is set to the input element with the id "upload".
+    page.setInputFiles({
+      name: 'file.txt',
+      mimetype: 'text/plain',
+      buffer: encoding.b64encode(buffer),
+    });
+  } finally {
+    page.close();
+  }
 }
 
 // readAll will read the whole of the file from the local filesystem into a

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/setinputfiles.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/setinputfiles.md
@@ -45,7 +45,7 @@ export default async function () {
   const page = browser.newPage();
 
   // In this example we create a simple web page with an upload input field.
-  // Usually you would use page.goto to navigate to a page with an file input field.
+  // Usually, you would use page.goto to navigate to a page with a file input field.
   page.setContent(`
     <html>
       <head></head>
@@ -103,7 +103,7 @@ export default async function () {
   const page = browser.newPage();
 
   // In this example we create a simple web page with an upload input field.
-  // Usually you would use page.goto to navigate to a page with an file input field.
+  // Usually, you would use page.goto to navigate to a page with a file input field.
   page.setContent(`
     <html>
       <head></head>


### PR DESCRIPTION
## What?

This adds an example to `setInputFiles` which reads a file from the local filesystem.

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [x] I have made my changes in the `docs/sources/next` folder of the documentation.
- [x] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.
- [ ] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->
<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
https://github.com/grafana/k6-docs/pull/1528#issuecomment-2013662608