### PR TITLE
Update to Async `BrowserContext`

### DIFF
--- a/docs/sources/next/javascript-api/k6-experimental/browser/_index.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/_index.md
@@ -251,7 +251,7 @@ export const options = {
 export default async function () {
   const iphoneX = devices['iPhone X'];
   const context = await browser.newContext(iphoneX);
-  const page = context.newPage();
+  const page = await context.newPage();
 
   try {
     await page.goto('https://test.k6.io/');

--- a/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/addcookies.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/addcookies.md
@@ -5,13 +5,19 @@ description: 'Clears context cookies.'
 
 # addCookies()
 
-Adds a list of [cookies](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext/cookie) into the [BrowserContext](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext/cookie). All pages within this [BrowserContext](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext/cookie) will have these [cookies](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext/cookie) set.
+Adds a list of [cookies](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext/cookie) into the [browser context](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext/). All pages within this [browser context](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext/) will have these [cookies](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext/cookie) set.
 
 {{% admonition type="note" %}}
 
 If a [cookie](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext/cookie)'s `url` property is not provided, both `domain` and `path` properties must be specified.
 
 {{% /admonition %}}
+
+### Returns
+
+| Type            | Description                                                                                                                                                                                                                                                                                  |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Promise<void>` | A Promise that fulfills when the [cookies](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext/cookie) have been added to the [browser context](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext/). |
 
 ### Example
 

--- a/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/addcookies.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/addcookies.md
@@ -35,7 +35,7 @@ export const options = {
 
 export default async function () {
   const context = await browser.newContext();
-  const page = context.newPage();
+  const page = await context.newPage();
 
   try {
     const unixTimeSinceEpoch = Math.round(new Date() / 1000);
@@ -43,7 +43,7 @@ export default async function () {
     const dayAfter = unixTimeSinceEpoch + day;
     const dayBefore = unixTimeSinceEpoch - day;
 
-    context.addCookies([
+    await context.addCookies([
       // this cookie expires at the end of the session
       {
         name: 'testcookie',

--- a/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/addinitscript.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/addinitscript.md
@@ -7,10 +7,16 @@ description: 'Adds an init script.'
 
 Adds a script which will be evaluated in one of the following scenarios:
 
-- Whenever a [page](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/page/) is created in the [browserContext](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext) or is navigated.
-- Whenever a child [frame](<[page](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/frame/)>) is attached or navigated in any [page](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/page/) in the [browserContext](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext). In this case, the script is evaluated in the context of the newly attached [frame](<[page](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/frame/)>).
+- Whenever a [page](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/page/) is created in the [browser context](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext) or is navigated.
+- Whenever a child [frame](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/frame/) is attached or navigated in any [page](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/page/) in the [browser context](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext). In this case, the script is evaluated in the context of the newly attached [frame](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/frame/).
 
 The script is evaluated after the document is created but before any of its scripts are run. This is useful to amend the JavaScript environment, for example, to override `Math.random`.
+
+### Returns
+
+| Type            | Description                                                                                                                                                                     |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Promise<void>` | A Promise that fulfills when the script has been added to the [browser context](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext). |
 
 ### Example
 

--- a/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/addinitscript.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/addinitscript.md
@@ -37,9 +37,9 @@ export default async function () {
   const browserContext = await browser.newContext();
 
   // This will execute and override the existing implementation of Math.random.
-  browserContext.addInitScript('Math.random = function(){return 0}');
+  await browserContext.addInitScript('Math.random = function(){return 0}');
 
-  const page = browserContext.newPage();
+  const page = await browserContext.newPage();
 
   // In this example we are going to set the content manually, so we first
   // navigate to about:blank which will execute the init script, before setting

--- a/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/clearcookies.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/clearcookies.md
@@ -5,7 +5,13 @@ description: 'Clears context cookies.'
 
 # clearCookies()
 
-Clears the `BrowserContext`'s cookies.
+Clears the [browser context](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext)'s cookies.
+
+### Returns
+
+| Type            | Description                                                                                                                                                                            |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Promise<void>` | A Promise that fulfills when the cookies have been cleared from the [browser context](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext). |
 
 ### Example
 

--- a/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/clearcookies.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/clearcookies.md
@@ -29,13 +29,15 @@ export const options = {
 
 export default async function () {
   const context = await browser.newContext();
-  const page = context.newPage();
+  const page = await context.newPage();
 
   await page.goto('https://httpbin.org/cookies/set?testcookie=testcookievalue');
-  console.log(context.cookies().length); // prints: 1
+  let cookies = await context.cookies();
+  console.log(cookies.length); // prints: 1
 
-  context.clearCookies();
-  console.log(context.cookies().length); // prints: 0
+  await context.clearCookies();
+  cookies = await context.cookies();
+  console.log(cookies.length); // prints: 0
 }
 ```
 

--- a/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/clearpermissions.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/clearpermissions.md
@@ -29,9 +29,9 @@ export const options = {
 
 export default function () {
   const context = await browser.newContext();
-  context.grantPermissions(['clipboard-read']);
+  await context.grantPermissions(['clipboard-read']);
   // do stuff ...
-  context.clearPermissions();
+  await context.clearPermissions();
 }
 ```
 

--- a/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/clearpermissions.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/clearpermissions.md
@@ -5,7 +5,13 @@ description: 'Clears all permission overrides for the BrowserContext.'
 
 # clearPermissions()
 
-Clears all permission overrides for the `BrowserContext`.
+Clears all permission overrides for the [browser context](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext).
+
+### Returns
+
+| Type            | Description                                                                                                                                                                            |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Promise<void>` | A Promise that fulfills when the permissions have been cleared from the [browser context](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext). |
 
 ### Example
 

--- a/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/close.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/close.md
@@ -29,9 +29,9 @@ export const options = {
 
 export default function () {
   const context = await browser.newContext();
-  context.newPage();
+await context.newPage();
 
-  context.close();
+  await context.close();
 }
 ```
 

--- a/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/close.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/close.md
@@ -5,7 +5,13 @@ description: 'Close the BrowserContext and all its pages.'
 
 # close()
 
-Close the `BrowserContext` and all its [page](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/page/)s. The `BrowserContext` is unusable after this call and a new one must be created. This is typically called to cleanup before ending the test.
+Close the [browser context](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext) and all its [pages](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/page/). The [browser context](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext) is unusable after this call and a new one must be created. This is typically called to cleanup before ending the test.
+
+### Returns
+
+| Type            | Description                                                                                                                                                                                                                                                                     |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Promise<void>` | A Promise that fulfills when the [browser context](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext) and all its [page](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/page/)s have been closed. |
 
 ### Example
 

--- a/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/close.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/close.md
@@ -29,7 +29,7 @@ export const options = {
 
 export default function () {
   const context = await browser.newContext();
-await context.newPage();
+  await context.newPage();
 
   await context.close();
 }

--- a/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/cookies.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/cookies.md
@@ -5,17 +5,17 @@ description: 'Retrieves context cookies.'
 
 # cookies([urls])
 
-Returns a list of [cookies](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext/cookie) from the [BrowserContext](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext) filtered by the provided `urls`. If no `urls` are provided, all cookies are returned.
+Returns a list of [cookies](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext/cookie) from the [browser context](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext) filtered by the provided `urls`. If no `urls` are provided, all cookies are returned.
 
 | Parameter | Type  | Description                                                                                                                                                                                                                                                                    |
 | --------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| urls      | array | A string array of URLs to filter the [cookies](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext/cookie) in the [BrowserContext](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext). |
+| urls      | array | A string array of URLs to filter the [cookies](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext/cookie) in the [browser context](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext). |
 
 ### Returns
 
-| Type  | Description                                                                                                                 |
-| ----- | --------------------------------------------------------------------------------------------------------------------------- |
-| array | A list of [cookies](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext/cookie). |
+| Type                     | Description                                                                                                                                                |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Promise<Array<Cookie>>` | A Promise that fulfills with an array of [cookies](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext/cookie). |
 
 {{% admonition type="note" %}}
 

--- a/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/cookies.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/cookies.md
@@ -45,26 +45,26 @@ export const options = {
 
 export default async function () {
   const context = await browser.newContext();
-  const page = context.newPage();
+  const page = await context.newPage();
 
   try {
     // get cookies from the browser context
-    let cookies = context.cookies();
+    let cookies = await context.cookies();
     console.log('initial cookies length:', cookies.length); // prints 0
 
     // let's add more cookies to filter by urls
-    context.addCookies([
+    await context.addCookies([
       { name: 'foo', value: 'foovalue', sameSite: 'Strict', url: 'http://foo.com' },
       { name: 'bar', value: 'barvalue', sameSite: 'Lax', url: 'https://bar.com' },
       { name: 'baz', value: 'bazvalue', sameSite: 'Lax', url: 'https://baz.com' },
     ]);
 
     // get all cookies
-    cookies = context.cookies();
+    cookies = await context.cookies();
     console.log('filtered cookies length:', cookies.length); // prints 3
 
     // get cookies filtered by urls
-    cookies = context.cookies('http://foo.com', 'https://baz.com');
+    cookies = await context.cookies('http://foo.com', 'https://baz.com');
     console.log('filtered cookies length:', cookies.length); // prints 2
 
     // the first filtered cookie

--- a/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/grantpermissions.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/grantpermissions.md
@@ -45,7 +45,7 @@ export const options = {
 
 export default function () {
   const context = await browser.newContext();
-  context.grantPermissions(['clipboard-read', 'clipboard-write'], {
+  await context.grantPermissions(['clipboard-read', 'clipboard-write'], {
     origin: 'https://example.com/',
   });
 }

--- a/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/grantpermissions.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/grantpermissions.md
@@ -5,7 +5,7 @@ description: 'Grants specified permissions to the BrowserContext.'
 
 # grantPermissions(permissions[, options])
 
-Grants specified permissions to the `BrowserContext`. Only grants corresponding permissions to the given origin if specified.
+Grants specified permissions to the [browser context](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext). Only grants corresponding permissions to the given origin if specified.
 
 <TableWithNestedRows>
 
@@ -16,6 +16,12 @@ Grants specified permissions to the `BrowserContext`. Only grants corresponding 
 | options.origin | string | The [origin](https://developer.mozilla.org/en-US/docs/Glossary/Origin) to grant permissions to, e.g. `'https://example.com'`.                                                                                                                                                                                                                                                                         |
 
 </TableWithNestedRows>
+
+### Returns
+
+| Type            | Description                                                     |
+| --------------- | --------------------------------------------------------------- |
+| `Promise<void>` | A Promise that fulfills when the permissions have been granted. |
 
 ### Example
 

--- a/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/newpage.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/newpage.md
@@ -5,13 +5,13 @@ description: 'Creates a new page inside this BrowserContext.'
 
 # newPage()
 
-Uses the `BrowserContext` to create a new [Page](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/page/) and returns it.
+Uses the [browser context](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext) to create and return a new [page](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/page/).
 
 ### Returns
 
-| Type   | Description                                                                                                 |
-| ------ | ----------------------------------------------------------------------------------------------------------- |
-| object | A new [Page](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/page/) object. |
+| Type            | Description                                                                                                                              |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `Promise<Page>` | A Promise that fulfills with a new [page](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/page/) object. |
 
 ### Example
 

--- a/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/newpage.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/newpage.md
@@ -22,7 +22,7 @@ import { browser } from 'k6/experimental/browser';
 
 export default async function () {
   const context = await browser.newContext();
-  const page = context.newPage();
+  const page = await context.newPage();
 
   try {
     await page.goto('https://test.k6.io/browser.php');

--- a/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/pages.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/pages.md
@@ -42,7 +42,7 @@ export const options = {
 
 export default function () {
   const context = await browser.newContext();
-await context.newPage();
+  await context.newPage();
   const pages = context.pages();
   console.log(pages.length); // 1
   await context.close();

--- a/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/pages.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/pages.md
@@ -16,9 +16,9 @@ Returns all open [Page](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/
 
 ### Returns
 
-| Type  | Description     |
-| ----- | --------------- |
-| array | All open pages. |
+| Type          | Description                                                                                                        |
+| ------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `Array<Page>` | An array of [page](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/page/) objects. |
 
 ### Example
 

--- a/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/pages.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/pages.md
@@ -42,10 +42,10 @@ export const options = {
 
 export default function () {
   const context = await browser.newContext();
-  context.newPage();
+await context.newPage();
   const pages = context.pages();
   console.log(pages.length); // 1
-  context.close();
+  await context.close();
 }
 ```
 

--- a/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/setdefaultnavigationtimeout.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/setdefaultnavigationtimeout.md
@@ -33,7 +33,7 @@ export const options = {
 
 export default async function () {
   const context = await browser.newContext();
-  const page = context.newPage();
+  const page = await context.newPage();
   context.setDefaultNavigationTimeout(1000); // 1s
 
   try {

--- a/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/setdefaulttimeout.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/setdefaulttimeout.md
@@ -34,7 +34,7 @@ export const options = {
 export default async function () {
   const context = await browser.newContext();
   context.setDefaultTimeout(1000); // 1s
-  const page = context.newPage();
+  const page = await context.newPage();
   await page.click('h2'); // times out
 }
 ```

--- a/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/setgeolocation.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/setgeolocation.md
@@ -47,7 +47,7 @@ export const options = {
 
 export default function () {
   const context = await browser.newContext();
-  context.setGeolocation({ latitude: 59.95, longitude: 30.31667 });
+  await context.setGeolocation({ latitude: 59.95, longitude: 30.31667 });
 }
 ```
 

--- a/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/setgeolocation.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/setgeolocation.md
@@ -12,7 +12,7 @@ This feature has **known issues**. For details, refer to
 
 {{% /admonition %}}
 
-Sets the context's geolocation.
+Sets the [browser context](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext)'s geolocation.
 
 <TableWithNestedRows>
 
@@ -24,6 +24,12 @@ Sets the context's geolocation.
 | geolocation.accuracy  | number | `0`     | Optional non-negative accuracy value. |
 
 </TableWithNestedRows>
+
+### Returns
+
+| Type            | Description                                                |
+| --------------- | ---------------------------------------------------------- |
+| `Promise<void>` | A Promise that fulfills when the geolocation has been set. |
 
 ### Example
 

--- a/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/setoffline.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/setoffline.md
@@ -5,11 +5,17 @@ description: "Toggles the BrowserContext's connectivity on/off."
 
 # setOffline(offline)
 
-Toggles the `BrowserContext`'s connectivity on/off.
+Toggles the [browser context](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext)'s connectivity on/off.
 
 | Parameter | Type    | Default | Description                                                                                 |
 | --------- | ------- | ------- | ------------------------------------------------------------------------------------------- |
-| offline   | boolean | `false` | Whether to emulate the `BrowserContext` being disconnected (`true`) or connected (`false`). |
+| offline   | boolean | `false` | Whether to emulate the [browser context](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/browsercontext) being disconnected (`true`) or connected (`false`). |
+
+### Returns
+
+| Type            | Description                                                 |
+| --------------- | ----------------------------------------------------------- |
+| `Promise<void>` | A Promise that fulfills when the connectivity has been set. |
 
 ### Example
 

--- a/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/setoffline.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/setoffline.md
@@ -34,9 +34,9 @@ export const options = {
 export default async function () {
   const context = await browser.newContext();
 
-  context.setOffline(true);
+  await context.setOffline(true);
 
-  const page = context.newPage();
+  const page = await context.newPage();
 
   try {
     // Will not be able to load the page

--- a/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/waitforevent.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/waitforevent.md
@@ -48,7 +48,7 @@ export default async function () {
   // Call waitForEvent with a predicate which will return true once at least
   // one page has been created.
   let counter = 0;
-  const promise = context.waitForEvent('page', {
+  const promise = await context.waitForEvent('page', {
     predicate: (page) => {
       if (++counter >= 1) {
         return true;
@@ -58,7 +58,7 @@ export default async function () {
   });
 
   // Now we create a page.
-  const page = context.newPage();
+  const page = await context.newPage();
 
   // Wait for the predicate to pass.
   await promise;

--- a/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/waitforevent.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/browsercontext/waitforevent.md
@@ -18,9 +18,9 @@ Waits for the event to fire and returns its value. If a predicate function has b
 
 ### Returns
 
-| Type              | Description                                                                                                                                  |
-| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Promise<Object>` | At the moment a [Page](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/page) object is the only return value |
+| Type            | Description                                                                                                                                                                |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Promise<Page>` | A Promise that fulfills with a [page](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/page) object when the `page` event has been emitted. |
 
 ### Example
 

--- a/docs/sources/next/javascript-api/k6-experimental/browser/context.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/context.md
@@ -42,10 +42,10 @@ export default function () {
 
   const page1 = await browser.newPage(); // implicitly creates a new browserContext
   const context = browser.context(); // underlying live browserContext associated with browser
-  const page2 = context.newPage(); // shares the browserContext with page1
+  const page2 = await context.newPage(); // shares the browserContext with page1
 
   page1.close();
   page2.close();
-  context.close();
+  await context.close();
 }
 ```

--- a/docs/sources/next/javascript-api/k6-experimental/browser/locator/clear.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/locator/clear.md
@@ -41,7 +41,7 @@ export const options = {
 
 export default async function () {
   const context = await browser.newContext();
-  const page = context.newPage();
+  const page = await context.newPage();
 
   await page.goto('https://test.k6.io/my_messages.php', { waitUntil: 'networkidle' });
 

--- a/docs/sources/next/javascript-api/k6-experimental/browser/newcontext.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/newcontext.md
@@ -82,7 +82,7 @@ export default async function () {
     },
     deviceScaleFactor: 3,
   });
-  const page = context.newPage();
+  const page = await context.newPage();
 
   try {
     await page.goto('https://test.k6.io/');

--- a/docs/sources/next/javascript-api/k6-experimental/browser/page/throttlecpu.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/page/throttlecpu.md
@@ -34,7 +34,7 @@ export const options = {
 
 export default async function () {
   const context = await browser.newContext();
-  const page = context.newPage();
+  const page = await context.newPage();
 
   try {
     page.throttleCPU({ rate: 4 });

--- a/docs/sources/next/javascript-api/k6-experimental/browser/page/throttlenetwork.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/page/throttlenetwork.md
@@ -44,7 +44,7 @@ export const options = {
 
 export default async function () {
   const context = await browser.newContext();
-  const page = context.newPage();
+  const page = await context.newPage();
 
   try {
     page.throttleNetwork(networkProfiles['Slow 3G']);


### PR DESCRIPTION
## What?

Update relevant `BrowserContext` methods from sync to async.

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [x] I have made my changes in the `docs/sources/next` folder of the documentation.
- [ ] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.
- [ ] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->

## Related PR(s)/Issue(s)

grafana/xk6-browser#1295