### PR TITLE
Fix broken admonition for experimental tracing

### DIFF
--- a/docs/sources/next/shared/experimental-tracing-module.md
+++ b/docs/sources/next/shared/experimental-tracing-module.md
@@ -4,7 +4,6 @@ title: Experimental tracing module admonition
 
 {{% admonition type="caution" %}}
 
-The experimental module `k6/experimental/tracing` is deprecated, it functionality is fully available as a jslib. Please refer to its [documentation](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/http-instrumentation-tempo/. The `k6/experimental/tracing` will be removed in the future.
+The experimental module `k6/experimental/tracing` is deprecated, it functionality is fully available as a jslib. Please refer to its [documentation](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/http-instrumentation-tempo/). The `k6/experimental/tracing` will be removed in the future.
 
 {{% /admonition %}}
-

--- a/docs/sources/v0.52.x/shared/experimental-tracing-module.md
+++ b/docs/sources/v0.52.x/shared/experimental-tracing-module.md
@@ -4,7 +4,6 @@ title: Experimental tracing module admonition
 
 {{% admonition type="caution" %}}
 
-The experimental module `k6/experimental/tracing` is deprecated, it functionality is fully available as a jslib. Please refer to its [documentation](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/http-instrumentation-tempo/. The `k6/experimental/tracing` will be removed in the future.
+The experimental module `k6/experimental/tracing` is deprecated, it functionality is fully available as a jslib. Please refer to its [documentation](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/http-instrumentation-tempo/). The `k6/experimental/tracing` will be removed in the future.
 
 {{% /admonition %}}
-


### PR DESCRIPTION
<!-- 
Please make sure you have read the contribution guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md as well as the
the code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md before opening a PR.
-->

## What?

This fixes the broken admonition:
![image](https://github.com/user-attachments/assets/503097fc-7052-4292-8b84-8342e2bfad72)

See https://grafana.com/docs/k6/latest/javascript-api/k6-experimental/tracing/


## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.
- [x] I have made my changes in the `docs/sources/next` folder of the documentation.
- [x] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.
- [x] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->


## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->
<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->