### PR TITLE
chore: remove broken link to setChecked page

### DIFF
--- a/docs/sources/next/javascript-api/k6-browser/elementhandle/_index.md
+++ b/docs/sources/next/javascript-api/k6-browser/elementhandle/_index.md
@@ -38,7 +38,7 @@ weight: 04
 | [scrollIntoViewIfNeeded([options])](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/elementhandle/scrollintoviewifneeded)  | Scrolls the element into view if needed.                                                                                                                                            |
 | [selectOption(values[, options])](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/elementhandle/selectoption)              | Selects the `select` element's one or more options which match the values.                                                                                                          |
 | [selectText([options])](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/elementhandle/selecttext)                          | Selects the text of the element.                                                                                                                                                    |
-| [setChecked(checked[, options])](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/elementhandle/setchecked)                 | Sets the `checkbox` or `radio` input element's value to the specified checked or unchecked state.                                                                                   |
+| setChecked(checked[, options])                                                                                                                | Sets the `checkbox` or `radio` input element's value to the specified checked or unchecked state.                                                                                   |
 | [setInputFiles(file[, options])](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/elementhandle/setinputfiles)              | Sets the file input element's value to the specified files.                                                                                                                         |
 | [tap(options)](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/elementhandle/tap)                                          | Taps the element.                                                                                                                                                                   |
 | [textContent()](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/elementhandle/textcontent)                                 | Returns the text content of the element.                                                                                                                                            |
@@ -48,8 +48,6 @@ weight: 04
 | [waitForSelector(selector[, options])](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/elementhandle/waitforselector)      | Waits for the element to be present in the DOM and to be visible.                                                                                                                   |
 
 ## Examples
-
-{{< code >}}
 
 ```javascript
 import { check } from 'k6';
@@ -84,7 +82,7 @@ export default async function () {
     const submitButton = await page.$('input[type="submit"]');
 
     await Promise.all([page.waitForNavigation(), submitButton.click()]);
-    const text = await p.$('h2');
+    const text = await page.$('h2');
     const content = await text.textContent();
     check(page, {
       header: () => text == 'Welcome, admin!',
@@ -95,9 +93,7 @@ export default async function () {
 }
 ```
 
-{{< /code >}}
-
-{{< code >}}
+<!-- eslint-skip -->
 
 ```javascript
 import { browser } from 'k6/browser';
@@ -167,5 +163,3 @@ export default function () {
   }
 }
 ```
-
-{{< /code >}}

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/_index.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/_index.md
@@ -38,7 +38,7 @@ weight: 04
 | [scrollIntoViewIfNeeded([options])](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/elementhandle/scrollintoviewifneeded)  | Scrolls the element into view if needed.                                                                                                                                            |
 | [selectOption(values[, options])](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/elementhandle/selectoption)              | Selects the `select` element's one or more options which match the values.                                                                                                          |
 | [selectText([options])](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/elementhandle/selecttext)                          | Selects the text of the element.                                                                                                                                                    |
-| [setChecked(checked[, options])](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/elementhandle/setchecked)                 | Sets the `checkbox` or `radio` input element's value to the specified checked or unchecked state.                                                                                   |
+| setChecked(checked[, options])                                                                                                                | Sets the `checkbox` or `radio` input element's value to the specified checked or unchecked state.                                                                                   |
 | [setInputFiles(file[, options])](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/elementhandle/setinputfiles)              | Sets the file input element's value to the specified files.                                                                                                                         |
 | [tap(options)](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/elementhandle/tap)                                          | Taps the element.                                                                                                                                                                   |
 | [textContent()](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/elementhandle/textcontent)                                 | Returns the text content of the element.                                                                                                                                            |
@@ -48,8 +48,6 @@ weight: 04
 | [waitForSelector(selector[, options])](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/elementhandle/waitforselector)      | Waits for the element to be present in the DOM and to be visible.                                                                                                                   |
 
 ## Examples
-
-{{< code >}}
 
 ```javascript
 import { check } from 'k6';
@@ -84,7 +82,7 @@ export default async function () {
     const submitButton = await page.$('input[type="submit"]');
 
     await Promise.all([page.waitForNavigation(), submitButton.click()]);
-    const text = await p.$('h2');
+    const text = await page.$('h2');
     const content = await text.textContent();
     check(page, {
       header: () => text == 'Welcome, admin!',
@@ -95,13 +93,11 @@ export default async function () {
 }
 ```
 
-{{< /code >}}
-
-{{< code >}}
+<!-- eslint-skip -->
 
 ```javascript
-import { browser } from 'k6/browser';
 import { check } from 'k6';
+import { browser } from 'k6/browser';
 
 export const options = {
   scenarios: {
@@ -167,5 +163,3 @@ export default function () {
   }
 }
 ```
-
-{{< /code >}}


### PR DESCRIPTION
## What?

Remove a broken link to the `setChecked` page for the k6/browser `ElementHandle` object.

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [x] I have made my changes in the `docs/sources/next` folder of the documentation.
- [x] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.
- [ ] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->
<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->