### PR TITLE
Remove tinkoff/xk6-output-error as it has been archived

### DIFF
--- a/docs/sources/next/extensions/explore.md
+++ b/docs/sources/next/extensions/explore.md
@@ -215,10 +215,6 @@ Use the table to explore the many extensions. Questions? Feel free to join the d
         <h4>xk6-output-elasticsearch</h4>
         <p>Export results to Elasticsearch 8.x</p>
     </a>
-    <a href="https://github.com/tinkoff/xk6-output-error" target="_blank" class="nav-cards__item nav-cards__item--guide">
-        <h4>xk6-output-error</h4>
-        <p>Add more information into StdErr k6 about requests</p>
-    </a>
     <a href="https://github.com/grafana/xk6-output-influxdb" target="_blank" class="nav-cards__item nav-cards__item--guide">
         <h4>xk6-output-influxdb</h4>
         <p>Export results to InfluxDB v2</p>

--- a/src/data/doc-extensions/extensions.json
+++ b/src/data/doc-extensions/extensions.json
@@ -587,21 +587,6 @@
       "cloudEnabled": false
     },
     {
-      "name": "xk6-output-error",
-      "description": "Add more information into StdErr k6 about requests",
-      "url": "https://github.com/tinkoff/xk6-output-error",
-      "logo": "",
-      "author": {
-        "name": "Maksimall89",
-        "url": "https://github.com/maksimall89"
-      },
-      "stars": "2",
-      "type": ["JavaScript"],
-      "categories": ["Reporting"],
-      "tiers": ["Community"],
-      "cloudEnabled": false
-    },
-    {
       "name": "xk6-oauth-pkce",
       "description": "Generate OAuth PKCE code verifier and code challenge",
       "url": "https://github.com/frankhefeng/xk6-oauth-pkce",


### PR DESCRIPTION
<!-- 
Please make sure you have read the contribution guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md as well as the
the code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md before opening a PR.
-->

## What?

Drop archived extension

## Checklist

<!-- Please fill in this template: -->
- [ ] I have used a meaningful title for the PR.
- [ ] I have described the changes I've made in the "What?" section above.
- [ ] I have performed a self-review of my changes.
- [ ] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [ ] I have made my changes in the `docs/sources/next` folder of the documentation.
- [ ] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.
- [ ] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->

<!-- 2. If updating the documentation for the next release of k6: -->
- [ ] I have made my changes in the `docs/sources/next` folder of the documentation.

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->
<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->