### PR TITLE
Mention `k6/experimental/fs` in `open()`

### DIFF
--- a/docs/sources/next/javascript-api/init-context/open.md
+++ b/docs/sources/next/javascript-api/init-context/open.md
@@ -9,15 +9,22 @@ description: 'Opens a file and reads all the contents into memory.'
 
 Opens a file, reading all its contents into memory for use in the script.
 
-`open()` can only be called from the [init context](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-lifecycle#the-init-stage) (aka _init code_). This restriction is necessary to determine the local files needed to bundle when distributing the test across multiple nodes.
+{{< admonition type="caution" >}}
 
-{{% admonition type="caution" %}}
+`open()` can only be called from the [init context](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-lifecycle#the-init-stage). This restriction is necessary to determine the local files needed to bundle when distributing the test across multiple nodes.
+
+{{< /admonition >}}
+
+{{< admonition type="note" >}}
 
 `open()` often consumes a large amount of memory because every VU keeps a separate copy of the file in memory.
 
-To reduce the memory consumption, we advise the usage of `open()` within a [SharedArray](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-data/sharedarray), which shares the allocated file memory between VUs. Alternatively, use the new [open() in `k6/experimental/fs`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/fs/), which initially loads as little as possible and can read the file in small chunks.
+To reduce the memory consumption, you can:
 
-{{% /admonition %}}
+- Use `open()` within a [SharedArray](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-data/sharedarray), which shares the allocated file memory between VUs.
+- Use [open() from the `k6/experimental/fs`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/fs/) module. It provides a memory-efficient way to handle file interactions in your test script and can read files in small chunks.
+
+{{< /admonition >}}
 
 | Parameter | Type   | Description                                                                                                                                       |
 | --------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/sources/next/javascript-api/init-context/open.md
+++ b/docs/sources/next/javascript-api/init-context/open.md
@@ -9,21 +9,13 @@ description: 'Opens a file and reads all the contents into memory.'
 
 Opens a file, reading all its contents into memory for use in the script.
 
-{{% admonition type="note" %}}
-
-`open()` often consumes a large amount of memory because every VU keeps a separate copy of the file in memory.
-
-To reduce the memory consumption, we strongly advise the usage of [SharedArray](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-data/sharedarray) for CSV, JSON and other files intended for script parametrization.
-
-{{% /admonition %}}
+`open()` can only be called from the [init context](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-lifecycle#the-init-stage) (aka _init code_). This restriction is necessary to determine the local files needed to bundle when distributing the test across multiple nodes.
 
 {{% admonition type="caution" %}}
 
-This function can only be called from the init context (aka _init code_), code in the global context that is, outside of the main export default function { ... }.
+`open()` often consumes a large amount of memory because every VU keeps a separate copy of the file in memory.
 
-By restricting it to the init context, we can easily determine what local files are needed to run the test and thus what we need to bundle up when distributing the test to multiple nodes in a clustered/distributed test.
-
-See the example further down on this page. For a more in-depth description, see [Test lifecycle](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-lifecycle).
+To reduce the memory consumption, we advise the usage of `open()` within a [SharedArray](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-data/sharedarray), which shares the allocated file memory between VUs. Alternatively, use the new [open() in `k6/experimental/fs`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/fs/), which initially loads as little as possible and can read the file in small chunks.
 
 {{% /admonition %}}
 
@@ -37,6 +29,8 @@ See the example further down on this page. For a more in-depth description, see 
 | Type                 | Description                                                                                     |
 | -------------------- | ----------------------------------------------------------------------------------------------- |
 | string / ArrayBuffer | The contents of the file, returned as string or ArrayBuffer (if `b` was specified as the mode). |
+
+### Examples
 
 {{< code >}}
 

--- a/docs/sources/v0.48.x/javascript-api/init-context/open.md
+++ b/docs/sources/v0.48.x/javascript-api/init-context/open.md
@@ -9,15 +9,22 @@ description: 'Opens a file and reads all the contents into memory.'
 
 Opens a file, reading all its contents into memory for use in the script.
 
-`open()` can only be called from the [init context](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-lifecycle#the-init-stage) (aka _init code_). This restriction is necessary to determine the local files needed to bundle when distributing the test across multiple nodes.
+{{< admonition type="caution" >}}
 
-{{% admonition type="caution" %}}
+`open()` can only be called from the [init context](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-lifecycle#the-init-stage). This restriction is necessary to determine the local files needed to bundle when distributing the test across multiple nodes.
+
+{{< /admonition >}}
+
+{{< admonition type="note" >}}
 
 `open()` often consumes a large amount of memory because every VU keeps a separate copy of the file in memory.
 
-To reduce the memory consumption, we advise the usage of `open()` within a [SharedArray](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-data/sharedarray), which shares the allocated file memory between VUs. Alternatively, use the new [open() in `k6/experimental/fs`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/fs/), which initially loads as little as possible and can read the file in small chunks.
+To reduce the memory consumption, you can:
 
-{{% /admonition %}}
+- Use `open()` within a [SharedArray](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-data/sharedarray), which shares the allocated file memory between VUs.
+- Use [open() from the `k6/experimental/fs`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/fs/) module. It provides a memory-efficient way to handle file interactions in your test script and can read files in small chunks.
+
+{{< /admonition >}}
 
 | Parameter | Type   | Description                                                                                                                                       |
 | --------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/sources/v0.48.x/javascript-api/init-context/open.md
+++ b/docs/sources/v0.48.x/javascript-api/init-context/open.md
@@ -9,21 +9,13 @@ description: 'Opens a file and reads all the contents into memory.'
 
 Opens a file, reading all its contents into memory for use in the script.
 
-{{% admonition type="note" %}}
-
-`open()` often consumes a large amount of memory because every VU keeps a separate copy of the file in memory.
-
-To reduce the memory consumption, we strongly advise the usage of [SharedArray](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-data/sharedarray) for CSV, JSON and other files intended for script parametrization.
-
-{{% /admonition %}}
+`open()` can only be called from the [init context](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-lifecycle#the-init-stage) (aka _init code_). This restriction is necessary to determine the local files needed to bundle when distributing the test across multiple nodes.
 
 {{% admonition type="caution" %}}
 
-This function can only be called from the init context (aka _init code_), code in the global context that is, outside of the main export default function { ... }.
+`open()` often consumes a large amount of memory because every VU keeps a separate copy of the file in memory.
 
-By restricting it to the init context, we can easily determine what local files are needed to run the test and thus what we need to bundle up when distributing the test to multiple nodes in a clustered/distributed test.
-
-See the example further down on this page. For a more in-depth description, see [Test lifecycle](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-lifecycle).
+To reduce the memory consumption, we advise the usage of `open()` within a [SharedArray](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-data/sharedarray), which shares the allocated file memory between VUs. Alternatively, use the new [open() in `k6/experimental/fs`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/fs/), which initially loads as little as possible and can read the file in small chunks.
 
 {{% /admonition %}}
 
@@ -37,6 +29,8 @@ See the example further down on this page. For a more in-depth description, see 
 | Type                 | Description                                                                                     |
 | -------------------- | ----------------------------------------------------------------------------------------------- |
 | string / ArrayBuffer | The contents of the file, returned as string or ArrayBuffer (if `b` was specified as the mode). |
+
+### Examples
 
 {{< code >}}
 

--- a/docs/sources/v0.49.x/javascript-api/init-context/open.md
+++ b/docs/sources/v0.49.x/javascript-api/init-context/open.md
@@ -9,15 +9,22 @@ description: 'Opens a file and reads all the contents into memory.'
 
 Opens a file, reading all its contents into memory for use in the script.
 
-`open()` can only be called from the [init context](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-lifecycle#the-init-stage) (aka _init code_). This restriction is necessary to determine the local files needed to bundle when distributing the test across multiple nodes.
+{{< admonition type="caution" >}}
 
-{{% admonition type="caution" %}}
+`open()` can only be called from the [init context](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-lifecycle#the-init-stage). This restriction is necessary to determine the local files needed to bundle when distributing the test across multiple nodes.
+
+{{< /admonition >}}
+
+{{< admonition type="note" >}}
 
 `open()` often consumes a large amount of memory because every VU keeps a separate copy of the file in memory.
 
-To reduce the memory consumption, we advise the usage of `open()` within a [SharedArray](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-data/sharedarray), which shares the allocated file memory between VUs. Alternatively, use the new [open() in `k6/experimental/fs`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/fs/), which initially loads as little as possible and can read the file in small chunks.
+To reduce the memory consumption, you can:
 
-{{% /admonition %}}
+- Use `open()` within a [SharedArray](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-data/sharedarray), which shares the allocated file memory between VUs.
+- Use [open() from the `k6/experimental/fs`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/fs/) module. It provides a memory-efficient way to handle file interactions in your test script and can read files in small chunks.
+
+{{< /admonition >}}
 
 | Parameter | Type   | Description                                                                                                                                       |
 | --------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/sources/v0.49.x/javascript-api/init-context/open.md
+++ b/docs/sources/v0.49.x/javascript-api/init-context/open.md
@@ -9,21 +9,13 @@ description: 'Opens a file and reads all the contents into memory.'
 
 Opens a file, reading all its contents into memory for use in the script.
 
-{{% admonition type="note" %}}
-
-`open()` often consumes a large amount of memory because every VU keeps a separate copy of the file in memory.
-
-To reduce the memory consumption, we strongly advise the usage of [SharedArray](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-data/sharedarray) for CSV, JSON and other files intended for script parametrization.
-
-{{% /admonition %}}
+`open()` can only be called from the [init context](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-lifecycle#the-init-stage) (aka _init code_). This restriction is necessary to determine the local files needed to bundle when distributing the test across multiple nodes.
 
 {{% admonition type="caution" %}}
 
-This function can only be called from the init context (aka _init code_), code in the global context that is, outside of the main export default function { ... }.
+`open()` often consumes a large amount of memory because every VU keeps a separate copy of the file in memory.
 
-By restricting it to the init context, we can easily determine what local files are needed to run the test and thus what we need to bundle up when distributing the test to multiple nodes in a clustered/distributed test.
-
-See the example further down on this page. For a more in-depth description, see [Test lifecycle](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-lifecycle).
+To reduce the memory consumption, we advise the usage of `open()` within a [SharedArray](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-data/sharedarray), which shares the allocated file memory between VUs. Alternatively, use the new [open() in `k6/experimental/fs`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/fs/), which initially loads as little as possible and can read the file in small chunks.
 
 {{% /admonition %}}
 
@@ -37,6 +29,8 @@ See the example further down on this page. For a more in-depth description, see 
 | Type                 | Description                                                                                     |
 | -------------------- | ----------------------------------------------------------------------------------------------- |
 | string / ArrayBuffer | The contents of the file, returned as string or ArrayBuffer (if `b` was specified as the mode). |
+
+### Examples
 
 {{< code >}}
 

--- a/docs/sources/v0.50.x/javascript-api/init-context/open.md
+++ b/docs/sources/v0.50.x/javascript-api/init-context/open.md
@@ -9,15 +9,22 @@ description: 'Opens a file and reads all the contents into memory.'
 
 Opens a file, reading all its contents into memory for use in the script.
 
-`open()` can only be called from the [init context](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-lifecycle#the-init-stage) (aka _init code_). This restriction is necessary to determine the local files needed to bundle when distributing the test across multiple nodes.
+{{< admonition type="caution" >}}
 
-{{% admonition type="caution" %}}
+`open()` can only be called from the [init context](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-lifecycle#the-init-stage). This restriction is necessary to determine the local files needed to bundle when distributing the test across multiple nodes.
+
+{{< /admonition >}}
+
+{{< admonition type="note" >}}
 
 `open()` often consumes a large amount of memory because every VU keeps a separate copy of the file in memory.
 
-To reduce the memory consumption, we advise the usage of `open()` within a [SharedArray](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-data/sharedarray), which shares the allocated file memory between VUs. Alternatively, use the new [open() in `k6/experimental/fs`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/fs/), which initially loads as little as possible and can read the file in small chunks.
+To reduce the memory consumption, you can:
 
-{{% /admonition %}}
+- Use `open()` within a [SharedArray](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-data/sharedarray), which shares the allocated file memory between VUs.
+- Use [open() from the `k6/experimental/fs`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/fs/) module. It provides a memory-efficient way to handle file interactions in your test script and can read files in small chunks.
+
+{{< /admonition >}}
 
 | Parameter | Type   | Description                                                                                                                                       |
 | --------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/sources/v0.50.x/javascript-api/init-context/open.md
+++ b/docs/sources/v0.50.x/javascript-api/init-context/open.md
@@ -9,21 +9,13 @@ description: 'Opens a file and reads all the contents into memory.'
 
 Opens a file, reading all its contents into memory for use in the script.
 
-{{% admonition type="note" %}}
-
-`open()` often consumes a large amount of memory because every VU keeps a separate copy of the file in memory.
-
-To reduce the memory consumption, we strongly advise the usage of [SharedArray](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-data/sharedarray) for CSV, JSON and other files intended for script parametrization.
-
-{{% /admonition %}}
+`open()` can only be called from the [init context](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-lifecycle#the-init-stage) (aka _init code_). This restriction is necessary to determine the local files needed to bundle when distributing the test across multiple nodes.
 
 {{% admonition type="caution" %}}
 
-This function can only be called from the init context (aka _init code_), code in the global context that is, outside of the main export default function { ... }.
+`open()` often consumes a large amount of memory because every VU keeps a separate copy of the file in memory.
 
-By restricting it to the init context, we can easily determine what local files are needed to run the test and thus what we need to bundle up when distributing the test to multiple nodes in a clustered/distributed test.
-
-See the example further down on this page. For a more in-depth description, see [Test lifecycle](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-lifecycle).
+To reduce the memory consumption, we advise the usage of `open()` within a [SharedArray](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-data/sharedarray), which shares the allocated file memory between VUs. Alternatively, use the new [open() in `k6/experimental/fs`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/fs/), which initially loads as little as possible and can read the file in small chunks.
 
 {{% /admonition %}}
 
@@ -37,6 +29,8 @@ See the example further down on this page. For a more in-depth description, see 
 | Type                 | Description                                                                                     |
 | -------------------- | ----------------------------------------------------------------------------------------------- |
 | string / ArrayBuffer | The contents of the file, returned as string or ArrayBuffer (if `b` was specified as the mode). |
+
+### Examples
 
 {{< code >}}
 

--- a/docs/sources/v0.51.x/javascript-api/init-context/open.md
+++ b/docs/sources/v0.51.x/javascript-api/init-context/open.md
@@ -9,15 +9,22 @@ description: 'Opens a file and reads all the contents into memory.'
 
 Opens a file, reading all its contents into memory for use in the script.
 
-`open()` can only be called from the [init context](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-lifecycle#the-init-stage) (aka _init code_). This restriction is necessary to determine the local files needed to bundle when distributing the test across multiple nodes.
+{{< admonition type="caution" >}}
 
-{{% admonition type="caution" %}}
+`open()` can only be called from the [init context](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-lifecycle#the-init-stage). This restriction is necessary to determine the local files needed to bundle when distributing the test across multiple nodes.
+
+{{< /admonition >}}
+
+{{< admonition type="note" >}}
 
 `open()` often consumes a large amount of memory because every VU keeps a separate copy of the file in memory.
 
-To reduce the memory consumption, we advise the usage of `open()` within a [SharedArray](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-data/sharedarray), which shares the allocated file memory between VUs. Alternatively, use the new [open() in `k6/experimental/fs`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/fs/), which initially loads as little as possible and can read the file in small chunks.
+To reduce the memory consumption, you can:
 
-{{% /admonition %}}
+- Use `open()` within a [SharedArray](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-data/sharedarray), which shares the allocated file memory between VUs.
+- Use [open() from the `k6/experimental/fs`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/fs/) module. It provides a memory-efficient way to handle file interactions in your test script and can read files in small chunks.
+
+{{< /admonition >}}
 
 | Parameter | Type   | Description                                                                                                                                       |
 | --------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/sources/v0.51.x/javascript-api/init-context/open.md
+++ b/docs/sources/v0.51.x/javascript-api/init-context/open.md
@@ -9,21 +9,13 @@ description: 'Opens a file and reads all the contents into memory.'
 
 Opens a file, reading all its contents into memory for use in the script.
 
-{{% admonition type="note" %}}
-
-`open()` often consumes a large amount of memory because every VU keeps a separate copy of the file in memory.
-
-To reduce the memory consumption, we strongly advise the usage of [SharedArray](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-data/sharedarray) for CSV, JSON and other files intended for script parametrization.
-
-{{% /admonition %}}
+`open()` can only be called from the [init context](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-lifecycle#the-init-stage) (aka _init code_). This restriction is necessary to determine the local files needed to bundle when distributing the test across multiple nodes.
 
 {{% admonition type="caution" %}}
 
-This function can only be called from the init context (aka _init code_), code in the global context that is, outside of the main export default function { ... }.
+`open()` often consumes a large amount of memory because every VU keeps a separate copy of the file in memory.
 
-By restricting it to the init context, we can easily determine what local files are needed to run the test and thus what we need to bundle up when distributing the test to multiple nodes in a clustered/distributed test.
-
-See the example further down on this page. For a more in-depth description, see [Test lifecycle](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-lifecycle).
+To reduce the memory consumption, we advise the usage of `open()` within a [SharedArray](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-data/sharedarray), which shares the allocated file memory between VUs. Alternatively, use the new [open() in `k6/experimental/fs`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/fs/), which initially loads as little as possible and can read the file in small chunks.
 
 {{% /admonition %}}
 
@@ -37,6 +29,8 @@ See the example further down on this page. For a more in-depth description, see 
 | Type                 | Description                                                                                     |
 | -------------------- | ----------------------------------------------------------------------------------------------- |
 | string / ArrayBuffer | The contents of the file, returned as string or ArrayBuffer (if `b` was specified as the mode). |
+
+### Examples
 
 {{< code >}}
 

--- a/docs/sources/v0.52.x/javascript-api/init-context/open.md
+++ b/docs/sources/v0.52.x/javascript-api/init-context/open.md
@@ -9,15 +9,22 @@ description: 'Opens a file and reads all the contents into memory.'
 
 Opens a file, reading all its contents into memory for use in the script.
 
-`open()` can only be called from the [init context](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-lifecycle#the-init-stage) (aka _init code_). This restriction is necessary to determine the local files needed to bundle when distributing the test across multiple nodes.
+{{< admonition type="caution" >}}
 
-{{% admonition type="caution" %}}
+`open()` can only be called from the [init context](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-lifecycle#the-init-stage). This restriction is necessary to determine the local files needed to bundle when distributing the test across multiple nodes.
+
+{{< /admonition >}}
+
+{{< admonition type="note" >}}
 
 `open()` often consumes a large amount of memory because every VU keeps a separate copy of the file in memory.
 
-To reduce the memory consumption, we advise the usage of `open()` within a [SharedArray](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-data/sharedarray), which shares the allocated file memory between VUs. Alternatively, use the new [open() in `k6/experimental/fs`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/fs/), which initially loads as little as possible and can read the file in small chunks.
+To reduce the memory consumption, you can:
 
-{{% /admonition %}}
+- Use `open()` within a [SharedArray](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-data/sharedarray), which shares the allocated file memory between VUs.
+- Use [open() from the `k6/experimental/fs`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/fs/) module. It provides a memory-efficient way to handle file interactions in your test script and can read files in small chunks.
+
+{{< /admonition >}}
 
 | Parameter | Type   | Description                                                                                                                                       |
 | --------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/sources/v0.52.x/javascript-api/init-context/open.md
+++ b/docs/sources/v0.52.x/javascript-api/init-context/open.md
@@ -9,21 +9,13 @@ description: 'Opens a file and reads all the contents into memory.'
 
 Opens a file, reading all its contents into memory for use in the script.
 
-{{% admonition type="note" %}}
-
-`open()` often consumes a large amount of memory because every VU keeps a separate copy of the file in memory.
-
-To reduce the memory consumption, we strongly advise the usage of [SharedArray](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-data/sharedarray) for CSV, JSON and other files intended for script parametrization.
-
-{{% /admonition %}}
+`open()` can only be called from the [init context](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-lifecycle#the-init-stage) (aka _init code_). This restriction is necessary to determine the local files needed to bundle when distributing the test across multiple nodes.
 
 {{% admonition type="caution" %}}
 
-This function can only be called from the init context (aka _init code_), code in the global context that is, outside of the main export default function { ... }.
+`open()` often consumes a large amount of memory because every VU keeps a separate copy of the file in memory.
 
-By restricting it to the init context, we can easily determine what local files are needed to run the test and thus what we need to bundle up when distributing the test to multiple nodes in a clustered/distributed test.
-
-See the example further down on this page. For a more in-depth description, see [Test lifecycle](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-lifecycle).
+To reduce the memory consumption, we advise the usage of `open()` within a [SharedArray](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-data/sharedarray), which shares the allocated file memory between VUs. Alternatively, use the new [open() in `k6/experimental/fs`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/fs/), which initially loads as little as possible and can read the file in small chunks.
 
 {{% /admonition %}}
 
@@ -37,6 +29,8 @@ See the example further down on this page. For a more in-depth description, see 
 | Type                 | Description                                                                                     |
 | -------------------- | ----------------------------------------------------------------------------------------------- |
 | string / ArrayBuffer | The contents of the file, returned as string or ArrayBuffer (if `b` was specified as the mode). |
+
+### Examples
 
 {{< code >}}
 


### PR DESCRIPTION

Update [JavaScript API / open()](https://grafana.com/docs/k6/latest/javascript-api/init-context/open/) to recommend the `k6/experimental/fs` API:

![Screenshot 2024-07-12 at 19 21 04](https://github.com/user-attachments/assets/74df94ed-4e68-487a-82e0-faa9a9bedc38)
