### PR TITLE
experimental-redis: mention minIdleConns defaults

### DIFF
--- a/docs/sources/next/javascript-api/k6-experimental/redis/redis-options.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/redis-options.md
@@ -28,20 +28,20 @@ The configuration for the overall Redis client, including authentication and con
 
 Socket-level settings for connecting to a Redis server.
 
-| Option Name        | Type                                                     | Description                                                                           |
-|--------------------|----------------------------------------------------------|---------------------------------------------------------------------------------------|
-| host               | String                                                   | IP address or hostname of the Redis server.                                           |
-| port               | Number (optional)                                        | Port number of the Redis server.                                                      |
-| tls                | [TLSOptions](#tls-configuration-options) (optional)      | The configuration for TLS/SSL.                                                        |
-| dialTimeout        | Number (optional, default is _5_ (seconds))              | Timeout for establishing a connection, in seconds.                                    |
-| readTimeout        | Number (optional, default is _3_ (seconds))              | Timeout for socket reads, in seconds. A value of `-1` disables the timeout.           |
-| writeTimeout       | Number (optional, default is `readTimeout`)              | Timeout for socket writes, in seconds. A value of `-1` disables the timeout.          |
-| poolSize           | Number (optional, default is _10_ (per CPU))             | Number of socket connections in the pool per CPU.                                     |
-| minIdleConns       | Number (optional)                                        | Minimum number of idle connections in the pool.                                       |
-| maxConnAge         | Number (optional, default is _0_ (no maximum idle time)) | Maximum time before closing a connection.                                             |
-| poolTimeout        | Number (optional, `readTimeout + 1`)                     | Timeout for acquiring a connection from the pool.                                     |
-| idleTimeout        | Number (optional, `readTimeout + 1`)                     | Timeout for idle connections in the pool.                                             |
-| idleCheckFrequency | Number (optional, default is _1_ (minute))               | Frequency of idle connection checks, in minutes. A value of `-1` disables the checks. |
+| Option Name        | Type                                                                           | Description                                                                           |
+| ------------------ | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------- |
+| host               | String                                                                         | IP address or hostname of the Redis server.                                           |
+| port               | Number (optional)                                                              | Port number of the Redis server.                                                      |
+| tls                | [TLSOptions](#tls-configuration-options) (optional)                            | The configuration for TLS/SSL.                                                        |
+| dialTimeout        | Number (optional, default is _5_ (seconds))                                    | Timeout for establishing a connection, in seconds.                                    |
+| readTimeout        | Number (optional, default is _3_ (seconds))                                    | Timeout for socket reads, in seconds. A value of `-1` disables the timeout.           |
+| writeTimeout       | Number (optional, default is `readTimeout`)                                    | Timeout for socket writes, in seconds. A value of `-1` disables the timeout.          |
+| poolSize           | Number (optional, default is _10_ (per CPU))                                   | Number of socket connections in the pool per CPU.                                     |
+| minIdleConns       | Number (optional, default is _0_ (idle connections are not closed by default)) | Minimum number of idle connections in the pool.                                       |
+| maxConnAge         | Number (optional, default is _0_ (no maximum idle time))                       | Maximum time before closing a connection.                                             |
+| poolTimeout        | Number (optional, `readTimeout + 1`)                                           | Timeout for acquiring a connection from the pool.                                     |
+| idleTimeout        | Number (optional, `readTimeout + 1`)                                           | Timeout for idle connections in the pool.                                             |
+| idleCheckFrequency | Number (optional, default is _1_ (minute))                                     | Frequency of idle connection checks, in minutes. A value of `-1` disables the checks. |
 
 #### TLS Configuration Options
 

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/redis/redis-options.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/redis/redis-options.md
@@ -28,20 +28,20 @@ The configuration for the overall Redis client, including authentication and con
 
 Socket-level settings for connecting to a Redis server.
 
-| Option Name        | Type                                                     | Description                                                                           |
-|--------------------|----------------------------------------------------------|---------------------------------------------------------------------------------------|
-| host               | String                                                   | IP address or hostname of the Redis server.                                           |
-| port               | Number (optional)                                        | Port number of the Redis server.                                                      |
-| tls                | [TLSOptions](#tls-configuration-options) (optional)      | The configuration for TLS/SSL.                                                        |
-| dialTimeout        | Number (optional, default is _5_ (seconds))              | Timeout for establishing a connection, in seconds.                                    |
-| readTimeout        | Number (optional, default is _3_ (seconds))              | Timeout for socket reads, in seconds. A value of `-1` disables the timeout.           |
-| writeTimeout       | Number (optional, default is `readTimeout`)              | Timeout for socket writes, in seconds. A value of `-1` disables the timeout.          |
-| poolSize           | Number (optional, default is _10_ (per CPU))             | Number of socket connections in the pool per CPU.                                     |
-| minIdleConns       | Number (optional)                                        | Minimum number of idle connections in the pool.                                       |
-| maxConnAge         | Number (optional, default is _0_ (no maximum idle time)) | Maximum time before closing a connection.                                             |
-| poolTimeout        | Number (optional, `readTimeout + 1`)                     | Timeout for acquiring a connection from the pool.                                     |
-| idleTimeout        | Number (optional, `readTimeout + 1`)                     | Timeout for idle connections in the pool.                                             |
-| idleCheckFrequency | Number (optional, default is _1_ (minute))               | Frequency of idle connection checks, in minutes. A value of `-1` disables the checks. |
+| Option Name        | Type                                                                           | Description                                                                           |
+| ------------------ | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------- |
+| host               | String                                                                         | IP address or hostname of the Redis server.                                           |
+| port               | Number (optional)                                                              | Port number of the Redis server.                                                      |
+| tls                | [TLSOptions](#tls-configuration-options) (optional)                            | The configuration for TLS/SSL.                                                        |
+| dialTimeout        | Number (optional, default is _5_ (seconds))                                    | Timeout for establishing a connection, in seconds.                                    |
+| readTimeout        | Number (optional, default is _3_ (seconds))                                    | Timeout for socket reads, in seconds. A value of `-1` disables the timeout.           |
+| writeTimeout       | Number (optional, default is `readTimeout`)                                    | Timeout for socket writes, in seconds. A value of `-1` disables the timeout.          |
+| poolSize           | Number (optional, default is _10_ (per CPU))                                   | Number of socket connections in the pool per CPU.                                     |
+| minIdleConns       | Number (optional, default is _0_ (idle connections are not closed by default)) | Minimum number of idle connections in the pool.                                       |
+| maxConnAge         | Number (optional, default is _0_ (no maximum idle time))                       | Maximum time before closing a connection.                                             |
+| poolTimeout        | Number (optional, `readTimeout + 1`)                                           | Timeout for acquiring a connection from the pool.                                     |
+| idleTimeout        | Number (optional, `readTimeout + 1`)                                           | Timeout for idle connections in the pool.                                             |
+| idleCheckFrequency | Number (optional, default is _1_ (minute))                                     | Frequency of idle connection checks, in minutes. A value of `-1` disables the checks. |
 
 #### TLS Configuration Options
 


### PR DESCRIPTION
<!-- 
Please make sure you have read the contribution guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md as well as the
the code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md before opening a PR.
-->

## What?

During the https://github.com/grafana/xk6-redis/issues/30 triage our user pointed out that we don't mention a default value of the `minIdleConns`. This PR is fixing this based on the https://github.com/redis/go-redis/blob/6833d2f8e18bf050d3d34a3a2bd9881a4de1525c/options.go#L110-L113

## Checklist

<!-- Please fill in this template: -->
- [ ] I have used a meaningful title for the PR.
- [ ] I have described the changes I've made in the "What?" section above.
- [ ] I have performed a self-review of my changes.
- [ ] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [ ] I have made my changes in the `docs/sources/next` folder of the documentation.
- [ ] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.

## Related PR(s)/Issue(s)

https://github.com/grafana/xk6-redis/issues/30

<!-- Does it close an issue? -->
<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->