### PR TITLE
Fix inline links in "modules" docs TOC

### DIFF
--- a/docs/sources/v0.47.x/using-k6/modules.md
+++ b/docs/sources/v0.47.x/using-k6/modules.md
@@ -13,8 +13,8 @@ It's common to import modules, or parts of modules, to use in your test scripts.
 In k6, you can import different kinds of modules:
 
 - [Built-in modules](#built-in-modules)
-- [Local filesystem modules](#local-filesystem-modules)
-- [Remote HTTP(S) modules](#remote-https-modules)
+- [Local filesystem modules](#local-modules)
+- [Remote HTTP(S) modules](#remote-modules)
 - [Extension modules](#extension-modules)
 
 ### Built-in modules

--- a/docs/sources/v0.48.x/using-k6/modules.md
+++ b/docs/sources/v0.48.x/using-k6/modules.md
@@ -13,8 +13,8 @@ It's common to import modules, or parts of modules, to use in your test scripts.
 In k6, you can import different kinds of modules:
 
 - [Built-in modules](#built-in-modules)
-- [Local filesystem modules](#local-filesystem-modules)
-- [Remote HTTP(S) modules](#remote-https-modules)
+- [Local filesystem modules](#local-modules)
+- [Remote HTTP(S) modules](#remote-modules)
 - [Extension modules](#extension-modules)
 
 ### Built-in modules

--- a/docs/sources/v0.49.x/using-k6/modules.md
+++ b/docs/sources/v0.49.x/using-k6/modules.md
@@ -13,8 +13,8 @@ It's common to import modules, or parts of modules, to use in your test scripts.
 In k6, you can import different kinds of modules:
 
 - [Built-in modules](#built-in-modules)
-- [Local filesystem modules](#local-filesystem-modules)
-- [Remote HTTP(S) modules](#remote-https-modules)
+- [Local filesystem modules](#local-modules)
+- [Remote HTTP(S) modules](#remote-modules)
 - [Extension modules](#extension-modules)
 
 ### Built-in modules


### PR DESCRIPTION
<!-- 
Please make sure you have read the contribution guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md as well as the
the code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md before opening a PR.
-->

## What?

<!-- A description of the changes this PR brings to the documentation. -->

The table of contents links in the modules docs are broken for _older_ versions of the docs. The docs for 0.50.x and up were already working. This PR fixes the links to navigate to the respective sections.

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [ ] I have made my changes in the `docs/sources/next` folder of the documentation.
- [ ] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.
- [x] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->

<!-- 2. If updating the documentation for the next release of k6: -->
- [ ] I have made my changes in the `docs/sources/next` folder of the documentation.

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->
<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->