### PR TITLE
chore: add link to LitmusChaos to Integrations & Tools

### DIFF
--- a/docs/sources/next/misc/integrations.md
+++ b/docs/sources/next/misc/integrations.md
@@ -71,6 +71,7 @@ By automating load testing with your CI / CD tools, you can quickly see when a c
 - [Steadybit](https://k6.io/blog/chaos-engineering-with-k6-and-steadybit) - Using k6 and Steadybit for chaos engineering.
 - [xk6-disruptor](https://grafana.com/docs/k6/<K6_VERSION>/testing-guides/injecting-faults-with-xk6-disruptor/xk6-disruptor) - A k6 extension for injecting faults into k6 tests.
 - [ChaosToolkit](http://chaostoolkit.org/drivers/k6/) - A collection of k6 actions and probes.
+- [LitmusChaos](https://litmuschaos.github.io/litmus/experiments/categories/load/k6-loadgen/) - Simulate load generation to the target application as a part of chaos testing on Kubernetes using Litmus.
 
 ## Test management
 

--- a/docs/sources/v0.48.x/misc/integrations.md
+++ b/docs/sources/v0.48.x/misc/integrations.md
@@ -71,6 +71,7 @@ By automating load testing with your CI / CD tools, you can quickly see when a c
 - [Steadybit](https://k6.io/blog/chaos-engineering-with-k6-and-steadybit) - Using k6 and Steadybit for chaos engineering.
 - [xk6-disruptor](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor) - A k6 extension for injecting faults into k6 tests.
 - [ChaosToolkit](http://chaostoolkit.org/drivers/k6/) - A collection of k6 actions and probes.
+- [LitmusChaos](https://litmuschaos.github.io/litmus/experiments/categories/load/k6-loadgen/) - Simulate load generation to the target application as a part of chaos testing on Kubernetes using Litmus.
 
 ## Test management
 

--- a/docs/sources/v0.49.x/misc/integrations.md
+++ b/docs/sources/v0.49.x/misc/integrations.md
@@ -71,6 +71,7 @@ By automating load testing with your CI / CD tools, you can quickly see when a c
 - [Steadybit](https://k6.io/blog/chaos-engineering-with-k6-and-steadybit) - Using k6 and Steadybit for chaos engineering.
 - [xk6-disruptor](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor) - A k6 extension for injecting faults into k6 tests.
 - [ChaosToolkit](http://chaostoolkit.org/drivers/k6/) - A collection of k6 actions and probes.
+- [LitmusChaos](https://litmuschaos.github.io/litmus/experiments/categories/load/k6-loadgen/) - Simulate load generation to the target application as a part of chaos testing on Kubernetes using Litmus.
 
 ## Test management
 

--- a/docs/sources/v0.50.x/misc/integrations.md
+++ b/docs/sources/v0.50.x/misc/integrations.md
@@ -71,6 +71,7 @@ By automating load testing with your CI / CD tools, you can quickly see when a c
 - [Steadybit](https://k6.io/blog/chaos-engineering-with-k6-and-steadybit) - Using k6 and Steadybit for chaos engineering.
 - [xk6-disruptor](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/xk6-disruptor) - A k6 extension for injecting faults into k6 tests.
 - [ChaosToolkit](http://chaostoolkit.org/drivers/k6/) - A collection of k6 actions and probes.
+- [LitmusChaos](https://litmuschaos.github.io/litmus/experiments/categories/load/k6-loadgen/) - Simulate load generation to the target application as a part of chaos testing on Kubernetes using Litmus.
 
 ## Test management
 


### PR DESCRIPTION
## What?

Add link to [Litmus platform k6 integration](https://litmuschaos.github.io/litmus/experiments/categories/load/k6-loadgen/) to Integrations & Tools page.

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [x] I have made my changes in the `docs/sources/next` folder of the documentation.
- [x] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.
- [x] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->
<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->