### PR TITLE
Update jslib aws references to 0.12.3

### DIFF
--- a/docs/sources/next/examples/http-authentication.md
+++ b/docs/sources/next/examples/http-authentication.md
@@ -123,7 +123,7 @@ Here's an example script to demonstrate how to sign a request to fetch an object
 
 ```javascript
 import http from 'k6/http';
-import { AWSConfig, SignatureV4 } from 'https://jslib.k6.io/aws/0.12.1/signature.js';
+import { AWSConfig, SignatureV4 } from 'https://jslib.k6.io/aws/0.12.3/signature.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/docs/sources/next/javascript-api/jslib/aws/EventBridgeClient/_index.md
+++ b/docs/sources/next/javascript-api/jslib/aws/EventBridgeClient/_index.md
@@ -34,7 +34,7 @@ EventBridgeClient methods will throw errors in case of failure.
 {{< code >}}
 
 ```javascript
-import { AWSConfig, EventBridgeClient } from 'https://jslib.k6.io/aws/0.12.1/event-bridge.js';
+import { AWSConfig, EventBridgeClient } from 'https://jslib.k6.io/aws/0.12.3/event-bridge.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/docs/sources/next/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
+++ b/docs/sources/next/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
@@ -44,7 +44,7 @@ weight: 10
 {{< code >}}
 
 ```javascript
-import { AWSConfig, EventBridgeClient } from 'https://jslib.k6.io/aws/0.12.1/event-bridge.js';
+import { AWSConfig, EventBridgeClient } from 'https://jslib.k6.io/aws/0.12.3/event-bridge.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/docs/sources/next/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
+++ b/docs/sources/next/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
@@ -25,7 +25,7 @@ For instance, the [`generateDataKey`](https://grafana.com/docs/k6/<K6_VERSION>/j
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.12.1/kms.js';
+import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.12.3/kms.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/docs/sources/next/javascript-api/jslib/aws/KMSClient/KMSKey.md
+++ b/docs/sources/next/javascript-api/jslib/aws/KMSClient/KMSKey.md
@@ -22,7 +22,7 @@ weight: 20
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.12.1/kms.js';
+import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.12.3/kms.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/docs/sources/next/javascript-api/jslib/aws/KMSClient/_index.md
+++ b/docs/sources/next/javascript-api/jslib/aws/KMSClient/_index.md
@@ -39,7 +39,7 @@ Both the dedicated `kms.js` jslib bundle and the all-encompassing `aws.js` bundl
 ```javascript
 import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.2/index.js';
 
-import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.12.1/kms.js';
+import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.12.3/kms.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/docs/sources/next/javascript-api/jslib/aws/KMSClient/generateDataKey.md
+++ b/docs/sources/next/javascript-api/jslib/aws/KMSClient/generateDataKey.md
@@ -30,7 +30,7 @@ weight: 10
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.12.1/kms.js';
+import { AWSConfig, KMSClient } from 'https://jslib.k6.io/aws/0.12.3/kms.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/docs/sources/next/javascript-api/jslib/aws/LambdaClient/_index.md
+++ b/docs/sources/next/javascript-api/jslib/aws/LambdaClient/_index.md
@@ -33,7 +33,7 @@ Both the dedicated `lambda.js` jslib bundle and the all-encompassing `aws.js` bu
 {{< code >}}
 
 ```javascript
-import { AWSConfig, LambdaClient } from 'https://jslib.k6.io/aws/0.12.1/lambda.js';
+import { AWSConfig, LambdaClient } from 'https://jslib.k6.io/aws/0.12.3/lambda.js';
 import { check } from 'k6';
 
 const awsConfig = new AWSConfig({

--- a/docs/sources/next/javascript-api/jslib/aws/LambdaClient/invoke.md
+++ b/docs/sources/next/javascript-api/jslib/aws/LambdaClient/invoke.md
@@ -51,7 +51,7 @@ InvocationResponse is an object that represents the response of an invocation. I
 {{< code >}}
 
 ```javascript
-import { AWSConfig, LambdaClient } from 'https://jslib.k6.io/aws/0.12.1/lambda.js';
+import { AWSConfig, LambdaClient } from 'https://jslib.k6.io/aws/0.12.3/lambda.js';
 import { check } from 'k6';
 
 const awsConfig = new AWSConfig({

--- a/docs/sources/next/javascript-api/jslib/aws/S3Client/Object.md
+++ b/docs/sources/next/javascript-api/jslib/aws/S3Client/Object.md
@@ -30,7 +30,7 @@ import {
   // listBuckets,
   AWSConfig,
   S3Client,
-} from 'https://jslib.k6.io/aws/0.12.1/s3.js';
+} from 'https://jslib.k6.io/aws/0.12.3/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/docs/sources/next/javascript-api/jslib/aws/S3Client/S3MultipartUpload.md
+++ b/docs/sources/next/javascript-api/jslib/aws/S3Client/S3MultipartUpload.md
@@ -18,7 +18,7 @@ S3MultipartUpload is returned by the [`createMultipartUpload(bucketName, objectK
 {{< code >}}
 
 ```javascript
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.12.1/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.12.3/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/docs/sources/next/javascript-api/jslib/aws/S3Client/S3Part.md
+++ b/docs/sources/next/javascript-api/jslib/aws/S3Client/S3Part.md
@@ -23,7 +23,7 @@ S3Part is returned by the [`uploadPart(bucketName, objectKey, uploadId, partNumb
 import crypto from 'k6/crypto';
 import exec from 'k6/execution';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.12.1/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.12.3/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/docs/sources/next/javascript-api/jslib/aws/S3Client/_index.md
+++ b/docs/sources/next/javascript-api/jslib/aws/S3Client/_index.md
@@ -49,7 +49,7 @@ import { check } from 'k6';
 import exec from 'k6/execution';
 import http from 'k6/http';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.12.1/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.12.3/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,
@@ -111,7 +111,7 @@ export async function handleSummary(data) {
 import crypto from 'k6/crypto';
 import exec from 'k6/execution';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.12.1/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.12.3/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/docs/sources/next/javascript-api/jslib/aws/S3Client/completeMultipartUpload.md
+++ b/docs/sources/next/javascript-api/jslib/aws/S3Client/completeMultipartUpload.md
@@ -32,7 +32,7 @@ weight: 10
 import crypto from 'k6/crypto';
 import exec from 'k6/execution';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.12.1/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.12.3/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/docs/sources/next/javascript-api/jslib/aws/S3Client/copyObject.md
+++ b/docs/sources/next/javascript-api/jslib/aws/S3Client/copyObject.md
@@ -31,7 +31,7 @@ weight: 10
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.12.1/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.12.3/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/docs/sources/next/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
+++ b/docs/sources/next/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
@@ -25,7 +25,7 @@ weight: 10
 {{< code >}}
 
 ```javascript
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.12.1/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.12.3/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/docs/sources/next/javascript-api/jslib/aws/S3Client/deleteObject.md
+++ b/docs/sources/next/javascript-api/jslib/aws/S3Client/deleteObject.md
@@ -29,7 +29,7 @@ weight: 10
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.12.1/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.12.3/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/docs/sources/next/javascript-api/jslib/aws/S3Client/getObject.md
+++ b/docs/sources/next/javascript-api/jslib/aws/S3Client/getObject.md
@@ -29,7 +29,7 @@ weight: 10
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.12.1/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.12.3/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/docs/sources/next/javascript-api/jslib/aws/S3Client/listBuckets.md
+++ b/docs/sources/next/javascript-api/jslib/aws/S3Client/listBuckets.md
@@ -22,7 +22,7 @@ weight: 10
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.12.1/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.12.3/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/docs/sources/next/javascript-api/jslib/aws/S3Client/listObjects.md
+++ b/docs/sources/next/javascript-api/jslib/aws/S3Client/listObjects.md
@@ -29,7 +29,7 @@ weight: 10
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.12.1/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.12.3/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/docs/sources/next/javascript-api/jslib/aws/S3Client/putObject.md
+++ b/docs/sources/next/javascript-api/jslib/aws/S3Client/putObject.md
@@ -39,7 +39,7 @@ weight: 10
 {{< code >}}
 
 ```javascript
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.12.1/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.12.3/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/docs/sources/next/javascript-api/jslib/aws/S3Client/uploadPart.md
+++ b/docs/sources/next/javascript-api/jslib/aws/S3Client/uploadPart.md
@@ -31,7 +31,7 @@ weight: 10
 import crypto from 'k6/crypto';
 import exec from 'k6/execution';
 
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.12.1/s3.js';
+import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.12.3/s3.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/docs/sources/next/javascript-api/jslib/aws/SQSClient/_index.md
+++ b/docs/sources/next/javascript-api/jslib/aws/SQSClient/_index.md
@@ -37,7 +37,7 @@ With it, the user can send messages to specified queues and list available queue
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SQSClient } from 'https://jslib.k6.io/aws/0.12.1/sqs.js';
+import { AWSConfig, SQSClient } from 'https://jslib.k6.io/aws/0.12.3/sqs.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/docs/sources/next/javascript-api/jslib/aws/SQSClient/listQueues.md
+++ b/docs/sources/next/javascript-api/jslib/aws/SQSClient/listQueues.md
@@ -29,7 +29,7 @@ weight: 10
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SQSClient } from 'https://jslib.k6.io/aws/0.12.1/sqs.js';
+import { AWSConfig, SQSClient } from 'https://jslib.k6.io/aws/0.12.3/sqs.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/docs/sources/next/javascript-api/jslib/aws/SQSClient/sendMessage.md
+++ b/docs/sources/next/javascript-api/jslib/aws/SQSClient/sendMessage.md
@@ -40,7 +40,7 @@ weight: 10
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SQSClient } from 'https://jslib.k6.io/aws/0.12.1/sqs.js';
+import { AWSConfig, SQSClient } from 'https://jslib.k6.io/aws/0.12.3/sqs.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/docs/sources/next/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
+++ b/docs/sources/next/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
@@ -28,7 +28,7 @@ Secret is returned by the SecretsManagerClient.\* methods that query secrets. Na
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.12.1/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.12.3/secrets-manager.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/docs/sources/next/javascript-api/jslib/aws/SecretsManagerClient/_index.md
+++ b/docs/sources/next/javascript-api/jslib/aws/SecretsManagerClient/_index.md
@@ -39,7 +39,7 @@ S3 Client methods will throw errors in case of failure.
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.12.1/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.12.3/secrets-manager.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/docs/sources/next/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
+++ b/docs/sources/next/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
@@ -30,7 +30,7 @@ weight: 10
 {{< code >}}
 
 ```javascript
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.12.1/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.12.3/secrets-manager.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/docs/sources/next/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
+++ b/docs/sources/next/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
@@ -27,7 +27,7 @@ weight: 10
 {{< code >}}
 
 ```javascript
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.12.1/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.12.3/secrets-manager.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/docs/sources/next/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
+++ b/docs/sources/next/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
@@ -26,7 +26,7 @@ weight: 10
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.12.1/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.12.3/secrets-manager.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/docs/sources/next/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
+++ b/docs/sources/next/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
@@ -22,7 +22,7 @@ weight: 10
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.12.1/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.12.3/secrets-manager.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/docs/sources/next/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
+++ b/docs/sources/next/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
@@ -29,7 +29,7 @@ weight: 10
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.12.1/secrets-manager.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.12.3/secrets-manager.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/docs/sources/next/javascript-api/jslib/aws/SignatureV4/_index.md
+++ b/docs/sources/next/javascript-api/jslib/aws/SignatureV4/_index.md
@@ -51,7 +51,7 @@ SignatureV4 methods throw errors on failure.
 ```javascript
 import http from 'k6/http';
 
-import { AWSConfig, Endpoint, SignatureV4 } from 'https://jslib.k6.io/aws/0.12.1/signature.js';
+import { AWSConfig, Endpoint, SignatureV4 } from 'https://jslib.k6.io/aws/0.12.3/signature.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/docs/sources/next/javascript-api/jslib/aws/SignatureV4/presign.md
+++ b/docs/sources/next/javascript-api/jslib/aws/SignatureV4/presign.md
@@ -56,7 +56,7 @@ import {
   SignatureV4,
   AMZ_CONTENT_SHA256_HEADER,
   UNSIGNED_PAYLOAD,
-} from 'https://jslib.k6.io/aws/0.12.1/signature.js';
+} from 'https://jslib.k6.io/aws/0.12.3/signature.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/docs/sources/next/javascript-api/jslib/aws/SignatureV4/sign.md
+++ b/docs/sources/next/javascript-api/jslib/aws/SignatureV4/sign.md
@@ -47,7 +47,7 @@ You can override SignatureV4 options in the context of this specific request. To
 ```javascript
 import http from 'k6/http';
 
-import { AWSConfig, Endpoint, SignatureV4 } from 'https://jslib.k6.io/aws/0.12.1/signature.js';
+import { AWSConfig, Endpoint, SignatureV4 } from 'https://jslib.k6.io/aws/0.12.3/signature.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/docs/sources/next/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
+++ b/docs/sources/next/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
@@ -29,7 +29,7 @@ weight: 20
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SystemsManagerClient } from 'https://jslib.k6.io/aws/0.12.1/ssm.js';
+import { AWSConfig, SystemsManagerClient } from 'https://jslib.k6.io/aws/0.12.3/ssm.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/docs/sources/next/javascript-api/jslib/aws/SystemsManagerClient/_index.md
+++ b/docs/sources/next/javascript-api/jslib/aws/SystemsManagerClient/_index.md
@@ -35,7 +35,7 @@ Both the dedicated `ssm.js` jslib bundle and the all-encompassing `aws.js` bundl
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SystemsManagerClient } from 'https://jslib.k6.io/aws/0.12.1/ssm.js';
+import { AWSConfig, SystemsManagerClient } from 'https://jslib.k6.io/aws/0.12.3/ssm.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/docs/sources/next/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
+++ b/docs/sources/next/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
@@ -22,7 +22,7 @@ weight: 10
 ```javascript
 import exec from 'k6/execution';
 
-import { AWSConfig, SystemsManagerClient } from 'https://jslib.k6.io/aws/0.12.1/ssm.js';
+import { AWSConfig, SystemsManagerClient } from 'https://jslib.k6.io/aws/0.12.3/ssm.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,

--- a/docs/sources/next/javascript-api/jslib/aws/awsconfig.md
+++ b/docs/sources/next/javascript-api/jslib/aws/awsconfig.md
@@ -44,7 +44,7 @@ import exec from 'k6/execution';
 
 // Note that you AWSConfig is also included in the dedicated service
 // client bundles such as `s3.js` and `secrets-manager.js`
-import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.12.1/aws.js';
+import { AWSConfig, SecretsManagerClient } from 'https://jslib.k6.io/aws/0.12.3/aws.js';
 
 const awsConfig = new AWSConfig({
   region: __ENV.AWS_REGION,


### PR DESCRIPTION
This PR updates every imports of jslib-aws to version `0.12.3`.