### PR TITLE
Removed duplication of ${exec.instance.iterationsCompleted}

### DIFF
--- a/src/data/markdown/translated-guides/en/02 Using k6/12 Execution context variables.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/12 Execution context variables.md
@@ -46,7 +46,6 @@ Instance info
 Vus active: ${exec.instance.vusActive}
 Iterations completed: ${exec.instance.iterationsCompleted}
 Iterations interrupted:  ${exec.instance.iterationsInterrupted}
-Iterations completed:  ${exec.instance.iterationsCompleted}
 Iterations active:  ${exec.instance.vusActive}
 Initialized vus:  ${exec.instance.vusInitialized}
 Time passed from start of run(ms):  ${exec.instance.currentTestRunDuration}


### PR DESCRIPTION
Hi,

just a small update. 
In `k6-docs/src/data/markdown/translated-guides/en/02 Using k6/12 Execution context variables.md`,
Line `47` and `49` are the same. 
