### PR TITLE
Add xk6-zeromq extension

### DIFF
--- a/docs/sources/next/extensions/explore.md
+++ b/docs/sources/next/extensions/explore.md
@@ -347,6 +347,10 @@ Use the table to explore the many extensions. Questions? Feel free to join the d
         <h4>xk6-yaml</h4>
         <p>Encode and decode YAML values</p>
     </a>
+    <a href="https://github.com/luissimas/xk6-zeromq" target="_blank" class="nav-cards__item nav-cards__item--guide">
+        <h4>xk6-zeromq</h4>
+        <p>Add support for the ZeroMQ networking library</p>
+    </a>
 </div>
 
 Don't see what you need? Learn how you can [create a custom extension](https://grafana.com/docs/k6/<K6_VERSION>/extensions/create/).

--- a/docs/sources/v0.50.x/extensions/explore.md
+++ b/docs/sources/v0.50.x/extensions/explore.md
@@ -347,6 +347,10 @@ Use the table to explore the many extensions. Questions? Feel free to join the d
         <h4>xk6-yaml</h4>
         <p>Encode and decode YAML values</p>
     </a>
+    <a href="https://github.com/luissimas/xk6-zeromq" target="_blank" class="nav-cards__item nav-cards__item--guide">
+        <h4>xk6-zeromq</h4>
+        <p>Add support for the ZeroMQ networking library</p>
+    </a>
 </div>
 
 Don't see what you need? Learn how you can [create a custom extension](https://grafana.com/docs/k6/<K6_VERSION>/extensions/create/).

--- a/src/data/doc-extensions/extensions.json
+++ b/src/data/doc-extensions/extensions.json
@@ -237,7 +237,7 @@
       },
       "stars": "38",
       "type": ["JavaScript"],
-      "categories": ["Containers","Kubernetes"],
+      "categories": ["Containers", "Kubernetes"],
       "tiers": ["Official"],
       "cloudEnabled": false
     },
@@ -1182,6 +1182,21 @@
         "url": "https://github.com/phymbert"
       },
       "stars": "1",
+      "type": ["JavaScript"],
+      "categories": ["Protocol"],
+      "tiers": ["Community"],
+      "cloudEnabled": false
+    },
+    {
+      "name": "xk6-zeromq",
+      "description": "Add support for the ZeroMQ networking library",
+      "url": "https://github.com/luissimas/xk6-zeromq",
+      "logo": "",
+      "author": {
+        "name": "Luís Simas",
+        "url": "https://github.com/luissimas"
+      },
+      "stars": "0",
       "type": ["JavaScript"],
       "categories": ["Protocol"],
       "tiers": ["Community"],


### PR DESCRIPTION
## What?

This PR adds the [xk6-zeromq](https://github.com/luissimas/xk6-zeromq) extension to the list of extensions.

## Checklist

- [X] I have used a meaningful title for the PR.
- [X] I have described the changes I've made in the "What?" section above.
- [X] I have performed a self-review of my changes.
- [X] I have run the `npm start` command locally and verified that the changes look good.

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [X] I have made my changes in the `docs/sources/next` folder of the documentation.
- [X] I have reflected my changes in the `docs/sources/v0.50.x` folder of the documentation.
- [X] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->

<!-- 2. If updating the documentation for the next release of k6: -->
- [X] I have made my changes in the `docs/sources/next` folder of the documentation.
