### PR TITLE
Replace PlayWright links with k6 Browser ones

### DIFF
--- a/docs/sources/next/javascript-api/k6-browser/browsercontext/setdefaultnavigationtimeout.md
+++ b/docs/sources/next/javascript-api/k6-browser/browsercontext/setdefaultnavigationtimeout.md
@@ -5,7 +5,7 @@ description: 'Sets the default navigation timeout in milliseconds.'
 
 # setDefaultNavigationTimeout(timeout)
 
-Sets the default maximum navigation timeout for [Page.goto()](https://playwright.dev/docs/api/class-page#page-goto).
+Sets the default maximum navigation timeout for [Page.goto()](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/goto).
 
 | Parameter | Type   | Default                  | Description                  |
 | --------- | ------ | ------------------------ | ---------------------------- |

--- a/docs/sources/next/javascript-api/k6-browser/request/size.md
+++ b/docs/sources/next/javascript-api/k6-browser/request/size.md
@@ -5,7 +5,7 @@ description: 'Browser module: Request.size method'
 
 # size()
 
-Similar to Playwright's [`request.sizes()`](https://playwright.dev/docs/api/class-request#request-sizes), this method returns the size (in bytes) of body and header sections of the [Request](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/request).
+This method returns the size (in bytes) of body and header sections of the [Request](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/request).
 
 ### Returns
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/browsercontext/setdefaultnavigationtimeout.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/browsercontext/setdefaultnavigationtimeout.md
@@ -5,7 +5,7 @@ description: 'Sets the default navigation timeout in milliseconds.'
 
 # setDefaultNavigationTimeout(timeout)
 
-Sets the default maximum navigation timeout for [Page.goto()](https://playwright.dev/docs/api/class-page#page-goto).
+Sets the default maximum navigation timeout for [Page.goto()](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/goto).
 
 | Parameter | Type   | Default                  | Description                  |
 | --------- | ------ | ------------------------ | ---------------------------- |

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/request/size.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/request/size.md
@@ -5,7 +5,7 @@ description: 'Browser module: Request.size method'
 
 # size()
 
-Similar to Playwright's [`request.sizes()`](https://playwright.dev/docs/api/class-request#request-sizes), this method returns the size (in bytes) of body and header sections of the [Request](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/request).
+This method returns the size (in bytes) of body and header sections of the [Request](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/request).
 
 ### Returns
 


### PR DESCRIPTION
## What?

Replaced references to PW docs with corresponding links to k6 docs.

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.
- [x] I have made my changes in the `docs/sources/next` folder of the documentation.
- [x] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.