### PR TITLE
chore: update browser example to point to correct element

### DIFF
--- a/docs/sources/next/using-k6-browser/running-browser-tests.md
+++ b/docs/sources/next/using-k6-browser/running-browser-tests.md
@@ -329,7 +329,7 @@ export async function browserTest() {
 
     await page.locator('#checkbox1').check();
 
-    const info = await page.locator('#counter-button').textContent();
+    const info = await page.locator('#checkbox-info-display').textContent();
     check(info, {
       'checkbox is checked': (info) => info === 'Thanks for checking the box',
     });

--- a/docs/sources/v0.52.x/using-k6-browser/running-browser-tests.md
+++ b/docs/sources/v0.52.x/using-k6-browser/running-browser-tests.md
@@ -329,7 +329,7 @@ export async function browserTest() {
 
     await page.locator('#checkbox1').check();
 
-    const info = await page.locator('#counter-button').textContent();
+    const info = await page.locator('#checkbox-info-display').textContent();
     check(info, {
       'checkbox is checked': (info) => info === 'Thanks for checking the box',
     });


### PR DESCRIPTION
# What?

Browser test example was pointing to the wrong element on the page when checking for the text content.

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [x] I have made my changes in the `docs/sources/next` folder of the documentation.
- [x] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.
- [x] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->
<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->