### PR TITLE
Update links to new GCk6 docs URL

### DIFF
--- a/docs/sources/next/get-started/running-k6.md
+++ b/docs/sources/next/get-started/running-k6.md
@@ -232,10 +232,10 @@ k6 supports three execution modes to run a k6 test: local, distributed, and clou
   kubectl apply -f /path/to/k6-resource.yaml
   ```
 
-- **Cloud**: the test runs on [Grafana Cloud k6](https://grafana.com/docs/grafana-cloud/k6/get-started/run-cloud-tests-from-the-cli/).
+- **Cloud**: the test runs on [Grafana Cloud k6](https://grafana.com/docs/grafana-cloud/testing/k6/get-started/run-cloud-tests-from-the-cli/).
 
   ```bash
   k6 cloud script.js
   ```
 
-  Additionally, cloud-based solutions can run cloud tests on your [own cloud infrastructure](https://grafana.com/docs/grafana-cloud/k6/author-run/private-load-zone-v2/), and accept the test results from a [local](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/cloud) or [distributed test](https://github.com/grafana/k6-operator#k6-cloud-output).
+  Additionally, cloud-based solutions can run cloud tests on your [own cloud infrastructure](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/private-load-zone-v2/), and accept the test results from a [local](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/cloud) or [distributed test](https://github.com/grafana/k6-operator#k6-cloud-output).

--- a/docs/sources/next/misc/glossary.md
+++ b/docs/sources/next/misc/glossary.md
@@ -130,7 +130,7 @@ An open standard, human-readable data-serialization format originally derived fr
 
 ## k6 Cloud
 
-The proper name for the entire cloud product, comprising both k6 Cloud Execution and k6 Cloud Test Results.<br/><br/>[k6 Cloud docs](https://grafana.com/docs/grafana-cloud/k6/)
+The proper name for the entire cloud product, comprising both k6 Cloud Execution and k6 Cloud Test Results.<br/><br/>[k6 Cloud docs](https://grafana.com/docs/grafana-cloud/testing/k6/)
 
 ## k6 options
 
@@ -146,7 +146,7 @@ A test that assesses the performance of the system under test in terms of concur
 
 ## Load zone
 
-The geographical instance from which a test runs.<br/><br/>[Private load zones](https://grafana.com/docs/grafana-cloud/k6/author-run/private-load-zone-v2/),[Declare load zones from the CLI](https://grafana.com/docs/grafana-cloud/k6/author-run/cloud-scripting-extras/load-zones/)
+The geographical instance from which a test runs.<br/><br/>[Private load zones](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/private-load-zone-v2/),[Declare load zones from the CLI](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/cloud-scripting-extras/load-zones/)
 
 ## Lifecycle function
 

--- a/docs/sources/next/results-output/real-time/_index.md
+++ b/docs/sources/next/results-output/real-time/_index.md
@@ -43,7 +43,7 @@ As well as the following third-party services:
 
 {{% admonition type="note" %}}
 
-This list applies to local tests, not to [cloud tests](https://grafana.com/docs/grafana-cloud/k6/).
+This list applies to local tests, not to [cloud tests](https://grafana.com/docs/grafana-cloud/testing/k6/).
 
 {{% /admonition %}}
 

--- a/docs/sources/next/results-output/real-time/cloud.md
+++ b/docs/sources/next/results-output/real-time/cloud.md
@@ -6,7 +6,7 @@ weight: 00
 
 # Grafana Cloud k6
 
-Besides [running cloud tests](https://grafana.com/docs/k6/<K6_VERSION>/get-started/running-k6#execution-modes), you can also run a test locally and stream the results to [Grafana Cloud k6](https://grafana.com/docs/grafana-cloud/k6/get-started/run-cloud-tests-from-the-cli/#run-locally-and-stream-to-the-cloud).
+Besides [running cloud tests](https://grafana.com/docs/k6/<K6_VERSION>/get-started/running-k6#execution-modes), you can also run a test locally and stream the results to [Grafana Cloud k6](https://grafana.com/docs/grafana-cloud/testing/k6/get-started/run-cloud-tests-from-the-cli/#run-locally-and-stream-to-the-cloud).
 
 When streaming the results to the cloud, the machine - where you execute the k6 CLI command - runs the test and uploads the results to the cloud-based solution. Then, you will be able to visualize and analyze the results on the web app in real-time.
 
@@ -36,7 +36,7 @@ so `k6 run --out cloud` will consume VUH or test runs from your subscription.
 
    With the `k6 login cloud` command, you can set up your API token on the k6 machine to authenticate against the cloud service.
 
-   Copy your token from [k6 Cloud](https://app.k6.io/account/api-token) or [Grafana Cloud k6](https://grafana.com/docs/grafana-cloud/k6/author-run/tokens-and-cli-authentication/) and pass it as:
+   Copy your token from [k6 Cloud](https://app.k6.io/account/api-token) or [Grafana Cloud k6](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/tokens-and-cli-authentication/) and pass it as:
 
    {{< code >}}
 

--- a/docs/sources/next/results-output/real-time/grafana-cloud-prometheus.md
+++ b/docs/sources/next/results-output/real-time/grafana-cloud-prometheus.md
@@ -11,7 +11,7 @@ weight: 00
 
 This page includes instructions for running a local test that sends the test results to a Prometheus instance in Grafana Cloud.
 
-For running and managing cloud tests in Grafana Cloud, check out [Grafana Cloud k6](https://grafana.com/docs/grafana-cloud/k6/).
+For running and managing cloud tests in Grafana Cloud, check out [Grafana Cloud k6](https://grafana.com/docs/grafana-cloud/testing/k6/).
 
 {{% /admonition %}}
 

--- a/docs/sources/next/testing-guides/api-load-testing.md
+++ b/docs/sources/next/testing-guides/api-load-testing.md
@@ -525,8 +525,8 @@ If the API is in an internal or restricted environment, you can use k6 to test i
 
 - Run the test from your private network using the k6 run command or the [Kubernetes operator](https://github.com/grafana/k6-operator). Optionally, store the test results in [k6 Cloud](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/cloud) or other [external services](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/).
 - For cloud tests:
-  - [Open your firewall](https://grafana.com/docs/grafana-cloud/k6/reference/cloud-ips/) for cloud test traffic.
-  - Run the cloud test from your [Kubernetes clusters](https://grafana.com/docs/grafana-cloud/k6/author-run/private-load-zone-v2/).
+  - [Open your firewall](https://grafana.com/docs/grafana-cloud/testing/k6/reference/cloud-ips/) for cloud test traffic.
+  - Run the cloud test from your [Kubernetes clusters](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/private-load-zone-v2/).
 
 ## Supplementary tools
 

--- a/docs/sources/next/testing-guides/automated-performance-testing.md
+++ b/docs/sources/next/testing-guides/automated-performance-testing.md
@@ -43,7 +43,7 @@ Automation often refers to running tests with pass/fail conditions as part of th
 [Automation into CI/CD pipelines](/integrations/#continuous-integration-and-continuous-delivery) is an option, but it's not the only method to schedule the execution of performance tests. When creating a performance testing plan, it’s important to remember that there are different ways to run performance tests in a frequent basis:
 
 - Cron and cron job runners.
-- Cloud testing tools, such as [scheduling in Grafana Cloud k6](https://grafana.com/docs/grafana-cloud/k6/author-run/schedule-a-test/).
+- Cloud testing tools, such as [scheduling in Grafana Cloud k6](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/schedule-a-test/).
 - Test management tools with automation capabilities.
 - Trigger manual tests. Include this as a step in your release checklist process.
 

--- a/docs/sources/next/testing-guides/running-large-tests.md
+++ b/docs/sources/next/testing-guides/running-large-tests.md
@@ -356,7 +356,7 @@ With the limitations mentioned above, we built a [Kubernetes operator](https://g
 
 ## Large-scale tests in the cloud
 
-[Grafana Cloud k6](https://grafana.com/products/cloud/k6/), our commercial offering, provides an instant solution for running large-scale tests, among other [benefits](https://grafana.com/docs/grafana-cloud/k6/).
+[Grafana Cloud k6](https://grafana.com/products/cloud/k6/), our commercial offering, provides an instant solution for running large-scale tests, among other [benefits](https://grafana.com/docs/grafana-cloud/testing/k6/).
 
 If you aren't sure whether OSS or Cloud is a better fit for your project, we recommend reading this [white paper](https://k6.io/what-to-consider-when-building-or-buying-a-load-testing-solution) to learn more about the risks and features to consider when building a scalable solution.
 

--- a/docs/sources/next/using-k6/environment-variables.md
+++ b/docs/sources/next/using-k6/environment-variables.md
@@ -123,4 +123,4 @@ $ k6 run -e MY_HOSTNAME=test.k6.io --duration 10s --vus 10 script.js
 
 ## Read more
 
-- [Manage environment variables in k6 Cloud](https://grafana.com/docs/grafana-cloud/k6/author-run/cloud-scripting-extras/cloud-environment-variables/)
+- [Manage environment variables in k6 Cloud](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/cloud-scripting-extras/cloud-environment-variables/)

--- a/docs/sources/next/using-k6/execution-context-variables.md
+++ b/docs/sources/next/using-k6/execution-context-variables.md
@@ -102,8 +102,8 @@ The variable is 0 when executing the setup and teardown functions.
 
 ### Running in k6 Cloud
 
-When you run tests in [k6 Cloud](https://grafana.com/docs/grafana-cloud/k6/), the **\_\_VU** value is per server/load generator.
-Read the details in the [cloud docs](https://grafana.com/docs/grafana-cloud/k6/reference/cloud-ips/).
+When you run tests in [k6 Cloud](https://grafana.com/docs/grafana-cloud/testing/k6/), the **\_\_VU** value is per server/load generator.
+Read the details in the [cloud docs](https://grafana.com/docs/grafana-cloud/testing/k6/reference/cloud-ips/).
 
 ### Examples
 
@@ -139,4 +139,4 @@ export default function () {
 ## Grafana Cloud k6 environment variables
 
 If you run tests in k6 Cloud, you have additional environment variables that tell you the server, load zone, and distribution of the currently running test.
-[Read about cloud environment variables](https://grafana.com/docs/grafana-cloud/k6/author-run/cloud-scripting-extras/cloud-environment-variables/).
+[Read about cloud environment variables](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/cloud-scripting-extras/cloud-environment-variables/).

--- a/docs/sources/next/using-k6/k6-options/reference.md
+++ b/docs/sources/next/using-k6/k6-options/reference.md
@@ -354,7 +354,7 @@ export const options = {
 
 ## Cloud options
 
-An object used to set configuration options for Grafana Cloud k6. For more information about available parameters, refer to [Cloud options](https://grafana.com/docs/grafana-cloud/k6/author-run/cloud-scripting-extras/cloud-options/).
+An object used to set configuration options for Grafana Cloud k6. For more information about available parameters, refer to [Cloud options](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/cloud-scripting-extras/cloud-options/).
 
 | Env | CLI | Code / Config file | Default |
 | --- | --- | ------------------ | ------- |
@@ -362,7 +362,7 @@ An object used to set configuration options for Grafana Cloud k6. For more infor
 
 This is an example of how to specify the test name (test runs/executions with the same name will be
 logically grouped for trending and comparison) when streaming results to
-[Grafana Cloud k6 Performance Insights](https://grafana.com/docs/grafana-cloud/k6/analyze-results/get-performance-insights/).
+[Grafana Cloud k6 Performance Insights](https://grafana.com/docs/grafana-cloud/testing/k6/analyze-results/get-performance-insights/).
 
 {{< code >}}
 

--- a/docs/sources/next/using-k6/test-authoring/create-tests-from-recordings/using-the-browser-recorder.md
+++ b/docs/sources/next/using-k6/test-authoring/create-tests-from-recordings/using-the-browser-recorder.md
@@ -16,7 +16,11 @@ Before you start, consider the following:
 - [Be sure to record realistically](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-authoring/create-tests-from-recordings#be-sure-to-record-realistically)
 - [A hybrid approach for load testing websites](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-authoring/create-tests-from-recordings#consider-hybrid-approach-for-load-testing-websites)
 
-> Note that the browser recorders **do not require a cloud account**. For cloud users, check out the [Grafana Cloud](https://grafana.com/docs/grafana-cloud/k6/author-run/browser-recorder/) instructions.
+{{< admonition type="note" >}}
+
+Note that the browser recorders **don't require a cloud account**. For cloud users, refer to the [Grafana Cloud](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/browser-recorder/) instructions.
+
+{{< /admonition >}}
 
 ## How to record
 

--- a/docs/sources/next/using-k6/test-authoring/test-builder.md
+++ b/docs/sources/next/using-k6/test-authoring/test-builder.md
@@ -16,6 +16,6 @@ Though we strongly believe that scriptable, code-based tools will help you get t
 
 The k6 Test Builder is **free to use** and is available in:
 
-- [Grafana Cloud k6](https://grafana.com/docs/grafana-cloud/k6/author-run/test-builder/)
+- [Grafana Cloud k6](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/test-builder/)
 
 ![k6 Test Builder](/media/docs/k6-oss/grafana-cloud-k6-test-builder.png)

--- a/docs/sources/v0.50.x/get-started/running-k6.md
+++ b/docs/sources/v0.50.x/get-started/running-k6.md
@@ -232,10 +232,10 @@ k6 supports three execution modes to run a k6 test: local, distributed, and clou
   kubectl apply -f /path/to/k6-resource.yaml
   ```
 
-- **Cloud**: the test runs on [Grafana Cloud k6](https://grafana.com/docs/grafana-cloud/k6/get-started/run-cloud-tests-from-the-cli/).
+- **Cloud**: the test runs on [Grafana Cloud k6](https://grafana.com/docs/grafana-cloud/testing/k6/get-started/run-cloud-tests-from-the-cli/).
 
   ```bash
   k6 cloud script.js
   ```
 
-  Additionally, cloud-based solutions can run cloud tests on your [own cloud infrastructure](https://grafana.com/docs/grafana-cloud/k6/author-run/private-load-zone-v2/), and accept the test results from a [local](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/cloud) or [distributed test](https://github.com/grafana/k6-operator#k6-cloud-output).
+  Additionally, cloud-based solutions can run cloud tests on your [own cloud infrastructure](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/private-load-zone-v2/), and accept the test results from a [local](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/cloud) or [distributed test](https://github.com/grafana/k6-operator#k6-cloud-output).

--- a/docs/sources/v0.50.x/misc/glossary.md
+++ b/docs/sources/v0.50.x/misc/glossary.md
@@ -130,7 +130,7 @@ An open standard, human-readable data-serialization format originally derived fr
 
 ## k6 Cloud
 
-The proper name for the entire cloud product, comprising both k6 Cloud Execution and k6 Cloud Test Results.<br/><br/>[k6 Cloud docs](https://grafana.com/docs/grafana-cloud/k6/)
+The proper name for the entire cloud product, comprising both k6 Cloud Execution and k6 Cloud Test Results.<br/><br/>[k6 Cloud docs](https://grafana.com/docs/grafana-cloud/testing/k6/)
 
 ## k6 options
 
@@ -146,7 +146,7 @@ A test that assesses the performance of the system under test in terms of concur
 
 ## Load zone
 
-The geographical instance from which a test runs.<br/><br/>[Private load zones](https://grafana.com/docs/grafana-cloud/k6/author-run/private-load-zone-v2/),[Declare load zones from the CLI](https://grafana.com/docs/grafana-cloud/k6/author-run/cloud-scripting-extras/load-zones/)
+The geographical instance from which a test runs.<br/><br/>[Private load zones](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/private-load-zone-v2/),[Declare load zones from the CLI](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/cloud-scripting-extras/load-zones/)
 
 ## Lifecycle function
 

--- a/docs/sources/v0.50.x/results-output/real-time/_index.md
+++ b/docs/sources/v0.50.x/results-output/real-time/_index.md
@@ -43,7 +43,7 @@ As well as the following third-party services:
 
 {{% admonition type="note" %}}
 
-This list applies to local tests, not to [cloud tests](https://grafana.com/docs/grafana-cloud/k6/).
+This list applies to local tests, not to [cloud tests](https://grafana.com/docs/grafana-cloud/testing/k6/).
 
 {{% /admonition %}}
 

--- a/docs/sources/v0.50.x/results-output/real-time/cloud.md
+++ b/docs/sources/v0.50.x/results-output/real-time/cloud.md
@@ -6,7 +6,7 @@ weight: 00
 
 # Grafana Cloud k6
 
-Besides [running cloud tests](https://grafana.com/docs/k6/<K6_VERSION>/get-started/running-k6#execution-modes), you can also run a test locally and stream the results to [Grafana Cloud k6](https://grafana.com/docs/grafana-cloud/k6/get-started/run-cloud-tests-from-the-cli/#run-locally-and-stream-to-the-cloud).
+Besides [running cloud tests](https://grafana.com/docs/k6/<K6_VERSION>/get-started/running-k6#execution-modes), you can also run a test locally and stream the results to [Grafana Cloud k6](https://grafana.com/docs/grafana-cloud/testing/k6/get-started/run-cloud-tests-from-the-cli/#run-locally-and-stream-to-the-cloud).
 
 When streaming the results to the cloud, the machine - where you execute the k6 CLI command - runs the test and uploads the results to the cloud-based solution. Then, you will be able to visualize and analyze the results on the web app in real-time.
 
@@ -36,7 +36,7 @@ so `k6 run --out cloud` will consume VUH or test runs from your subscription.
 
    With the `k6 login cloud` command, you can set up your API token on the k6 machine to authenticate against the cloud service.
 
-   Copy your token from [k6 Cloud](https://app.k6.io/account/api-token) or [Grafana Cloud k6](https://grafana.com/docs/grafana-cloud/k6/author-run/tokens-and-cli-authentication/) and pass it as:
+   Copy your token from [k6 Cloud](https://app.k6.io/account/api-token) or [Grafana Cloud k6](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/tokens-and-cli-authentication/) and pass it as:
 
    {{< code >}}
 

--- a/docs/sources/v0.50.x/results-output/real-time/grafana-cloud-prometheus.md
+++ b/docs/sources/v0.50.x/results-output/real-time/grafana-cloud-prometheus.md
@@ -11,7 +11,7 @@ weight: 00
 
 This page includes instructions for running a local test that sends the test results to a Prometheus instance in Grafana Cloud.
 
-For running and managing cloud tests in Grafana Cloud, check out [Grafana Cloud k6](https://grafana.com/docs/grafana-cloud/k6/).
+For running and managing cloud tests in Grafana Cloud, check out [Grafana Cloud k6](https://grafana.com/docs/grafana-cloud/testing/k6/).
 
 {{% /admonition %}}
 

--- a/docs/sources/v0.50.x/testing-guides/api-load-testing.md
+++ b/docs/sources/v0.50.x/testing-guides/api-load-testing.md
@@ -525,8 +525,8 @@ If the API is in an internal or restricted environment, you can use k6 to test i
 
 - Run the test from your private network using the k6 run command or the [Kubernetes operator](https://github.com/grafana/k6-operator). Optionally, store the test results in [k6 Cloud](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/cloud) or other [external services](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/).
 - For cloud tests:
-  - [Open your firewall](https://grafana.com/docs/grafana-cloud/k6/reference/cloud-ips/) for cloud test traffic.
-  - Run the cloud test from your [Kubernetes clusters](https://grafana.com/docs/grafana-cloud/k6/author-run/private-load-zone-v2/).
+  - [Open your firewall](https://grafana.com/docs/grafana-cloud/testing/k6/reference/cloud-ips/) for cloud test traffic.
+  - Run the cloud test from your [Kubernetes clusters](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/private-load-zone-v2/).
 
 ## Supplementary tools
 

--- a/docs/sources/v0.50.x/testing-guides/automated-performance-testing.md
+++ b/docs/sources/v0.50.x/testing-guides/automated-performance-testing.md
@@ -43,7 +43,7 @@ Automation often refers to running tests with pass/fail conditions as part of th
 [Automation into CI/CD pipelines](/integrations/#continuous-integration-and-continuous-delivery) is an option, but it's not the only method to schedule the execution of performance tests. When creating a performance testing plan, it’s important to remember that there are different ways to run performance tests in a frequent basis:
 
 - Cron and cron job runners.
-- Cloud testing tools, such as [scheduling in Grafana Cloud k6](https://grafana.com/docs/grafana-cloud/k6/author-run/schedule-a-test/).
+- Cloud testing tools, such as [scheduling in Grafana Cloud k6](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/schedule-a-test/).
 - Test management tools with automation capabilities.
 - Trigger manual tests. Include this as a step in your release checklist process.
 

--- a/docs/sources/v0.50.x/testing-guides/running-large-tests.md
+++ b/docs/sources/v0.50.x/testing-guides/running-large-tests.md
@@ -356,7 +356,7 @@ With the limitations mentioned above, we built a [Kubernetes operator](https://g
 
 ## Large-scale tests in the cloud
 
-[Grafana Cloud k6](https://grafana.com/products/cloud/k6/), our commercial offering, provides an instant solution for running large-scale tests, among other [benefits](https://grafana.com/docs/grafana-cloud/k6/).
+[Grafana Cloud k6](https://grafana.com/products/cloud/k6/), our commercial offering, provides an instant solution for running large-scale tests, among other [benefits](https://grafana.com/docs/grafana-cloud/testing/k6/).
 
 If you aren't sure whether OSS or Cloud is a better fit for your project, we recommend reading this [white paper](https://k6.io/what-to-consider-when-building-or-buying-a-load-testing-solution) to learn more about the risks and features to consider when building a scalable solution.
 

--- a/docs/sources/v0.50.x/using-k6/environment-variables.md
+++ b/docs/sources/v0.50.x/using-k6/environment-variables.md
@@ -123,4 +123,4 @@ $ k6 run -e MY_HOSTNAME=test.k6.io --duration 10s --vus 10 script.js
 
 ## Read more
 
-- [Manage environment variables in k6 Cloud](https://grafana.com/docs/grafana-cloud/k6/author-run/cloud-scripting-extras/cloud-environment-variables/)
+- [Manage environment variables in k6 Cloud](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/cloud-scripting-extras/cloud-environment-variables/)

--- a/docs/sources/v0.50.x/using-k6/execution-context-variables.md
+++ b/docs/sources/v0.50.x/using-k6/execution-context-variables.md
@@ -102,8 +102,8 @@ The variable is 0 when executing the setup and teardown functions.
 
 ### Running in k6 Cloud
 
-When you run tests in [k6 Cloud](https://grafana.com/docs/grafana-cloud/k6/), the **\_\_VU** value is per server/load generator.
-Read the details in the [cloud docs](https://grafana.com/docs/grafana-cloud/k6/reference/cloud-ips/).
+When you run tests in [k6 Cloud](https://grafana.com/docs/grafana-cloud/testing/k6/), the **\_\_VU** value is per server/load generator.
+Read the details in the [cloud docs](https://grafana.com/docs/grafana-cloud/testing/k6/reference/cloud-ips/).
 
 ### Examples
 
@@ -139,4 +139,4 @@ export default function () {
 ## Grafana Cloud k6 environment variables
 
 If you run tests in k6 Cloud, you have additional environment variables that tell you the server, load zone, and distribution of the currently running test.
-[Read about cloud environment variables](https://grafana.com/docs/grafana-cloud/k6/author-run/cloud-scripting-extras/cloud-environment-variables/).
+[Read about cloud environment variables](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/cloud-scripting-extras/cloud-environment-variables/).

--- a/docs/sources/v0.50.x/using-k6/k6-options/reference.md
+++ b/docs/sources/v0.50.x/using-k6/k6-options/reference.md
@@ -354,7 +354,7 @@ export const options = {
 
 ## Cloud options
 
-An object used to set configuration options for Grafana Cloud k6. For more information about available parameters, refer to [Cloud options](https://grafana.com/docs/grafana-cloud/k6/author-run/cloud-scripting-extras/cloud-options/).
+An object used to set configuration options for Grafana Cloud k6. For more information about available parameters, refer to [Cloud options](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/cloud-scripting-extras/cloud-options/).
 
 | Env | CLI | Code / Config file | Default |
 | --- | --- | ------------------ | ------- |
@@ -362,7 +362,7 @@ An object used to set configuration options for Grafana Cloud k6. For more infor
 
 This is an example of how to specify the test name (test runs/executions with the same name will be
 logically grouped for trending and comparison) when streaming results to
-[Grafana Cloud k6 Performance Insights](https://grafana.com/docs/grafana-cloud/k6/analyze-results/get-performance-insights/).
+[Grafana Cloud k6 Performance Insights](https://grafana.com/docs/grafana-cloud/testing/k6/analyze-results/get-performance-insights/).
 
 {{< code >}}
 

--- a/docs/sources/v0.50.x/using-k6/test-authoring/create-tests-from-recordings/using-the-browser-recorder.md
+++ b/docs/sources/v0.50.x/using-k6/test-authoring/create-tests-from-recordings/using-the-browser-recorder.md
@@ -16,7 +16,11 @@ Before you start, consider the following:
 - [Be sure to record realistically](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-authoring/create-tests-from-recordings#be-sure-to-record-realistically)
 - [A hybrid approach for load testing websites](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-authoring/create-tests-from-recordings#consider-hybrid-approach-for-load-testing-websites)
 
-> Note that the browser recorders **do not require a cloud account**. For cloud users, check out the [Grafana Cloud](https://grafana.com/docs/grafana-cloud/k6/author-run/browser-recorder/) instructions.
+{{< admonition type="note" >}}
+
+Note that the browser recorders **don't require a cloud account**. For cloud users, refer to the [Grafana Cloud](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/browser-recorder/) instructions.
+
+{{< /admonition >}}
 
 ## How to record
 

--- a/docs/sources/v0.50.x/using-k6/test-authoring/test-builder.md
+++ b/docs/sources/v0.50.x/using-k6/test-authoring/test-builder.md
@@ -16,6 +16,6 @@ Though we strongly believe that scriptable, code-based tools will help you get t
 
 The k6 Test Builder is **free to use** and is available in:
 
-- [Grafana Cloud k6](https://grafana.com/docs/grafana-cloud/k6/author-run/test-builder/)
+- [Grafana Cloud k6](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/test-builder/)
 
 ![k6 Test Builder](/media/docs/k6-oss/grafana-cloud-k6-test-builder.png)


### PR DESCRIPTION
## What?

Update links to point to the new Grafana Cloud k6 URL: https://grafana.com/docs/grafana-cloud/testing/k6/.

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [x] I have made my changes in the `docs/sources/next` folder of the documentation.
- [x] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.
- [x] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->

## Related PR(s)/Issue(s)

Closes #1563.