### PR TITLE
Update release note titles to match Grafana

### DIFF
--- a/docs/sources/next/release-notes/v0.47.0.md
+++ b/docs/sources/next/release-notes/v0.47.0.md
@@ -1,12 +1,12 @@
 ---
-title: Grafana k6 version 0.47.0 release notes
+title: Version 0.47.0 release notes
 menuTitle: v0.47.0
 description: The release notes for Grafana k6 version 0.47.0
 weight: 10000
 canonical: https://github.com/grafana/k6/blob/master/release%20notes/v0.47.0.md
 ---
 
-# Grafana k6 version 0.47.0 release notes
+# Version 0.47.0 release notes
 
 k6 `v0.47.0` is here 🎉! This release includes:
 

--- a/docs/sources/next/release-notes/v0.48.0.md
+++ b/docs/sources/next/release-notes/v0.48.0.md
@@ -1,12 +1,12 @@
 ---
-title: Grafana k6 version 0.48.0 release notes
+title: Version 0.48.0 release notes
 menuTitle: v0.48.0
 description: The release notes for Grafana k6 version 0.48.0
 weight: 9999
 canonical: https://github.com/grafana/k6/blob/master/release%20notes/v0.48.0.md
 ---
 
-# Grafana k6 version 0.48.0 release notes
+# Version 0.48.0 release notes
 
 k6 v0.48.0 is here 🎉! This release includes:
 

--- a/docs/sources/next/release-notes/v0.49.0.md
+++ b/docs/sources/next/release-notes/v0.49.0.md
@@ -1,12 +1,12 @@
 ---
-title: Grafana k6 version 0.49.0 release notes
+title: Version 0.49.0 release notes
 menuTitle: v0.49.0
 description: The release notes for Grafana k6 version 0.49.0
 weight: 9998
 canonical: https://github.com/grafana/k6/blob/master/release%20notes/v0.49.0.md
 ---
 
-# Grafana k6 version 0.49.0 release notes
+# Version 0.49.0 release notes
 
 k6 `v0.49.0` is here 🎉! This release:
 

--- a/docs/sources/next/release-notes/v0.50.0.md
+++ b/docs/sources/next/release-notes/v0.50.0.md
@@ -1,12 +1,12 @@
 ---
-title: Grafana k6 version 0.50.0 release notes
+title: Version 0.50.0 release notes
 menuTitle: v0.50.0
 description: The release notes for Grafana k6 version 0.50.0
 weight: 9997
 canonical: https://github.com/grafana/k6/blob/master/release%20notes/v0.50.0.md
 ---
 
-# Grafana k6 version 0.50.0 release notes
+# Version 0.50.0 release notes
 
 k6 `v0.50.0` is here 🎉!
 

--- a/docs/sources/next/release-notes/v0.51.0.md
+++ b/docs/sources/next/release-notes/v0.51.0.md
@@ -1,12 +1,12 @@
 ---
-title: Grafana k6 version 0.51.0 release notes
+title: Version 0.51.0 release notes
 menuTitle: v0.51.0
 description: The release notes for Grafana k6 version 0.51.0
 weight: 9996
 canonical: https://github.com/grafana/k6/blob/master/release%20notes/v0.51.0.md
 ---
 
-# Grafana k6 version 0.51.0 release notes
+# Version 0.51.0 release notes
 
 k6 `v0.51.0` is here 🎉! Some special mentions included in this release:
 

--- a/docs/sources/next/release-notes/v0.52.0.md
+++ b/docs/sources/next/release-notes/v0.52.0.md
@@ -1,12 +1,12 @@
 ---
-title: Grafana k6 version 0.52.0 release notes
+title: Version 0.52.0 release notes
 menuTitle: v0.52.0
 description: The release notes for Grafana k6 version 0.52.0
 weight: 9995
 canonical: https://github.com/grafana/k6/blob/master/release%20notes/v0.52.0.md
 ---
 
-# Grafana k6 version 0.52.0 release notes
+# Version 0.52.0 release notes
 
 k6 `v0.52.0` is here 🎉! Some special mentions included in this release:
 

--- a/docs/sources/v0.52.x/release-notes/v0.47.0.md
+++ b/docs/sources/v0.52.x/release-notes/v0.47.0.md
@@ -1,12 +1,12 @@
 ---
-title: Grafana k6 version 0.47.0 release notes
+title: Version 0.47.0 release notes
 menuTitle: v0.47.0
 description: The release notes for Grafana k6 version 0.47.0
 weight: 10000
 canonical: https://github.com/grafana/k6/blob/master/release%20notes/v0.47.0.md
 ---
 
-# Grafana k6 version 0.47.0 release notes
+# Version 0.47.0 release notes
 
 k6 `v0.47.0` is here 🎉! This release includes:
 

--- a/docs/sources/v0.52.x/release-notes/v0.48.0.md
+++ b/docs/sources/v0.52.x/release-notes/v0.48.0.md
@@ -1,12 +1,12 @@
 ---
-title: Grafana k6 version 0.48.0 release notes
+title: Version 0.48.0 release notes
 menuTitle: v0.48.0
 description: The release notes for Grafana k6 version 0.48.0
 weight: 9999
 canonical: https://github.com/grafana/k6/blob/master/release%20notes/v0.48.0.md
 ---
 
-# Grafana k6 version 0.48.0 release notes
+# Version 0.48.0 release notes
 
 k6 v0.48.0 is here 🎉! This release includes:
 

--- a/docs/sources/v0.52.x/release-notes/v0.49.0.md
+++ b/docs/sources/v0.52.x/release-notes/v0.49.0.md
@@ -1,12 +1,12 @@
 ---
-title: Grafana k6 version 0.49.0 release notes
+title: Version 0.49.0 release notes
 menuTitle: v0.49.0
 description: The release notes for Grafana k6 version 0.49.0
 weight: 9998
 canonical: https://github.com/grafana/k6/blob/master/release%20notes/v0.49.0.md
 ---
 
-# Grafana k6 version 0.49.0 release notes
+# Version 0.49.0 release notes
 
 k6 `v0.49.0` is here 🎉! This release:
 

--- a/docs/sources/v0.52.x/release-notes/v0.50.0.md
+++ b/docs/sources/v0.52.x/release-notes/v0.50.0.md
@@ -1,12 +1,12 @@
 ---
-title: Grafana k6 version 0.50.0 release notes
+title: Version 0.50.0 release notes
 menuTitle: v0.50.0
 description: The release notes for Grafana k6 version 0.50.0
 weight: 9997
 canonical: https://github.com/grafana/k6/blob/master/release%20notes/v0.50.0.md
 ---
 
-# Grafana k6 version 0.50.0 release notes
+# Version 0.50.0 release notes
 
 k6 `v0.50.0` is here 🎉!
 

--- a/docs/sources/v0.52.x/release-notes/v0.51.0.md
+++ b/docs/sources/v0.52.x/release-notes/v0.51.0.md
@@ -1,12 +1,12 @@
 ---
-title: Grafana k6 version 0.51.0 release notes
+title: Version 0.51.0 release notes
 menuTitle: v0.51.0
 description: The release notes for Grafana k6 version 0.51.0
 weight: 9996
 canonical: https://github.com/grafana/k6/blob/master/release%20notes/v0.51.0.md
 ---
 
-# Grafana k6 version 0.51.0 release notes
+# Version 0.51.0 release notes
 
 k6 `v0.51.0` is here 🎉! Some special mentions included in this release:
 

--- a/docs/sources/v0.52.x/release-notes/v0.52.0.md
+++ b/docs/sources/v0.52.x/release-notes/v0.52.0.md
@@ -1,12 +1,12 @@
 ---
-title: Grafana k6 version 0.52.0 release notes
+title: Version 0.52.0 release notes
 menuTitle: v0.52.0
 description: The release notes for Grafana k6 version 0.52.0
 weight: 9995
 canonical: https://github.com/grafana/k6/blob/master/release%20notes/v0.52.0.md
 ---
 
-# Grafana k6 version 0.52.0 release notes
+# Version 0.52.0 release notes
 
 k6 `v0.52.0` is here 🎉! Some special mentions included in this release:
 


### PR DESCRIPTION
## What?

Update release note titles to match other Grafana projects. This will make the version number render correctly once it's listed in grafana.com/docs.

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [x] I have made my changes in the `docs/sources/next` folder of the documentation.
- [x] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->
<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->