### PR TITLE
docs: Add endpoint to AWSConfig in readme

### DIFF
--- a/docs/sources/next/javascript-api/jslib/aws/awsconfig.md
+++ b/docs/sources/next/javascript-api/jslib/aws/awsconfig.md
@@ -20,6 +20,7 @@ It takes an options object as its single parameter, with the following propertie
 | accessKeyID             | string | The AWS access key ID credential to use for authentication.                                                               |
 | secretAccessKey         | string | The AWS secret access credential to use for authentication.                                                               |
 | sessionToken (optional) | string | The AWS secret access token to use for authentication.                                                                    |
+| endpoint (optional)    | string | The AWS endpoint. Useful for local testing.                                                                                |
 
 ### Methods
 

--- a/src/data/markdown/docs/20 jslib/01 jslib/01 aws/00 AwsConfig.md
+++ b/src/data/markdown/docs/20 jslib/01 jslib/01 aws/00 AwsConfig.md
@@ -17,7 +17,8 @@ It takes an options object as its single parameter, with the following propertie
 | region                     | string | the AWS region to connect to. As described by [Amazon AWS docs](https://docs.aws.amazon.com/general/latest/gr/rande.html) |
 | accessKeyID                | string | The AWS access key ID credential to use for authentication.                                                               |
 | secretAccessKey            | string | The AWS secret access credential to use for authentication.                                                               |
-| sessionToken (optional)    | string | The AWS secret access token to use for authentication.                                                               |
+| sessionToken (optional)    | string | The AWS secret access token to use for authentication.                                                                    |
+| endpoint (optional)    | string | The AWS endpoint. Useful for local testing.                                                                                   |
 
 ### Methods
 


### PR DESCRIPTION
## What?

Add `endpoint` to the `AWSConfig` configuration. The AWS `endpoint` is useful to configure when testing locally e.g. against [localstack](https://github.com/localstack/localstack).

## Checklist

- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.

- [x] I have made my changes in the `docs/sources/next` folder of the documentation.

## Related PR(s)/Issue(s)
