### PR TITLE
Document changes in k6/expeimental/websockets

### DIFF
--- a/docs/sources/next/javascript-api/k6-experimental/websockets/_index.md
+++ b/docs/sources/next/javascript-api/k6-experimental/websockets/_index.md
@@ -34,7 +34,7 @@ A WebSocket instance also has the following properties:
 | WebSocket.readyState                                                                                                                    | The current state of the connection. Could be one of [the four states](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/readyState).                                                 |
 | WebSocket.url                                                                                                                           | The URL of the connection as resolved by the constructor.                                                                                                                                      |
 | WebSocket.bufferedAmount                                                                                                                | The number of bytes of data that have been queued using calls to `send()` but not yet transmitted to the network.                                                                              |
-| WebSocket.binaryType                                                                                                                    | The [`binaryType`](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/binaryType) is by default `"ArrayBuffer"`. Setting it throws an exception, as k6 does not support the Blob type. |
+| WebSocket.binaryType                                                                                                                    | The [`binaryType`](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/binaryType) is by default `""`. If a binary message is received it will be automatically set to `"arraybuffer"` if empty and warning will be printed. In the future it will move to default to `"blob"`. If you want to have the same behaviour - you should always be setting it to `"arraybuffer"`. |
 | [WebSocket.onmessage](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/websockets/websocket/websocket-onmessage) | A handler for `message` events.                                                                                                                                                                |
 | [WebSocket.onerror](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/websockets/websocket/websocket-onerror)     | A handler for `error` events.                                                                                                                                                                  |
 | [WebSocket.onopen](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/websockets/websocket/websocket-onopen)       | A handler for `open` events.                                                                                                                                                                   |
@@ -75,6 +75,7 @@ export default function () {
 function startWSWorker(id) {
   // create a new websocket connection
   const ws = new WebSocket(`wss://test-api.k6.io/ws/crocochat/${chatRoomName}/`);
+  ws.binaryType = "arraybuffer";
 
   ws.addEventListener('open', () => {
     // change the user name

--- a/docs/sources/next/javascript-api/k6-experimental/websockets/websocket/websocket-addeventlistener.md
+++ b/docs/sources/next/javascript-api/k6-experimental/websockets/websocket/websocket-addeventlistener.md
@@ -33,6 +33,7 @@ import { WebSocket } from 'k6/experimental/websockets';
 
 export default function () {
   const ws = new WebSocket('ws://localhost:10000');
+  ws.binaryType = "arraybuffer";
 
   ws.onopen = () => {
     console.log('connected');

--- a/docs/sources/next/javascript-api/k6-experimental/websockets/websocket/websocket-onmessage.md
+++ b/docs/sources/next/javascript-api/k6-experimental/websockets/websocket/websocket-onmessage.md
@@ -20,6 +20,7 @@ import { WebSocket } from 'k6/experimental/websockets';
 
 export default function () {
   const ws = new WebSocket('ws://localhost:10000');
+  ws.binaryType = "arraybuffer";
 
   ws.onmessage = (data) => {
     console.log('a message received');


### PR DESCRIPTION

## What?

Update with changes in `k6/experimental/websockets`.

https://github.com/grafana/xk6-websockets/pull/64

## Checklist

<!-- Please fill in this template: -->
- [ ] I have used a meaningful title for the PR.
- [ ] I have described the changes I've made in the "What?" section above.
- [ ] I have performed a self-review of my changes.
- [ ] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [ ] I have made my changes in the `docs/sources/next` folder of the documentation.
- [ ] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.
- [ ] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->

<!-- 2. If updating the documentation for the next release of k6: -->
- [ ] I have made my changes in the `docs/sources/next` folder of the documentation.

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->
<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->