### PR TITLE
Update Browser API migration to async note

### DIFF
--- a/docs/sources/next/using-k6-browser/running-browser-tests.md
+++ b/docs/sources/next/using-k6-browser/running-browser-tests.md
@@ -70,7 +70,7 @@ To run a simple local script:
 
    {{% admonition type="note" %}}
 
-   Starting from v0.52.0 the browser module API has been converted to an asynchronous API. This means that most of the methods now return promises. See the [migration guide](https://grafana.com/docs/k6/<K6_VERSION>/using-k6-browser/migrating-to-k6-v0-52/) to learn more about the changes and how to update your scripts.
+   Starting from v0.52.0 the browser module API has been converted to an asynchronous API. That means that most of the methods now return promises. Refer to the [migration guide](https://grafana.com/docs/k6/<K6_VERSION>/using-k6-browser/migrating-to-k6-v0-52/) to learn more about the changes and how to update your scripts.
 
    {{% /admonition %}}
 

--- a/docs/sources/next/using-k6-browser/running-browser-tests.md
+++ b/docs/sources/next/using-k6-browser/running-browser-tests.md
@@ -70,7 +70,7 @@ To run a simple local script:
 
    {{% admonition type="note" %}}
 
-   To provide rough compatibility with the Playwright API, the browser module API is also being converted from synchronous to asynchronous. `page.goto()` is now asynchronous so `await` keyword is used to deal with the asynchronous nature of the operation.
+   Starting from v0.52.0 the browser module API has been converted to an asynchronous API. This means that most of the methods now return promises. See the [migration guide](https://grafana.com/docs/k6/<K6_VERSION>/using-k6-browser/migrating-to-k6-v0-52/) to learn more about the changes and how to update your scripts.
 
    {{% /admonition %}}
 
@@ -257,21 +257,18 @@ export default async function () {
   const page = await browser.newPage();
 
   try {
-    await page.goto("https://test.k6.io/my_messages.php");
+    await page.goto('https://test.k6.io/my_messages.php');
 
-    await page.locator('input[name="login"]').type("admin");
-    await page.locator('input[name="password"]').type("123");
+    await page.locator('input[name="login"]').type('admin');
+    await page.locator('input[name="password"]').type('123');
 
     const submitButton = page.locator('input[type="submit"]');
 
-    await Promise.all([
-      page.waitForNavigation(),
-      submitButton.click(),
-    ]);
+    await Promise.all([page.waitForNavigation(), submitButton.click()]);
 
-    const header = await page.locator("h2").textContent();
+    const header = await page.locator('h2').textContent();
     check(header, {
-      header: h => h == "Welcome, admin!",
+      header: (h) => h == 'Welcome, admin!',
     });
   } finally {
     await page.close();
@@ -340,7 +337,7 @@ export async function browserTest() {
 
     const info = await page.locator('#counter-button').textContent();
     check(info, {
-      'checkbox is checked': info => info === 'Thanks for checking the box',
+      'checkbox is checked': (info) => info === 'Thanks for checking the box',
     });
   } finally {
     await page.close();

--- a/docs/sources/v0.52.x/using-k6-browser/running-browser-tests.md
+++ b/docs/sources/v0.52.x/using-k6-browser/running-browser-tests.md
@@ -70,7 +70,7 @@ To run a simple local script:
 
    {{% admonition type="note" %}}
 
-   Starting from v0.52.0 the browser module API has been converted to an asynchronous API. This means that most of the methods now return promises. See the [migration guide](https://grafana.com/docs/k6/<K6_VERSION>/using-k6-browser/migrating-to-k6-v0-52/) to learn more about the changes and how to update your scripts.
+   Starting from v0.52.0 the browser module API has been converted to an asynchronous API. That means that most of the methods now return promises. Refer to the [migration guide](https://grafana.com/docs/k6/<K6_VERSION>/using-k6-browser/migrating-to-k6-v0-52/) to learn more about the changes and how to update your scripts.
 
    {{% /admonition %}}
 

--- a/docs/sources/v0.52.x/using-k6-browser/running-browser-tests.md
+++ b/docs/sources/v0.52.x/using-k6-browser/running-browser-tests.md
@@ -70,7 +70,7 @@ To run a simple local script:
 
    {{% admonition type="note" %}}
 
-   To provide rough compatibility with the Playwright API, the browser module API is also being converted from synchronous to asynchronous. `page.goto()` is now asynchronous so `await` keyword is used to deal with the asynchronous nature of the operation.
+   Starting from v0.52.0 the browser module API has been converted to an asynchronous API. This means that most of the methods now return promises. See the [migration guide](https://grafana.com/docs/k6/<K6_VERSION>/using-k6-browser/migrating-to-k6-v0-52/) to learn more about the changes and how to update your scripts.
 
    {{% /admonition %}}
 
@@ -257,21 +257,18 @@ export default async function () {
   const page = await browser.newPage();
 
   try {
-    await page.goto("https://test.k6.io/my_messages.php");
+    await page.goto('https://test.k6.io/my_messages.php');
 
-    await page.locator('input[name="login"]').type("admin");
-    await page.locator('input[name="password"]').type("123");
+    await page.locator('input[name="login"]').type('admin');
+    await page.locator('input[name="password"]').type('123');
 
     const submitButton = page.locator('input[type="submit"]');
 
-    await Promise.all([
-      page.waitForNavigation(),
-      submitButton.click(),
-    ]);
+    await Promise.all([page.waitForNavigation(), submitButton.click()]);
 
-    const header = await page.locator("h2").textContent();
+    const header = await page.locator('h2').textContent();
     check(header, {
-      header: h => h == "Welcome, admin!",
+      header: (h) => h == 'Welcome, admin!',
     });
   } finally {
     await page.close();
@@ -340,7 +337,7 @@ export async function browserTest() {
 
     const info = await page.locator('#counter-button').textContent();
     check(info, {
-      'checkbox is checked': info => info === 'Thanks for checking the box',
+      'checkbox is checked': (info) => info === 'Thanks for checking the box',
     });
   } finally {
     await page.close();


### PR DESCRIPTION
## What?

Starting from v0.52.0 Browser API is fully async. This PR updates the outdated note to mention this and refer users to the migration guide.

## Checklist

- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.
- [x] I have made my changes in the `docs/sources/next` folder of the documentation.
- [x] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.
