### PR TITLE
browser request.size update

### DIFF
--- a/docs/sources/next/javascript-api/k6-experimental/browser/request/size.md
+++ b/docs/sources/next/javascript-api/k6-experimental/browser/request/size.md
@@ -9,9 +9,16 @@ Similar to Playwright's [`request.sizes()`](https://playwright.dev/docs/api/clas
 
 ### Returns
 
-| Type   | Description                           |
-| ------ | ------------------------------------- |
-| object | `{ body: <bytes>, headers: <bytes> }` |
+| Type          | Description            |
+| ------------- | ---------------------- |
+| Promise<Size> | Returns [Size](#size). |
+
+### Size
+
+| Property | Type   | Description                        |
+| -------- | ------ | ---------------------------------- |
+| body     | number | Size in bytes of the request body. |
+| headers  | number | Size in bytes of the headers body. |
 
 ### Example
 
@@ -40,7 +47,7 @@ export default async function () {
     const res = await page.goto('https://test.k6.io/');
     const req = res.request();
 
-    const size = await req.size();
+    const size = req.size();
     console.log(`size: ${JSON.stringify(size)}`); // size: {"headers":344,"body":0}
   } finally {
     await page.close();


### PR DESCRIPTION
<!-- 
Please make sure you have read the contribution guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md as well as the
the code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md before opening a PR.
-->

## What?

The request.size needs to be updated so that the example doesn't `await`. The return object is placed in its own table.

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 2. If updating the documentation for the next release of k6: -->
- [x] I have made my changes in the `docs/sources/next` folder of the documentation.

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->
<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
https://github.com/grafana/xk6-browser/issues/1308