### PR TITLE
chore: add instructions for bundling Node.js modules

### DIFF
--- a/docs/sources/next/using-k6/modules.md
+++ b/docs/sources/next/using-k6/modules.md
@@ -189,7 +189,7 @@ You can also use these two example repositories as a starting point:
 - [k6-template-es6](https://github.com/grafana/k6-template-es6): Template using Webpack and Babel to enable ES6 features in k6 tests.
 - [k6-rollup-example](https://github.com/grafana/k6-rollup-example/): Example using Rollup to bundle k6 tests and release a shared library.
 
-### Set up Webpack
+### Webpack setup example
 
 Setting up a Babel and Webpack project from scratch might sound like a big undertaking, but
 is usually accomplished within minutes. Start by creating a project folder and initializing
@@ -201,7 +201,7 @@ $ mkdir ./example-project && \
     npm init -y
 ```
 
-### Install packages
+#### Install packages
 
 Then, install the packages needed:
 
@@ -226,7 +226,7 @@ $ npm install --save-dev \
 | [@babel/preset-env](https://github.com/babel/babel/tree/master/packages/babel-preset-env) | A smart preset using [browserlist](https://github.com/browserslist/browserslist), [compat-table](https://github.com/kangax/compat-table) and [electron-to-chromium](https://github.com/Kilian/electron-to-chromium) to determine what code to transpile and polyfill. |
 | [core-js](https://github.com/zloirock/core-js)                                            | A modular standard library for JS including polyfills                                                                                                                                                                                                                 |
 
-### Configure Webpack
+#### Configure Webpack
 
 Once these packages have been added, the next step will be to set up a `webpack.config.js` file:
 
@@ -302,7 +302,7 @@ The `filename` key, as the name suggests, configures the name of the finished bu
 example, the [template string](https://webpack.js.org/configuration/output/#template-strings) `[name]`
 is used to add a dynamic part to the output filename.
 
-### Add a bundle command
+#### Add a bundle command
 
 Open the `package.json` file and add a new script entry, used for running the bundling process.
 
@@ -319,7 +319,7 @@ Open the `package.json` file and add a new script entry, used for running the bu
 }
 ```
 
-### Bundle tests
+#### Bundle tests
 
 Running webpack will now output two different test bundles, that may be executed independently:
 
@@ -335,7 +335,7 @@ dist
 0 directories, 2 files
 ```
 
-### Run tests
+#### Run tests
 
 ```bash
 $ npm run bundle

--- a/docs/sources/next/using-k6/modules.md
+++ b/docs/sources/next/using-k6/modules.md
@@ -13,8 +13,8 @@ It's common to import modules, or parts of modules, to use in your test scripts.
 In k6, you can import different kinds of modules:
 
 - [Built-in modules](#built-in-modules)
-- [Local filesystem modules](#local-filesystem-modules)
-- [Remote HTTP(S) modules](#remote-https-modules)
+- [Local modules](#local-modules)
+- [Remote modules](#remote-modules)
 - [Extension modules](#extension-modules)
 
 ### Built-in modules

--- a/docs/sources/next/using-k6/modules.md
+++ b/docs/sources/next/using-k6/modules.md
@@ -7,7 +7,7 @@ weight: 07
 
 # Modules
 
-## Importing modules
+## Import modules
 
 It's common to import modules, or parts of modules, to use in your test scripts.
 In k6, you can import different kinds of modules:
@@ -106,7 +106,7 @@ How do k6 extensions (Go-to-JS modules) work? For enhanced performance, the k6 e
 
 To learn more about using or creating k6 extensions, refer to the [Extension documentation](https://grafana.com/docs/k6/<K6_VERSION>/extensions).
 
-## Sharing JavaScript modules
+## Share JavaScript modules
 
 As mentioned previously, users can import custom JavaScript libraries by loading either local or remote modules. Because of that, we have two options to import JavaScript modules, along with various methods to distribute them.
 
@@ -116,7 +116,7 @@ The following options for distributing and sharing JavaScript libraries are avai
 
 {{< /admonition >}}
 
-**As remote modules**
+### Remote modules
 
 You can host your modules in a public webserver like GitHub and any CDN and be imported remotely.
 
@@ -138,7 +138,7 @@ When the library consists of multiple files and modules, you may want to bundle 
 
 Be aware that k6 automatically executes remote modules, making it crucial to trust the source code of these remote modules. There is a **risk of altering the remote modules with certain hosting mechanisms**. To mitigate this security risk, some users prefer to download and import the modules locally to ensure full control of the source code.
 
-**As local modules**
+### Local modules
 
 In this example, the previous remote modules have been downloaded to the `lib` folder of the testing project and imported as follows:
 
@@ -152,14 +152,14 @@ Another option to distribute libraries is to use a package manager tool like npm
 
 Although k6 does not resolve node modules, you can utilize a Bundler to load npm dependencies, as shown in the [k6-rollup-example](https://github.com/grafana/k6-rollup-example).
 
-## Using TypeScript
+## Use TypeScript
 
 k6 does not natively support TypeScript. If you wish to write k6 tests in Typescript, you will need a bundler, as demonstrated in the previous examples:
 
 - Using Webpack: Refer to [k6-template-typescript](https://github.com/grafana/k6-template-typescript) and [k6-jslib-aws](https://github.com/grafana/k6-jslib-aws).
 - Using Rollup: Apply the [@rollup/plugin-typescript](https://github.com/rollup/plugins/tree/master/packages/typescript) to the [k6-rollup-example](https://github.com/grafana/k6-rollup-example).
 
-## Using modules with Docker
+## Use modules with Docker
 
 Built-in and remote modules work out of the box when running k6 in a Docker container like the [Grafana k6 Docker image](https://hub.docker.com/r/grafana/k6).
 

--- a/docs/sources/v0.50.x/using-k6/modules.md
+++ b/docs/sources/v0.50.x/using-k6/modules.md
@@ -7,14 +7,14 @@ weight: 07
 
 # Modules
 
-## Importing modules
+## Import modules
 
 It's common to import modules, or parts of modules, to use in your test scripts.
 In k6, you can import different kinds of modules:
 
 - [Built-in modules](#built-in-modules)
-- [Local filesystem modules](#local-filesystem-modules)
-- [Remote HTTP(S) modules](#remote-https-modules)
+- [Local modules](#local-modules)
+- [Remote modules](#remote-modules)
 - [Extension modules](#extension-modules)
 
 ### Built-in modules
@@ -106,7 +106,7 @@ How do k6 extensions (Go-to-JS modules) work? For enhanced performance, the k6 e
 
 To learn more about using or creating k6 extensions, refer to the [Extension documentation](https://grafana.com/docs/k6/<K6_VERSION>/extensions).
 
-## Sharing JavaScript modules
+## Share JavaScript modules
 
 As mentioned previously, users can import custom JavaScript libraries by loading either local or remote modules. Because of that, we have two options to import JavaScript modules, along with various methods to distribute them.
 
@@ -116,7 +116,7 @@ The following options for distributing and sharing JavaScript libraries are avai
 
 {{< /admonition >}}
 
-**As remote modules**
+### Remote modules
 
 You can host your modules in a public webserver like GitHub and any CDN and be imported remotely.
 
@@ -138,7 +138,7 @@ When the library consists of multiple files and modules, you may want to bundle 
 
 Be aware that k6 automatically executes remote modules, making it crucial to trust the source code of these remote modules. There is a **risk of altering the remote modules with certain hosting mechanisms**. To mitigate this security risk, some users prefer to download and import the modules locally to ensure full control of the source code.
 
-**As local modules**
+### Local modules
 
 In this example, the previous remote modules have been downloaded to the `lib` folder of the testing project and imported as follows:
 
@@ -152,14 +152,215 @@ Another option to distribute libraries is to use a package manager tool like npm
 
 Although k6 does not resolve node modules, you can utilize a Bundler to load npm dependencies, as shown in the [k6-rollup-example](https://github.com/grafana/k6-rollup-example).
 
-## Using TypeScript
+## Use Node.js modules
+
+{{< admonition type="caution" >}}
+
+k6 isn't Node.js or a browser. Packages that rely on APIs provided by Node.js, for instance the `os` and `fs` modules, won't work in k6. The same goes for browser-specific APIs, such as the `window` object.
+
+{{< /admonition >}}
+
+In a JavaScript project running Node.js, modules are imported using either `import` or `require()`, using the Node.js module resolution algorithm. This means that a user can import modules by name, without providing the full filesystem path to the module. For instance:
+
+```javascript
+import { ClassInAModule } from 'cool-module';
+```
+
+The `import` statement would be automatically resolved by the node resolution algorithm by searching:
+
+- The current directory
+- Any `node_modules` folder in the directory
+- Any `node_modules` folder in a parent directory, up to the closest `package.json` file.
+
+As the implementation of `import` in k6 lacks support for the node module resolution algorithm, Node.js modules that resolve external dependencies need to be transformed into a self-contained, isolated, bundle.
+
+That's done with the help of a bundling tool, such as Webpack, which analyses the test script, identifies all external dependencies, and then creates a self-contained bundle including everything necessary to run the script.
+
+If the test script has no external dependencies, already has them vendored in a k6 compatible way, or only uses ES5.1+ features, using a bundler isn't necessary.
+
+### Pick a bundler
+
+You can use any bundler that supports transpilation. Popular ones include, but are not limited to, [webpack](https://github.com/webpack/webpack), [parcel](https://github.com/parcel-bundler/parcel), [rollup](https://github.com/rollup/rollup) and [browserify](https://github.com/browserify/browserify).
+
+Due to its flexibility, ease of use, relatively low resource consumption, and known compatibility with k6, it is recommended to use [webpack](https://github.com/webpack/webpack).
+
+You can also use these two example repositories as a starting point:
+
+- [k6-template-es6](https://github.com/grafana/k6-template-es6): Template using Webpack and Babel to enable ES6 features in k6 tests.
+- [k6-rollup-example](https://github.com/grafana/k6-rollup-example/): Example using Rollup to bundle k6 tests and release a shared library.
+
+### Webpack setup example
+
+Setting up a Babel and Webpack project from scratch might sound like a big undertaking, but
+is usually accomplished within minutes. Start by creating a project folder and initializing
+`npm`:
+
+```bash
+$ mkdir ./example-project && \
+    cd "$_" && \
+    npm init -y
+```
+
+#### Install packages
+
+Then, install the packages needed:
+
+```bash
+$ npm install --save-dev \
+    webpack \
+    webpack-cli \
+    @types/k6 \
+    babel-loader \
+    @babel/core \
+    @babel/preset-env \
+    core-js
+```
+
+| Package                                                                                   | Usage                                                                                                                                                                                                                                                                 |
+| :---------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [webpack](https://github.com/webpack/webpack)                                             | The bundler part of Webpack                                                                                                                                                                                                                                           |
+| [webpack-cli](https://github.com/webpack/webpack-cli)                                     | The CLI part of Webpack, which allows us to use it from the terminal                                                                                                                                                                                                  |
+| [@types/k6](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/k6)      | k6 Typescript definition                                                                                                                                                                                                                                              |
+| [babel-loader](https://github.com/babel/babel-loader)                                     | A loader used by Webpack to leverage babel functionality while bundling                                                                                                                                                                                               |
+| [@babel/core](https://github.com/babel/babel/tree/master/packages/babel-core)             | The core functionality of Babel                                                                                                                                                                                                                                       |
+| [@babel/preset-env](https://github.com/babel/babel/tree/master/packages/babel-preset-env) | A smart preset using [browserlist](https://github.com/browserslist/browserslist), [compat-table](https://github.com/kangax/compat-table) and [electron-to-chromium](https://github.com/Kilian/electron-to-chromium) to determine what code to transpile and polyfill. |
+| [core-js](https://github.com/zloirock/core-js)                                            | A modular standard library for JS including polyfills                                                                                                                                                                                                                 |
+
+#### Configure Webpack
+
+Once these packages have been added, the next step will be to set up a `webpack.config.js` file:
+
+```javascript
+const path = require('path');
+
+module.exports = {
+  mode: 'production',
+  entry: {
+    login: './src/login.test.js',
+    signup: './src/signup.test.js',
+  },
+  output: {
+    path: path.resolve(__dirname, 'dist'), // eslint-disable-line
+    libraryTarget: 'commonjs',
+    filename: '[name].bundle.js',
+  },
+  module: {
+    rules: [{ test: /\.js$/, use: 'babel-loader' }],
+  },
+  target: 'web',
+  externals: /k6(\/.*)?/,
+};
+```
+
+`Mode`
+
+Tells Webpack to automatically use the optimizations associated with the `mode`.
+Additional details available in [the webpack docs](https://webpack.js.org/configuration/mode/).
+
+`Entry`
+
+The files Webpack will use as its entry points while performing the bundling. From these points,
+Webpack will automatically traverse all imports recursively until every possible dependency path has
+been exhausted. For instance:
+
+```javascript
+// login.test.js
+
+import { SomeService } from './some.service.js';
+
+const svc = new SomeService();
+```
+
+and:
+
+```javascript
+// some.service.js
+
+import * as lodash from 'lodash';
+
+export class SomeService {
+  constructor() {
+    this._ = lodash;
+  }
+}
+```
+
+would result in Webpack bundling `login.test.js`, `some.service.js` and all upstream dependencies
+utilized by `lodash`.
+
+`Output`
+
+The `path` key takes an absolute path which is where the finished bundle will be placed. In
+this example, `path.resolve` is used to concatenate `__dirname` and `'dist'` into an absolute
+path.
+
+The `libraryTarget` key configures how the library will be exposed. Setting it to `commonjs`
+will result in it being exported using `module.exports`. Additional details available in [the
+Webpack docs](https://webpack.js.org/configuration/output/#outputlibrarytarget).
+
+The `filename` key, as the name suggests, configures the name of the finished bundles. In this
+example, the [template string](https://webpack.js.org/configuration/output/#template-strings) `[name]`
+is used to add a dynamic part to the output filename.
+
+#### Add a bundle command
+
+Open the `package.json` file and add a new script entry, used for running the bundling process.
+
+```diff
+{
+  "name": "bundling-example",
+  "description": "",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
++    "bundle": "webpack"
+  }
+  ...
+}
+```
+
+#### Bundle tests
+
+Running webpack will now output two different test bundles, that may be executed independently:
+
+```bash
+$ npm run bundle
+# ...
+$ tree dist
+
+dist
+├── login.bundle.js
+└── signup.bundle.js
+
+0 directories, 2 files
+```
+
+#### Run tests
+
+```bash
+$ npm run bundle
+# ...
+$ k6 run dist/login.bundle.js
+# ...
+```
+
+```bash
+$ npm run bundle
+# ...
+$ k6 run dist/signup.bundle.js \
+    --vus 10 \
+    --duration 10s
+# ...
+```
+
+## Use TypeScript
 
 k6 does not natively support TypeScript. If you wish to write k6 tests in Typescript, you will need a bundler, as demonstrated in the previous examples:
 
 - Using Webpack: Refer to [k6-template-typescript](https://github.com/grafana/k6-template-typescript) and [k6-jslib-aws](https://github.com/grafana/k6-jslib-aws).
 - Using Rollup: Apply the [@rollup/plugin-typescript](https://github.com/rollup/plugins/tree/master/packages/typescript) to the [k6-rollup-example](https://github.com/grafana/k6-rollup-example).
 
-## Using modules with Docker
+## Use modules with Docker
 
 Built-in and remote modules work out of the box when running k6 in a Docker container like the [Grafana k6 Docker image](https://hub.docker.com/r/grafana/k6).
 

--- a/docs/sources/v0.51.x/using-k6/modules.md
+++ b/docs/sources/v0.51.x/using-k6/modules.md
@@ -7,14 +7,14 @@ weight: 07
 
 # Modules
 
-## Importing modules
+## Import modules
 
 It's common to import modules, or parts of modules, to use in your test scripts.
 In k6, you can import different kinds of modules:
 
 - [Built-in modules](#built-in-modules)
-- [Local filesystem modules](#local-filesystem-modules)
-- [Remote HTTP(S) modules](#remote-https-modules)
+- [Local modules](#local-modules)
+- [Remote modules](#remote-modules)
 - [Extension modules](#extension-modules)
 
 ### Built-in modules
@@ -106,7 +106,7 @@ How do k6 extensions (Go-to-JS modules) work? For enhanced performance, the k6 e
 
 To learn more about using or creating k6 extensions, refer to the [Extension documentation](https://grafana.com/docs/k6/<K6_VERSION>/extensions).
 
-## Sharing JavaScript modules
+## Share JavaScript modules
 
 As mentioned previously, users can import custom JavaScript libraries by loading either local or remote modules. Because of that, we have two options to import JavaScript modules, along with various methods to distribute them.
 
@@ -116,7 +116,7 @@ The following options for distributing and sharing JavaScript libraries are avai
 
 {{< /admonition >}}
 
-**As remote modules**
+### Remote modules
 
 You can host your modules in a public webserver like GitHub and any CDN and be imported remotely.
 
@@ -138,7 +138,7 @@ When the library consists of multiple files and modules, you may want to bundle 
 
 Be aware that k6 automatically executes remote modules, making it crucial to trust the source code of these remote modules. There is a **risk of altering the remote modules with certain hosting mechanisms**. To mitigate this security risk, some users prefer to download and import the modules locally to ensure full control of the source code.
 
-**As local modules**
+### Local modules
 
 In this example, the previous remote modules have been downloaded to the `lib` folder of the testing project and imported as follows:
 
@@ -152,14 +152,215 @@ Another option to distribute libraries is to use a package manager tool like npm
 
 Although k6 does not resolve node modules, you can utilize a Bundler to load npm dependencies, as shown in the [k6-rollup-example](https://github.com/grafana/k6-rollup-example).
 
-## Using TypeScript
+## Use Node.js modules
+
+{{< admonition type="caution" >}}
+
+k6 isn't Node.js or a browser. Packages that rely on APIs provided by Node.js, for instance the `os` and `fs` modules, won't work in k6. The same goes for browser-specific APIs, such as the `window` object.
+
+{{< /admonition >}}
+
+In a JavaScript project running Node.js, modules are imported using either `import` or `require()`, using the Node.js module resolution algorithm. This means that a user can import modules by name, without providing the full filesystem path to the module. For instance:
+
+```javascript
+import { ClassInAModule } from 'cool-module';
+```
+
+The `import` statement would be automatically resolved by the node resolution algorithm by searching:
+
+- The current directory
+- Any `node_modules` folder in the directory
+- Any `node_modules` folder in a parent directory, up to the closest `package.json` file.
+
+As the implementation of `import` in k6 lacks support for the node module resolution algorithm, Node.js modules that resolve external dependencies need to be transformed into a self-contained, isolated, bundle.
+
+That's done with the help of a bundling tool, such as Webpack, which analyses the test script, identifies all external dependencies, and then creates a self-contained bundle including everything necessary to run the script.
+
+If the test script has no external dependencies, already has them vendored in a k6 compatible way, or only uses ES5.1+ features, using a bundler isn't necessary.
+
+### Pick a bundler
+
+You can use any bundler that supports transpilation. Popular ones include, but are not limited to, [webpack](https://github.com/webpack/webpack), [parcel](https://github.com/parcel-bundler/parcel), [rollup](https://github.com/rollup/rollup) and [browserify](https://github.com/browserify/browserify).
+
+Due to its flexibility, ease of use, relatively low resource consumption, and known compatibility with k6, it is recommended to use [webpack](https://github.com/webpack/webpack).
+
+You can also use these two example repositories as a starting point:
+
+- [k6-template-es6](https://github.com/grafana/k6-template-es6): Template using Webpack and Babel to enable ES6 features in k6 tests.
+- [k6-rollup-example](https://github.com/grafana/k6-rollup-example/): Example using Rollup to bundle k6 tests and release a shared library.
+
+### Webpack setup example
+
+Setting up a Babel and Webpack project from scratch might sound like a big undertaking, but
+is usually accomplished within minutes. Start by creating a project folder and initializing
+`npm`:
+
+```bash
+$ mkdir ./example-project && \
+    cd "$_" && \
+    npm init -y
+```
+
+#### Install packages
+
+Then, install the packages needed:
+
+```bash
+$ npm install --save-dev \
+    webpack \
+    webpack-cli \
+    @types/k6 \
+    babel-loader \
+    @babel/core \
+    @babel/preset-env \
+    core-js
+```
+
+| Package                                                                                   | Usage                                                                                                                                                                                                                                                                 |
+| :---------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [webpack](https://github.com/webpack/webpack)                                             | The bundler part of Webpack                                                                                                                                                                                                                                           |
+| [webpack-cli](https://github.com/webpack/webpack-cli)                                     | The CLI part of Webpack, which allows us to use it from the terminal                                                                                                                                                                                                  |
+| [@types/k6](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/k6)      | k6 Typescript definition                                                                                                                                                                                                                                              |
+| [babel-loader](https://github.com/babel/babel-loader)                                     | A loader used by Webpack to leverage babel functionality while bundling                                                                                                                                                                                               |
+| [@babel/core](https://github.com/babel/babel/tree/master/packages/babel-core)             | The core functionality of Babel                                                                                                                                                                                                                                       |
+| [@babel/preset-env](https://github.com/babel/babel/tree/master/packages/babel-preset-env) | A smart preset using [browserlist](https://github.com/browserslist/browserslist), [compat-table](https://github.com/kangax/compat-table) and [electron-to-chromium](https://github.com/Kilian/electron-to-chromium) to determine what code to transpile and polyfill. |
+| [core-js](https://github.com/zloirock/core-js)                                            | A modular standard library for JS including polyfills                                                                                                                                                                                                                 |
+
+#### Configure Webpack
+
+Once these packages have been added, the next step will be to set up a `webpack.config.js` file:
+
+```javascript
+const path = require('path');
+
+module.exports = {
+  mode: 'production',
+  entry: {
+    login: './src/login.test.js',
+    signup: './src/signup.test.js',
+  },
+  output: {
+    path: path.resolve(__dirname, 'dist'), // eslint-disable-line
+    libraryTarget: 'commonjs',
+    filename: '[name].bundle.js',
+  },
+  module: {
+    rules: [{ test: /\.js$/, use: 'babel-loader' }],
+  },
+  target: 'web',
+  externals: /k6(\/.*)?/,
+};
+```
+
+`Mode`
+
+Tells Webpack to automatically use the optimizations associated with the `mode`.
+Additional details available in [the webpack docs](https://webpack.js.org/configuration/mode/).
+
+`Entry`
+
+The files Webpack will use as its entry points while performing the bundling. From these points,
+Webpack will automatically traverse all imports recursively until every possible dependency path has
+been exhausted. For instance:
+
+```javascript
+// login.test.js
+
+import { SomeService } from './some.service.js';
+
+const svc = new SomeService();
+```
+
+and:
+
+```javascript
+// some.service.js
+
+import * as lodash from 'lodash';
+
+export class SomeService {
+  constructor() {
+    this._ = lodash;
+  }
+}
+```
+
+would result in Webpack bundling `login.test.js`, `some.service.js` and all upstream dependencies
+utilized by `lodash`.
+
+`Output`
+
+The `path` key takes an absolute path which is where the finished bundle will be placed. In
+this example, `path.resolve` is used to concatenate `__dirname` and `'dist'` into an absolute
+path.
+
+The `libraryTarget` key configures how the library will be exposed. Setting it to `commonjs`
+will result in it being exported using `module.exports`. Additional details available in [the
+Webpack docs](https://webpack.js.org/configuration/output/#outputlibrarytarget).
+
+The `filename` key, as the name suggests, configures the name of the finished bundles. In this
+example, the [template string](https://webpack.js.org/configuration/output/#template-strings) `[name]`
+is used to add a dynamic part to the output filename.
+
+#### Add a bundle command
+
+Open the `package.json` file and add a new script entry, used for running the bundling process.
+
+```diff
+{
+  "name": "bundling-example",
+  "description": "",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
++    "bundle": "webpack"
+  }
+  ...
+}
+```
+
+#### Bundle tests
+
+Running webpack will now output two different test bundles, that may be executed independently:
+
+```bash
+$ npm run bundle
+# ...
+$ tree dist
+
+dist
+├── login.bundle.js
+└── signup.bundle.js
+
+0 directories, 2 files
+```
+
+#### Run tests
+
+```bash
+$ npm run bundle
+# ...
+$ k6 run dist/login.bundle.js
+# ...
+```
+
+```bash
+$ npm run bundle
+# ...
+$ k6 run dist/signup.bundle.js \
+    --vus 10 \
+    --duration 10s
+# ...
+```
+
+## Use TypeScript
 
 k6 does not natively support TypeScript. If you wish to write k6 tests in Typescript, you will need a bundler, as demonstrated in the previous examples:
 
 - Using Webpack: Refer to [k6-template-typescript](https://github.com/grafana/k6-template-typescript) and [k6-jslib-aws](https://github.com/grafana/k6-jslib-aws).
 - Using Rollup: Apply the [@rollup/plugin-typescript](https://github.com/rollup/plugins/tree/master/packages/typescript) to the [k6-rollup-example](https://github.com/grafana/k6-rollup-example).
 
-## Using modules with Docker
+## Use modules with Docker
 
 Built-in and remote modules work out of the box when running k6 in a Docker container like the [Grafana k6 Docker image](https://hub.docker.com/r/grafana/k6).
 


### PR DESCRIPTION
## What?

Reintroduce the section for how to bundle Node.js modules to the Modules page.

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [x] I have made my changes in the `docs/sources/next` folder of the documentation.
- [x] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.
- [x] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->
