### PR TITLE
Deprecate k6/experimental/tracing

### DIFF
--- a/docs/sources/next/javascript-api/jslib/http-instrumentation-tempo/_index.md
+++ b/docs/sources/next/javascript-api/jslib/http-instrumentation-tempo/_index.md
@@ -9,6 +9,11 @@ weight: 04
 
 With this jslib, you can _instrument_ HTTP requests so that they emit traces as the test runs. Use it to include a tracing context in HTTP requests, which can then be used by a tracing backend such as [Grafana Tempo](https://grafana.com/docs/grafana-cloud/testing/k6/analyze-results/integration-with-grafana-cloud-traces/).
 
+## Migration from `k6/experimental/tracing`
+
+This jslib is a drop in replacement, so all you need to migrate to it is to replace `'k6/experimental/tracing'` import with `'https://jslib.k6.io/http-instrumentation-tempo/1.0.0/index.js'`
+
+
 ## About trace contexts
 
 A _trace context_ is a set of standardized HTTP headers added to a request that lets a tracing system correlate it with other requests as they navigate through a system. The trace context specifications, such as the supported [W3C Trace Context](https://www.w3.org/TR/trace-context/) and [Jaeger Trace Context](https://www.jaegertracing.io/docs/1.21/client-libraries/#propagation-format), define specific header names and an encoding format for the header values.

--- a/docs/sources/next/javascript-api/k6-experimental/tracing/_index.md
+++ b/docs/sources/next/javascript-api/k6-experimental/tracing/_index.md
@@ -7,7 +7,7 @@ weight: 04
 
 # tracing
 
-{{< docs/shared source="k6" lookup="experimental-module.md" version="<K6_VERSION>" >}}
+{{< docs/shared source="k6" lookup="experimental-tracing-module.md" version="<K6_VERSION>" >}}
 
 With this experimental module, you can _instrument_ HTTP requests so that they emit traces as the test runs.
 

--- a/docs/sources/next/javascript-api/k6-experimental/tracing/client.md
+++ b/docs/sources/next/javascript-api/k6-experimental/tracing/client.md
@@ -6,6 +6,8 @@ weight: 02
 
 # Client
 
+{{< docs/shared source="k6" lookup="experimental-tracing-module.md" version="<K6_VERSION>" >}}
+
 `Client` is an HTTP client constructor that attaches tracing information to its requests. Use it to include a tracing context in HTTP requests so that tracing backends (such as [Grafana Tempo](https://grafana.com/oss/tempo/)) can incorporate their results.
 
 The `Client` class acts as a drop-in replacement for the standard `http` module and attaches a [trace context](https://www.w3.org/TR/trace-context/) to the requests headers, and add a `trace_id` to HTTP-related k6 output's data points metadata. It currently supports the [W3C Trace Context](https://www.w3.org/TR/trace-context/) and [Jaeger](https://www.jaegertracing.io/docs/1.21/client-libraries/#propagation-format) trace context propagation formats. For details about propagation, refer to [About trace contexts](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/tracing#about-trace-contexts).

--- a/docs/sources/next/javascript-api/k6-experimental/tracing/instrumenthttp.md
+++ b/docs/sources/next/javascript-api/k6-experimental/tracing/instrumenthttp.md
@@ -6,6 +6,8 @@ weight: 01
 
 # instrumentHTTP
 
+{{< docs/shared source="k6" lookup="experimental-tracing-module.md" version="<K6_VERSION>" >}}
+
 The `instrumentHTTP` function instruments the k6 http module with tracing capabilities. It transparently replaces each of the k6 http module functions with versions that automatically attach a trace context to every request. Instrumented functions include [del](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-http/del),[get](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-http/get),[head](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-http/head),[options](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-http/options),[patch](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-http/patch),[post](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-http/post),[put](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-http/head), and [request](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-http/request).
 
 The `instrumentHTTP` automatically adds tracing information to HTTP requests performed using the `k6/http` module functions (mentioned above).

--- a/docs/sources/next/javascript-api/k6-experimental/tracing/options.md
+++ b/docs/sources/next/javascript-api/k6-experimental/tracing/options.md
@@ -6,6 +6,8 @@ weight: 03
 
 # Options
 
+{{< docs/shared source="k6" lookup="experimental-tracing-module.md" version="<K6_VERSION>" >}}
+
 Use the `Options` object to configure the tracing instrumentation behavior. It is used during the instantiation of a [`Client`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/tracing/client) instance and also as a parameter to the [`instrumentHTTP`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/tracing/instrumenthttp) function. It controls the general behavior of the tracing instrumentation and is unspecific to any particular tracing client instance.
 
 ## Options

--- a/docs/sources/next/shared/experimental-tracing-module.md
+++ b/docs/sources/next/shared/experimental-tracing-module.md
@@ -1,0 +1,10 @@
+---
+title: Experimental tracing module admonition
+---
+
+{{% admonition type="caution" %}}
+
+The experimental module `k6/experimental/tracing` is deprecated, it functionality is fully available as a jslib. Please refer to its [documentation](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/http-instrumentation-tempo/. The `k6/experimental/tracing` will be removed in the future.
+
+{{% /admonition %}}
+

--- a/docs/sources/v0.52.x/javascript-api/jslib/http-instrumentation-tempo/_index.md
+++ b/docs/sources/v0.52.x/javascript-api/jslib/http-instrumentation-tempo/_index.md
@@ -9,6 +9,10 @@ weight: 04
 
 With this jslib, you can _instrument_ HTTP requests so that they emit traces as the test runs. Use it to include a tracing context in HTTP requests, which can then be used by a tracing backend such as [Grafana Tempo](https://grafana.com/docs/grafana-cloud/testing/k6/analyze-results/integration-with-grafana-cloud-traces/).
 
+## Migration from `k6/experimental/tracing`
+
+This jslib is a drop in replacement, so all you need to migrate to it is to replace `'k6/experimental/tracing'` import with `'https://jslib.k6.io/http-instrumentation-tempo/1.0.0/index.js'`
+
 ## About trace contexts
 
 A _trace context_ is a set of standardized HTTP headers added to a request that lets a tracing system correlate it with other requests as they navigate through a system. The trace context specifications, such as the supported [W3C Trace Context](https://www.w3.org/TR/trace-context/) and [Jaeger Trace Context](https://www.jaegertracing.io/docs/1.21/client-libraries/#propagation-format), define specific header names and an encoding format for the header values.

--- a/docs/sources/v0.52.x/javascript-api/k6-experimental/tracing/_index.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-experimental/tracing/_index.md
@@ -7,7 +7,7 @@ weight: 04
 
 # tracing
 
-{{< docs/shared source="k6" lookup="experimental-module.md" version="<K6_VERSION>" >}}
+{{< docs/shared source="k6" lookup="experimental-tracing-module.md" version="<K6_VERSION>" >}}
 
 With this experimental module, you can _instrument_ HTTP requests so that they emit traces as the test runs.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-experimental/tracing/client.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-experimental/tracing/client.md
@@ -6,6 +6,8 @@ weight: 02
 
 # Client
 
+{{< docs/shared source="k6" lookup="experimental-tracing-module.md" version="<K6_VERSION>" >}}
+
 `Client` is an HTTP client constructor that attaches tracing information to its requests. Use it to include a tracing context in HTTP requests so that tracing backends (such as [Grafana Tempo](https://grafana.com/oss/tempo/)) can incorporate their results.
 
 The `Client` class acts as a drop-in replacement for the standard `http` module and attaches a [trace context](https://www.w3.org/TR/trace-context/) to the requests headers, and add a `trace_id` to HTTP-related k6 output's data points metadata. It currently supports the [W3C Trace Context](https://www.w3.org/TR/trace-context/) and [Jaeger](https://www.jaegertracing.io/docs/1.21/client-libraries/#propagation-format) trace context propagation formats. For details about propagation, refer to [About trace contexts](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/tracing#about-trace-contexts).

--- a/docs/sources/v0.52.x/javascript-api/k6-experimental/tracing/instrumenthttp.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-experimental/tracing/instrumenthttp.md
@@ -6,6 +6,8 @@ weight: 01
 
 # instrumentHTTP
 
+{{< docs/shared source="k6" lookup="experimental-tracing-module.md" version="<K6_VERSION>" >}}
+
 The `instrumentHTTP` function instruments the k6 http module with tracing capabilities. It transparently replaces each of the k6 http module functions with versions that automatically attach a trace context to every request. Instrumented functions include [del](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-http/del),[get](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-http/get),[head](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-http/head),[options](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-http/options),[patch](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-http/patch),[post](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-http/post),[put](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-http/head), and [request](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-http/request).
 
 The `instrumentHTTP` automatically adds tracing information to HTTP requests performed using the `k6/http` module functions (mentioned above).

--- a/docs/sources/v0.52.x/javascript-api/k6-experimental/tracing/options.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-experimental/tracing/options.md
@@ -6,6 +6,8 @@ weight: 03
 
 # Options
 
+{{< docs/shared source="k6" lookup="experimental-tracing-module.md" version="<K6_VERSION>" >}}
+
 Use the `Options` object to configure the tracing instrumentation behavior. It is used during the instantiation of a [`Client`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/tracing/client) instance and also as a parameter to the [`instrumentHTTP`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/tracing/instrumenthttp) function. It controls the general behavior of the tracing instrumentation and is unspecific to any particular tracing client instance.
 
 ## Options

--- a/docs/sources/v0.52.x/shared/experimental-tracing-module.md
+++ b/docs/sources/v0.52.x/shared/experimental-tracing-module.md
@@ -1,0 +1,10 @@
+---
+title: Experimental tracing module admonition
+---
+
+{{% admonition type="caution" %}}
+
+The experimental module `k6/experimental/tracing` is deprecated, it functionality is fully available as a jslib. Please refer to its [documentation](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/http-instrumentation-tempo/. The `k6/experimental/tracing` will be removed in the future.
+
+{{% /admonition %}}
+


### PR DESCRIPTION
## What?

k6/experimental/tracing is now available as jslib. 
As such it will be dropped in k6 in the future - lets document this and make it easier for users to find what they need to do.
## Checklist

<!-- Please fill in this template: -->
- [ ] I have used a meaningful title for the PR.
- [ ] I have described the changes I've made in the "What?" section above.
- [ ] I have performed a self-review of my changes.
- [ ] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [ ] I have made my changes in the `docs/sources/next` folder of the documentation.
- [ ] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.
- [ ] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->

<!-- 2. If updating the documentation for the next release of k6: -->
- [ ] I have made my changes in the `docs/sources/next` folder of the documentation.

## Related PR(s)/Issue(s)
https://github.com/grafana/k6/pull/3854
https://github.com/grafana/k6/pull/3855