### PR TITLE
chore: fix link to xk6-kafka

### DIFF
--- a/docs/sources/next/extensions/explore.md
+++ b/docs/sources/next/extensions/explore.md
@@ -159,9 +159,9 @@ Use the table to explore the many extensions. Questions? Feel free to join the d
         <h4>xk6-jose</h4>
         <p>Javascript Object Signing and Encryption (JOSE)</p>
     </a>
-    <a href="https://github.com/grafana/xk6-output-kafka" target="_blank" class="nav-cards__item nav-cards__item--guide">
-        <h4>xk6-output-kafka</h4>
-        <p>Export k6 results in real-time to Kafka</p>
+    <a href="https://github.com/mostafa/xk6-kafka" target="_blank" class="nav-cards__item nav-cards__item--guide">
+        <h4>xk6-kafka</h4>
+        <p>Load test Apache Kafka. Includes support for Avro messages.</p>
     </a>
     <a href="https://github.com/grafana/xk6-kubernetes" target="_blank" class="nav-cards__item nav-cards__item--guide">
         <h4>xk6-kubernetes</h4>

--- a/docs/sources/v0.49.x/extensions/explore.md
+++ b/docs/sources/v0.49.x/extensions/explore.md
@@ -159,9 +159,9 @@ Use the table to explore the many extensions. Questions? Feel free to join the d
         <h4>xk6-jose</h4>
         <p>Javascript Object Signing and Encryption (JOSE)</p>
     </a>
-    <a href="https://github.com/grafana/xk6-output-kafka" target="_blank" class="nav-cards__item nav-cards__item--guide">
-        <h4>xk6-output-kafka</h4>
-        <p>Export k6 results in real-time to Kafka</p>
+    <a href="https://github.com/mostafa/xk6-kafka" target="_blank" class="nav-cards__item nav-cards__item--guide">
+        <h4>xk6-kafka</h4>
+        <p>Load test Apache Kafka. Includes support for Avro messages.</p>
     </a>
     <a href="https://github.com/grafana/xk6-kubernetes" target="_blank" class="nav-cards__item nav-cards__item--guide">
         <h4>xk6-kubernetes</h4>

--- a/docs/sources/v0.50.x/extensions/explore.md
+++ b/docs/sources/v0.50.x/extensions/explore.md
@@ -159,9 +159,9 @@ Use the table to explore the many extensions. Questions? Feel free to join the d
         <h4>xk6-jose</h4>
         <p>Javascript Object Signing and Encryption (JOSE)</p>
     </a>
-    <a href="https://github.com/grafana/xk6-output-kafka" target="_blank" class="nav-cards__item nav-cards__item--guide">
-        <h4>xk6-output-kafka</h4>
-        <p>Export k6 results in real-time to Kafka</p>
+    <a href="https://github.com/mostafa/xk6-kafka" target="_blank" class="nav-cards__item nav-cards__item--guide">
+        <h4>xk6-kafka</h4>
+        <p>Load test Apache Kafka. Includes support for Avro messages.</p>
     </a>
     <a href="https://github.com/grafana/xk6-kubernetes" target="_blank" class="nav-cards__item nav-cards__item--guide">
         <h4>xk6-kubernetes</h4>

--- a/docs/sources/v0.51.x/extensions/explore.md
+++ b/docs/sources/v0.51.x/extensions/explore.md
@@ -159,9 +159,9 @@ Use the table to explore the many extensions. Questions? Feel free to join the d
         <h4>xk6-jose</h4>
         <p>Javascript Object Signing and Encryption (JOSE)</p>
     </a>
-    <a href="https://github.com/grafana/xk6-output-kafka" target="_blank" class="nav-cards__item nav-cards__item--guide">
-        <h4>xk6-output-kafka</h4>
-        <p>Export k6 results in real-time to Kafka</p>
+    <a href="https://github.com/mostafa/xk6-kafka" target="_blank" class="nav-cards__item nav-cards__item--guide">
+        <h4>xk6-kafka</h4>
+        <p>Load test Apache Kafka. Includes support for Avro messages.</p>
     </a>
     <a href="https://github.com/grafana/xk6-kubernetes" target="_blank" class="nav-cards__item nav-cards__item--guide">
         <h4>xk6-kubernetes</h4>


### PR DESCRIPTION
<!-- 
Please make sure you have read the contribution guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md as well as the
the code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md before opening a PR.
-->

## What?

The extensions page had duplicate links to xk6-output-kafka, and was missing a link to the xk6-kafka extension.

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [x] I have made my changes in the `docs/sources/next` folder of the documentation.
- [x] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.
- [x] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->
<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->