### PR TITLE
docs: fix misleading description on xk6-redis

### DIFF
--- a/docs/sources/next/javascript-api/k6-experimental/redis/redis-options.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/redis-options.md
@@ -29,7 +29,7 @@ The configuration for the overall Redis client, including authentication and con
 Socket-level settings for connecting to a Redis server.
 
 | Option Name        | Type                                                     | Description                                                                           |
-| ------------------ | -------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+|--------------------|----------------------------------------------------------|---------------------------------------------------------------------------------------|
 | host               | String                                                   | IP address or hostname of the Redis server.                                           |
 | port               | Number (optional)                                        | Port number of the Redis server.                                                      |
 | tls                | [TLSOptions](#tls-configuration-options) (optional)      | The configuration for TLS/SSL.                                                        |
@@ -38,7 +38,7 @@ Socket-level settings for connecting to a Redis server.
 | writeTimeout       | Number (optional, default is `readTimeout`)              | Timeout for socket writes, in seconds. A value of `-1` disables the timeout.          |
 | poolSize           | Number (optional, default is _10_ (per CPU))             | Number of socket connections in the pool per CPU.                                     |
 | minIdleConns       | Number (optional)                                        | Minimum number of idle connections in the pool.                                       |
-| maxConnAge         | Number (optional, default is _0_ (no maximum idle time)) | Maximum idle time before closing a connection.                                        |
+| maxConnAge         | Number (optional, default is _0_ (no maximum idle time)) | Maximum time before closing a connection.                                             |
 | poolTimeout        | Number (optional, `readTimeout + 1`)                     | Timeout for acquiring a connection from the pool.                                     |
 | idleTimeout        | Number (optional, `readTimeout + 1`)                     | Timeout for idle connections in the pool.                                             |
 | idleCheckFrequency | Number (optional, default is _1_ (minute))               | Frequency of idle connection checks, in minutes. A value of `-1` disables the checks. |

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/redis/redis-options.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/redis/redis-options.md
@@ -29,7 +29,7 @@ The configuration for the overall Redis client, including authentication and con
 Socket-level settings for connecting to a Redis server.
 
 | Option Name        | Type                                                     | Description                                                                           |
-| ------------------ | -------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+|--------------------|----------------------------------------------------------|---------------------------------------------------------------------------------------|
 | host               | String                                                   | IP address or hostname of the Redis server.                                           |
 | port               | Number (optional)                                        | Port number of the Redis server.                                                      |
 | tls                | [TLSOptions](#tls-configuration-options) (optional)      | The configuration for TLS/SSL.                                                        |
@@ -38,7 +38,7 @@ Socket-level settings for connecting to a Redis server.
 | writeTimeout       | Number (optional, default is `readTimeout`)              | Timeout for socket writes, in seconds. A value of `-1` disables the timeout.          |
 | poolSize           | Number (optional, default is _10_ (per CPU))             | Number of socket connections in the pool per CPU.                                     |
 | minIdleConns       | Number (optional)                                        | Minimum number of idle connections in the pool.                                       |
-| maxConnAge         | Number (optional, default is _0_ (no maximum idle time)) | Maximum idle time before closing a connection.                                        |
+| maxConnAge         | Number (optional, default is _0_ (no maximum idle time)) | Maximum time before closing a connection.                                             |
 | poolTimeout        | Number (optional, `readTimeout + 1`)                     | Timeout for acquiring a connection from the pool.                                     |
 | idleTimeout        | Number (optional, `readTimeout + 1`)                     | Timeout for idle connections in the pool.                                             |
 | idleCheckFrequency | Number (optional, default is _1_ (minute))               | Frequency of idle connection checks, in minutes. A value of `-1` disables the checks. |

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/redis/redis-options.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/redis/redis-options.md
@@ -29,7 +29,7 @@ The configuration for the overall Redis client, including authentication and con
 Socket-level settings for connecting to a Redis server.
 
 | Option Name        | Type                                                     | Description                                                                           |
-| ------------------ | -------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+|--------------------|----------------------------------------------------------|---------------------------------------------------------------------------------------|
 | host               | String                                                   | IP address or hostname of the Redis server.                                           |
 | port               | Number (optional)                                        | Port number of the Redis server.                                                      |
 | tls                | [TLSOptions](#tls-configuration-options) (optional)      | The configuration for TLS/SSL.                                                        |
@@ -38,7 +38,7 @@ Socket-level settings for connecting to a Redis server.
 | writeTimeout       | Number (optional, default is `readTimeout`)              | Timeout for socket writes, in seconds. A value of `-1` disables the timeout.          |
 | poolSize           | Number (optional, default is _10_ (per CPU))             | Number of socket connections in the pool per CPU.                                     |
 | minIdleConns       | Number (optional)                                        | Minimum number of idle connections in the pool.                                       |
-| maxConnAge         | Number (optional, default is _0_ (no maximum idle time)) | Maximum idle time before closing a connection.                                        |
+| maxConnAge         | Number (optional, default is _0_ (no maximum idle time)) | Maximum time before closing a connection.                                             |
 | poolTimeout        | Number (optional, `readTimeout + 1`)                     | Timeout for acquiring a connection from the pool.                                     |
 | idleTimeout        | Number (optional, `readTimeout + 1`)                     | Timeout for idle connections in the pool.                                             |
 | idleCheckFrequency | Number (optional, default is _1_ (minute))               | Frequency of idle connection checks, in minutes. A value of `-1` disables the checks. |

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/redis/redis-options.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/redis/redis-options.md
@@ -29,7 +29,7 @@ The configuration for the overall Redis client, including authentication and con
 Socket-level settings for connecting to a Redis server.
 
 | Option Name        | Type                                                     | Description                                                                           |
-| ------------------ | -------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+|--------------------|----------------------------------------------------------|---------------------------------------------------------------------------------------|
 | host               | String                                                   | IP address or hostname of the Redis server.                                           |
 | port               | Number (optional)                                        | Port number of the Redis server.                                                      |
 | tls                | [TLSOptions](#tls-configuration-options) (optional)      | The configuration for TLS/SSL.                                                        |
@@ -38,7 +38,7 @@ Socket-level settings for connecting to a Redis server.
 | writeTimeout       | Number (optional, default is `readTimeout`)              | Timeout for socket writes, in seconds. A value of `-1` disables the timeout.          |
 | poolSize           | Number (optional, default is _10_ (per CPU))             | Number of socket connections in the pool per CPU.                                     |
 | minIdleConns       | Number (optional)                                        | Minimum number of idle connections in the pool.                                       |
-| maxConnAge         | Number (optional, default is _0_ (no maximum idle time)) | Maximum idle time before closing a connection.                                        |
+| maxConnAge         | Number (optional, default is _0_ (no maximum idle time)) | Maximum time before closing a connection.                                             |
 | poolTimeout        | Number (optional, `readTimeout + 1`)                     | Timeout for acquiring a connection from the pool.                                     |
 | idleTimeout        | Number (optional, `readTimeout + 1`)                     | Timeout for idle connections in the pool.                                             |
 | idleCheckFrequency | Number (optional, default is _1_ (minute))               | Frequency of idle connection checks, in minutes. A value of `-1` disables the checks. |


### PR DESCRIPTION
## What?

Minor fix for a misleading description on [xk6-redis](https://github.com/grafana/xk6-redis).

More details [here](https://github.com/grafana/xk6-redis/issues/32).

## Checklist

<!-- Please fill in this template: -->
- [X] I have used a meaningful title for the PR.
- [X] I have described the changes I've made in the "What?" section above.
- [X] I have performed a self-review of my changes.
- [X] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

- [X] I have made my changes in the `docs/sources/next` folder of the documentation.
- [X] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.
- [X] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).

## Related PR(s)/Issue(s)

Closes https://github.com/grafana/xk6-redis/issues/32

<!-- Thanks for your contribution! 🙏🏼 -->