### PR TITLE
Update browser `Tap` methods from sync to async

### DIFF
--- a/docs/sources/next/javascript-api/k6-experimental/browser/locator/tap.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/locator/tap.md
@@ -30,6 +30,12 @@ Tap on the chosen element.
 
 </TableWithNestedRows>
 
+### Returns
+
+| Type            | Description                                              |
+| --------------- | -------------------------------------------------------- |
+| `Promise<void>` | A Promise that fulfills when the tap action is finished. |
+
 ### Example
 
 {{< code >}}
@@ -44,7 +50,7 @@ export default async function () {
 
   await page.goto('https://test.k6.io/browser.php');
   const options = page.locator('#numbers-options');
-  options.tap();
+  await options.tap();
 }
 ```
 

--- a/docs/sources/next/javascript-api/k6-experimental/browser/page/tap.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/page/tap.md
@@ -31,6 +31,12 @@ Tap the first element that matches the selector.
 
 </TableWithNestedRows>
 
+### Returns
+
+| Type            | Description                                              |
+| --------------- | -------------------------------------------------------- |
+| `Promise<void>` | A Promise that fulfills when the tap action is finished. |
+
 ### Example
 
 {{< code >}}
@@ -55,7 +61,7 @@ export default async function () {
   const page = browser.newPage();
 
   await page.goto('https://test.k6.io/browser.php');
-  page.tap('#numbers-options');
+  await page.tap('#numbers-options');
 }
 ```
 


### PR DESCRIPTION
## What?

Update browser `Tap` method docs to async.

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 2. If updating the documentation for the next release of k6: -->
- [x] I have made my changes in the `docs/sources/next` folder of the documentation.

## Related PR(s)/Issue(s)

https://github.com/grafana/xk6-browser/issues/1251