### PR TITLE
Use http-instrumentation-pyroscope@1.0.1 in examples

### DIFF
--- a/docs/sources/next/javascript-api/jslib/http-instrumentation-pyroscope/_index.md
+++ b/docs/sources/next/javascript-api/jslib/http-instrumentation-pyroscope/_index.md
@@ -36,7 +36,7 @@ This example demonstrates how to use the this library to instrument every HTTP r
 
 ```javascript
 import { check } from 'k6';
-import pyroscope from 'https://jslib.k6.io/http-instrumentation-pyroscope/1.0.0/index.js';
+import pyroscope from 'https://jslib.k6.io/http-instrumentation-pyroscope/1.0.1/index.js';
 import http from 'k6/http';
 
 // instrumentHTTP will ensure that all requests made by the http module

--- a/docs/sources/next/javascript-api/jslib/http-instrumentation-pyroscope/client.md
+++ b/docs/sources/next/javascript-api/jslib/http-instrumentation-pyroscope/client.md
@@ -23,7 +23,7 @@ This example demonstrates how to instantiate a client and use it to instrument H
 
 ```javascript
 import { check } from 'k6';
-import pyroscope from 'https://jslib.k6.io/http-instrumentation-pyroscope/1.0.0/index.js';
+import pyroscope from 'https://jslib.k6.io/http-instrumentation-pyroscope/1.0.1/index.js';
 import http from 'k6/http';
 
 // Explicitly instantiating a Pyroscope client allows to distinguish

--- a/docs/sources/next/javascript-api/jslib/http-instrumentation-pyroscope/instrumenthttp.md
+++ b/docs/sources/next/javascript-api/jslib/http-instrumentation-pyroscope/instrumenthttp.md
@@ -28,7 +28,7 @@ This example demonstrates how to use the this library to instrument every HTTP r
 
 ```javascript
 import { check } from 'k6';
-import pyroscope from 'https://jslib.k6.io/http-instrumentation-pyroscope/1.0.0/index.js';
+import pyroscope from 'https://jslib.k6.io/http-instrumentation-pyroscope/1.0.1/index.js';
 import http from 'k6/http';
 
 // instrumentHTTP will ensure that all requests made by the `http` module

--- a/docs/sources/v0.51.x/javascript-api/jslib/http-instrumentation-pyroscope/_index.md
+++ b/docs/sources/v0.51.x/javascript-api/jslib/http-instrumentation-pyroscope/_index.md
@@ -34,7 +34,7 @@ This example demonstrates how to use the this library to instrument every HTTP r
 
 ```javascript
 import { check } from 'k6';
-import pyroscope from 'https://jslib.k6.io/http-instrumentation-pyroscope/1.0.0/index.js';
+import pyroscope from 'https://jslib.k6.io/http-instrumentation-pyroscope/1.0.1/index.js';
 import http from 'k6/http';
 
 // instrumentHTTP will ensure that all requests made by the http module

--- a/docs/sources/v0.51.x/javascript-api/jslib/http-instrumentation-pyroscope/client.md
+++ b/docs/sources/v0.51.x/javascript-api/jslib/http-instrumentation-pyroscope/client.md
@@ -23,7 +23,7 @@ This example demonstrates how to instantiate a client and use it to instrument H
 
 ```javascript
 import { check } from 'k6';
-import pyroscope from 'https://jslib.k6.io/http-instrumentation-pyroscope/1.0.0/index.js';
+import pyroscope from 'https://jslib.k6.io/http-instrumentation-pyroscope/1.0.1/index.js';
 import http from 'k6/http';
 
 // Explicitly instantiating a Pyroscope client allows to distinguish

--- a/docs/sources/v0.51.x/javascript-api/jslib/http-instrumentation-pyroscope/instrumenthttp.md
+++ b/docs/sources/v0.51.x/javascript-api/jslib/http-instrumentation-pyroscope/instrumenthttp.md
@@ -28,7 +28,7 @@ This example demonstrates how to use the this library to instrument every HTTP r
 
 ```javascript
 import { check } from 'k6';
-import pyroscope from 'https://jslib.k6.io/http-instrumentation-pyroscope/1.0.0/index.js';
+import pyroscope from 'https://jslib.k6.io/http-instrumentation-pyroscope/1.0.1/index.js';
 import http from 'k6/http';
 
 // instrumentHTTP will ensure that all requests made by the `http` module

--- a/docs/sources/v0.52.x/javascript-api/jslib/http-instrumentation-pyroscope/_index.md
+++ b/docs/sources/v0.52.x/javascript-api/jslib/http-instrumentation-pyroscope/_index.md
@@ -36,7 +36,7 @@ This example demonstrates how to use the this library to instrument every HTTP r
 
 ```javascript
 import { check } from 'k6';
-import pyroscope from 'https://jslib.k6.io/http-instrumentation-pyroscope/1.0.0/index.js';
+import pyroscope from 'https://jslib.k6.io/http-instrumentation-pyroscope/1.0.1/index.js';
 import http from 'k6/http';
 
 // instrumentHTTP will ensure that all requests made by the http module

--- a/docs/sources/v0.52.x/javascript-api/jslib/http-instrumentation-pyroscope/client.md
+++ b/docs/sources/v0.52.x/javascript-api/jslib/http-instrumentation-pyroscope/client.md
@@ -23,7 +23,7 @@ This example demonstrates how to instantiate a client and use it to instrument H
 
 ```javascript
 import { check } from 'k6';
-import pyroscope from 'https://jslib.k6.io/http-instrumentation-pyroscope/1.0.0/index.js';
+import pyroscope from 'https://jslib.k6.io/http-instrumentation-pyroscope/1.0.1/index.js';
 import http from 'k6/http';
 
 // Explicitly instantiating a Pyroscope client allows to distinguish

--- a/docs/sources/v0.52.x/javascript-api/jslib/http-instrumentation-pyroscope/instrumenthttp.md
+++ b/docs/sources/v0.52.x/javascript-api/jslib/http-instrumentation-pyroscope/instrumenthttp.md
@@ -28,7 +28,7 @@ This example demonstrates how to use the this library to instrument every HTTP r
 
 ```javascript
 import { check } from 'k6';
-import pyroscope from 'https://jslib.k6.io/http-instrumentation-pyroscope/1.0.0/index.js';
+import pyroscope from 'https://jslib.k6.io/http-instrumentation-pyroscope/1.0.1/index.js';
 import http from 'k6/http';
 
 // instrumentHTTP will ensure that all requests made by the `http` module


### PR DESCRIPTION
## What?

Update the http-instrumentation-pyroscope JSLib version in examples. I have backported these changes to v0.52.x and v0.51.x too, to avoid users use the buggy version.

## Checklist

- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.
- [x] I have made my changes in the `docs/sources/next` folder of the documentation.
- [x] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.
- [x] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).

## Related PR(s)/Issue(s)

https://github.com/grafana/jslib.k6.io/pull/134