### PR TITLE
Fix caution and warning admonitions

### DIFF
--- a/docs/sources/next/extensions/build-k6-binary-using-docker.md
+++ b/docs/sources/next/extensions/build-k6-binary-using-docker.md
@@ -122,7 +122,7 @@ Flags:
 
 {{< /code >}}
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 The use of `--replace` should be considered an advanced feature to be avoided unless required.
 

--- a/docs/sources/next/extensions/create/javascript-extensions.md
+++ b/docs/sources/next/extensions/create/javascript-extensions.md
@@ -176,7 +176,7 @@ to access the [`modules.VU`](https://pkg.go.dev/go.k6.io/k6/js/modules#VU) to in
 Additionally, there should be a root module implementation of the [`modules.Module`](https://pkg.go.dev/go.k6.io/k6/js/modules#Module)
 interface to serve as a factory of `Compare` instances for each VU.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 The significance depends on the size of your module.
 

--- a/docs/sources/next/extensions/explanations/extension-graduation.md
+++ b/docs/sources/next/extensions/explanations/extension-graduation.md
@@ -39,7 +39,7 @@ There should be a reasonably high degree of quality and stability at this point.
 This phase makes the feature accessible to more users, which in turn gives k6 developers more chances to receive feedback.
 The key will be to achieve a balance between usability and stability.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Not all experimental modules will progress to become a core module!
 The k6 team reserves the right to discontinue and remove any experimental module if is no longer deemed desirable.

--- a/docs/sources/next/javascript-api/jslib/httpx/_index.md
+++ b/docs/sources/next/javascript-api/jslib/httpx/_index.md
@@ -19,7 +19,7 @@ httpx module integrates well with the expect library.
 The source code is [on GitHub](https://github.com/k6io/k6-jslib-httpx).
 Please request features and report bugs through [GitHub issues](https://github.com/k6io/k6-jslib-httpx/issues).
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 **This library is in active development.**
 

--- a/docs/sources/next/javascript-api/k6-browser/browsercontext/pages.md
+++ b/docs/sources/next/javascript-api/k6-browser/browsercontext/pages.md
@@ -5,7 +5,7 @@ description: 'Returns a list of pages inside this BrowserContext.'
 
 # pages()
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**. For details, refer to
 [#444](https://github.com/grafana/xk6-browser/issues/444).

--- a/docs/sources/next/javascript-api/k6-browser/browsercontext/setgeolocation.md
+++ b/docs/sources/next/javascript-api/k6-browser/browsercontext/setgeolocation.md
@@ -5,7 +5,7 @@ description: "Sets the BrowserContext's geolocation."
 
 # setGeolocation(geolocation)
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**. For details, refer to
 [#435](https://github.com/grafana/xk6-browser/issues/435).

--- a/docs/sources/next/javascript-api/k6-browser/elementhandle/check.md
+++ b/docs/sources/next/javascript-api/k6-browser/elementhandle/check.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.check method'
 
 # check([options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.check([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/check/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/elementhandle/click.md
+++ b/docs/sources/next/javascript-api/k6-browser/elementhandle/click.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.click method'
 
 # click([options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.click([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/click/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/elementhandle/dblclick.md
+++ b/docs/sources/next/javascript-api/k6-browser/elementhandle/dblclick.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.dblclick method'
 
 # dblclick([options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.dblclick([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/dblclick/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/elementhandle/dispatchevent.md
+++ b/docs/sources/next/javascript-api/k6-browser/elementhandle/dispatchevent.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.dispatchEvent method'
 
 # dispatchEvent(type, eventInit)
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.dispatchEvent(type, eventInit[, options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/dispatchevent/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/elementhandle/fill.md
+++ b/docs/sources/next/javascript-api/k6-browser/elementhandle/fill.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.fill method'
 
 # fill(value, [options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.fill(value, [options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/fill/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/elementhandle/focus.md
+++ b/docs/sources/next/javascript-api/k6-browser/elementhandle/focus.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.focus method'
 
 # focus()
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.focus([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/focus/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/elementhandle/getattribute.md
+++ b/docs/sources/next/javascript-api/k6-browser/elementhandle/getattribute.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.getAttribute method'
 
 # getAttribute(name)
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.getAttribute(name[, options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/getattribute/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/elementhandle/hover.md
+++ b/docs/sources/next/javascript-api/k6-browser/elementhandle/hover.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.hover method'
 
 # hover([options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.hover([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/hover/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/elementhandle/innerhtml.md
+++ b/docs/sources/next/javascript-api/k6-browser/elementhandle/innerhtml.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.innerHTML method'
 
 # innerHTML()
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.innerHTML([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/innerhtml/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/elementhandle/innertext.md
+++ b/docs/sources/next/javascript-api/k6-browser/elementhandle/innertext.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.innerText method'
 
 # innerText()
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.innerText([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/innertext/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/elementhandle/ischecked.md
+++ b/docs/sources/next/javascript-api/k6-browser/elementhandle/ischecked.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.isChecked method'
 
 # isChecked()
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.isChecked([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/ischecked/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/elementhandle/isdisabled.md
+++ b/docs/sources/next/javascript-api/k6-browser/elementhandle/isdisabled.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.isDisabled method'
 
 # isDisabled()
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.isDisabled([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/isdisabled/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/elementhandle/iseditable.md
+++ b/docs/sources/next/javascript-api/k6-browser/elementhandle/iseditable.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.isEditable method'
 
 # isEditable()
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.isEditable([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/iseditable/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/elementhandle/isenabled.md
+++ b/docs/sources/next/javascript-api/k6-browser/elementhandle/isenabled.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.isEnabled method'
 
 # isEnabled()
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.isEnabled([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/isenabled/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/elementhandle/ishidden.md
+++ b/docs/sources/next/javascript-api/k6-browser/elementhandle/ishidden.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.isHidden method'
 
 # isHidden()
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.isHidden()`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/ishidden/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/elementhandle/isvisible.md
+++ b/docs/sources/next/javascript-api/k6-browser/elementhandle/isvisible.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.isVisible method'
 
 # isVisible()
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.isVisible()`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/isvisible/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/elementhandle/press.md
+++ b/docs/sources/next/javascript-api/k6-browser/elementhandle/press.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.press method'
 
 # press(key, [options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.press(key[, options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/press/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/elementhandle/query.md
+++ b/docs/sources/next/javascript-api/k6-browser/elementhandle/query.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.$ method'
 
 # $(selector)
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`page.locator(selector[, options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/elementhandle/selectoption.md
+++ b/docs/sources/next/javascript-api/k6-browser/elementhandle/selectoption.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.selectOption method'
 
 # selectOption(values, [options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.selectOption(values[, options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/selectoption/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/elementhandle/tap.md
+++ b/docs/sources/next/javascript-api/k6-browser/elementhandle/tap.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementhandle.tap method'
 
 # tap(options)
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.tap([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/tap/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/elementhandle/textcontent.md
+++ b/docs/sources/next/javascript-api/k6-browser/elementhandle/textcontent.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.textContent method'
 
 # textContent()
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.textContent([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/textcontent/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/elementhandle/type.md
+++ b/docs/sources/next/javascript-api/k6-browser/elementhandle/type.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.type method'
 
 # type(text, [options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.type([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/type/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/elementhandle/uncheck.md
+++ b/docs/sources/next/javascript-api/k6-browser/elementhandle/uncheck.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.uncheck method'
 
 # uncheck([options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.uncheck([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/uncheck/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/elementhandle/waitforselector.md
+++ b/docs/sources/next/javascript-api/k6-browser/elementhandle/waitforselector.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.waitForSelector method'
 
 # waitForSelector(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.waitFor([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/waitfor/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/frame/check.md
+++ b/docs/sources/next/javascript-api/k6-browser/frame/check.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.check(selector[, options]) method'
 
 # check(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.check([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/check/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/frame/click.md
+++ b/docs/sources/next/javascript-api/k6-browser/frame/click.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.click(selector[, options]) method'
 
 # click(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.click([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/click/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/frame/dblclick.md
+++ b/docs/sources/next/javascript-api/k6-browser/frame/dblclick.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.dblclick(selector[, options]) method'
 
 # dblclick(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.dblclick([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/dblclick/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/frame/dispatchevent.md
+++ b/docs/sources/next/javascript-api/k6-browser/frame/dispatchevent.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.dispatchEvent(selector, type, eventInit[, op
 
 # dispatchEvent(selector, type, eventInit[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.dispatchEvent(type, eventInit[, options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/dispatchevent/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/frame/dollar.md
+++ b/docs/sources/next/javascript-api/k6-browser/frame/dollar.md
@@ -6,7 +6,7 @@ description: 'Browser module: frame.$(selector) method'
 
 # $(selector)
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`frame.locator(selector)`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/frame/locator/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/frame/doubledollar.md
+++ b/docs/sources/next/javascript-api/k6-browser/frame/doubledollar.md
@@ -6,7 +6,7 @@ description: 'Browser module: frame.$$(selector) method'
 
 # $$(selector)
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`frame.locator(selector)`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/frame/locator/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/frame/fill.md
+++ b/docs/sources/next/javascript-api/k6-browser/frame/fill.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.fill(selector, value[, options]) method'
 
 # fill(selector, value[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.fill(value[, options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/fill/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/frame/focus.md
+++ b/docs/sources/next/javascript-api/k6-browser/frame/focus.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.focus(selector[, options]) method'
 
 # focus(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.focus([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/focus/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/frame/getattribute.md
+++ b/docs/sources/next/javascript-api/k6-browser/frame/getattribute.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.getAttribute(selector, name[, options]) meth
 
 # getAttribute(selector, name[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.getAttribute()`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/getattribute/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/frame/goto.md
+++ b/docs/sources/next/javascript-api/k6-browser/frame/goto.md
@@ -23,7 +23,7 @@ Navigating to `about:blank` or navigation to the same URL with a different hash,
 
 ### Events
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 `networkidle` is DISCOURAGED. Don't use this method for testing especially with chatty websites where the event may never fire, rely on web assertions to assess readiness instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/frame/hover.md
+++ b/docs/sources/next/javascript-api/k6-browser/frame/hover.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.hover(selector[, options]) method'
 
 # hover(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.hover([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/hover/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/frame/innerhtml.md
+++ b/docs/sources/next/javascript-api/k6-browser/frame/innerhtml.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.innerHTML(selector[, options]) method'
 
 # innerHTML(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.innerHTML([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/innerhtml/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/frame/innertext.md
+++ b/docs/sources/next/javascript-api/k6-browser/frame/innertext.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.innerText(selector[, options]) method'
 
 # innerText(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.innerText([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/innertext/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/frame/inputvalue.md
+++ b/docs/sources/next/javascript-api/k6-browser/frame/inputvalue.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.inputValue(selector[, options]) method'
 
 # inputValue(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.inputValue([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/inputvalue/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/frame/ischecked.md
+++ b/docs/sources/next/javascript-api/k6-browser/frame/ischecked.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.isChecked(selector[, options]) method'
 
 # isChecked(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isChecked([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/ischecked/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/frame/isdisabled.md
+++ b/docs/sources/next/javascript-api/k6-browser/frame/isdisabled.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.isDisabled(selector[, options]) method'
 
 # isDisabled(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isDisabled([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/isdisabled/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/frame/iseditable.md
+++ b/docs/sources/next/javascript-api/k6-browser/frame/iseditable.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.isEditable(selector[, options]) method'
 
 # isEditable(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isEditable([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/iseditable/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/frame/isenabled.md
+++ b/docs/sources/next/javascript-api/k6-browser/frame/isenabled.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.isEnabled(selector[, options]) method'
 
 # isEnabled(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isEnabled([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/isenabled/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/frame/ishidden.md
+++ b/docs/sources/next/javascript-api/k6-browser/frame/ishidden.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.isHidden(selector[, options]) method'
 
 # isHidden(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isHidden([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/ishidden/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/frame/isvisible.md
+++ b/docs/sources/next/javascript-api/k6-browser/frame/isvisible.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.isVisible(selector[, options]) method'
 
 # isVisible(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isVisible([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/isvisible/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/frame/press.md
+++ b/docs/sources/next/javascript-api/k6-browser/frame/press.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.press(selector, key[, options]) method'
 
 # press(selector, key[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.press()`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/press/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/frame/selectoption.md
+++ b/docs/sources/next/javascript-api/k6-browser/frame/selectoption.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.selectOption(selector, values[, options]) me
 
 # selectOption(selector, values[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.selectOption()`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/selectoption/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/frame/textcontent.md
+++ b/docs/sources/next/javascript-api/k6-browser/frame/textcontent.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.textContent(selector[, options]) method'
 
 # textContent(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.textContent([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/textcontent/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/frame/type.md
+++ b/docs/sources/next/javascript-api/k6-browser/frame/type.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.type(selector, text[, options]) method'
 
 # type(selector, text[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.type()`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/type/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/frame/uncheck.md
+++ b/docs/sources/next/javascript-api/k6-browser/frame/uncheck.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.uncheck(selector[, options]) method'
 
 # uncheck(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.uncheck([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/uncheck/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/frame/waitforloadstate.md
+++ b/docs/sources/next/javascript-api/k6-browser/frame/waitforloadstate.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.waitForLoadState(state[, options]) method'
 
 # waitForLoadState(state[, options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This method has **known issues**. For details, refer to [#880](https://github.com/grafana/xk6-browser/issues/880).
 
@@ -25,7 +25,7 @@ This waits for the given load state to be reached. It will immediately unblock i
 
 ### Events
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 `networkidle` is DISCOURAGED. Don't use this method for testing especially with chatty websites where the event may never fire, rely on web assertions to assess readiness instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/frame/waitfornavigation.md
+++ b/docs/sources/next/javascript-api/k6-browser/frame/waitfornavigation.md
@@ -19,7 +19,7 @@ Waits for the given navigation lifecycle event to occur and returns the main res
 
 ### Events
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 `networkidle` is DISCOURAGED. Don't use this method for testing especially with chatty websites where the event may never fire, rely on web assertions to assess readiness instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/isconnected.md
+++ b/docs/sources/next/javascript-api/k6-browser/isconnected.md
@@ -5,7 +5,7 @@ description: 'Browser module: isConnected method'
 
 # isConnected()
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**.
 For details, refer to [#453](https://github.com/grafana/xk6-browser/issues/453).

--- a/docs/sources/next/javascript-api/k6-browser/locator/check.md
+++ b/docs/sources/next/javascript-api/k6-browser/locator/check.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.check method'
 
 # check([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has known issues. For details, refer to
 [#471](https://github.com/grafana/xk6-browser/issues/471) and [#475](https://github.com/grafana/xk6-browser/issues/475).

--- a/docs/sources/next/javascript-api/k6-browser/locator/click.md
+++ b/docs/sources/next/javascript-api/k6-browser/locator/click.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.click method'
 
 # click([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This method has **known issues**. For details, refer to [#471](https://github.com/grafana/xk6-browser/issues/471) and [#474](https://github.com/grafana/xk6-browser/issues/474).
 

--- a/docs/sources/next/javascript-api/k6-browser/locator/dblclick.md
+++ b/docs/sources/next/javascript-api/k6-browser/locator/dblclick.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.dblclick method'
 
 # dblclick([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has known issues. For details, refer to [#471](https://github.com/grafana/xk6-browser/issues/471).
 

--- a/docs/sources/next/javascript-api/k6-browser/locator/hover.md
+++ b/docs/sources/next/javascript-api/k6-browser/locator/hover.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.hover method'
 
 # hover([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has known issues. For details, refer to
 [#471](https://github.com/grafana/xk6-browser/issues/471).

--- a/docs/sources/next/javascript-api/k6-browser/locator/selectoption.md
+++ b/docs/sources/next/javascript-api/k6-browser/locator/selectoption.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.selectOption method'
 
 # selectOption(values, [options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**. For details, refer to
 [#470](https://github.com/grafana/xk6-browser/issues/470) and [#471](https://github.com/grafana/xk6-browser/issues/471).

--- a/docs/sources/next/javascript-api/k6-browser/locator/tap.md
+++ b/docs/sources/next/javascript-api/k6-browser/locator/tap.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.tap method'
 
 # tap([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**. For details, refer to
 [#436](https://github.com/grafana/xk6-browser/issues/436) and [#471](https://github.com/grafana/xk6-browser/issues/471).

--- a/docs/sources/next/javascript-api/k6-browser/locator/uncheck.md
+++ b/docs/sources/next/javascript-api/k6-browser/locator/uncheck.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.uncheck method'
 
 # uncheck([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**.
 For details, refer to [#471](https://github.com/grafana/xk6-browser/issues/471).

--- a/docs/sources/next/javascript-api/k6-browser/locator/waitfor.md
+++ b/docs/sources/next/javascript-api/k6-browser/locator/waitfor.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.waitFor method'
 
 # waitFor([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**. For details,
 refer to [#472](https://github.com/grafana/xk6-browser/issues/472).

--- a/docs/sources/next/javascript-api/k6-browser/newpage.md
+++ b/docs/sources/next/javascript-api/k6-browser/newpage.md
@@ -13,7 +13,7 @@ A 1-to-1 mapping between [Browser](https://grafana.com/docs/k6/<K6_VERSION>/java
 
 {{< /admonition >}}
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Pages that have been opened ought to be closed using [`Page.close`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/close/). Pages left open could potentially distort the results of Web Vital metrics.
 

--- a/docs/sources/next/javascript-api/k6-browser/page/check.md
+++ b/docs/sources/next/javascript-api/k6-browser/page/check.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.check(selector[, options]) method'
 
 # check(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.check([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/check/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/page/click.md
+++ b/docs/sources/next/javascript-api/k6-browser/page/click.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.click(selector[, options]) method'
 
 # click(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.click([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/click/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/page/dblclick.md
+++ b/docs/sources/next/javascript-api/k6-browser/page/dblclick.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.dblclick(selector[, options]) method'
 
 # dblclick(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.dblclick([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/dblclick/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/page/dispatchevent.md
+++ b/docs/sources/next/javascript-api/k6-browser/page/dispatchevent.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.dispatchEvent(selector, type, eventInit[, opt
 
 # dispatchEvent(selector, type, eventInit[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.dispatchEvent(type, eventInit[, options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/dispatchevent/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/page/dollar.md
+++ b/docs/sources/next/javascript-api/k6-browser/page/dollar.md
@@ -6,7 +6,7 @@ description: 'Browser module: page.$(selector) method'
 
 # page.$(selector)
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`page.locator(selector)`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/locator/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/page/doubledollar.md
+++ b/docs/sources/next/javascript-api/k6-browser/page/doubledollar.md
@@ -6,7 +6,7 @@ description: 'Browser module: page.$$(selector) method'
 
 # page.$$(selector)
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`page.locator(selector)`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/locator/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/page/fill.md
+++ b/docs/sources/next/javascript-api/k6-browser/page/fill.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.fill(selector, value[, options]) method'
 
 # fill(selector, value[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.fill(value[, options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/fill/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/page/focus.md
+++ b/docs/sources/next/javascript-api/k6-browser/page/focus.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.focus(selector[, options]) method'
 
 # focus(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.focus([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/focus/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/page/getattribute.md
+++ b/docs/sources/next/javascript-api/k6-browser/page/getattribute.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.getAttribute(selector, name[, options]) metho
 
 # getAttribute(selector, name[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.getAttribute()`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/getattribute/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/page/goto.md
+++ b/docs/sources/next/javascript-api/k6-browser/page/goto.md
@@ -23,7 +23,7 @@ Navigating to `about:blank` or navigation to the same URL with a different hash,
 
 ### Events
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 `networkidle` is DISCOURAGED. Don't use this method for testing especially with chatty websites where the event may never fire, rely on web assertions to assess readiness instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/page/hover.md
+++ b/docs/sources/next/javascript-api/k6-browser/page/hover.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.hover(selector[, options]) method'
 
 # hover(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.hover([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/hover/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/page/innerhtml.md
+++ b/docs/sources/next/javascript-api/k6-browser/page/innerhtml.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.innerHTML(selector[, options]) method'
 
 # innerHTML(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.innerHTML([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/innerhtml/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/page/innertext.md
+++ b/docs/sources/next/javascript-api/k6-browser/page/innertext.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.innerText(selector[, options]) method'
 
 # innerText(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.innerText([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/innertext/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/page/inputvalue.md
+++ b/docs/sources/next/javascript-api/k6-browser/page/inputvalue.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.inputValue(selector[, options]) method'
 
 # inputValue(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.inputValue([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/inputvalue/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/page/ischecked.md
+++ b/docs/sources/next/javascript-api/k6-browser/page/ischecked.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isChecked(selector[, options]) method'
 
 # isChecked(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isChecked([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/ischecked/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/page/isclosed.md
+++ b/docs/sources/next/javascript-api/k6-browser/page/isclosed.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isClosed() method'
 
 # isClosed()
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This method has **known issues**. For details, refer to [#878](https://github.com/grafana/xk6-browser/issues/878).
 

--- a/docs/sources/next/javascript-api/k6-browser/page/isdisabled.md
+++ b/docs/sources/next/javascript-api/k6-browser/page/isdisabled.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isDisabled(selector[, options]) method'
 
 # isDisabled(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isDisabled([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/isdisabled/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/page/iseditable.md
+++ b/docs/sources/next/javascript-api/k6-browser/page/iseditable.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isEditable(selector[, options]) method'
 
 # isEditable(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isEditable([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/iseditable/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/page/isenabled.md
+++ b/docs/sources/next/javascript-api/k6-browser/page/isenabled.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isEnabled(selector[, options]) method'
 
 # isEnabled(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isEnabled([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/isenabled/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/page/ishidden.md
+++ b/docs/sources/next/javascript-api/k6-browser/page/ishidden.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isHidden(selector[, options) method'
 
 # isHidden(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isHidden([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/ishidden/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/page/isvisible.md
+++ b/docs/sources/next/javascript-api/k6-browser/page/isvisible.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isVisible(selector[, options]) method'
 
 # isVisible(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isVisible([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/isvisible/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/page/on.md
+++ b/docs/sources/next/javascript-api/k6-browser/page/on.md
@@ -12,7 +12,7 @@ Registers a handler to be called whenever the specified event occurs.
 | event     | string   | `''`    | Event to attach the handler to. Currently, only the `'console'` event is supported. |
 | handler   | function | `null`  | A function to be called every time the specified event is emitted.                  |
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 When using the `page.on` method, the page has to be explicitly [closed](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/close/) for the iteration to be able to finish.
 

--- a/docs/sources/next/javascript-api/k6-browser/page/press.md
+++ b/docs/sources/next/javascript-api/k6-browser/page/press.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.press(selector, key[, options]) method'
 
 # press(selector, key[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.press()`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/press/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/page/reload.md
+++ b/docs/sources/next/javascript-api/k6-browser/page/reload.md
@@ -19,7 +19,7 @@ This reloads the current page and returns the main resource response.
 
 ### Events
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 `networkidle` is DISCOURAGED. Don't use this method for testing especially with chatty websites where the event may never fire, rely on web assertions to assess readiness instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/page/selectoption.md
+++ b/docs/sources/next/javascript-api/k6-browser/page/selectoption.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.selectOption(selector, values[, options]) met
 
 # selectOption(selector, values[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.selectOption()`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/selectoption/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/page/tap.md
+++ b/docs/sources/next/javascript-api/k6-browser/page/tap.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.tap(selector[, options]) method'
 
 # tap(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.tap([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/tap/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/page/textcontent.md
+++ b/docs/sources/next/javascript-api/k6-browser/page/textcontent.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.textContent(selector[, options]) method'
 
 # textContent(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.textContent([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/textcontent/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/page/type.md
+++ b/docs/sources/next/javascript-api/k6-browser/page/type.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.type(selector, text[, options]) method'
 
 # type(selector, text[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.type()`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/type/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/page/uncheck.md
+++ b/docs/sources/next/javascript-api/k6-browser/page/uncheck.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.uncheck(selector[, options]) method'
 
 # uncheck(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.uncheck([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/uncheck/) instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/page/waitforloadstate.md
+++ b/docs/sources/next/javascript-api/k6-browser/page/waitforloadstate.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.waitForLoadState(state[, options]) method'
 
 # waitForLoadState(state[, options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This method has **known issues**. For details, refer to [#880](https://github.com/grafana/xk6-browser/issues/880).
 
@@ -25,7 +25,7 @@ This waits for the given load state to be reached. It will immediately unblock i
 
 ### Events
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 `networkidle` is DISCOURAGED. Don't use this method for testing especially with chatty websites where the event may never fire, rely on web assertions to assess readiness instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/page/waitfornavigation.md
+++ b/docs/sources/next/javascript-api/k6-browser/page/waitfornavigation.md
@@ -19,7 +19,7 @@ Waits for the given navigation lifecycle event to occur and returns the main res
 
 ### Events
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 `networkidle` is DISCOURAGED. Don't use this method for testing especially with chatty websites where the event may never fire, rely on web assertions to assess readiness instead.
 

--- a/docs/sources/next/javascript-api/k6-browser/request/allheaders.md
+++ b/docs/sources/next/javascript-api/k6-browser/request/allheaders.md
@@ -5,7 +5,7 @@ description: 'Browser module: Request.allHeaders method'
 
 # allHeaders()
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This method has a **known issue**. For details, refer to [#965](https://github.com/grafana/xk6-browser/issues/965).
 

--- a/docs/sources/next/javascript-api/k6-browser/response/allheaders.md
+++ b/docs/sources/next/javascript-api/k6-browser/response/allheaders.md
@@ -5,7 +5,7 @@ description: 'Browser module: Response.allHeaders method'
 
 # allHeaders()
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This method has a **known issue**. For details, refer to [#965](https://github.com/grafana/xk6-browser/issues/965).
 

--- a/docs/sources/next/javascript-api/k6-data/sharedarray.md
+++ b/docs/sources/next/javascript-api/k6-data/sharedarray.md
@@ -37,7 +37,7 @@ Supported operations on a `SharedArray` include:
 In most cases, you should be able to reduce the memory usage of an array data structure by wrapping it in a `SharedArray`.
 Once constructed, a `SharedArray` is read-only, so **you can't use a SharedArray to communicate data between VUs**.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Attempting to instantiate a `SharedArray` outside of the [init context](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-lifecycle) results in the exception `new SharedArray must be called in the init context`.
 

--- a/docs/sources/next/javascript-api/k6-http/batch.md
+++ b/docs/sources/next/javascript-api/k6-http/batch.md
@@ -30,7 +30,7 @@ You can use this GET shortcut in objects&mdash;name a key and give it a URL valu
 
 You can define a request specified as an array or object with the following parameters.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 When you define requests as an array, you must use a specific order of items.
 Note the `Position` column for the correct order.

--- a/docs/sources/next/javascript-api/k6/group.md
+++ b/docs/sources/next/javascript-api/k6/group.md
@@ -19,7 +19,7 @@ Run code inside a group. Groups are used to organize results in a test.
 | ---- | ------------------------- |
 | any  | The return value of _fn_. |
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Avoid using `group` with async functions or asynchronous code.
 If you do, k6 might apply tags in a way that is unreliable or unintuitive.

--- a/docs/sources/next/results-output/real-time/amazon-cloudwatch.md
+++ b/docs/sources/next/results-output/real-time/amazon-cloudwatch.md
@@ -6,7 +6,7 @@ weight: 00
 
 # Amazon CloudWatch
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 The built-in StatsD output has been deprecated on k6 v0.47.0. You can continue to use this feature by using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd), and this guide has been updated to include instructions for how to use it.
 

--- a/docs/sources/next/results-output/real-time/cloud.md
+++ b/docs/sources/next/results-output/real-time/cloud.md
@@ -21,7 +21,7 @@ Fundamentally the difference is the machine that the test runs on:
 
 In all cases you'll be able to see your test results at [k6 Cloud](https://app.k6.io) or [Grafana Cloud](https://grafana.com/products/cloud/).
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Data storage and processing are primary cloud costs,
 so `k6 run --out cloud` will consume VUH or test runs from your subscription.

--- a/docs/sources/next/results-output/real-time/datadog.md
+++ b/docs/sources/next/results-output/real-time/datadog.md
@@ -6,7 +6,7 @@ weight: 00
 
 # Datadog
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 The built-in StatsD output has been deprecated on k6 v0.47.0. You can continue to use this feature by using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd), and this guide has been updated to include instructions for how to use it.
 

--- a/docs/sources/next/results-output/real-time/dynatrace.md
+++ b/docs/sources/next/results-output/real-time/dynatrace.md
@@ -39,7 +39,7 @@ To learn more about how to build custom k6 versions, check out [xk6](https://git
 
 Create a Dynatrace API token to send the data.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 The Dynatrace API Token must have the scope name "metrics.ingest" (scope type `API v2`).
 {{< /admonition >}}
 

--- a/docs/sources/next/results-output/real-time/elasticsearch.md
+++ b/docs/sources/next/results-output/real-time/elasticsearch.md
@@ -62,7 +62,7 @@ export K6_ELASTICSEARCH_URL=http://localhost:9200
 ./k6 run script.js -o output-elasticsearch
 ```
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 Security and self-signed certificates for non-cloud clusters are not yet supported.
 {{< /admonition >}}
 

--- a/docs/sources/next/results-output/real-time/grafana-cloud-prometheus.md
+++ b/docs/sources/next/results-output/real-time/grafana-cloud-prometheus.md
@@ -7,7 +7,7 @@ weight: 00
 
 # Grafana Cloud Prometheus
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This page includes instructions for running a local test that sends the test results to a Prometheus instance in Grafana Cloud.
 

--- a/docs/sources/next/results-output/real-time/netdata.md
+++ b/docs/sources/next/results-output/real-time/netdata.md
@@ -6,7 +6,7 @@ weight: 00
 
 # Netdata
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 The built-in StatsD output has been deprecated on k6 v0.47.0. You can continue to use this feature by using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd), and this guide has been updated to include instructions for how to use it.
 

--- a/docs/sources/next/results-output/real-time/newrelic.md
+++ b/docs/sources/next/results-output/real-time/newrelic.md
@@ -7,7 +7,7 @@ slug: 'new-relic'
 
 # New Relic
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 The built-in StatsD output has been deprecated on k6 v0.47.0. You can continue to use this feature by using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd), and this guide has been updated to include instructions for how to use it.
 

--- a/docs/sources/next/results-output/real-time/statsd.md
+++ b/docs/sources/next/results-output/real-time/statsd.md
@@ -6,7 +6,7 @@ weight: 00
 
 # StatsD
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 The built-in StatsD output has been deprecated on k6 v0.47.0. You can continue to use this feature by using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd), and this guide has been updated to include instructions for how to use it.
 

--- a/docs/sources/next/set-up/fine-tune-os.md
+++ b/docs/sources/next/set-up/fine-tune-os.md
@@ -252,7 +252,7 @@ All that is left after this is to reboot your Mac back to the Recovery Mode, ope
 
 In most cases these limits should be enough to run most of your simple tests locally for some time, but you can modify the files above to any values you will need in your testing.
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Please be aware that all of these limitations are put in place to protect your operating system from files and applications that are poorly written and might leak memory like in huge quantities. We would suggest not going too overboard with the values, or you might find your system slowing down to a crawl if or when it runs out of RAM.
 

--- a/docs/sources/next/shared/blocking-aws-blockquote.md
+++ b/docs/sources/next/shared/blocking-aws-blockquote.md
@@ -2,7 +2,7 @@
 title: jslib/aws module blocking admonition
 ---
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 In some cases, using this library&apos;s operations might impact performance and skew your test results.
 <br>

--- a/docs/sources/next/shared/browser-module-wip.md
+++ b/docs/sources/next/shared/browser-module-wip.md
@@ -2,7 +2,7 @@
 title: k6/experimental/browser module admonition
 ---
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This API is a work in progress. Some of the following functionalities might behave unexpectedly.
 

--- a/docs/sources/next/shared/experimental-module.md
+++ b/docs/sources/next/shared/experimental-module.md
@@ -2,7 +2,7 @@
 title: Experimental module admonition
 ---
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This is an experimental module.
 <br>

--- a/docs/sources/next/shared/experimental-timers-module.md
+++ b/docs/sources/next/shared/experimental-timers-module.md
@@ -2,7 +2,7 @@
 title: Experimental timers module admonition
 ---
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 The experimental module `k6/experimental/timers` has graduated, and its functionality is now available globally and through the [`k6/timers` module](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-timers/). The `k6/experimental/timers` is deprecated and will be removed.
 

--- a/docs/sources/next/shared/experimental-tracing-module.md
+++ b/docs/sources/next/shared/experimental-tracing-module.md
@@ -2,7 +2,7 @@
 title: Experimental tracing module admonition
 ---
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 The experimental module `k6/experimental/tracing` is deprecated, it functionality is fully available as a jslib. Please refer to its [documentation](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/http-instrumentation-tempo/). The `k6/experimental/tracing` will be removed in the future.
 

--- a/docs/sources/next/testing-guides/running-distributed-tests.md
+++ b/docs/sources/next/testing-guides/running-distributed-tests.md
@@ -165,7 +165,7 @@ Let's create our ConfigMap as `my-test` with the content of our `test.js` script
 kubectl create configmap my-test --from-file test.js
 ```
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Limitations exist on how large your test script can be when deployed within a `ConfigMap`.
 Kubernetes imposes a size limit of 1,048,576 bytes (1 MiB) for the data, therefore if your test scripts exceed this limit, you'll need to mount a `PersistentVolume`.
@@ -189,7 +189,7 @@ Organizing your test scripts was part of the discussion during [episode #76](htt
 
 {{< /admonition >}}
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 When using a `PersistentVolume`, the operator will expect all test scripts to be contained within a directory named `/test/`.
 
@@ -244,7 +244,7 @@ The test script content was added to the map using the filename as the key-value
 The amount of `parallelism` is up to you; how many pods do you want to split the test amongst?
 The operator will split the workload between the pods using [execution segments](https://grafana.com/docs/k6/<K6_VERSION>/misc/glossary#execution-segment).
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 It is important that the `ConfigMap` and `CustomResource` are created in the same [Namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/).
 
@@ -275,7 +275,7 @@ spec:
 
 {{< /code >}}
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 It is important that the `PersistentVolumeClaim` and `CustomResource` are created in the same [Namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/).
 

--- a/docs/sources/next/using-k6-browser/metrics.md
+++ b/docs/sources/next/using-k6-browser/metrics.md
@@ -80,7 +80,7 @@ To set thresholds for your browser metrics:
 
 As the following example shows, you can also pass in different URLs if you're going to set a threshold for other pages, especially when your script contains page navigations.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Currently, you can only use URLs to specify thresholds for different pages. If you use [Groups](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/tags-and-groups/#groups), the metrics are not correctly grouped as described in [#721](https://github.com/grafana/xk6-browser/issues/721).
 

--- a/docs/sources/next/using-k6/k6-options/reference.md
+++ b/docs/sources/next/using-k6/k6-options/reference.md
@@ -960,7 +960,7 @@ $ k6 run --out influxdb=http://localhost:8086/k6 script.js
 
 The maximum number of requests to make per second, in total across all VUs. Available in `k6 run` and `k6 cloud` commands.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 **This option is discouraged.**
 <br>
@@ -1382,7 +1382,7 @@ export const options = {
 A list of cipher suites allowed to be used by in SSL/TLS interactions with a server.
 For a full listing of available ciphers go [here](https://golang.org/pkg/crypto/tls/#pkg-constants).
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Due to limitations in the underlying [go implementation](https://github.com/golang/go/issues/29349), changing the ciphers for TLS 1.3 is _not_ supported and will do nothing.
 

--- a/docs/sources/next/using-k6/scenarios/concepts/arrival-rate-vu-allocation.md
+++ b/docs/sources/next/using-k6/scenarios/concepts/arrival-rate-vu-allocation.md
@@ -15,7 +15,7 @@ In other words, before the tests runs, you must both:
 
 Read on to learn about how k6 allocates VUs in the arrival-rate executors.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 In cloud tests, **`preAllocatedVUs` count against your subscription.**
 
@@ -91,7 +91,7 @@ As dropped iterations can also indicate that the system performance is degrading
 
 ## You probably don't need `maxVUs`
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 In cloud tests, the number of `maxVUs` counts against your subscription,
 **overriding the number set by `preAllocatedVUs`**.

--- a/docs/sources/next/using-k6/thresholds.md
+++ b/docs/sources/next/using-k6/thresholds.md
@@ -186,7 +186,7 @@ export default function () {
 
 {{< /code >}}
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Do not specify multiple thresholds for the same metric by repeating the same object key.
 
@@ -445,7 +445,7 @@ export default function () {
 
 {{< /code >}}
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 When k6 runs in the cloud, thresholds are evaluated every 60 seconds.
 Therefore, the `abortOnFail` feature may be delayed by up to 60 seconds.

--- a/docs/sources/v0.47.x/extensions/build-k6-binary-using-docker.md
+++ b/docs/sources/v0.47.x/extensions/build-k6-binary-using-docker.md
@@ -122,7 +122,7 @@ Flags:
 
 {{< /code >}}
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 The use of `--replace` should be considered an advanced feature to be avoided unless required.
 

--- a/docs/sources/v0.47.x/extensions/create/javascript-extensions.md
+++ b/docs/sources/v0.47.x/extensions/create/javascript-extensions.md
@@ -176,7 +176,7 @@ to access the [`modules.VU`](https://pkg.go.dev/go.k6.io/k6/js/modules#VU) to in
 Additionally, there should be a root module implementation of the [`modules.Module`](https://pkg.go.dev/go.k6.io/k6/js/modules#Module)
 interface to serve as a factory of `Compare` instances for each VU.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 The significance depends on the size of your module.
 

--- a/docs/sources/v0.47.x/extensions/explanations/extension-graduation.md
+++ b/docs/sources/v0.47.x/extensions/explanations/extension-graduation.md
@@ -39,7 +39,7 @@ There should be a reasonably high degree of quality and stability at this point.
 This phase makes the feature accessible to more users, which in turn gives k6 developers more chances to receive feedback.
 The key will be to achieve a balance between usability and stability.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Not all experimental modules will progress to become a core module!
 The k6 team reserves the right to discontinue and remove any experimental module if is no longer deemed desirable.

--- a/docs/sources/v0.47.x/javascript-api/init-context/open.md
+++ b/docs/sources/v0.47.x/javascript-api/init-context/open.md
@@ -17,7 +17,7 @@ To reduce the memory consumption, we strongly advise the usage of [SharedArray](
 
 {{< /admonition >}}
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This function can only be called from the init context (aka _init code_), code in the global context that is, outside of the main export default function { ... }.
 

--- a/docs/sources/v0.47.x/javascript-api/jslib/httpx/_index.md
+++ b/docs/sources/v0.47.x/javascript-api/jslib/httpx/_index.md
@@ -19,7 +19,7 @@ httpx module integrates well with the expect library.
 The source code is [on GitHub](https://github.com/k6io/k6-jslib-httpx).
 Please request features and report bugs through [GitHub issues](https://github.com/k6io/k6-jslib-httpx/issues).
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 **This library is in active development.**
 

--- a/docs/sources/v0.47.x/javascript-api/k6-data/sharedarray.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-data/sharedarray.md
@@ -37,7 +37,7 @@ Supported operations on a `SharedArray` include:
 In most cases, you should be able to reduce the memory usage of an array data structure by wrapping it in a `SharedArray`.
 Once constructed, a `SharedArray` is read-only, so **you can't use a SharedArray to communicate data between VUs**.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Attempting to instantiate a `SharedArray` outside of the [init context](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-lifecycle) results in the exception `new SharedArray must be called in the init context`.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/browsercontext/clearpermissions.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/browsercontext/clearpermissions.md
@@ -5,7 +5,7 @@ description: 'Clears all permission overrides for the BrowserContext.'
 
 # clearPermissions()
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has known issues.
 For details, refer to [issue #443](https://github.com/grafana/xk6-browser/issues/443).

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/browsercontext/pages.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/browsercontext/pages.md
@@ -5,7 +5,7 @@ description: 'Returns a list of pages inside this BrowserContext.'
 
 # pages()
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**. For details, refer to
 [#444](https://github.com/grafana/xk6-browser/issues/444).

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/browsercontext/setgeolocation.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/browsercontext/setgeolocation.md
@@ -5,7 +5,7 @@ description: "Sets the BrowserContext's geolocation."
 
 # setGeolocation(geolocation)
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**. For details, refer to
 [#435](https://github.com/grafana/xk6-browser/issues/435).

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/browsercontext/waitforevent.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/browsercontext/waitforevent.md
@@ -5,7 +5,7 @@ description: 'Waits for event to fire and passes its value into the predicate fu
 
 # waitForEvent(event[, optionsOrPredicate])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This method is a work in progress.
 It requires async functionality and returning a `Promise` to be useful in scripts.

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/isconnected.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/isconnected.md
@@ -5,7 +5,7 @@ description: 'Browser module: isConnected method'
 
 # isConnected()
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**.
 For details, refer to [#453](https://github.com/grafana/xk6-browser/issues/453).

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/locator/check.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/locator/check.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.check method'
 
 # check([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has known issues. For details, refer to
 [#471](https://github.com/grafana/xk6-browser/issues/471) and [#475](https://github.com/grafana/xk6-browser/issues/475).

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/locator/click.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/locator/click.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.click method'
 
 # click([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This method has **known issues**. For details, refer to [#471](https://github.com/grafana/xk6-browser/issues/471) and [#474](https://github.com/grafana/xk6-browser/issues/474).
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/locator/dblclick.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/locator/dblclick.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.dblclick method'
 
 # dblclick([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has known issues. For details, refer to
 [#469](https://github.com/grafana/xk6-browser/issues/469) and [#471](https://github.com/grafana/xk6-browser/issues/471).

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/locator/hover.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/locator/hover.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.hover method'
 
 # hover([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has known issues. For details, refer to
 [#471](https://github.com/grafana/xk6-browser/issues/471).

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/locator/selectoption.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/locator/selectoption.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.selectOption method'
 
 # selectOption(values, [options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**. For details, refer to
 [#470](https://github.com/grafana/xk6-browser/issues/470) and [#471](https://github.com/grafana/xk6-browser/issues/471).

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/locator/tap.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/locator/tap.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.tap method'
 
 # tap([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**. For details, refer to
 [#436](https://github.com/grafana/xk6-browser/issues/436) and [#471](https://github.com/grafana/xk6-browser/issues/471).

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/locator/uncheck.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/locator/uncheck.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.uncheck method'
 
 # uncheck([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**.
 For details, refer to [#471](https://github.com/grafana/xk6-browser/issues/471).

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/locator/waitfor.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/locator/waitfor.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.waitFor method'
 
 # waitFor([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**. For details,
 refer to [#472](https://github.com/grafana/xk6-browser/issues/472).

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/newpage.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/newpage.md
@@ -13,7 +13,7 @@ A 1-to-1 mapping between [Browser](https://grafana.com/docs/k6/<K6_VERSION>/java
 
 {{< /admonition >}}
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Pages that have been opened ought to be closed using [`Page.close`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/page/close/). Pages left open could potentially distort the results of Web Vital metrics.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/check.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/check.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.check(selector[, options]) method'
 
 # check(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.check([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/check/) instead.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/click.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/click.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.click(selector[, options]) method'
 
 # click(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.click([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/click/) instead.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/dblclick.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/dblclick.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.dblclick(selector[, options]) method'
 
 # dblclick(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.dblclick([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/dblclick/) instead.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/dispatchevent.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/dispatchevent.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.dispatchEvent(selector, type, eventInit[, opt
 
 # dispatchEvent(selector, type, eventInit[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.dispatchEvent(type, eventInit[, options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/dispatchevent/) instead.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/dollar.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/dollar.md
@@ -6,7 +6,7 @@ description: 'Browser module: page.$(selector) method'
 
 # page.$(selector)
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`page.locator(selector)`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/page/locator/) instead.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/doubledollar.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/doubledollar.md
@@ -6,7 +6,7 @@ description: 'Browser module: page.$$(selector) method'
 
 # page.$$(selector)
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`page.locator(selector)`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/page/locator/) instead.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/fill.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/fill.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.fill(selector, value[, options]) method'
 
 # fill(selector, value[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.fill(value[, options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/fill/) instead.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/focus.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/focus.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.focus(selector[, options]) method'
 
 # focus(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.focus([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/focus/) instead.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/getattribute.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/getattribute.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.getAttribute(selector, name[, options]) metho
 
 # getAttribute(selector, name[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.getAttribute()`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/getattribute/) instead.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/goto.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/goto.md
@@ -23,7 +23,7 @@ Navigating to `about:blank` or navigation to the same URL with a different hash,
 
 ### Events
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 `networkidle` is DISCOURAGED. Don't use this method for testing especially with chatty websites where the event may never fire, rely on web assertions to assess readiness instead.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/hover.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/hover.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.hover(selector[, options]) method'
 
 # hover(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.hover([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/hover/) instead.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/innerhtml.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/innerhtml.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.innerHTML(selector[, options]) method'
 
 # innerHTML(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.innerHTML([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/innerhtml/) instead.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/innertext.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/innertext.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.innerText(selector[, options]) method'
 
 # innerText(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.innerText([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/innertext/) instead.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/inputvalue.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/inputvalue.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.inputValue(selector[, options]) method'
 
 # inputValue(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.inputValue([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/inputvalue/) instead.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/ischecked.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/ischecked.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isChecked(selector[, options]) method'
 
 # isChecked(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isChecked([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/ischecked/) instead.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/isclosed.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/isclosed.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isClosed() method'
 
 # isClosed()
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This method has **known issues**. For details, refer to [#878](https://github.com/grafana/xk6-browser/issues/878).
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/isdisabled.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/isdisabled.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isDisabled(selector[, options]) method'
 
 # isDisabled(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isDisabled([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/isdisabled/) instead.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/iseditable.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/iseditable.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isEditable(selector[, options]) method'
 
 # isEditable(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isEditable([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/iseditable/) instead.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/isenabled.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/isenabled.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isEnabled(selector[, options]) method'
 
 # isEnabled(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isEnabled([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/isenabled/) instead.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/ishidden.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/ishidden.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isHidden(selector[, options) method'
 
 # isHidden(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isHidden([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/ishidden/) instead.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/isvisible.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/isvisible.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isVisible(selector[, options]) method'
 
 # isVisible(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isVisible([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/isvisible/) instead.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/on.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/on.md
@@ -12,7 +12,7 @@ Registers a handler to be called whenever the specified event occurs.
 | event     | string   | `''`    | Event to attach the handler to. Currently, only the `'console'` event is supported. |
 | handler   | function | `null`  | A function to be called every time the specified event is emitted.                  |
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 When using the `page.on` method, the page has to be explicitly [closed](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/page/close/) for the iteration to be able to finish.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/press.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/press.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.press(selector, key[, options]) method'
 
 # press(selector, key[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.press()`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/press/) instead.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/reload.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/reload.md
@@ -19,7 +19,7 @@ This reloads the current page and returns the main resource response.
 
 ### Events
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 `networkidle` is DISCOURAGED. Don't use this method for testing especially with chatty websites where the event may never fire, rely on web assertions to assess readiness instead.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/selectoption.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/selectoption.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.selectOption(selector, values[, options]) met
 
 # selectOption(selector, values[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.selectOption()`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/selectoption/) instead.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/tap.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/tap.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.tap(selector[, options]) method'
 
 # tap(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.tap([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/tap/) instead.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/textcontent.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/textcontent.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.textContent(selector[, options]) method'
 
 # textContent(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.textContent([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/textcontent/) instead.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/type.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/type.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.type(selector, text[, options]) method'
 
 # type(selector, text[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.type()`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/type/) instead.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/uncheck.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/uncheck.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.uncheck(selector[, options]) method'
 
 # uncheck(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.uncheck([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/uncheck/) instead.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/waitforloadstate.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/waitforloadstate.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.waitForLoadState(state[, options]) method'
 
 # waitForLoadState(state[, options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This method has **known issues**. For details, refer to [#880](https://github.com/grafana/xk6-browser/issues/880).
 
@@ -25,7 +25,7 @@ This waits for the given load state to be reached. It will immediately unblock i
 
 ### Events
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 `networkidle` is DISCOURAGED. Don't use this method for testing especially with chatty websites where the event may never fire, rely on web assertions to assess readiness instead.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/waitfornavigation.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/waitfornavigation.md
@@ -19,7 +19,7 @@ Waits for the given navigation lifecycle event to occur and returns the main res
 
 ### Events
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 `networkidle` is DISCOURAGED. Don't use this method for testing especially with chatty websites where the event may never fire, rely on web assertions to assess readiness instead.
 

--- a/docs/sources/v0.47.x/javascript-api/k6-http/batch.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-http/batch.md
@@ -30,7 +30,7 @@ You can use this GET shortcut in objects&mdash;name a key and give it a URL valu
 
 You can define a request specified as an array or object with the following parameters.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 When you define requests as an array, you must use a specific order of items.
 Note the `Position` column for the correct order.

--- a/docs/sources/v0.47.x/javascript-api/k6/group.md
+++ b/docs/sources/v0.47.x/javascript-api/k6/group.md
@@ -19,7 +19,7 @@ Run code inside a group. Groups are used to organize results in a test.
 | ---- | ------------------------- |
 | any  | The return value of _fn_. |
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Avoid using `group` with async functions or asynchronous code.
 If you do, k6 might apply tags in a way that is unreliable or unintuitive.

--- a/docs/sources/v0.47.x/misc/fine-tuning-os.md
+++ b/docs/sources/v0.47.x/misc/fine-tuning-os.md
@@ -246,7 +246,7 @@ All that is left after this is to reboot your Mac back to the Recovery Mode, ope
 
 In most cases these limits should be enough to run most of your simple tests locally for some time, but you can modify the files above to any values you will need in your testing.
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Please be aware that all of these limitations are put in place to protect your operating system from files and applications that are poorly written and might leak memory like in huge quantities. We would suggest not going too overboard with the values, or you might find your system slowing down to a crawl if or when it runs out of RAM.
 

--- a/docs/sources/v0.47.x/results-output/real-time/amazon-cloudwatch.md
+++ b/docs/sources/v0.47.x/results-output/real-time/amazon-cloudwatch.md
@@ -6,7 +6,7 @@ weight: 00
 
 # Amazon CloudWatch
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 The built-in StatsD output has been deprecated on k6 v0.47.0. You can continue to use this feature by using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd), and this guide has been updated to include instructions for how to use it.
 

--- a/docs/sources/v0.47.x/results-output/real-time/cloud.md
+++ b/docs/sources/v0.47.x/results-output/real-time/cloud.md
@@ -21,7 +21,7 @@ Fundamentally the difference is the machine that the test runs on:
 
 In all cases you'll be able to see your test results at [k6 Cloud](https://app.k6.io) or [Grafana Cloud](https://grafana.com/products/cloud/).
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Data storage and processing are primary cloud costs,
 so `k6 run --out cloud` will consume VUh or test runs from your subscription.

--- a/docs/sources/v0.47.x/results-output/real-time/datadog.md
+++ b/docs/sources/v0.47.x/results-output/real-time/datadog.md
@@ -6,7 +6,7 @@ weight: 00
 
 # Datadog
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 The built-in StatsD output has been deprecated on k6 v0.47.0. You can continue to use this feature by using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd), and this guide has been updated to include instructions for how to use it.
 

--- a/docs/sources/v0.47.x/results-output/real-time/dynatrace.md
+++ b/docs/sources/v0.47.x/results-output/real-time/dynatrace.md
@@ -39,7 +39,7 @@ To learn more about how to build custom k6 versions, check out [xk6](https://git
 
 Create a Dynatrace API token to send the data.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 The Dynatrace API Token must have the scope name "metrics.ingest" (scope type `API v2`).
 {{< /admonition >}}
 

--- a/docs/sources/v0.47.x/results-output/real-time/elasticsearch.md
+++ b/docs/sources/v0.47.x/results-output/real-time/elasticsearch.md
@@ -62,7 +62,7 @@ export K6_ELASTICSEARCH_URL=http://localhost:9200
 ./k6 run script.js -o output-elasticsearch
 ```
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 Security and self-signed certificates for non-cloud clusters are not yet supported.
 {{< /admonition >}}
 

--- a/docs/sources/v0.47.x/results-output/real-time/grafana-cloud-prometheus.md
+++ b/docs/sources/v0.47.x/results-output/real-time/grafana-cloud-prometheus.md
@@ -7,7 +7,7 @@ weight: 00
 
 # Grafana Cloud Prometheus
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This page includes instructions for running a local test that sends the test results to a Prometheus instance in Grafana Cloud.
 

--- a/docs/sources/v0.47.x/results-output/real-time/netdata.md
+++ b/docs/sources/v0.47.x/results-output/real-time/netdata.md
@@ -6,7 +6,7 @@ weight: 00
 
 # Netdata
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 The built-in StatsD output has been deprecated on k6 v0.47.0. You can continue to use this feature by using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd), and this guide has been updated to include instructions for how to use it.
 

--- a/docs/sources/v0.47.x/results-output/real-time/newrelic.md
+++ b/docs/sources/v0.47.x/results-output/real-time/newrelic.md
@@ -7,7 +7,7 @@ slug: 'new-relic'
 
 # New Relic
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 The built-in StatsD output has been deprecated on k6 v0.47.0. You can continue to use this feature by using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd), and this guide has been updated to include instructions for how to use it.
 

--- a/docs/sources/v0.47.x/results-output/real-time/statsd.md
+++ b/docs/sources/v0.47.x/results-output/real-time/statsd.md
@@ -6,7 +6,7 @@ weight: 00
 
 # StatsD
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 The built-in StatsD output has been deprecated on k6 v0.47.0. You can continue to use this feature by using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd), and this guide has been updated to include instructions for how to use it.
 

--- a/docs/sources/v0.47.x/shared/blocking-aws-blockquote.md
+++ b/docs/sources/v0.47.x/shared/blocking-aws-blockquote.md
@@ -2,7 +2,7 @@
 title: jslib/aws module blocking admonition
 ---
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 In some cases, using this library&apos;s operations might impact performance and skew your test results.
 <br>

--- a/docs/sources/v0.47.x/shared/browser-module-wip.md
+++ b/docs/sources/v0.47.x/shared/browser-module-wip.md
@@ -2,7 +2,7 @@
 title: k6/experimental/browser module admonition
 ---
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This API is a work in progress. Some of the following functionalities might behave unexpectedly.
 

--- a/docs/sources/v0.47.x/shared/experimental-grpc-module.md
+++ b/docs/sources/v0.47.x/shared/experimental-grpc-module.md
@@ -2,7 +2,7 @@
 title: Experimental grpc module admonition
 ---
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Starting on k6 `v0.49`, the experimental module `k6/experimental/grpc` has been graduated, and its functionality is now available in the [`k6/net/grpc` module](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-net-grpc/). The `k6/experimental/grpc` is deprecated and will be removed in `v0.51.0`.
 

--- a/docs/sources/v0.47.x/shared/experimental-module.md
+++ b/docs/sources/v0.47.x/shared/experimental-module.md
@@ -2,7 +2,7 @@
 title: Experimental module admonition
 ---
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This is an experimental module.
 <br>

--- a/docs/sources/v0.47.x/testing-guides/running-distributed-tests.md
+++ b/docs/sources/v0.47.x/testing-guides/running-distributed-tests.md
@@ -165,7 +165,7 @@ Let's create our ConfigMap as `my-test` with the content of our `test.js` script
 kubectl create configmap my-test --from-file test.js
 ```
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Limitations exist on how large your test script can be when deployed within a `ConfigMap`.
 Kubernetes imposes a size limit of 1,048,576 bytes (1 MiB) for the data, therefore if your test scripts exceed this limit, you'll need to mount a `PersistentVolume`.
@@ -189,7 +189,7 @@ Organizing your test scripts was part of the discussion during [episode #76](htt
 
 {{< /admonition >}}
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 When using a `PersistentVolume`, the operator will expect all test scripts to be contained within a directory named `/test/`.
 
@@ -244,7 +244,7 @@ The test script content was added to the map using the filename as the key-value
 The amount of `parallelism` is up to you; how many pods do you want to split the test amongst?
 The operator will split the workload between the pods using [execution segments](https://grafana.com/docs/k6/<K6_VERSION>/misc/glossary#execution-segment).
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 It is important that the `ConfigMap` and `CustomResource` are created in the same [Namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/).
 
@@ -275,7 +275,7 @@ spec:
 
 {{< /code >}}
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 It is important that the `PersistentVolumeClaim` and `CustomResource` are created in the same [Namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/).
 

--- a/docs/sources/v0.47.x/using-k6-browser/metrics.md
+++ b/docs/sources/v0.47.x/using-k6-browser/metrics.md
@@ -69,7 +69,7 @@ To set thresholds for your browser metrics:
 
 As the following example shows, you can also pass in different URLs if you're going to set a threshold for other pages, especially when your script contains page navigations.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Currently, you can only use URLs to specify thresholds for different pages. If you use [Groups](https://grafana.com/docs/k6/latest/using-k6/tags-and-groups/#groups), the metrics are not correctly grouped as described in [#721](https://github.com/grafana/xk6-browser/issues/721).
 

--- a/docs/sources/v0.47.x/using-k6/k6-options/reference.md
+++ b/docs/sources/v0.47.x/using-k6/k6-options/reference.md
@@ -942,7 +942,7 @@ $ k6 run --out influxdb=http://localhost:8086/k6 script.js
 
 The maximum number of requests to make per second, in total across all VUs. Available in `k6 run` and `k6 cloud` commands.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 **This option is discouraged.**
 <br>
@@ -1364,7 +1364,7 @@ export const options = {
 A list of cipher suites allowed to be used by in SSL/TLS interactions with a server.
 For a full listing of available ciphers go [here](https://golang.org/pkg/crypto/tls/#pkg-constants).
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Due to limitations in the underlying [go implementation](https://github.com/golang/go/issues/29349), changing the ciphers for TLS 1.3 is _not_ supported and will do nothing.
 

--- a/docs/sources/v0.47.x/using-k6/scenarios/concepts/arrival-rate-vu-allocation.md
+++ b/docs/sources/v0.47.x/using-k6/scenarios/concepts/arrival-rate-vu-allocation.md
@@ -15,7 +15,7 @@ In other words, before the tests runs, you must both:
 
 Read on to learn about how k6 allocates VUs in the arrival-rate executors.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 In cloud tests, **`preAllocatedVUs` count against your subscription.**
 
@@ -91,7 +91,7 @@ As dropped iterations can also indicate that the system performance is degrading
 
 ## You probably don't need `maxVUs`
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 In cloud tests, the number of `maxVUs` counts against your subscription,
 **overriding the number set by `preAllocatedVUs`**.

--- a/docs/sources/v0.47.x/using-k6/thresholds.md
+++ b/docs/sources/v0.47.x/using-k6/thresholds.md
@@ -186,7 +186,7 @@ export default function () {
 
 {{< /code >}}
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Do not specify multiple thresholds for the same metric by repeating the same object key.
 
@@ -445,7 +445,7 @@ export default function () {
 
 {{< /code >}}
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 When k6 runs in the cloud, thresholds are evaluated every 60 seconds.
 Therefore, the `abortOnFail` feature may be delayed by up to 60 seconds.

--- a/docs/sources/v0.48.x/extensions/build-k6-binary-using-docker.md
+++ b/docs/sources/v0.48.x/extensions/build-k6-binary-using-docker.md
@@ -122,7 +122,7 @@ Flags:
 
 {{< /code >}}
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 The use of `--replace` should be considered an advanced feature to be avoided unless required.
 

--- a/docs/sources/v0.48.x/extensions/create/javascript-extensions.md
+++ b/docs/sources/v0.48.x/extensions/create/javascript-extensions.md
@@ -176,7 +176,7 @@ to access the [`modules.VU`](https://pkg.go.dev/go.k6.io/k6/js/modules#VU) to in
 Additionally, there should be a root module implementation of the [`modules.Module`](https://pkg.go.dev/go.k6.io/k6/js/modules#Module)
 interface to serve as a factory of `Compare` instances for each VU.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 The significance depends on the size of your module.
 

--- a/docs/sources/v0.48.x/extensions/explanations/extension-graduation.md
+++ b/docs/sources/v0.48.x/extensions/explanations/extension-graduation.md
@@ -39,7 +39,7 @@ There should be a reasonably high degree of quality and stability at this point.
 This phase makes the feature accessible to more users, which in turn gives k6 developers more chances to receive feedback.
 The key will be to achieve a balance between usability and stability.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Not all experimental modules will progress to become a core module!
 The k6 team reserves the right to discontinue and remove any experimental module if is no longer deemed desirable.

--- a/docs/sources/v0.48.x/javascript-api/jslib/httpx/_index.md
+++ b/docs/sources/v0.48.x/javascript-api/jslib/httpx/_index.md
@@ -19,7 +19,7 @@ httpx module integrates well with the expect library.
 The source code is [on GitHub](https://github.com/k6io/k6-jslib-httpx).
 Please request features and report bugs through [GitHub issues](https://github.com/k6io/k6-jslib-httpx/issues).
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 **This library is in active development.**
 

--- a/docs/sources/v0.48.x/javascript-api/k6-data/sharedarray.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-data/sharedarray.md
@@ -37,7 +37,7 @@ Supported operations on a `SharedArray` include:
 In most cases, you should be able to reduce the memory usage of an array data structure by wrapping it in a `SharedArray`.
 Once constructed, a `SharedArray` is read-only, so **you can't use a SharedArray to communicate data between VUs**.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Attempting to instantiate a `SharedArray` outside of the [init context](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-lifecycle) results in the exception `new SharedArray must be called in the init context`.
 

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/browsercontext/pages.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/browsercontext/pages.md
@@ -5,7 +5,7 @@ description: 'Returns a list of pages inside this BrowserContext.'
 
 # pages()
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**. For details, refer to
 [#444](https://github.com/grafana/xk6-browser/issues/444).

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/browsercontext/setgeolocation.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/browsercontext/setgeolocation.md
@@ -5,7 +5,7 @@ description: "Sets the BrowserContext's geolocation."
 
 # setGeolocation(geolocation)
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**. For details, refer to
 [#435](https://github.com/grafana/xk6-browser/issues/435).

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/isconnected.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/isconnected.md
@@ -5,7 +5,7 @@ description: 'Browser module: isConnected method'
 
 # isConnected()
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**.
 For details, refer to [#453](https://github.com/grafana/xk6-browser/issues/453).

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/locator/check.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/locator/check.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.check method'
 
 # check([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has known issues. For details, refer to
 [#471](https://github.com/grafana/xk6-browser/issues/471) and [#475](https://github.com/grafana/xk6-browser/issues/475).

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/locator/click.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/locator/click.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.click method'
 
 # click([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This method has **known issues**. For details, refer to [#471](https://github.com/grafana/xk6-browser/issues/471) and [#474](https://github.com/grafana/xk6-browser/issues/474).
 

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/locator/dblclick.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/locator/dblclick.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.dblclick method'
 
 # dblclick([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has known issues. For details, refer to
 [#469](https://github.com/grafana/xk6-browser/issues/469) and [#471](https://github.com/grafana/xk6-browser/issues/471).

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/locator/hover.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/locator/hover.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.hover method'
 
 # hover([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has known issues. For details, refer to
 [#471](https://github.com/grafana/xk6-browser/issues/471).

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/locator/selectoption.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/locator/selectoption.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.selectOption method'
 
 # selectOption(values, [options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**. For details, refer to
 [#470](https://github.com/grafana/xk6-browser/issues/470) and [#471](https://github.com/grafana/xk6-browser/issues/471).

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/locator/tap.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/locator/tap.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.tap method'
 
 # tap([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**. For details, refer to
 [#436](https://github.com/grafana/xk6-browser/issues/436) and [#471](https://github.com/grafana/xk6-browser/issues/471).

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/locator/uncheck.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/locator/uncheck.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.uncheck method'
 
 # uncheck([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**.
 For details, refer to [#471](https://github.com/grafana/xk6-browser/issues/471).

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/locator/waitfor.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/locator/waitfor.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.waitFor method'
 
 # waitFor([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**. For details,
 refer to [#472](https://github.com/grafana/xk6-browser/issues/472).

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/newpage.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/newpage.md
@@ -13,7 +13,7 @@ A 1-to-1 mapping between [Browser](https://grafana.com/docs/k6/<K6_VERSION>/java
 
 {{< /admonition >}}
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Pages that have been opened ought to be closed using [`Page.close`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/page/close/). Pages left open could potentially distort the results of Web Vital metrics.
 

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/check.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/check.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.check(selector[, options]) method'
 
 # check(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.check([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/check/) instead.
 

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/click.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/click.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.click(selector[, options]) method'
 
 # click(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.click([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/click/) instead.
 

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/dblclick.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/dblclick.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.dblclick(selector[, options]) method'
 
 # dblclick(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.dblclick([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/dblclick/) instead.
 

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/dispatchevent.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/dispatchevent.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.dispatchEvent(selector, type, eventInit[, opt
 
 # dispatchEvent(selector, type, eventInit[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.dispatchEvent(type, eventInit[, options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/dispatchevent/) instead.
 

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/dollar.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/dollar.md
@@ -6,7 +6,7 @@ description: 'Browser module: page.$(selector) method'
 
 # page.$(selector)
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`page.locator(selector)`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/page/locator/) instead.
 

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/doubledollar.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/doubledollar.md
@@ -6,7 +6,7 @@ description: 'Browser module: page.$$(selector) method'
 
 # page.$$(selector)
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`page.locator(selector)`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/page/locator/) instead.
 

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/fill.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/fill.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.fill(selector, value[, options]) method'
 
 # fill(selector, value[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.fill(value[, options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/fill/) instead.
 

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/focus.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/focus.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.focus(selector[, options]) method'
 
 # focus(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.focus([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/focus/) instead.
 

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/getattribute.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/getattribute.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.getAttribute(selector, name[, options]) metho
 
 # getAttribute(selector, name[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.getAttribute()`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/getattribute/) instead.
 

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/goto.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/goto.md
@@ -23,7 +23,7 @@ Navigating to `about:blank` or navigation to the same URL with a different hash,
 
 ### Events
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 `networkidle` is DISCOURAGED. Don't use this method for testing especially with chatty websites where the event may never fire, rely on web assertions to assess readiness instead.
 

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/hover.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/hover.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.hover(selector[, options]) method'
 
 # hover(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.hover([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/hover/) instead.
 

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/innerhtml.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/innerhtml.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.innerHTML(selector[, options]) method'
 
 # innerHTML(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.innerHTML([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/innerhtml/) instead.
 

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/innertext.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/innertext.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.innerText(selector[, options]) method'
 
 # innerText(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.innerText([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/innertext/) instead.
 

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/inputvalue.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/inputvalue.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.inputValue(selector[, options]) method'
 
 # inputValue(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.inputValue([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/inputvalue/) instead.
 

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/ischecked.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/ischecked.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isChecked(selector[, options]) method'
 
 # isChecked(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isChecked([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/ischecked/) instead.
 

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/isclosed.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/isclosed.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isClosed() method'
 
 # isClosed()
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This method has **known issues**. For details, refer to [#878](https://github.com/grafana/xk6-browser/issues/878).
 

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/isdisabled.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/isdisabled.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isDisabled(selector[, options]) method'
 
 # isDisabled(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isDisabled([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/isdisabled/) instead.
 

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/iseditable.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/iseditable.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isEditable(selector[, options]) method'
 
 # isEditable(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isEditable([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/iseditable/) instead.
 

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/isenabled.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/isenabled.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isEnabled(selector[, options]) method'
 
 # isEnabled(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isEnabled([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/isenabled/) instead.
 

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/ishidden.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/ishidden.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isHidden(selector[, options) method'
 
 # isHidden(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isHidden([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/ishidden/) instead.
 

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/isvisible.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/isvisible.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isVisible(selector[, options]) method'
 
 # isVisible(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isVisible([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/isvisible/) instead.
 

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/on.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/on.md
@@ -12,7 +12,7 @@ Registers a handler to be called whenever the specified event occurs.
 | event     | string   | `''`    | Event to attach the handler to. Currently, only the `'console'` event is supported. |
 | handler   | function | `null`  | A function to be called every time the specified event is emitted.                  |
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 When using the `page.on` method, the page has to be explicitly [closed](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/page/close/) for the iteration to be able to finish.
 

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/press.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/press.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.press(selector, key[, options]) method'
 
 # press(selector, key[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.press()`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/press/) instead.
 

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/reload.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/reload.md
@@ -19,7 +19,7 @@ This reloads the current page and returns the main resource response.
 
 ### Events
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 `networkidle` is DISCOURAGED. Don't use this method for testing especially with chatty websites where the event may never fire, rely on web assertions to assess readiness instead.
 

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/selectoption.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/selectoption.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.selectOption(selector, values[, options]) met
 
 # selectOption(selector, values[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.selectOption()`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/selectoption/) instead.
 

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/tap.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/tap.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.tap(selector[, options]) method'
 
 # tap(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.tap([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/tap/) instead.
 

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/textcontent.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/textcontent.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.textContent(selector[, options]) method'
 
 # textContent(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.textContent([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/textcontent/) instead.
 

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/type.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/type.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.type(selector, text[, options]) method'
 
 # type(selector, text[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.type()`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/type/) instead.
 

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/uncheck.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/uncheck.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.uncheck(selector[, options]) method'
 
 # uncheck(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.uncheck([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/uncheck/) instead.
 

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/waitforloadstate.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/waitforloadstate.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.waitForLoadState(state[, options]) method'
 
 # waitForLoadState(state[, options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This method has **known issues**. For details, refer to [#880](https://github.com/grafana/xk6-browser/issues/880).
 
@@ -25,7 +25,7 @@ This waits for the given load state to be reached. It will immediately unblock i
 
 ### Events
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 `networkidle` is DISCOURAGED. Don't use this method for testing especially with chatty websites where the event may never fire, rely on web assertions to assess readiness instead.
 

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/waitfornavigation.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/waitfornavigation.md
@@ -19,7 +19,7 @@ Waits for the given navigation lifecycle event to occur and returns the main res
 
 ### Events
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 `networkidle` is DISCOURAGED. Don't use this method for testing especially with chatty websites where the event may never fire, rely on web assertions to assess readiness instead.
 

--- a/docs/sources/v0.48.x/javascript-api/k6-http/batch.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-http/batch.md
@@ -30,7 +30,7 @@ You can use this GET shortcut in objects&mdash;name a key and give it a URL valu
 
 You can define a request specified as an array or object with the following parameters.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 When you define requests as an array, you must use a specific order of items.
 Note the `Position` column for the correct order.

--- a/docs/sources/v0.48.x/javascript-api/k6/group.md
+++ b/docs/sources/v0.48.x/javascript-api/k6/group.md
@@ -19,7 +19,7 @@ Run code inside a group. Groups are used to organize results in a test.
 | ---- | ------------------------- |
 | any  | The return value of _fn_. |
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Avoid using `group` with async functions or asynchronous code.
 If you do, k6 might apply tags in a way that is unreliable or unintuitive.

--- a/docs/sources/v0.48.x/misc/fine-tuning-os.md
+++ b/docs/sources/v0.48.x/misc/fine-tuning-os.md
@@ -246,7 +246,7 @@ All that is left after this is to reboot your Mac back to the Recovery Mode, ope
 
 In most cases these limits should be enough to run most of your simple tests locally for some time, but you can modify the files above to any values you will need in your testing.
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Please be aware that all of these limitations are put in place to protect your operating system from files and applications that are poorly written and might leak memory like in huge quantities. We would suggest not going too overboard with the values, or you might find your system slowing down to a crawl if or when it runs out of RAM.
 

--- a/docs/sources/v0.48.x/results-output/real-time/amazon-cloudwatch.md
+++ b/docs/sources/v0.48.x/results-output/real-time/amazon-cloudwatch.md
@@ -6,7 +6,7 @@ weight: 00
 
 # Amazon CloudWatch
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 The built-in StatsD output has been deprecated on k6 v0.47.0. You can continue to use this feature by using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd), and this guide has been updated to include instructions for how to use it.
 

--- a/docs/sources/v0.48.x/results-output/real-time/cloud.md
+++ b/docs/sources/v0.48.x/results-output/real-time/cloud.md
@@ -21,7 +21,7 @@ Fundamentally the difference is the machine that the test runs on:
 
 In all cases you'll be able to see your test results at [k6 Cloud](https://app.k6.io) or [Grafana Cloud](https://grafana.com/products/cloud/).
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Data storage and processing are primary cloud costs,
 so `k6 run --out cloud` will consume VUH or test runs from your subscription.

--- a/docs/sources/v0.48.x/results-output/real-time/datadog.md
+++ b/docs/sources/v0.48.x/results-output/real-time/datadog.md
@@ -6,7 +6,7 @@ weight: 00
 
 # Datadog
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 The built-in StatsD output has been deprecated on k6 v0.47.0. You can continue to use this feature by using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd), and this guide has been updated to include instructions for how to use it.
 

--- a/docs/sources/v0.48.x/results-output/real-time/dynatrace.md
+++ b/docs/sources/v0.48.x/results-output/real-time/dynatrace.md
@@ -39,7 +39,7 @@ To learn more about how to build custom k6 versions, check out [xk6](https://git
 
 Create a Dynatrace API token to send the data.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 The Dynatrace API Token must have the scope name "metrics.ingest" (scope type `API v2`).
 {{< /admonition >}}
 

--- a/docs/sources/v0.48.x/results-output/real-time/elasticsearch.md
+++ b/docs/sources/v0.48.x/results-output/real-time/elasticsearch.md
@@ -62,7 +62,7 @@ export K6_ELASTICSEARCH_URL=http://localhost:9200
 ./k6 run script.js -o output-elasticsearch
 ```
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 Security and self-signed certificates for non-cloud clusters are not yet supported.
 {{< /admonition >}}
 

--- a/docs/sources/v0.48.x/results-output/real-time/grafana-cloud-prometheus.md
+++ b/docs/sources/v0.48.x/results-output/real-time/grafana-cloud-prometheus.md
@@ -7,7 +7,7 @@ weight: 00
 
 # Grafana Cloud Prometheus
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This page includes instructions for running a local test that sends the test results to a Prometheus instance in Grafana Cloud.
 

--- a/docs/sources/v0.48.x/results-output/real-time/netdata.md
+++ b/docs/sources/v0.48.x/results-output/real-time/netdata.md
@@ -6,7 +6,7 @@ weight: 00
 
 # Netdata
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 The built-in StatsD output has been deprecated on k6 v0.47.0. You can continue to use this feature by using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd), and this guide has been updated to include instructions for how to use it.
 

--- a/docs/sources/v0.48.x/results-output/real-time/newrelic.md
+++ b/docs/sources/v0.48.x/results-output/real-time/newrelic.md
@@ -7,7 +7,7 @@ slug: 'new-relic'
 
 # New Relic
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 The built-in StatsD output has been deprecated on k6 v0.47.0. You can continue to use this feature by using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd), and this guide has been updated to include instructions for how to use it.
 

--- a/docs/sources/v0.48.x/results-output/real-time/statsd.md
+++ b/docs/sources/v0.48.x/results-output/real-time/statsd.md
@@ -6,7 +6,7 @@ weight: 00
 
 # StatsD
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 The built-in StatsD output has been deprecated on k6 v0.47.0. You can continue to use this feature by using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd), and this guide has been updated to include instructions for how to use it.
 

--- a/docs/sources/v0.48.x/shared/blocking-aws-blockquote.md
+++ b/docs/sources/v0.48.x/shared/blocking-aws-blockquote.md
@@ -2,7 +2,7 @@
 title: jslib/aws module blocking admonition
 ---
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 In some cases, using this library&apos;s operations might impact performance and skew your test results.
 <br>

--- a/docs/sources/v0.48.x/shared/browser-module-wip.md
+++ b/docs/sources/v0.48.x/shared/browser-module-wip.md
@@ -2,7 +2,7 @@
 title: k6/experimental/browser module admonition
 ---
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This API is a work in progress. Some of the following functionalities might behave unexpectedly.
 

--- a/docs/sources/v0.48.x/shared/experimental-grpc-module.md
+++ b/docs/sources/v0.48.x/shared/experimental-grpc-module.md
@@ -2,7 +2,7 @@
 title: Experimental grpc module admonition
 ---
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Starting on k6 `v0.49`, the experimental module `k6/experimental/grpc` has been graduated, and its functionality is now available in the [`k6/net/grpc` module](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-net-grpc/). The `k6/experimental/grpc` is deprecated and will be removed in `v0.51.0`.
 

--- a/docs/sources/v0.48.x/shared/experimental-module.md
+++ b/docs/sources/v0.48.x/shared/experimental-module.md
@@ -2,7 +2,7 @@
 title: Experimental module admonition
 ---
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This is an experimental module.
 <br>

--- a/docs/sources/v0.48.x/testing-guides/running-distributed-tests.md
+++ b/docs/sources/v0.48.x/testing-guides/running-distributed-tests.md
@@ -165,7 +165,7 @@ Let's create our ConfigMap as `my-test` with the content of our `test.js` script
 kubectl create configmap my-test --from-file test.js
 ```
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Limitations exist on how large your test script can be when deployed within a `ConfigMap`.
 Kubernetes imposes a size limit of 1,048,576 bytes (1 MiB) for the data, therefore if your test scripts exceed this limit, you'll need to mount a `PersistentVolume`.
@@ -189,7 +189,7 @@ Organizing your test scripts was part of the discussion during [episode #76](htt
 
 {{< /admonition >}}
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 When using a `PersistentVolume`, the operator will expect all test scripts to be contained within a directory named `/test/`.
 
@@ -244,7 +244,7 @@ The test script content was added to the map using the filename as the key-value
 The amount of `parallelism` is up to you; how many pods do you want to split the test amongst?
 The operator will split the workload between the pods using [execution segments](https://grafana.com/docs/k6/<K6_VERSION>/misc/glossary#execution-segment).
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 It is important that the `ConfigMap` and `CustomResource` are created in the same [Namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/).
 
@@ -275,7 +275,7 @@ spec:
 
 {{< /code >}}
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 It is important that the `PersistentVolumeClaim` and `CustomResource` are created in the same [Namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/).
 

--- a/docs/sources/v0.48.x/using-k6-browser/metrics.md
+++ b/docs/sources/v0.48.x/using-k6-browser/metrics.md
@@ -69,7 +69,7 @@ To set thresholds for your browser metrics:
 
 As the following example shows, you can also pass in different URLs if you're going to set a threshold for other pages, especially when your script contains page navigations.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Currently, you can only use URLs to specify thresholds for different pages. If you use [Groups](https://grafana.com/docs/k6/latest/using-k6/tags-and-groups/#groups), the metrics are not correctly grouped as described in [#721](https://github.com/grafana/xk6-browser/issues/721).
 

--- a/docs/sources/v0.48.x/using-k6/k6-options/reference.md
+++ b/docs/sources/v0.48.x/using-k6/k6-options/reference.md
@@ -960,7 +960,7 @@ $ k6 run --out influxdb=http://localhost:8086/k6 script.js
 
 The maximum number of requests to make per second, in total across all VUs. Available in `k6 run` and `k6 cloud` commands.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 **This option is discouraged.**
 <br>
@@ -1382,7 +1382,7 @@ export const options = {
 A list of cipher suites allowed to be used by in SSL/TLS interactions with a server.
 For a full listing of available ciphers go [here](https://golang.org/pkg/crypto/tls/#pkg-constants).
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Due to limitations in the underlying [go implementation](https://github.com/golang/go/issues/29349), changing the ciphers for TLS 1.3 is _not_ supported and will do nothing.
 

--- a/docs/sources/v0.48.x/using-k6/scenarios/concepts/arrival-rate-vu-allocation.md
+++ b/docs/sources/v0.48.x/using-k6/scenarios/concepts/arrival-rate-vu-allocation.md
@@ -15,7 +15,7 @@ In other words, before the tests runs, you must both:
 
 Read on to learn about how k6 allocates VUs in the arrival-rate executors.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 In cloud tests, **`preAllocatedVUs` count against your subscription.**
 
@@ -91,7 +91,7 @@ As dropped iterations can also indicate that the system performance is degrading
 
 ## You probably don't need `maxVUs`
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 In cloud tests, the number of `maxVUs` counts against your subscription,
 **overriding the number set by `preAllocatedVUs`**.

--- a/docs/sources/v0.48.x/using-k6/thresholds.md
+++ b/docs/sources/v0.48.x/using-k6/thresholds.md
@@ -186,7 +186,7 @@ export default function () {
 
 {{< /code >}}
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Do not specify multiple thresholds for the same metric by repeating the same object key.
 
@@ -445,7 +445,7 @@ export default function () {
 
 {{< /code >}}
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 When k6 runs in the cloud, thresholds are evaluated every 60 seconds.
 Therefore, the `abortOnFail` feature may be delayed by up to 60 seconds.

--- a/docs/sources/v0.49.x/extensions/build-k6-binary-using-docker.md
+++ b/docs/sources/v0.49.x/extensions/build-k6-binary-using-docker.md
@@ -122,7 +122,7 @@ Flags:
 
 {{< /code >}}
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 The use of `--replace` should be considered an advanced feature to be avoided unless required.
 

--- a/docs/sources/v0.49.x/extensions/create/javascript-extensions.md
+++ b/docs/sources/v0.49.x/extensions/create/javascript-extensions.md
@@ -176,7 +176,7 @@ to access the [`modules.VU`](https://pkg.go.dev/go.k6.io/k6/js/modules#VU) to in
 Additionally, there should be a root module implementation of the [`modules.Module`](https://pkg.go.dev/go.k6.io/k6/js/modules#Module)
 interface to serve as a factory of `Compare` instances for each VU.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 The significance depends on the size of your module.
 

--- a/docs/sources/v0.49.x/extensions/explanations/extension-graduation.md
+++ b/docs/sources/v0.49.x/extensions/explanations/extension-graduation.md
@@ -39,7 +39,7 @@ There should be a reasonably high degree of quality and stability at this point.
 This phase makes the feature accessible to more users, which in turn gives k6 developers more chances to receive feedback.
 The key will be to achieve a balance between usability and stability.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Not all experimental modules will progress to become a core module!
 The k6 team reserves the right to discontinue and remove any experimental module if is no longer deemed desirable.

--- a/docs/sources/v0.49.x/javascript-api/jslib/httpx/_index.md
+++ b/docs/sources/v0.49.x/javascript-api/jslib/httpx/_index.md
@@ -19,7 +19,7 @@ httpx module integrates well with the expect library.
 The source code is [on GitHub](https://github.com/k6io/k6-jslib-httpx).
 Please request features and report bugs through [GitHub issues](https://github.com/k6io/k6-jslib-httpx/issues).
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 **This library is in active development.**
 

--- a/docs/sources/v0.49.x/javascript-api/k6-data/sharedarray.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-data/sharedarray.md
@@ -37,7 +37,7 @@ Supported operations on a `SharedArray` include:
 In most cases, you should be able to reduce the memory usage of an array data structure by wrapping it in a `SharedArray`.
 Once constructed, a `SharedArray` is read-only, so **you can't use a SharedArray to communicate data between VUs**.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Attempting to instantiate a `SharedArray` outside of the [init context](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-lifecycle) results in the exception `new SharedArray must be called in the init context`.
 

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/browsercontext/pages.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/browsercontext/pages.md
@@ -5,7 +5,7 @@ description: 'Returns a list of pages inside this BrowserContext.'
 
 # pages()
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**. For details, refer to
 [#444](https://github.com/grafana/xk6-browser/issues/444).

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/browsercontext/setgeolocation.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/browsercontext/setgeolocation.md
@@ -5,7 +5,7 @@ description: "Sets the BrowserContext's geolocation."
 
 # setGeolocation(geolocation)
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**. For details, refer to
 [#435](https://github.com/grafana/xk6-browser/issues/435).

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/frame/dblclick.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/frame/dblclick.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.dblclick(selector[, options]) method'
 
 # dblclick(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.dblclick([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/dblclick/) instead.
 

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/frame/ishidden.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/frame/ishidden.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.isHidden(selector[, options]) method'
 
 # isHidden(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isHidden([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/ishidden/) instead.
 

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/frame/isvisible.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/frame/isvisible.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.isVisible(selector[, options]) method'
 
 # isVisible(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isVisible([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/isvisible/) instead.
 

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/isconnected.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/isconnected.md
@@ -5,7 +5,7 @@ description: 'Browser module: isConnected method'
 
 # isConnected()
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**.
 For details, refer to [#453](https://github.com/grafana/xk6-browser/issues/453).

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/locator/check.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/locator/check.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.check method'
 
 # check([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has known issues. For details, refer to
 [#471](https://github.com/grafana/xk6-browser/issues/471) and [#475](https://github.com/grafana/xk6-browser/issues/475).

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/locator/click.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/locator/click.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.click method'
 
 # click([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This method has **known issues**. For details, refer to [#471](https://github.com/grafana/xk6-browser/issues/471) and [#474](https://github.com/grafana/xk6-browser/issues/474).
 

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/locator/dblclick.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/locator/dblclick.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.dblclick method'
 
 # dblclick([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has known issues. For details, refer to [#471](https://github.com/grafana/xk6-browser/issues/471).
 

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/locator/hover.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/locator/hover.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.hover method'
 
 # hover([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has known issues. For details, refer to
 [#471](https://github.com/grafana/xk6-browser/issues/471).

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/locator/selectoption.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/locator/selectoption.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.selectOption method'
 
 # selectOption(values, [options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**. For details, refer to
 [#470](https://github.com/grafana/xk6-browser/issues/470) and [#471](https://github.com/grafana/xk6-browser/issues/471).

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/locator/tap.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/locator/tap.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.tap method'
 
 # tap([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**. For details, refer to
 [#436](https://github.com/grafana/xk6-browser/issues/436) and [#471](https://github.com/grafana/xk6-browser/issues/471).

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/locator/uncheck.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/locator/uncheck.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.uncheck method'
 
 # uncheck([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**.
 For details, refer to [#471](https://github.com/grafana/xk6-browser/issues/471).

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/locator/waitfor.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/locator/waitfor.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.waitFor method'
 
 # waitFor([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**. For details,
 refer to [#472](https://github.com/grafana/xk6-browser/issues/472).

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/newpage.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/newpage.md
@@ -13,7 +13,7 @@ A 1-to-1 mapping between [Browser](https://grafana.com/docs/k6/<K6_VERSION>/java
 
 {{< /admonition >}}
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Pages that have been opened ought to be closed using [`Page.close`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/page/close/). Pages left open could potentially distort the results of Web Vital metrics.
 

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/check.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/check.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.check(selector[, options]) method'
 
 # check(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.check([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/check/) instead.
 

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/click.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/click.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.click(selector[, options]) method'
 
 # click(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.click([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/click/) instead.
 

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/dblclick.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/dblclick.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.dblclick(selector[, options]) method'
 
 # dblclick(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.dblclick([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/dblclick/) instead.
 

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/dispatchevent.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/dispatchevent.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.dispatchEvent(selector, type, eventInit[, opt
 
 # dispatchEvent(selector, type, eventInit[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.dispatchEvent(type, eventInit[, options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/dispatchevent/) instead.
 

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/dollar.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/dollar.md
@@ -6,7 +6,7 @@ description: 'Browser module: page.$(selector) method'
 
 # page.$(selector)
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`page.locator(selector)`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/page/locator/) instead.
 

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/doubledollar.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/doubledollar.md
@@ -6,7 +6,7 @@ description: 'Browser module: page.$$(selector) method'
 
 # page.$$(selector)
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`page.locator(selector)`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/page/locator/) instead.
 

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/fill.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/fill.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.fill(selector, value[, options]) method'
 
 # fill(selector, value[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.fill(value[, options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/fill/) instead.
 

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/focus.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/focus.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.focus(selector[, options]) method'
 
 # focus(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.focus([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/focus/) instead.
 

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/getattribute.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/getattribute.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.getAttribute(selector, name[, options]) metho
 
 # getAttribute(selector, name[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.getAttribute()`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/getattribute/) instead.
 

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/goto.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/goto.md
@@ -23,7 +23,7 @@ Navigating to `about:blank` or navigation to the same URL with a different hash,
 
 ### Events
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 `networkidle` is DISCOURAGED. Don't use this method for testing especially with chatty websites where the event may never fire, rely on web assertions to assess readiness instead.
 

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/hover.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/hover.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.hover(selector[, options]) method'
 
 # hover(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.hover([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/hover/) instead.
 

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/innerhtml.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/innerhtml.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.innerHTML(selector[, options]) method'
 
 # innerHTML(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.innerHTML([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/innerhtml/) instead.
 

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/innertext.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/innertext.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.innerText(selector[, options]) method'
 
 # innerText(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.innerText([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/innertext/) instead.
 

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/inputvalue.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/inputvalue.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.inputValue(selector[, options]) method'
 
 # inputValue(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.inputValue([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/inputvalue/) instead.
 

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/ischecked.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/ischecked.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isChecked(selector[, options]) method'
 
 # isChecked(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isChecked([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/ischecked/) instead.
 

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/isclosed.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/isclosed.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isClosed() method'
 
 # isClosed()
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This method has **known issues**. For details, refer to [#878](https://github.com/grafana/xk6-browser/issues/878).
 

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/isdisabled.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/isdisabled.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isDisabled(selector[, options]) method'
 
 # isDisabled(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isDisabled([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/isdisabled/) instead.
 

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/iseditable.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/iseditable.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isEditable(selector[, options]) method'
 
 # isEditable(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isEditable([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/iseditable/) instead.
 

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/isenabled.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/isenabled.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isEnabled(selector[, options]) method'
 
 # isEnabled(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isEnabled([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/isenabled/) instead.
 

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/ishidden.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/ishidden.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isHidden(selector[, options) method'
 
 # isHidden(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isHidden([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/ishidden/) instead.
 

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/isvisible.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/isvisible.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isVisible(selector[, options]) method'
 
 # isVisible(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isVisible([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/isvisible/) instead.
 

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/on.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/on.md
@@ -12,7 +12,7 @@ Registers a handler to be called whenever the specified event occurs.
 | event     | string   | `''`    | Event to attach the handler to. Currently, only the `'console'` event is supported. |
 | handler   | function | `null`  | A function to be called every time the specified event is emitted.                  |
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 When using the `page.on` method, the page has to be explicitly [closed](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/page/close/) for the iteration to be able to finish.
 

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/press.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/press.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.press(selector, key[, options]) method'
 
 # press(selector, key[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.press()`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/press/) instead.
 

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/reload.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/reload.md
@@ -19,7 +19,7 @@ This reloads the current page and returns the main resource response.
 
 ### Events
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 `networkidle` is DISCOURAGED. Don't use this method for testing especially with chatty websites where the event may never fire, rely on web assertions to assess readiness instead.
 

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/selectoption.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/selectoption.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.selectOption(selector, values[, options]) met
 
 # selectOption(selector, values[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.selectOption()`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/selectoption/) instead.
 

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/tap.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/tap.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.tap(selector[, options]) method'
 
 # tap(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.tap([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/tap/) instead.
 

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/textcontent.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/textcontent.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.textContent(selector[, options]) method'
 
 # textContent(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.textContent([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/textcontent/) instead.
 

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/type.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/type.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.type(selector, text[, options]) method'
 
 # type(selector, text[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.type()`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/type/) instead.
 

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/uncheck.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/uncheck.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.uncheck(selector[, options]) method'
 
 # uncheck(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.uncheck([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/uncheck/) instead.
 

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/waitforloadstate.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/waitforloadstate.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.waitForLoadState(state[, options]) method'
 
 # waitForLoadState(state[, options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This method has **known issues**. For details, refer to [#880](https://github.com/grafana/xk6-browser/issues/880).
 
@@ -25,7 +25,7 @@ This waits for the given load state to be reached. It will immediately unblock i
 
 ### Events
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 `networkidle` is DISCOURAGED. Don't use this method for testing especially with chatty websites where the event may never fire, rely on web assertions to assess readiness instead.
 

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/waitfornavigation.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/waitfornavigation.md
@@ -19,7 +19,7 @@ Waits for the given navigation lifecycle event to occur and returns the main res
 
 ### Events
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 `networkidle` is DISCOURAGED. Don't use this method for testing especially with chatty websites where the event may never fire, rely on web assertions to assess readiness instead.
 

--- a/docs/sources/v0.49.x/javascript-api/k6-http/batch.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-http/batch.md
@@ -30,7 +30,7 @@ You can use this GET shortcut in objects&mdash;name a key and give it a URL valu
 
 You can define a request specified as an array or object with the following parameters.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 When you define requests as an array, you must use a specific order of items.
 Note the `Position` column for the correct order.

--- a/docs/sources/v0.49.x/javascript-api/k6/group.md
+++ b/docs/sources/v0.49.x/javascript-api/k6/group.md
@@ -19,7 +19,7 @@ Run code inside a group. Groups are used to organize results in a test.
 | ---- | ------------------------- |
 | any  | The return value of _fn_. |
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Avoid using `group` with async functions or asynchronous code.
 If you do, k6 might apply tags in a way that is unreliable or unintuitive.

--- a/docs/sources/v0.49.x/misc/fine-tuning-os.md
+++ b/docs/sources/v0.49.x/misc/fine-tuning-os.md
@@ -246,7 +246,7 @@ All that is left after this is to reboot your Mac back to the Recovery Mode, ope
 
 In most cases these limits should be enough to run most of your simple tests locally for some time, but you can modify the files above to any values you will need in your testing.
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Please be aware that all of these limitations are put in place to protect your operating system from files and applications that are poorly written and might leak memory like in huge quantities. We would suggest not going too overboard with the values, or you might find your system slowing down to a crawl if or when it runs out of RAM.
 

--- a/docs/sources/v0.49.x/results-output/real-time/amazon-cloudwatch.md
+++ b/docs/sources/v0.49.x/results-output/real-time/amazon-cloudwatch.md
@@ -6,7 +6,7 @@ weight: 00
 
 # Amazon CloudWatch
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 The built-in StatsD output has been deprecated on k6 v0.47.0. You can continue to use this feature by using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd), and this guide has been updated to include instructions for how to use it.
 

--- a/docs/sources/v0.49.x/results-output/real-time/cloud.md
+++ b/docs/sources/v0.49.x/results-output/real-time/cloud.md
@@ -21,7 +21,7 @@ Fundamentally the difference is the machine that the test runs on:
 
 In all cases you'll be able to see your test results at [k6 Cloud](https://app.k6.io) or [Grafana Cloud](https://grafana.com/products/cloud/).
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Data storage and processing are primary cloud costs,
 so `k6 run --out cloud` will consume VUH or test runs from your subscription.

--- a/docs/sources/v0.49.x/results-output/real-time/datadog.md
+++ b/docs/sources/v0.49.x/results-output/real-time/datadog.md
@@ -6,7 +6,7 @@ weight: 00
 
 # Datadog
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 The built-in StatsD output has been deprecated on k6 v0.47.0. You can continue to use this feature by using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd), and this guide has been updated to include instructions for how to use it.
 

--- a/docs/sources/v0.49.x/results-output/real-time/dynatrace.md
+++ b/docs/sources/v0.49.x/results-output/real-time/dynatrace.md
@@ -39,7 +39,7 @@ To learn more about how to build custom k6 versions, check out [xk6](https://git
 
 Create a Dynatrace API token to send the data.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 The Dynatrace API Token must have the scope name "metrics.ingest" (scope type `API v2`).
 {{< /admonition >}}
 

--- a/docs/sources/v0.49.x/results-output/real-time/elasticsearch.md
+++ b/docs/sources/v0.49.x/results-output/real-time/elasticsearch.md
@@ -62,7 +62,7 @@ export K6_ELASTICSEARCH_URL=http://localhost:9200
 ./k6 run script.js -o output-elasticsearch
 ```
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 Security and self-signed certificates for non-cloud clusters are not yet supported.
 {{< /admonition >}}
 

--- a/docs/sources/v0.49.x/results-output/real-time/grafana-cloud-prometheus.md
+++ b/docs/sources/v0.49.x/results-output/real-time/grafana-cloud-prometheus.md
@@ -7,7 +7,7 @@ weight: 00
 
 # Grafana Cloud Prometheus
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This page includes instructions for running a local test that sends the test results to a Prometheus instance in Grafana Cloud.
 

--- a/docs/sources/v0.49.x/results-output/real-time/netdata.md
+++ b/docs/sources/v0.49.x/results-output/real-time/netdata.md
@@ -6,7 +6,7 @@ weight: 00
 
 # Netdata
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 The built-in StatsD output has been deprecated on k6 v0.47.0. You can continue to use this feature by using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd), and this guide has been updated to include instructions for how to use it.
 

--- a/docs/sources/v0.49.x/results-output/real-time/newrelic.md
+++ b/docs/sources/v0.49.x/results-output/real-time/newrelic.md
@@ -7,7 +7,7 @@ slug: 'new-relic'
 
 # New Relic
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 The built-in StatsD output has been deprecated on k6 v0.47.0. You can continue to use this feature by using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd), and this guide has been updated to include instructions for how to use it.
 

--- a/docs/sources/v0.49.x/results-output/real-time/statsd.md
+++ b/docs/sources/v0.49.x/results-output/real-time/statsd.md
@@ -6,7 +6,7 @@ weight: 00
 
 # StatsD
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 The built-in StatsD output has been deprecated on k6 v0.47.0. You can continue to use this feature by using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd), and this guide has been updated to include instructions for how to use it.
 

--- a/docs/sources/v0.49.x/shared/blocking-aws-blockquote.md
+++ b/docs/sources/v0.49.x/shared/blocking-aws-blockquote.md
@@ -2,7 +2,7 @@
 title: jslib/aws module blocking admonition
 ---
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 In some cases, using this library&apos;s operations might impact performance and skew your test results.
 <br>

--- a/docs/sources/v0.49.x/shared/browser-module-wip.md
+++ b/docs/sources/v0.49.x/shared/browser-module-wip.md
@@ -2,7 +2,7 @@
 title: k6/experimental/browser module admonition
 ---
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This API is a work in progress. Some of the following functionalities might behave unexpectedly.
 

--- a/docs/sources/v0.49.x/shared/experimental-grpc-module.md
+++ b/docs/sources/v0.49.x/shared/experimental-grpc-module.md
@@ -2,7 +2,7 @@
 title: Experimental grpc module admonition
 ---
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Starting on k6 `v0.49`, the experimental module `k6/experimental/grpc` has been graduated, and its functionality is now available in the [`k6/net/grpc` module](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-net-grpc/). The `k6/experimental/grpc` is deprecated and will be removed in `v0.51.0`.
 

--- a/docs/sources/v0.49.x/shared/experimental-module.md
+++ b/docs/sources/v0.49.x/shared/experimental-module.md
@@ -2,7 +2,7 @@
 title: Experimental module admonition
 ---
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This is an experimental module.
 <br>

--- a/docs/sources/v0.49.x/testing-guides/running-distributed-tests.md
+++ b/docs/sources/v0.49.x/testing-guides/running-distributed-tests.md
@@ -165,7 +165,7 @@ Let's create our ConfigMap as `my-test` with the content of our `test.js` script
 kubectl create configmap my-test --from-file test.js
 ```
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Limitations exist on how large your test script can be when deployed within a `ConfigMap`.
 Kubernetes imposes a size limit of 1,048,576 bytes (1 MiB) for the data, therefore if your test scripts exceed this limit, you'll need to mount a `PersistentVolume`.
@@ -189,7 +189,7 @@ Organizing your test scripts was part of the discussion during [episode #76](htt
 
 {{< /admonition >}}
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 When using a `PersistentVolume`, the operator will expect all test scripts to be contained within a directory named `/test/`.
 
@@ -244,7 +244,7 @@ The test script content was added to the map using the filename as the key-value
 The amount of `parallelism` is up to you; how many pods do you want to split the test amongst?
 The operator will split the workload between the pods using [execution segments](https://grafana.com/docs/k6/<K6_VERSION>/misc/glossary#execution-segment).
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 It is important that the `ConfigMap` and `CustomResource` are created in the same [Namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/).
 
@@ -275,7 +275,7 @@ spec:
 
 {{< /code >}}
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 It is important that the `PersistentVolumeClaim` and `CustomResource` are created in the same [Namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/).
 

--- a/docs/sources/v0.49.x/using-k6-browser/metrics.md
+++ b/docs/sources/v0.49.x/using-k6-browser/metrics.md
@@ -69,7 +69,7 @@ To set thresholds for your browser metrics:
 
 As the following example shows, you can also pass in different URLs if you're going to set a threshold for other pages, especially when your script contains page navigations.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Currently, you can only use URLs to specify thresholds for different pages. If you use [Groups](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/tags-and-groups/#groups), the metrics are not correctly grouped as described in [#721](https://github.com/grafana/xk6-browser/issues/721).
 

--- a/docs/sources/v0.49.x/using-k6/k6-options/reference.md
+++ b/docs/sources/v0.49.x/using-k6/k6-options/reference.md
@@ -960,7 +960,7 @@ $ k6 run --out influxdb=http://localhost:8086/k6 script.js
 
 The maximum number of requests to make per second, in total across all VUs. Available in `k6 run` and `k6 cloud` commands.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 **This option is discouraged.**
 <br>
@@ -1382,7 +1382,7 @@ export const options = {
 A list of cipher suites allowed to be used by in SSL/TLS interactions with a server.
 For a full listing of available ciphers go [here](https://golang.org/pkg/crypto/tls/#pkg-constants).
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Due to limitations in the underlying [go implementation](https://github.com/golang/go/issues/29349), changing the ciphers for TLS 1.3 is _not_ supported and will do nothing.
 

--- a/docs/sources/v0.49.x/using-k6/scenarios/concepts/arrival-rate-vu-allocation.md
+++ b/docs/sources/v0.49.x/using-k6/scenarios/concepts/arrival-rate-vu-allocation.md
@@ -15,7 +15,7 @@ In other words, before the tests runs, you must both:
 
 Read on to learn about how k6 allocates VUs in the arrival-rate executors.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 In cloud tests, **`preAllocatedVUs` count against your subscription.**
 
@@ -91,7 +91,7 @@ As dropped iterations can also indicate that the system performance is degrading
 
 ## You probably don't need `maxVUs`
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 In cloud tests, the number of `maxVUs` counts against your subscription,
 **overriding the number set by `preAllocatedVUs`**.

--- a/docs/sources/v0.49.x/using-k6/thresholds.md
+++ b/docs/sources/v0.49.x/using-k6/thresholds.md
@@ -186,7 +186,7 @@ export default function () {
 
 {{< /code >}}
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Do not specify multiple thresholds for the same metric by repeating the same object key.
 
@@ -445,7 +445,7 @@ export default function () {
 
 {{< /code >}}
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 When k6 runs in the cloud, thresholds are evaluated every 60 seconds.
 Therefore, the `abortOnFail` feature may be delayed by up to 60 seconds.

--- a/docs/sources/v0.50.x/extensions/build-k6-binary-using-docker.md
+++ b/docs/sources/v0.50.x/extensions/build-k6-binary-using-docker.md
@@ -122,7 +122,7 @@ Flags:
 
 {{< /code >}}
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 The use of `--replace` should be considered an advanced feature to be avoided unless required.
 

--- a/docs/sources/v0.50.x/extensions/create/javascript-extensions.md
+++ b/docs/sources/v0.50.x/extensions/create/javascript-extensions.md
@@ -176,7 +176,7 @@ to access the [`modules.VU`](https://pkg.go.dev/go.k6.io/k6/js/modules#VU) to in
 Additionally, there should be a root module implementation of the [`modules.Module`](https://pkg.go.dev/go.k6.io/k6/js/modules#Module)
 interface to serve as a factory of `Compare` instances for each VU.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 The significance depends on the size of your module.
 

--- a/docs/sources/v0.50.x/extensions/explanations/extension-graduation.md
+++ b/docs/sources/v0.50.x/extensions/explanations/extension-graduation.md
@@ -39,7 +39,7 @@ There should be a reasonably high degree of quality and stability at this point.
 This phase makes the feature accessible to more users, which in turn gives k6 developers more chances to receive feedback.
 The key will be to achieve a balance between usability and stability.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Not all experimental modules will progress to become a core module!
 The k6 team reserves the right to discontinue and remove any experimental module if is no longer deemed desirable.

--- a/docs/sources/v0.50.x/javascript-api/jslib/httpx/_index.md
+++ b/docs/sources/v0.50.x/javascript-api/jslib/httpx/_index.md
@@ -19,7 +19,7 @@ httpx module integrates well with the expect library.
 The source code is [on GitHub](https://github.com/k6io/k6-jslib-httpx).
 Please request features and report bugs through [GitHub issues](https://github.com/k6io/k6-jslib-httpx/issues).
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 **This library is in active development.**
 

--- a/docs/sources/v0.50.x/javascript-api/k6-data/sharedarray.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-data/sharedarray.md
@@ -37,7 +37,7 @@ Supported operations on a `SharedArray` include:
 In most cases, you should be able to reduce the memory usage of an array data structure by wrapping it in a `SharedArray`.
 Once constructed, a `SharedArray` is read-only, so **you can't use a SharedArray to communicate data between VUs**.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Attempting to instantiate a `SharedArray` outside of the [init context](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-lifecycle) results in the exception `new SharedArray must be called in the init context`.
 

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/browsercontext/pages.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/browsercontext/pages.md
@@ -5,7 +5,7 @@ description: 'Returns a list of pages inside this BrowserContext.'
 
 # pages()
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**. For details, refer to
 [#444](https://github.com/grafana/xk6-browser/issues/444).

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/browsercontext/setgeolocation.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/browsercontext/setgeolocation.md
@@ -5,7 +5,7 @@ description: "Sets the BrowserContext's geolocation."
 
 # setGeolocation(geolocation)
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**. For details, refer to
 [#435](https://github.com/grafana/xk6-browser/issues/435).

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/frame/dblclick.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/frame/dblclick.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.dblclick(selector[, options]) method'
 
 # dblclick(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.dblclick([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/dblclick/) instead.
 

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/frame/ishidden.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/frame/ishidden.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.isHidden(selector[, options]) method'
 
 # isHidden(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isHidden([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/ishidden/) instead.
 

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/frame/isvisible.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/frame/isvisible.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.isVisible(selector[, options]) method'
 
 # isVisible(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isVisible([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/isvisible/) instead.
 

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/isconnected.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/isconnected.md
@@ -5,7 +5,7 @@ description: 'Browser module: isConnected method'
 
 # isConnected()
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**.
 For details, refer to [#453](https://github.com/grafana/xk6-browser/issues/453).

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/locator/check.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/locator/check.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.check method'
 
 # check([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has known issues. For details, refer to
 [#471](https://github.com/grafana/xk6-browser/issues/471) and [#475](https://github.com/grafana/xk6-browser/issues/475).

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/locator/click.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/locator/click.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.click method'
 
 # click([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This method has **known issues**. For details, refer to [#471](https://github.com/grafana/xk6-browser/issues/471) and [#474](https://github.com/grafana/xk6-browser/issues/474).
 

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/locator/dblclick.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/locator/dblclick.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.dblclick method'
 
 # dblclick([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has known issues. For details, refer to [#471](https://github.com/grafana/xk6-browser/issues/471).
 

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/locator/hover.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/locator/hover.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.hover method'
 
 # hover([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has known issues. For details, refer to
 [#471](https://github.com/grafana/xk6-browser/issues/471).

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/locator/selectoption.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/locator/selectoption.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.selectOption method'
 
 # selectOption(values, [options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**. For details, refer to
 [#470](https://github.com/grafana/xk6-browser/issues/470) and [#471](https://github.com/grafana/xk6-browser/issues/471).

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/locator/tap.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/locator/tap.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.tap method'
 
 # tap([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**. For details, refer to
 [#436](https://github.com/grafana/xk6-browser/issues/436) and [#471](https://github.com/grafana/xk6-browser/issues/471).

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/locator/uncheck.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/locator/uncheck.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.uncheck method'
 
 # uncheck([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**.
 For details, refer to [#471](https://github.com/grafana/xk6-browser/issues/471).

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/locator/waitfor.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/locator/waitfor.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.waitFor method'
 
 # waitFor([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**. For details,
 refer to [#472](https://github.com/grafana/xk6-browser/issues/472).

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/newpage.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/newpage.md
@@ -13,7 +13,7 @@ A 1-to-1 mapping between [Browser](https://grafana.com/docs/k6/<K6_VERSION>/java
 
 {{< /admonition >}}
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Pages that have been opened ought to be closed using [`Page.close`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/page/close/). Pages left open could potentially distort the results of Web Vital metrics.
 

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/check.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/check.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.check(selector[, options]) method'
 
 # check(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.check([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/check/) instead.
 

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/click.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/click.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.click(selector[, options]) method'
 
 # click(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.click([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/click/) instead.
 

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/dblclick.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/dblclick.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.dblclick(selector[, options]) method'
 
 # dblclick(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.dblclick([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/dblclick/) instead.
 

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/dispatchevent.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/dispatchevent.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.dispatchEvent(selector, type, eventInit[, opt
 
 # dispatchEvent(selector, type, eventInit[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.dispatchEvent(type, eventInit[, options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/dispatchevent/) instead.
 

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/dollar.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/dollar.md
@@ -6,7 +6,7 @@ description: 'Browser module: page.$(selector) method'
 
 # page.$(selector)
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`page.locator(selector)`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/page/locator/) instead.
 

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/doubledollar.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/doubledollar.md
@@ -6,7 +6,7 @@ description: 'Browser module: page.$$(selector) method'
 
 # page.$$(selector)
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`page.locator(selector)`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/page/locator/) instead.
 

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/fill.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/fill.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.fill(selector, value[, options]) method'
 
 # fill(selector, value[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.fill(value[, options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/fill/) instead.
 

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/focus.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/focus.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.focus(selector[, options]) method'
 
 # focus(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.focus([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/focus/) instead.
 

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/getattribute.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/getattribute.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.getAttribute(selector, name[, options]) metho
 
 # getAttribute(selector, name[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.getAttribute()`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/getattribute/) instead.
 

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/goto.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/goto.md
@@ -23,7 +23,7 @@ Navigating to `about:blank` or navigation to the same URL with a different hash,
 
 ### Events
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 `networkidle` is DISCOURAGED. Don't use this method for testing especially with chatty websites where the event may never fire, rely on web assertions to assess readiness instead.
 

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/hover.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/hover.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.hover(selector[, options]) method'
 
 # hover(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.hover([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/hover/) instead.
 

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/innerhtml.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/innerhtml.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.innerHTML(selector[, options]) method'
 
 # innerHTML(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.innerHTML([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/innerhtml/) instead.
 

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/innertext.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/innertext.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.innerText(selector[, options]) method'
 
 # innerText(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.innerText([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/innertext/) instead.
 

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/inputvalue.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/inputvalue.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.inputValue(selector[, options]) method'
 
 # inputValue(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.inputValue([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/inputvalue/) instead.
 

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/ischecked.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/ischecked.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isChecked(selector[, options]) method'
 
 # isChecked(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isChecked([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/ischecked/) instead.
 

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/isclosed.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/isclosed.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isClosed() method'
 
 # isClosed()
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This method has **known issues**. For details, refer to [#878](https://github.com/grafana/xk6-browser/issues/878).
 

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/isdisabled.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/isdisabled.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isDisabled(selector[, options]) method'
 
 # isDisabled(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isDisabled([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/isdisabled/) instead.
 

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/iseditable.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/iseditable.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isEditable(selector[, options]) method'
 
 # isEditable(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isEditable([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/iseditable/) instead.
 

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/isenabled.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/isenabled.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isEnabled(selector[, options]) method'
 
 # isEnabled(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isEnabled([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/isenabled/) instead.
 

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/ishidden.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/ishidden.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isHidden(selector[, options) method'
 
 # isHidden(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isHidden([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/ishidden/) instead.
 

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/isvisible.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/isvisible.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isVisible(selector[, options]) method'
 
 # isVisible(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isVisible([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/isvisible/) instead.
 

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/on.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/on.md
@@ -12,7 +12,7 @@ Registers a handler to be called whenever the specified event occurs.
 | event     | string   | `''`    | Event to attach the handler to. Currently, only the `'console'` event is supported. |
 | handler   | function | `null`  | A function to be called every time the specified event is emitted.                  |
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 When using the `page.on` method, the page has to be explicitly [closed](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/page/close/) for the iteration to be able to finish.
 

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/press.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/press.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.press(selector, key[, options]) method'
 
 # press(selector, key[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.press()`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/press/) instead.
 

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/reload.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/reload.md
@@ -19,7 +19,7 @@ This reloads the current page and returns the main resource response.
 
 ### Events
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 `networkidle` is DISCOURAGED. Don't use this method for testing especially with chatty websites where the event may never fire, rely on web assertions to assess readiness instead.
 

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/selectoption.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/selectoption.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.selectOption(selector, values[, options]) met
 
 # selectOption(selector, values[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.selectOption()`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/selectoption/) instead.
 

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/tap.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/tap.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.tap(selector[, options]) method'
 
 # tap(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.tap([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/tap/) instead.
 

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/textcontent.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/textcontent.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.textContent(selector[, options]) method'
 
 # textContent(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.textContent([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/textcontent/) instead.
 

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/type.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/type.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.type(selector, text[, options]) method'
 
 # type(selector, text[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.type()`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/type/) instead.
 

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/uncheck.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/uncheck.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.uncheck(selector[, options]) method'
 
 # uncheck(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.uncheck([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/uncheck/) instead.
 

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/waitforloadstate.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/waitforloadstate.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.waitForLoadState(state[, options]) method'
 
 # waitForLoadState(state[, options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This method has **known issues**. For details, refer to [#880](https://github.com/grafana/xk6-browser/issues/880).
 
@@ -25,7 +25,7 @@ This waits for the given load state to be reached. It will immediately unblock i
 
 ### Events
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 `networkidle` is DISCOURAGED. Don't use this method for testing especially with chatty websites where the event may never fire, rely on web assertions to assess readiness instead.
 

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/waitfornavigation.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/waitfornavigation.md
@@ -19,7 +19,7 @@ Waits for the given navigation lifecycle event to occur and returns the main res
 
 ### Events
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 `networkidle` is DISCOURAGED. Don't use this method for testing especially with chatty websites where the event may never fire, rely on web assertions to assess readiness instead.
 

--- a/docs/sources/v0.50.x/javascript-api/k6-http/batch.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-http/batch.md
@@ -30,7 +30,7 @@ You can use this GET shortcut in objects&mdash;name a key and give it a URL valu
 
 You can define a request specified as an array or object with the following parameters.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 When you define requests as an array, you must use a specific order of items.
 Note the `Position` column for the correct order.

--- a/docs/sources/v0.50.x/javascript-api/k6/group.md
+++ b/docs/sources/v0.50.x/javascript-api/k6/group.md
@@ -19,7 +19,7 @@ Run code inside a group. Groups are used to organize results in a test.
 | ---- | ------------------------- |
 | any  | The return value of _fn_. |
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Avoid using `group` with async functions or asynchronous code.
 If you do, k6 might apply tags in a way that is unreliable or unintuitive.

--- a/docs/sources/v0.50.x/results-output/real-time/amazon-cloudwatch.md
+++ b/docs/sources/v0.50.x/results-output/real-time/amazon-cloudwatch.md
@@ -6,7 +6,7 @@ weight: 00
 
 # Amazon CloudWatch
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 The built-in StatsD output has been deprecated on k6 v0.47.0. You can continue to use this feature by using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd), and this guide has been updated to include instructions for how to use it.
 

--- a/docs/sources/v0.50.x/results-output/real-time/cloud.md
+++ b/docs/sources/v0.50.x/results-output/real-time/cloud.md
@@ -21,7 +21,7 @@ Fundamentally the difference is the machine that the test runs on:
 
 In all cases you'll be able to see your test results at [k6 Cloud](https://app.k6.io) or [Grafana Cloud](https://grafana.com/products/cloud/).
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Data storage and processing are primary cloud costs,
 so `k6 run --out cloud` will consume VUH or test runs from your subscription.

--- a/docs/sources/v0.50.x/results-output/real-time/datadog.md
+++ b/docs/sources/v0.50.x/results-output/real-time/datadog.md
@@ -6,7 +6,7 @@ weight: 00
 
 # Datadog
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 The built-in StatsD output has been deprecated on k6 v0.47.0. You can continue to use this feature by using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd), and this guide has been updated to include instructions for how to use it.
 

--- a/docs/sources/v0.50.x/results-output/real-time/dynatrace.md
+++ b/docs/sources/v0.50.x/results-output/real-time/dynatrace.md
@@ -39,7 +39,7 @@ To learn more about how to build custom k6 versions, check out [xk6](https://git
 
 Create a Dynatrace API token to send the data.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 The Dynatrace API Token must have the scope name "metrics.ingest" (scope type `API v2`).
 {{< /admonition >}}
 

--- a/docs/sources/v0.50.x/results-output/real-time/elasticsearch.md
+++ b/docs/sources/v0.50.x/results-output/real-time/elasticsearch.md
@@ -62,7 +62,7 @@ export K6_ELASTICSEARCH_URL=http://localhost:9200
 ./k6 run script.js -o output-elasticsearch
 ```
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 Security and self-signed certificates for non-cloud clusters are not yet supported.
 {{< /admonition >}}
 

--- a/docs/sources/v0.50.x/results-output/real-time/grafana-cloud-prometheus.md
+++ b/docs/sources/v0.50.x/results-output/real-time/grafana-cloud-prometheus.md
@@ -7,7 +7,7 @@ weight: 00
 
 # Grafana Cloud Prometheus
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This page includes instructions for running a local test that sends the test results to a Prometheus instance in Grafana Cloud.
 

--- a/docs/sources/v0.50.x/results-output/real-time/netdata.md
+++ b/docs/sources/v0.50.x/results-output/real-time/netdata.md
@@ -6,7 +6,7 @@ weight: 00
 
 # Netdata
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 The built-in StatsD output has been deprecated on k6 v0.47.0. You can continue to use this feature by using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd), and this guide has been updated to include instructions for how to use it.
 

--- a/docs/sources/v0.50.x/results-output/real-time/newrelic.md
+++ b/docs/sources/v0.50.x/results-output/real-time/newrelic.md
@@ -7,7 +7,7 @@ slug: 'new-relic'
 
 # New Relic
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 The built-in StatsD output has been deprecated on k6 v0.47.0. You can continue to use this feature by using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd), and this guide has been updated to include instructions for how to use it.
 

--- a/docs/sources/v0.50.x/results-output/real-time/statsd.md
+++ b/docs/sources/v0.50.x/results-output/real-time/statsd.md
@@ -6,7 +6,7 @@ weight: 00
 
 # StatsD
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 The built-in StatsD output has been deprecated on k6 v0.47.0. You can continue to use this feature by using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd), and this guide has been updated to include instructions for how to use it.
 

--- a/docs/sources/v0.50.x/set-up/fine-tune-os.md
+++ b/docs/sources/v0.50.x/set-up/fine-tune-os.md
@@ -252,7 +252,7 @@ All that is left after this is to reboot your Mac back to the Recovery Mode, ope
 
 In most cases these limits should be enough to run most of your simple tests locally for some time, but you can modify the files above to any values you will need in your testing.
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Please be aware that all of these limitations are put in place to protect your operating system from files and applications that are poorly written and might leak memory like in huge quantities. We would suggest not going too overboard with the values, or you might find your system slowing down to a crawl if or when it runs out of RAM.
 

--- a/docs/sources/v0.50.x/shared/blocking-aws-blockquote.md
+++ b/docs/sources/v0.50.x/shared/blocking-aws-blockquote.md
@@ -2,7 +2,7 @@
 title: jslib/aws module blocking admonition
 ---
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 In some cases, using this library&apos;s operations might impact performance and skew your test results.
 <br>

--- a/docs/sources/v0.50.x/shared/browser-module-wip.md
+++ b/docs/sources/v0.50.x/shared/browser-module-wip.md
@@ -2,7 +2,7 @@
 title: k6/experimental/browser module admonition
 ---
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This API is a work in progress. Some of the following functionalities might behave unexpectedly.
 

--- a/docs/sources/v0.50.x/shared/experimental-grpc-module.md
+++ b/docs/sources/v0.50.x/shared/experimental-grpc-module.md
@@ -2,7 +2,7 @@
 title: Experimental grpc module admonition
 ---
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Starting on k6 `v0.49`, the experimental module `k6/experimental/grpc` has been graduated, and its functionality is now available in the [`k6/net/grpc` module](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-net-grpc/). The `k6/experimental/grpc` is deprecated and will be removed in `v0.51.0`.
 

--- a/docs/sources/v0.50.x/shared/experimental-module.md
+++ b/docs/sources/v0.50.x/shared/experimental-module.md
@@ -2,7 +2,7 @@
 title: Experimental module admonition
 ---
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This is an experimental module.
 <br>

--- a/docs/sources/v0.50.x/shared/experimental-timers-module.md
+++ b/docs/sources/v0.50.x/shared/experimental-timers-module.md
@@ -2,7 +2,7 @@
 title: Experimental timers module admonition
 ---
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Starting on k6 `v0.50`, the experimental module `k6/experimental/timers` has been graduated, and its functionality is now available in the [`k6/timers` module](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-timers/). The `k6/experimental/timers` is deprecated and will be removed in `v0.52.0`.
 

--- a/docs/sources/v0.50.x/testing-guides/running-distributed-tests.md
+++ b/docs/sources/v0.50.x/testing-guides/running-distributed-tests.md
@@ -165,7 +165,7 @@ Let's create our ConfigMap as `my-test` with the content of our `test.js` script
 kubectl create configmap my-test --from-file test.js
 ```
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Limitations exist on how large your test script can be when deployed within a `ConfigMap`.
 Kubernetes imposes a size limit of 1,048,576 bytes (1 MiB) for the data, therefore if your test scripts exceed this limit, you'll need to mount a `PersistentVolume`.
@@ -189,7 +189,7 @@ Organizing your test scripts was part of the discussion during [episode #76](htt
 
 {{< /admonition >}}
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 When using a `PersistentVolume`, the operator will expect all test scripts to be contained within a directory named `/test/`.
 
@@ -244,7 +244,7 @@ The test script content was added to the map using the filename as the key-value
 The amount of `parallelism` is up to you; how many pods do you want to split the test amongst?
 The operator will split the workload between the pods using [execution segments](https://grafana.com/docs/k6/<K6_VERSION>/misc/glossary#execution-segment).
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 It is important that the `ConfigMap` and `CustomResource` are created in the same [Namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/).
 
@@ -275,7 +275,7 @@ spec:
 
 {{< /code >}}
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 It is important that the `PersistentVolumeClaim` and `CustomResource` are created in the same [Namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/).
 

--- a/docs/sources/v0.50.x/using-k6-browser/metrics.md
+++ b/docs/sources/v0.50.x/using-k6-browser/metrics.md
@@ -69,7 +69,7 @@ To set thresholds for your browser metrics:
 
 As the following example shows, you can also pass in different URLs if you're going to set a threshold for other pages, especially when your script contains page navigations.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Currently, you can only use URLs to specify thresholds for different pages. If you use [Groups](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/tags-and-groups/#groups), the metrics are not correctly grouped as described in [#721](https://github.com/grafana/xk6-browser/issues/721).
 

--- a/docs/sources/v0.50.x/using-k6/k6-options/reference.md
+++ b/docs/sources/v0.50.x/using-k6/k6-options/reference.md
@@ -960,7 +960,7 @@ $ k6 run --out influxdb=http://localhost:8086/k6 script.js
 
 The maximum number of requests to make per second, in total across all VUs. Available in `k6 run` and `k6 cloud` commands.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 **This option is discouraged.**
 <br>
@@ -1382,7 +1382,7 @@ export const options = {
 A list of cipher suites allowed to be used by in SSL/TLS interactions with a server.
 For a full listing of available ciphers go [here](https://golang.org/pkg/crypto/tls/#pkg-constants).
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Due to limitations in the underlying [go implementation](https://github.com/golang/go/issues/29349), changing the ciphers for TLS 1.3 is _not_ supported and will do nothing.
 

--- a/docs/sources/v0.50.x/using-k6/scenarios/concepts/arrival-rate-vu-allocation.md
+++ b/docs/sources/v0.50.x/using-k6/scenarios/concepts/arrival-rate-vu-allocation.md
@@ -15,7 +15,7 @@ In other words, before the tests runs, you must both:
 
 Read on to learn about how k6 allocates VUs in the arrival-rate executors.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 In cloud tests, **`preAllocatedVUs` count against your subscription.**
 
@@ -91,7 +91,7 @@ As dropped iterations can also indicate that the system performance is degrading
 
 ## You probably don't need `maxVUs`
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 In cloud tests, the number of `maxVUs` counts against your subscription,
 **overriding the number set by `preAllocatedVUs`**.

--- a/docs/sources/v0.50.x/using-k6/thresholds.md
+++ b/docs/sources/v0.50.x/using-k6/thresholds.md
@@ -186,7 +186,7 @@ export default function () {
 
 {{< /code >}}
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Do not specify multiple thresholds for the same metric by repeating the same object key.
 
@@ -445,7 +445,7 @@ export default function () {
 
 {{< /code >}}
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 When k6 runs in the cloud, thresholds are evaluated every 60 seconds.
 Therefore, the `abortOnFail` feature may be delayed by up to 60 seconds.

--- a/docs/sources/v0.51.x/extensions/build-k6-binary-using-docker.md
+++ b/docs/sources/v0.51.x/extensions/build-k6-binary-using-docker.md
@@ -122,7 +122,7 @@ Flags:
 
 {{< /code >}}
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 The use of `--replace` should be considered an advanced feature to be avoided unless required.
 

--- a/docs/sources/v0.51.x/extensions/create/javascript-extensions.md
+++ b/docs/sources/v0.51.x/extensions/create/javascript-extensions.md
@@ -176,7 +176,7 @@ to access the [`modules.VU`](https://pkg.go.dev/go.k6.io/k6/js/modules#VU) to in
 Additionally, there should be a root module implementation of the [`modules.Module`](https://pkg.go.dev/go.k6.io/k6/js/modules#Module)
 interface to serve as a factory of `Compare` instances for each VU.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 The significance depends on the size of your module.
 

--- a/docs/sources/v0.51.x/extensions/explanations/extension-graduation.md
+++ b/docs/sources/v0.51.x/extensions/explanations/extension-graduation.md
@@ -39,7 +39,7 @@ There should be a reasonably high degree of quality and stability at this point.
 This phase makes the feature accessible to more users, which in turn gives k6 developers more chances to receive feedback.
 The key will be to achieve a balance between usability and stability.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Not all experimental modules will progress to become a core module!
 The k6 team reserves the right to discontinue and remove any experimental module if is no longer deemed desirable.

--- a/docs/sources/v0.51.x/javascript-api/jslib/httpx/_index.md
+++ b/docs/sources/v0.51.x/javascript-api/jslib/httpx/_index.md
@@ -19,7 +19,7 @@ httpx module integrates well with the expect library.
 The source code is [on GitHub](https://github.com/k6io/k6-jslib-httpx).
 Please request features and report bugs through [GitHub issues](https://github.com/k6io/k6-jslib-httpx/issues).
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 **This library is in active development.**
 

--- a/docs/sources/v0.51.x/javascript-api/k6-data/sharedarray.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-data/sharedarray.md
@@ -37,7 +37,7 @@ Supported operations on a `SharedArray` include:
 In most cases, you should be able to reduce the memory usage of an array data structure by wrapping it in a `SharedArray`.
 Once constructed, a `SharedArray` is read-only, so **you can't use a SharedArray to communicate data between VUs**.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Attempting to instantiate a `SharedArray` outside of the [init context](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-lifecycle) results in the exception `new SharedArray must be called in the init context`.
 

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/browsercontext/pages.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/browsercontext/pages.md
@@ -5,7 +5,7 @@ description: 'Returns a list of pages inside this BrowserContext.'
 
 # pages()
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**. For details, refer to
 [#444](https://github.com/grafana/xk6-browser/issues/444).

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/browsercontext/setgeolocation.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/browsercontext/setgeolocation.md
@@ -5,7 +5,7 @@ description: "Sets the BrowserContext's geolocation."
 
 # setGeolocation(geolocation)
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**. For details, refer to
 [#435](https://github.com/grafana/xk6-browser/issues/435).

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/frame/dblclick.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/frame/dblclick.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.dblclick(selector[, options]) method'
 
 # dblclick(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.dblclick([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/dblclick/) instead.
 

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/frame/ishidden.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/frame/ishidden.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.isHidden(selector[, options]) method'
 
 # isHidden(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isHidden([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/ishidden/) instead.
 

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/frame/isvisible.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/frame/isvisible.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.isVisible(selector[, options]) method'
 
 # isVisible(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isVisible([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/isvisible/) instead.
 

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/isconnected.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/isconnected.md
@@ -5,7 +5,7 @@ description: 'Browser module: isConnected method'
 
 # isConnected()
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**.
 For details, refer to [#453](https://github.com/grafana/xk6-browser/issues/453).

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/locator/check.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/locator/check.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.check method'
 
 # check([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has known issues. For details, refer to
 [#471](https://github.com/grafana/xk6-browser/issues/471) and [#475](https://github.com/grafana/xk6-browser/issues/475).

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/locator/click.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/locator/click.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.click method'
 
 # click([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This method has **known issues**. For details, refer to [#471](https://github.com/grafana/xk6-browser/issues/471) and [#474](https://github.com/grafana/xk6-browser/issues/474).
 

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/locator/dblclick.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/locator/dblclick.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.dblclick method'
 
 # dblclick([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has known issues. For details, refer to [#471](https://github.com/grafana/xk6-browser/issues/471).
 

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/locator/hover.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/locator/hover.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.hover method'
 
 # hover([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has known issues. For details, refer to
 [#471](https://github.com/grafana/xk6-browser/issues/471).

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/locator/selectoption.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/locator/selectoption.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.selectOption method'
 
 # selectOption(values, [options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**. For details, refer to
 [#470](https://github.com/grafana/xk6-browser/issues/470) and [#471](https://github.com/grafana/xk6-browser/issues/471).

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/locator/tap.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/locator/tap.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.tap method'
 
 # tap([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**. For details, refer to
 [#436](https://github.com/grafana/xk6-browser/issues/436) and [#471](https://github.com/grafana/xk6-browser/issues/471).

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/locator/uncheck.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/locator/uncheck.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.uncheck method'
 
 # uncheck([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**.
 For details, refer to [#471](https://github.com/grafana/xk6-browser/issues/471).

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/locator/waitfor.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/locator/waitfor.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.waitFor method'
 
 # waitFor([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**. For details,
 refer to [#472](https://github.com/grafana/xk6-browser/issues/472).

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/newpage.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/newpage.md
@@ -13,7 +13,7 @@ A 1-to-1 mapping between [Browser](https://grafana.com/docs/k6/<K6_VERSION>/java
 
 {{< /admonition >}}
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Pages that have been opened ought to be closed using [`Page.close`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/page/close/). Pages left open could potentially distort the results of Web Vital metrics.
 

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/check.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/check.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.check(selector[, options]) method'
 
 # check(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.check([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/check/) instead.
 

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/click.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/click.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.click(selector[, options]) method'
 
 # click(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.click([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/click/) instead.
 

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/dblclick.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/dblclick.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.dblclick(selector[, options]) method'
 
 # dblclick(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.dblclick([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/dblclick/) instead.
 

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/dispatchevent.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/dispatchevent.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.dispatchEvent(selector, type, eventInit[, opt
 
 # dispatchEvent(selector, type, eventInit[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.dispatchEvent(type, eventInit[, options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/dispatchevent/) instead.
 

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/dollar.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/dollar.md
@@ -6,7 +6,7 @@ description: 'Browser module: page.$(selector) method'
 
 # page.$(selector)
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`page.locator(selector)`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/page/locator/) instead.
 

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/doubledollar.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/doubledollar.md
@@ -6,7 +6,7 @@ description: 'Browser module: page.$$(selector) method'
 
 # page.$$(selector)
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`page.locator(selector)`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/page/locator/) instead.
 

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/fill.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/fill.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.fill(selector, value[, options]) method'
 
 # fill(selector, value[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.fill(value[, options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/fill/) instead.
 

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/focus.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/focus.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.focus(selector[, options]) method'
 
 # focus(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.focus([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/focus/) instead.
 

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/getattribute.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/getattribute.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.getAttribute(selector, name[, options]) metho
 
 # getAttribute(selector, name[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.getAttribute()`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/getattribute/) instead.
 

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/goto.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/goto.md
@@ -23,7 +23,7 @@ Navigating to `about:blank` or navigation to the same URL with a different hash,
 
 ### Events
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 `networkidle` is DISCOURAGED. Don't use this method for testing especially with chatty websites where the event may never fire, rely on web assertions to assess readiness instead.
 

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/hover.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/hover.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.hover(selector[, options]) method'
 
 # hover(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.hover([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/hover/) instead.
 

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/innerhtml.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/innerhtml.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.innerHTML(selector[, options]) method'
 
 # innerHTML(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.innerHTML([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/innerhtml/) instead.
 

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/innertext.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/innertext.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.innerText(selector[, options]) method'
 
 # innerText(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.innerText([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/innertext/) instead.
 

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/inputvalue.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/inputvalue.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.inputValue(selector[, options]) method'
 
 # inputValue(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.inputValue([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/inputvalue/) instead.
 

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/ischecked.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/ischecked.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isChecked(selector[, options]) method'
 
 # isChecked(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isChecked([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/ischecked/) instead.
 

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/isclosed.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/isclosed.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isClosed() method'
 
 # isClosed()
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This method has **known issues**. For details, refer to [#878](https://github.com/grafana/xk6-browser/issues/878).
 

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/isdisabled.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/isdisabled.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isDisabled(selector[, options]) method'
 
 # isDisabled(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isDisabled([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/isdisabled/) instead.
 

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/iseditable.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/iseditable.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isEditable(selector[, options]) method'
 
 # isEditable(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isEditable([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/iseditable/) instead.
 

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/isenabled.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/isenabled.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isEnabled(selector[, options]) method'
 
 # isEnabled(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isEnabled([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/isenabled/) instead.
 

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/ishidden.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/ishidden.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isHidden(selector[, options) method'
 
 # isHidden(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isHidden([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/ishidden/) instead.
 

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/isvisible.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/isvisible.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isVisible(selector[, options]) method'
 
 # isVisible(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isVisible([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/isvisible/) instead.
 

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/on.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/on.md
@@ -12,7 +12,7 @@ Registers a handler to be called whenever the specified event occurs.
 | event     | string   | `''`    | Event to attach the handler to. Currently, only the `'console'` event is supported. |
 | handler   | function | `null`  | A function to be called every time the specified event is emitted.                  |
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 When using the `page.on` method, the page has to be explicitly [closed](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/page/close/) for the iteration to be able to finish.
 

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/press.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/press.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.press(selector, key[, options]) method'
 
 # press(selector, key[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.press()`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/press/) instead.
 

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/reload.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/reload.md
@@ -19,7 +19,7 @@ This reloads the current page and returns the main resource response.
 
 ### Events
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 `networkidle` is DISCOURAGED. Don't use this method for testing especially with chatty websites where the event may never fire, rely on web assertions to assess readiness instead.
 

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/selectoption.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/selectoption.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.selectOption(selector, values[, options]) met
 
 # selectOption(selector, values[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.selectOption()`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/selectoption/) instead.
 

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/tap.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/tap.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.tap(selector[, options]) method'
 
 # tap(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.tap([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/tap/) instead.
 

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/textcontent.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/textcontent.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.textContent(selector[, options]) method'
 
 # textContent(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.textContent([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/textcontent/) instead.
 

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/type.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/type.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.type(selector, text[, options]) method'
 
 # type(selector, text[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.type()`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/type/) instead.
 

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/uncheck.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/uncheck.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.uncheck(selector[, options]) method'
 
 # uncheck(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.uncheck([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser/locator/uncheck/) instead.
 

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/waitforloadstate.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/waitforloadstate.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.waitForLoadState(state[, options]) method'
 
 # waitForLoadState(state[, options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This method has **known issues**. For details, refer to [#880](https://github.com/grafana/xk6-browser/issues/880).
 
@@ -25,7 +25,7 @@ This waits for the given load state to be reached. It will immediately unblock i
 
 ### Events
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 `networkidle` is DISCOURAGED. Don't use this method for testing especially with chatty websites where the event may never fire, rely on web assertions to assess readiness instead.
 

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/waitfornavigation.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/waitfornavigation.md
@@ -19,7 +19,7 @@ Waits for the given navigation lifecycle event to occur and returns the main res
 
 ### Events
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 `networkidle` is DISCOURAGED. Don't use this method for testing especially with chatty websites where the event may never fire, rely on web assertions to assess readiness instead.
 

--- a/docs/sources/v0.51.x/javascript-api/k6-http/batch.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-http/batch.md
@@ -30,7 +30,7 @@ You can use this GET shortcut in objects&mdash;name a key and give it a URL valu
 
 You can define a request specified as an array or object with the following parameters.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 When you define requests as an array, you must use a specific order of items.
 Note the `Position` column for the correct order.

--- a/docs/sources/v0.51.x/javascript-api/k6/group.md
+++ b/docs/sources/v0.51.x/javascript-api/k6/group.md
@@ -19,7 +19,7 @@ Run code inside a group. Groups are used to organize results in a test.
 | ---- | ------------------------- |
 | any  | The return value of _fn_. |
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Avoid using `group` with async functions or asynchronous code.
 If you do, k6 might apply tags in a way that is unreliable or unintuitive.

--- a/docs/sources/v0.51.x/results-output/real-time/amazon-cloudwatch.md
+++ b/docs/sources/v0.51.x/results-output/real-time/amazon-cloudwatch.md
@@ -6,7 +6,7 @@ weight: 00
 
 # Amazon CloudWatch
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 The built-in StatsD output has been deprecated on k6 v0.47.0. You can continue to use this feature by using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd), and this guide has been updated to include instructions for how to use it.
 

--- a/docs/sources/v0.51.x/results-output/real-time/cloud.md
+++ b/docs/sources/v0.51.x/results-output/real-time/cloud.md
@@ -21,7 +21,7 @@ Fundamentally the difference is the machine that the test runs on:
 
 In all cases you'll be able to see your test results at [k6 Cloud](https://app.k6.io) or [Grafana Cloud](https://grafana.com/products/cloud/).
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Data storage and processing are primary cloud costs,
 so `k6 run --out cloud` will consume VUH or test runs from your subscription.

--- a/docs/sources/v0.51.x/results-output/real-time/datadog.md
+++ b/docs/sources/v0.51.x/results-output/real-time/datadog.md
@@ -6,7 +6,7 @@ weight: 00
 
 # Datadog
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 The built-in StatsD output has been deprecated on k6 v0.47.0. You can continue to use this feature by using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd), and this guide has been updated to include instructions for how to use it.
 

--- a/docs/sources/v0.51.x/results-output/real-time/dynatrace.md
+++ b/docs/sources/v0.51.x/results-output/real-time/dynatrace.md
@@ -39,7 +39,7 @@ To learn more about how to build custom k6 versions, check out [xk6](https://git
 
 Create a Dynatrace API token to send the data.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 The Dynatrace API Token must have the scope name "metrics.ingest" (scope type `API v2`).
 {{< /admonition >}}
 

--- a/docs/sources/v0.51.x/results-output/real-time/elasticsearch.md
+++ b/docs/sources/v0.51.x/results-output/real-time/elasticsearch.md
@@ -62,7 +62,7 @@ export K6_ELASTICSEARCH_URL=http://localhost:9200
 ./k6 run script.js -o output-elasticsearch
 ```
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 Security and self-signed certificates for non-cloud clusters are not yet supported.
 {{< /admonition >}}
 

--- a/docs/sources/v0.51.x/results-output/real-time/grafana-cloud-prometheus.md
+++ b/docs/sources/v0.51.x/results-output/real-time/grafana-cloud-prometheus.md
@@ -7,7 +7,7 @@ weight: 00
 
 # Grafana Cloud Prometheus
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This page includes instructions for running a local test that sends the test results to a Prometheus instance in Grafana Cloud.
 

--- a/docs/sources/v0.51.x/results-output/real-time/netdata.md
+++ b/docs/sources/v0.51.x/results-output/real-time/netdata.md
@@ -6,7 +6,7 @@ weight: 00
 
 # Netdata
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 The built-in StatsD output has been deprecated on k6 v0.47.0. You can continue to use this feature by using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd), and this guide has been updated to include instructions for how to use it.
 

--- a/docs/sources/v0.51.x/results-output/real-time/newrelic.md
+++ b/docs/sources/v0.51.x/results-output/real-time/newrelic.md
@@ -7,7 +7,7 @@ slug: 'new-relic'
 
 # New Relic
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 The built-in StatsD output has been deprecated on k6 v0.47.0. You can continue to use this feature by using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd), and this guide has been updated to include instructions for how to use it.
 

--- a/docs/sources/v0.51.x/results-output/real-time/statsd.md
+++ b/docs/sources/v0.51.x/results-output/real-time/statsd.md
@@ -6,7 +6,7 @@ weight: 00
 
 # StatsD
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 The built-in StatsD output has been deprecated on k6 v0.47.0. You can continue to use this feature by using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd), and this guide has been updated to include instructions for how to use it.
 

--- a/docs/sources/v0.51.x/set-up/fine-tune-os.md
+++ b/docs/sources/v0.51.x/set-up/fine-tune-os.md
@@ -252,7 +252,7 @@ All that is left after this is to reboot your Mac back to the Recovery Mode, ope
 
 In most cases these limits should be enough to run most of your simple tests locally for some time, but you can modify the files above to any values you will need in your testing.
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Please be aware that all of these limitations are put in place to protect your operating system from files and applications that are poorly written and might leak memory like in huge quantities. We would suggest not going too overboard with the values, or you might find your system slowing down to a crawl if or when it runs out of RAM.
 

--- a/docs/sources/v0.51.x/shared/blocking-aws-blockquote.md
+++ b/docs/sources/v0.51.x/shared/blocking-aws-blockquote.md
@@ -2,7 +2,7 @@
 title: jslib/aws module blocking admonition
 ---
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 In some cases, using this library&apos;s operations might impact performance and skew your test results.
 <br>

--- a/docs/sources/v0.51.x/shared/browser-module-wip.md
+++ b/docs/sources/v0.51.x/shared/browser-module-wip.md
@@ -2,7 +2,7 @@
 title: k6/experimental/browser module admonition
 ---
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This API is a work in progress. Some of the following functionalities might behave unexpectedly.
 

--- a/docs/sources/v0.51.x/shared/experimental-grpc-module.md
+++ b/docs/sources/v0.51.x/shared/experimental-grpc-module.md
@@ -2,7 +2,7 @@
 title: Experimental grpc module admonition
 ---
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Starting on k6 `v0.49`, the experimental module `k6/experimental/grpc` has been graduated, and its functionality is now available in the [`k6/net/grpc` module](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-net-grpc/). The `k6/experimental/grpc` is deprecated and will be removed in `v0.51.0`.
 

--- a/docs/sources/v0.51.x/shared/experimental-module.md
+++ b/docs/sources/v0.51.x/shared/experimental-module.md
@@ -2,7 +2,7 @@
 title: Experimental module admonition
 ---
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This is an experimental module.
 <br>

--- a/docs/sources/v0.51.x/shared/experimental-timers-module.md
+++ b/docs/sources/v0.51.x/shared/experimental-timers-module.md
@@ -2,7 +2,7 @@
 title: Experimental timers module admonition
 ---
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Starting on k6 `v0.50`, the experimental module `k6/experimental/timers` has been graduated, and its functionality is now available in the [`k6/timers` module](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-timers/). The `k6/experimental/timers` is deprecated and will be removed in `v0.52.0`.
 

--- a/docs/sources/v0.51.x/testing-guides/running-distributed-tests.md
+++ b/docs/sources/v0.51.x/testing-guides/running-distributed-tests.md
@@ -165,7 +165,7 @@ Let's create our ConfigMap as `my-test` with the content of our `test.js` script
 kubectl create configmap my-test --from-file test.js
 ```
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Limitations exist on how large your test script can be when deployed within a `ConfigMap`.
 Kubernetes imposes a size limit of 1,048,576 bytes (1 MiB) for the data, therefore if your test scripts exceed this limit, you'll need to mount a `PersistentVolume`.
@@ -189,7 +189,7 @@ Organizing your test scripts was part of the discussion during [episode #76](htt
 
 {{< /admonition >}}
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 When using a `PersistentVolume`, the operator will expect all test scripts to be contained within a directory named `/test/`.
 
@@ -244,7 +244,7 @@ The test script content was added to the map using the filename as the key-value
 The amount of `parallelism` is up to you; how many pods do you want to split the test amongst?
 The operator will split the workload between the pods using [execution segments](https://grafana.com/docs/k6/<K6_VERSION>/misc/glossary#execution-segment).
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 It is important that the `ConfigMap` and `CustomResource` are created in the same [Namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/).
 
@@ -275,7 +275,7 @@ spec:
 
 {{< /code >}}
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 It is important that the `PersistentVolumeClaim` and `CustomResource` are created in the same [Namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/).
 

--- a/docs/sources/v0.51.x/using-k6-browser/metrics.md
+++ b/docs/sources/v0.51.x/using-k6-browser/metrics.md
@@ -69,7 +69,7 @@ To set thresholds for your browser metrics:
 
 As the following example shows, you can also pass in different URLs if you're going to set a threshold for other pages, especially when your script contains page navigations.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Currently, you can only use URLs to specify thresholds for different pages. If you use [Groups](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/tags-and-groups/#groups), the metrics are not correctly grouped as described in [#721](https://github.com/grafana/xk6-browser/issues/721).
 

--- a/docs/sources/v0.51.x/using-k6/k6-options/reference.md
+++ b/docs/sources/v0.51.x/using-k6/k6-options/reference.md
@@ -960,7 +960,7 @@ $ k6 run --out influxdb=http://localhost:8086/k6 script.js
 
 The maximum number of requests to make per second, in total across all VUs. Available in `k6 run` and `k6 cloud` commands.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 **This option is discouraged.**
 <br>
@@ -1382,7 +1382,7 @@ export const options = {
 A list of cipher suites allowed to be used by in SSL/TLS interactions with a server.
 For a full listing of available ciphers go [here](https://golang.org/pkg/crypto/tls/#pkg-constants).
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Due to limitations in the underlying [go implementation](https://github.com/golang/go/issues/29349), changing the ciphers for TLS 1.3 is _not_ supported and will do nothing.
 

--- a/docs/sources/v0.51.x/using-k6/scenarios/concepts/arrival-rate-vu-allocation.md
+++ b/docs/sources/v0.51.x/using-k6/scenarios/concepts/arrival-rate-vu-allocation.md
@@ -15,7 +15,7 @@ In other words, before the tests runs, you must both:
 
 Read on to learn about how k6 allocates VUs in the arrival-rate executors.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 In cloud tests, **`preAllocatedVUs` count against your subscription.**
 
@@ -91,7 +91,7 @@ As dropped iterations can also indicate that the system performance is degrading
 
 ## You probably don't need `maxVUs`
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 In cloud tests, the number of `maxVUs` counts against your subscription,
 **overriding the number set by `preAllocatedVUs`**.

--- a/docs/sources/v0.51.x/using-k6/thresholds.md
+++ b/docs/sources/v0.51.x/using-k6/thresholds.md
@@ -186,7 +186,7 @@ export default function () {
 
 {{< /code >}}
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Do not specify multiple thresholds for the same metric by repeating the same object key.
 
@@ -445,7 +445,7 @@ export default function () {
 
 {{< /code >}}
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 When k6 runs in the cloud, thresholds are evaluated every 60 seconds.
 Therefore, the `abortOnFail` feature may be delayed by up to 60 seconds.

--- a/docs/sources/v0.52.x/extensions/build-k6-binary-using-docker.md
+++ b/docs/sources/v0.52.x/extensions/build-k6-binary-using-docker.md
@@ -122,7 +122,7 @@ Flags:
 
 {{< /code >}}
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 The use of `--replace` should be considered an advanced feature to be avoided unless required.
 

--- a/docs/sources/v0.52.x/extensions/create/javascript-extensions.md
+++ b/docs/sources/v0.52.x/extensions/create/javascript-extensions.md
@@ -176,7 +176,7 @@ to access the [`modules.VU`](https://pkg.go.dev/go.k6.io/k6/js/modules#VU) to in
 Additionally, there should be a root module implementation of the [`modules.Module`](https://pkg.go.dev/go.k6.io/k6/js/modules#Module)
 interface to serve as a factory of `Compare` instances for each VU.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 The significance depends on the size of your module.
 

--- a/docs/sources/v0.52.x/extensions/explanations/extension-graduation.md
+++ b/docs/sources/v0.52.x/extensions/explanations/extension-graduation.md
@@ -39,7 +39,7 @@ There should be a reasonably high degree of quality and stability at this point.
 This phase makes the feature accessible to more users, which in turn gives k6 developers more chances to receive feedback.
 The key will be to achieve a balance between usability and stability.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Not all experimental modules will progress to become a core module!
 The k6 team reserves the right to discontinue and remove any experimental module if is no longer deemed desirable.

--- a/docs/sources/v0.52.x/javascript-api/jslib/httpx/_index.md
+++ b/docs/sources/v0.52.x/javascript-api/jslib/httpx/_index.md
@@ -19,7 +19,7 @@ httpx module integrates well with the expect library.
 The source code is [on GitHub](https://github.com/k6io/k6-jslib-httpx).
 Please request features and report bugs through [GitHub issues](https://github.com/k6io/k6-jslib-httpx/issues).
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 **This library is in active development.**
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/browsercontext/pages.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/browsercontext/pages.md
@@ -5,7 +5,7 @@ description: 'Returns a list of pages inside this BrowserContext.'
 
 # pages()
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**. For details, refer to
 [#444](https://github.com/grafana/xk6-browser/issues/444).

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/browsercontext/setgeolocation.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/browsercontext/setgeolocation.md
@@ -5,7 +5,7 @@ description: "Sets the BrowserContext's geolocation."
 
 # setGeolocation(geolocation)
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**. For details, refer to
 [#435](https://github.com/grafana/xk6-browser/issues/435).

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/check.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/check.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.check method'
 
 # check([options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.check([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/check/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/click.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/click.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.click method'
 
 # click([options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.click([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/click/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/dblclick.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/dblclick.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.dblclick method'
 
 # dblclick([options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.dblclick([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/dblclick/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/dispatchevent.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/dispatchevent.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.dispatchEvent method'
 
 # dispatchEvent(type, eventInit)
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.dispatchEvent(type, eventInit[, options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/dispatchevent/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/fill.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/fill.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.fill method'
 
 # fill(value, [options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.fill(value, [options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/fill/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/focus.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/focus.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.focus method'
 
 # focus()
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.focus([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/focus/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/getattribute.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/getattribute.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.getAttribute method'
 
 # getAttribute(name)
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.getAttribute(name[, options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/getattribute/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/hover.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/hover.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.hover method'
 
 # hover([options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.hover([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/hover/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/innerhtml.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/innerhtml.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.innerHTML method'
 
 # innerHTML()
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.innerHTML([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/innerhtml/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/innertext.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/innertext.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.innerText method'
 
 # innerText()
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.innerText([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/innertext/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/ischecked.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/ischecked.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.isChecked method'
 
 # isChecked()
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.isChecked([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/ischecked/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/isdisabled.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/isdisabled.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.isDisabled method'
 
 # isDisabled()
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.isDisabled([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/isdisabled/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/iseditable.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/iseditable.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.isEditable method'
 
 # isEditable()
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.isEditable([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/iseditable/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/isenabled.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/isenabled.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.isEnabled method'
 
 # isEnabled()
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.isEnabled([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/isenabled/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/ishidden.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/ishidden.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.isHidden method'
 
 # isHidden()
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.isHidden()`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/ishidden/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/isvisible.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/isvisible.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.isVisible method'
 
 # isVisible()
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.isVisible()`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/isvisible/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/press.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/press.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.press method'
 
 # press(key, [options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.press(key[, options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/press/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/query.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/query.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.$ method'
 
 # $(selector)
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`page.locator(selector[, options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/selectoption.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/selectoption.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.selectOption method'
 
 # selectOption(values, [options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.selectOption(values[, options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/selectoption/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/tap.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/tap.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementhandle.tap method'
 
 # tap(options)
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.tap([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/tap/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/textcontent.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/textcontent.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.textContent method'
 
 # textContent()
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.textContent([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/textcontent/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/type.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/type.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.type method'
 
 # type(text, [options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.type([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/type/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/uncheck.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/uncheck.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.uncheck method'
 
 # uncheck([options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.uncheck([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/uncheck/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/waitforselector.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/waitforselector.md
@@ -5,7 +5,7 @@ description: 'Browser module: elementHandle.waitForSelector method'
 
 # waitForSelector(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use [`locator.waitFor([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/waitfor/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/frame/check.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/frame/check.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.check(selector[, options]) method'
 
 # check(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.check([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/check/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/frame/click.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/frame/click.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.click(selector[, options]) method'
 
 # click(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.click([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/click/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/frame/dblclick.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/frame/dblclick.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.dblclick(selector[, options]) method'
 
 # dblclick(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.dblclick([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/dblclick/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/frame/dispatchevent.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/frame/dispatchevent.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.dispatchEvent(selector, type, eventInit[, op
 
 # dispatchEvent(selector, type, eventInit[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.dispatchEvent(type, eventInit[, options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/dispatchevent/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/frame/dollar.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/frame/dollar.md
@@ -6,7 +6,7 @@ description: 'Browser module: frame.$(selector) method'
 
 # $(selector)
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`frame.locator(selector)`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/frame/locator/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/frame/doubledollar.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/frame/doubledollar.md
@@ -6,7 +6,7 @@ description: 'Browser module: frame.$$(selector) method'
 
 # $$(selector)
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`frame.locator(selector)`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/frame/locator/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/frame/fill.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/frame/fill.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.fill(selector, value[, options]) method'
 
 # fill(selector, value[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.fill(value[, options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/fill/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/frame/focus.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/frame/focus.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.focus(selector[, options]) method'
 
 # focus(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.focus([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/focus/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/frame/getattribute.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/frame/getattribute.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.getAttribute(selector, name[, options]) meth
 
 # getAttribute(selector, name[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.getAttribute()`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/getattribute/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/frame/goto.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/frame/goto.md
@@ -23,7 +23,7 @@ Navigating to `about:blank` or navigation to the same URL with a different hash,
 
 ### Events
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 `networkidle` is DISCOURAGED. Don't use this method for testing especially with chatty websites where the event may never fire, rely on web assertions to assess readiness instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/frame/hover.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/frame/hover.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.hover(selector[, options]) method'
 
 # hover(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.hover([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/hover/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/frame/innerhtml.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/frame/innerhtml.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.innerHTML(selector[, options]) method'
 
 # innerHTML(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.innerHTML([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/innerhtml/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/frame/innertext.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/frame/innertext.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.innerText(selector[, options]) method'
 
 # innerText(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.innerText([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/innertext/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/frame/inputvalue.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/frame/inputvalue.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.inputValue(selector[, options]) method'
 
 # inputValue(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.inputValue([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/inputvalue/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/frame/ischecked.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/frame/ischecked.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.isChecked(selector[, options]) method'
 
 # isChecked(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isChecked([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/ischecked/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/frame/isdisabled.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/frame/isdisabled.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.isDisabled(selector[, options]) method'
 
 # isDisabled(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isDisabled([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/isdisabled/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/frame/iseditable.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/frame/iseditable.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.isEditable(selector[, options]) method'
 
 # isEditable(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isEditable([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/iseditable/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/frame/isenabled.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/frame/isenabled.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.isEnabled(selector[, options]) method'
 
 # isEnabled(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isEnabled([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/isenabled/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/frame/ishidden.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/frame/ishidden.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.isHidden(selector[, options]) method'
 
 # isHidden(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isHidden([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/ishidden/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/frame/isvisible.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/frame/isvisible.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.isVisible(selector[, options]) method'
 
 # isVisible(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isVisible([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/isvisible/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/frame/press.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/frame/press.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.press(selector, key[, options]) method'
 
 # press(selector, key[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.press()`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/press/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/frame/selectoption.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/frame/selectoption.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.selectOption(selector, values[, options]) me
 
 # selectOption(selector, values[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.selectOption()`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/selectoption/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/frame/textcontent.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/frame/textcontent.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.textContent(selector[, options]) method'
 
 # textContent(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.textContent([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/textcontent/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/frame/type.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/frame/type.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.type(selector, text[, options]) method'
 
 # type(selector, text[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.type()`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/type/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/frame/uncheck.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/frame/uncheck.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.uncheck(selector[, options]) method'
 
 # uncheck(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.uncheck([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/uncheck/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/frame/waitforloadstate.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/frame/waitforloadstate.md
@@ -5,7 +5,7 @@ description: 'Browser module: frame.waitForLoadState(state[, options]) method'
 
 # waitForLoadState(state[, options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This method has **known issues**. For details, refer to [#880](https://github.com/grafana/xk6-browser/issues/880).
 
@@ -25,7 +25,7 @@ This waits for the given load state to be reached. It will immediately unblock i
 
 ### Events
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 `networkidle` is DISCOURAGED. Don't use this method for testing especially with chatty websites where the event may never fire, rely on web assertions to assess readiness instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/frame/waitfornavigation.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/frame/waitfornavigation.md
@@ -19,7 +19,7 @@ Waits for the given navigation lifecycle event to occur and returns the main res
 
 ### Events
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 `networkidle` is DISCOURAGED. Don't use this method for testing especially with chatty websites where the event may never fire, rely on web assertions to assess readiness instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/isconnected.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/isconnected.md
@@ -5,7 +5,7 @@ description: 'Browser module: isConnected method'
 
 # isConnected()
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**.
 For details, refer to [#453](https://github.com/grafana/xk6-browser/issues/453).

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/locator/check.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/locator/check.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.check method'
 
 # check([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has known issues. For details, refer to
 [#471](https://github.com/grafana/xk6-browser/issues/471) and [#475](https://github.com/grafana/xk6-browser/issues/475).

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/locator/click.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/locator/click.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.click method'
 
 # click([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This method has **known issues**. For details, refer to [#471](https://github.com/grafana/xk6-browser/issues/471) and [#474](https://github.com/grafana/xk6-browser/issues/474).
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/locator/dblclick.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/locator/dblclick.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.dblclick method'
 
 # dblclick([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has known issues. For details, refer to [#471](https://github.com/grafana/xk6-browser/issues/471).
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/locator/hover.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/locator/hover.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.hover method'
 
 # hover([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has known issues. For details, refer to
 [#471](https://github.com/grafana/xk6-browser/issues/471).

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/locator/selectoption.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/locator/selectoption.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.selectOption method'
 
 # selectOption(values, [options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**. For details, refer to
 [#470](https://github.com/grafana/xk6-browser/issues/470) and [#471](https://github.com/grafana/xk6-browser/issues/471).

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/locator/tap.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/locator/tap.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.tap method'
 
 # tap([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**. For details, refer to
 [#436](https://github.com/grafana/xk6-browser/issues/436) and [#471](https://github.com/grafana/xk6-browser/issues/471).

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/locator/uncheck.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/locator/uncheck.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.uncheck method'
 
 # uncheck([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**.
 For details, refer to [#471](https://github.com/grafana/xk6-browser/issues/471).

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/locator/waitfor.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/locator/waitfor.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.waitFor method'
 
 # waitFor([options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This feature has **known issues**. For details,
 refer to [#472](https://github.com/grafana/xk6-browser/issues/472).

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/newpage.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/newpage.md
@@ -13,7 +13,7 @@ A 1-to-1 mapping between [Browser](https://grafana.com/docs/k6/<K6_VERSION>/java
 
 {{< /admonition >}}
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Pages that have been opened ought to be closed using [`Page.close`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/close/). Pages left open could potentially distort the results of Web Vital metrics.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/page/check.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/page/check.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.check(selector[, options]) method'
 
 # check(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.check([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/check/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/page/click.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/page/click.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.click(selector[, options]) method'
 
 # click(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.click([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/click/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/page/dblclick.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/page/dblclick.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.dblclick(selector[, options]) method'
 
 # dblclick(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.dblclick([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/dblclick/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/page/dispatchevent.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/page/dispatchevent.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.dispatchEvent(selector, type, eventInit[, opt
 
 # dispatchEvent(selector, type, eventInit[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.dispatchEvent(type, eventInit[, options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/dispatchevent/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/page/dollar.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/page/dollar.md
@@ -6,7 +6,7 @@ description: 'Browser module: page.$(selector) method'
 
 # page.$(selector)
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`page.locator(selector)`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/locator/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/page/doubledollar.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/page/doubledollar.md
@@ -6,7 +6,7 @@ description: 'Browser module: page.$$(selector) method'
 
 # page.$$(selector)
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`page.locator(selector)`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/locator/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/page/fill.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/page/fill.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.fill(selector, value[, options]) method'
 
 # fill(selector, value[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.fill(value[, options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/fill/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/page/focus.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/page/focus.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.focus(selector[, options]) method'
 
 # focus(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.focus([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/focus/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/page/getattribute.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/page/getattribute.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.getAttribute(selector, name[, options]) metho
 
 # getAttribute(selector, name[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.getAttribute()`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/getattribute/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/page/goto.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/page/goto.md
@@ -23,7 +23,7 @@ Navigating to `about:blank` or navigation to the same URL with a different hash,
 
 ### Events
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 `networkidle` is DISCOURAGED. Don't use this method for testing especially with chatty websites where the event may never fire, rely on web assertions to assess readiness instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/page/hover.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/page/hover.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.hover(selector[, options]) method'
 
 # hover(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.hover([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/hover/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/page/innerhtml.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/page/innerhtml.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.innerHTML(selector[, options]) method'
 
 # innerHTML(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.innerHTML([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/innerhtml/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/page/innertext.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/page/innertext.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.innerText(selector[, options]) method'
 
 # innerText(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.innerText([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/innertext/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/page/inputvalue.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/page/inputvalue.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.inputValue(selector[, options]) method'
 
 # inputValue(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.inputValue([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/inputvalue/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/page/ischecked.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/page/ischecked.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isChecked(selector[, options]) method'
 
 # isChecked(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isChecked([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/ischecked/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/page/isclosed.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/page/isclosed.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isClosed() method'
 
 # isClosed()
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This method has **known issues**. For details, refer to [#878](https://github.com/grafana/xk6-browser/issues/878).
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/page/isdisabled.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/page/isdisabled.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isDisabled(selector[, options]) method'
 
 # isDisabled(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isDisabled([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/isdisabled/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/page/iseditable.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/page/iseditable.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isEditable(selector[, options]) method'
 
 # isEditable(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isEditable([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/iseditable/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/page/isenabled.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/page/isenabled.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isEnabled(selector[, options]) method'
 
 # isEnabled(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isEnabled([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/isenabled/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/page/ishidden.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/page/ishidden.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isHidden(selector[, options) method'
 
 # isHidden(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isHidden([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/ishidden/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/page/isvisible.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/page/isvisible.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.isVisible(selector[, options]) method'
 
 # isVisible(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.isVisible([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/isvisible/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/page/on.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/page/on.md
@@ -12,7 +12,7 @@ Registers a handler to be called whenever the specified event occurs.
 | event     | string   | `''`    | Event to attach the handler to. Currently, only the `'console'` event is supported. |
 | handler   | function | `null`  | A function to be called every time the specified event is emitted.                  |
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 When using the `page.on` method, the page has to be explicitly [closed](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/close/) for the iteration to be able to finish.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/page/press.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/page/press.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.press(selector, key[, options]) method'
 
 # press(selector, key[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.press()`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/press/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/page/reload.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/page/reload.md
@@ -19,7 +19,7 @@ This reloads the current page and returns the main resource response.
 
 ### Events
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 `networkidle` is DISCOURAGED. Don't use this method for testing especially with chatty websites where the event may never fire, rely on web assertions to assess readiness instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/page/selectoption.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/page/selectoption.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.selectOption(selector, values[, options]) met
 
 # selectOption(selector, values[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.selectOption()`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/selectoption/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/page/tap.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/page/tap.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.tap(selector[, options]) method'
 
 # tap(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.tap([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/tap/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/page/textcontent.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/page/textcontent.md
@@ -5,7 +5,7 @@ description: 'Browser module: locator.textContent(selector[, options]) method'
 
 # textContent(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.textContent([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/textcontent/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/page/type.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/page/type.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.type(selector, text[, options]) method'
 
 # type(selector, text[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.type()`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/type/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/page/uncheck.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/page/uncheck.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.uncheck(selector[, options]) method'
 
 # uncheck(selector[, options])
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Use locator-based [`locator.uncheck([options])`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/uncheck/) instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/page/waitforloadstate.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/page/waitforloadstate.md
@@ -5,7 +5,7 @@ description: 'Browser module: page.waitForLoadState(state[, options]) method'
 
 # waitForLoadState(state[, options])
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This method has **known issues**. For details, refer to [#880](https://github.com/grafana/xk6-browser/issues/880).
 
@@ -25,7 +25,7 @@ This waits for the given load state to be reached. It will immediately unblock i
 
 ### Events
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 `networkidle` is DISCOURAGED. Don't use this method for testing especially with chatty websites where the event may never fire, rely on web assertions to assess readiness instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/page/waitfornavigation.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/page/waitfornavigation.md
@@ -19,7 +19,7 @@ Waits for the given navigation lifecycle event to occur and returns the main res
 
 ### Events
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 `networkidle` is DISCOURAGED. Don't use this method for testing especially with chatty websites where the event may never fire, rely on web assertions to assess readiness instead.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/request/allheaders.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/request/allheaders.md
@@ -5,7 +5,7 @@ description: 'Browser module: Request.allHeaders method'
 
 # allHeaders()
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This method has a **known issue**. For details, refer to [#965](https://github.com/grafana/xk6-browser/issues/965).
 

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/response/allheaders.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/response/allheaders.md
@@ -5,7 +5,7 @@ description: 'Browser module: Response.allHeaders method'
 
 # allHeaders()
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This method has a **known issue**. For details, refer to [#965](https://github.com/grafana/xk6-browser/issues/965).
 

--- a/docs/sources/v0.52.x/javascript-api/k6-data/sharedarray.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-data/sharedarray.md
@@ -37,7 +37,7 @@ Supported operations on a `SharedArray` include:
 In most cases, you should be able to reduce the memory usage of an array data structure by wrapping it in a `SharedArray`.
 Once constructed, a `SharedArray` is read-only, so **you can't use a SharedArray to communicate data between VUs**.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Attempting to instantiate a `SharedArray` outside of the [init context](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-lifecycle) results in the exception `new SharedArray must be called in the init context`.
 

--- a/docs/sources/v0.52.x/javascript-api/k6-http/batch.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-http/batch.md
@@ -30,7 +30,7 @@ You can use this GET shortcut in objects&mdash;name a key and give it a URL valu
 
 You can define a request specified as an array or object with the following parameters.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 When you define requests as an array, you must use a specific order of items.
 Note the `Position` column for the correct order.

--- a/docs/sources/v0.52.x/javascript-api/k6/group.md
+++ b/docs/sources/v0.52.x/javascript-api/k6/group.md
@@ -19,7 +19,7 @@ Run code inside a group. Groups are used to organize results in a test.
 | ---- | ------------------------- |
 | any  | The return value of _fn_. |
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Avoid using `group` with async functions or asynchronous code.
 If you do, k6 might apply tags in a way that is unreliable or unintuitive.

--- a/docs/sources/v0.52.x/results-output/real-time/amazon-cloudwatch.md
+++ b/docs/sources/v0.52.x/results-output/real-time/amazon-cloudwatch.md
@@ -6,7 +6,7 @@ weight: 00
 
 # Amazon CloudWatch
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 The built-in StatsD output has been deprecated on k6 v0.47.0. You can continue to use this feature by using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd), and this guide has been updated to include instructions for how to use it.
 

--- a/docs/sources/v0.52.x/results-output/real-time/cloud.md
+++ b/docs/sources/v0.52.x/results-output/real-time/cloud.md
@@ -21,7 +21,7 @@ Fundamentally the difference is the machine that the test runs on:
 
 In all cases you'll be able to see your test results at [k6 Cloud](https://app.k6.io) or [Grafana Cloud](https://grafana.com/products/cloud/).
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Data storage and processing are primary cloud costs,
 so `k6 run --out cloud` will consume VUH or test runs from your subscription.

--- a/docs/sources/v0.52.x/results-output/real-time/datadog.md
+++ b/docs/sources/v0.52.x/results-output/real-time/datadog.md
@@ -6,7 +6,7 @@ weight: 00
 
 # Datadog
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 The built-in StatsD output has been deprecated on k6 v0.47.0. You can continue to use this feature by using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd), and this guide has been updated to include instructions for how to use it.
 

--- a/docs/sources/v0.52.x/results-output/real-time/dynatrace.md
+++ b/docs/sources/v0.52.x/results-output/real-time/dynatrace.md
@@ -39,7 +39,7 @@ To learn more about how to build custom k6 versions, check out [xk6](https://git
 
 Create a Dynatrace API token to send the data.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 The Dynatrace API Token must have the scope name "metrics.ingest" (scope type `API v2`).
 {{< /admonition >}}
 

--- a/docs/sources/v0.52.x/results-output/real-time/elasticsearch.md
+++ b/docs/sources/v0.52.x/results-output/real-time/elasticsearch.md
@@ -62,7 +62,7 @@ export K6_ELASTICSEARCH_URL=http://localhost:9200
 ./k6 run script.js -o output-elasticsearch
 ```
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 Security and self-signed certificates for non-cloud clusters are not yet supported.
 {{< /admonition >}}
 

--- a/docs/sources/v0.52.x/results-output/real-time/grafana-cloud-prometheus.md
+++ b/docs/sources/v0.52.x/results-output/real-time/grafana-cloud-prometheus.md
@@ -7,7 +7,7 @@ weight: 00
 
 # Grafana Cloud Prometheus
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This page includes instructions for running a local test that sends the test results to a Prometheus instance in Grafana Cloud.
 

--- a/docs/sources/v0.52.x/results-output/real-time/netdata.md
+++ b/docs/sources/v0.52.x/results-output/real-time/netdata.md
@@ -6,7 +6,7 @@ weight: 00
 
 # Netdata
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 The built-in StatsD output has been deprecated on k6 v0.47.0. You can continue to use this feature by using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd), and this guide has been updated to include instructions for how to use it.
 

--- a/docs/sources/v0.52.x/results-output/real-time/newrelic.md
+++ b/docs/sources/v0.52.x/results-output/real-time/newrelic.md
@@ -7,7 +7,7 @@ slug: 'new-relic'
 
 # New Relic
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 The built-in StatsD output has been deprecated on k6 v0.47.0. You can continue to use this feature by using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd), and this guide has been updated to include instructions for how to use it.
 

--- a/docs/sources/v0.52.x/results-output/real-time/statsd.md
+++ b/docs/sources/v0.52.x/results-output/real-time/statsd.md
@@ -6,7 +6,7 @@ weight: 00
 
 # StatsD
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 The built-in StatsD output has been deprecated on k6 v0.47.0. You can continue to use this feature by using the [xk6-output-statsd extension](https://github.com/LeonAdato/xk6-output-statsd), and this guide has been updated to include instructions for how to use it.
 

--- a/docs/sources/v0.52.x/set-up/fine-tune-os.md
+++ b/docs/sources/v0.52.x/set-up/fine-tune-os.md
@@ -252,7 +252,7 @@ All that is left after this is to reboot your Mac back to the Recovery Mode, ope
 
 In most cases these limits should be enough to run most of your simple tests locally for some time, but you can modify the files above to any values you will need in your testing.
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Please be aware that all of these limitations are put in place to protect your operating system from files and applications that are poorly written and might leak memory like in huge quantities. We would suggest not going too overboard with the values, or you might find your system slowing down to a crawl if or when it runs out of RAM.
 

--- a/docs/sources/v0.52.x/shared/blocking-aws-blockquote.md
+++ b/docs/sources/v0.52.x/shared/blocking-aws-blockquote.md
@@ -2,7 +2,7 @@
 title: jslib/aws module blocking admonition
 ---
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 In some cases, using this library&apos;s operations might impact performance and skew your test results.
 <br>

--- a/docs/sources/v0.52.x/shared/browser-module-wip.md
+++ b/docs/sources/v0.52.x/shared/browser-module-wip.md
@@ -2,7 +2,7 @@
 title: k6/experimental/browser module admonition
 ---
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This API is a work in progress. Some of the following functionalities might behave unexpectedly.
 

--- a/docs/sources/v0.52.x/shared/experimental-module.md
+++ b/docs/sources/v0.52.x/shared/experimental-module.md
@@ -2,7 +2,7 @@
 title: Experimental module admonition
 ---
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 This is an experimental module.
 <br>

--- a/docs/sources/v0.52.x/shared/experimental-timers-module.md
+++ b/docs/sources/v0.52.x/shared/experimental-timers-module.md
@@ -2,7 +2,7 @@
 title: Experimental timers module admonition
 ---
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 The experimental module `k6/experimental/timers` has graduated, and its functionality is now globally available and through the [`k6/timers` module](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-timers/). The `k6/experimental/timers` is deprecated and will be removed.
 

--- a/docs/sources/v0.52.x/shared/experimental-tracing-module.md
+++ b/docs/sources/v0.52.x/shared/experimental-tracing-module.md
@@ -2,7 +2,7 @@
 title: Experimental tracing module admonition
 ---
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 The experimental module `k6/experimental/tracing` is deprecated, it functionality is fully available as a jslib. Please refer to its [documentation](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/http-instrumentation-tempo/). The `k6/experimental/tracing` will be removed in the future.
 

--- a/docs/sources/v0.52.x/testing-guides/running-distributed-tests.md
+++ b/docs/sources/v0.52.x/testing-guides/running-distributed-tests.md
@@ -165,7 +165,7 @@ Let's create our ConfigMap as `my-test` with the content of our `test.js` script
 kubectl create configmap my-test --from-file test.js
 ```
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Limitations exist on how large your test script can be when deployed within a `ConfigMap`.
 Kubernetes imposes a size limit of 1,048,576 bytes (1 MiB) for the data, therefore if your test scripts exceed this limit, you'll need to mount a `PersistentVolume`.
@@ -189,7 +189,7 @@ Organizing your test scripts was part of the discussion during [episode #76](htt
 
 {{< /admonition >}}
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 When using a `PersistentVolume`, the operator will expect all test scripts to be contained within a directory named `/test/`.
 
@@ -244,7 +244,7 @@ The test script content was added to the map using the filename as the key-value
 The amount of `parallelism` is up to you; how many pods do you want to split the test amongst?
 The operator will split the workload between the pods using [execution segments](https://grafana.com/docs/k6/<K6_VERSION>/misc/glossary#execution-segment).
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 It is important that the `ConfigMap` and `CustomResource` are created in the same [Namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/).
 
@@ -275,7 +275,7 @@ spec:
 
 {{< /code >}}
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 It is important that the `PersistentVolumeClaim` and `CustomResource` are created in the same [Namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/).
 

--- a/docs/sources/v0.52.x/using-k6-browser/metrics.md
+++ b/docs/sources/v0.52.x/using-k6-browser/metrics.md
@@ -80,7 +80,7 @@ To set thresholds for your browser metrics:
 
 As the following example shows, you can also pass in different URLs if you're going to set a threshold for other pages, especially when your script contains page navigations.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Currently, you can only use URLs to specify thresholds for different pages. If you use [Groups](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/tags-and-groups/#groups), the metrics are not correctly grouped as described in [#721](https://github.com/grafana/xk6-browser/issues/721).
 

--- a/docs/sources/v0.52.x/using-k6/k6-options/reference.md
+++ b/docs/sources/v0.52.x/using-k6/k6-options/reference.md
@@ -960,7 +960,7 @@ $ k6 run --out influxdb=http://localhost:8086/k6 script.js
 
 The maximum number of requests to make per second, in total across all VUs. Available in `k6 run` and `k6 cloud` commands.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 **This option is discouraged.**
 <br>
@@ -1382,7 +1382,7 @@ export const options = {
 A list of cipher suites allowed to be used by in SSL/TLS interactions with a server.
 For a full listing of available ciphers go [here](https://golang.org/pkg/crypto/tls/#pkg-constants).
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Due to limitations in the underlying [go implementation](https://github.com/golang/go/issues/29349), changing the ciphers for TLS 1.3 is _not_ supported and will do nothing.
 

--- a/docs/sources/v0.52.x/using-k6/scenarios/concepts/arrival-rate-vu-allocation.md
+++ b/docs/sources/v0.52.x/using-k6/scenarios/concepts/arrival-rate-vu-allocation.md
@@ -15,7 +15,7 @@ In other words, before the tests runs, you must both:
 
 Read on to learn about how k6 allocates VUs in the arrival-rate executors.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 In cloud tests, **`preAllocatedVUs` count against your subscription.**
 
@@ -91,7 +91,7 @@ As dropped iterations can also indicate that the system performance is degrading
 
 ## You probably don't need `maxVUs`
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 In cloud tests, the number of `maxVUs` counts against your subscription,
 **overriding the number set by `preAllocatedVUs`**.

--- a/docs/sources/v0.52.x/using-k6/thresholds.md
+++ b/docs/sources/v0.52.x/using-k6/thresholds.md
@@ -186,7 +186,7 @@ export default function () {
 
 {{< /code >}}
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 Do not specify multiple thresholds for the same metric by repeating the same object key.
 
@@ -445,7 +445,7 @@ export default function () {
 
 {{< /code >}}
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 When k6 runs in the cloud, thresholds are evaluated every 60 seconds.
 Therefore, the `abortOnFail` feature may be delayed by up to 60 seconds.


### PR DESCRIPTION
## What?

Related to https://github.com/grafana/k6-docs/pull/1680. I forgot to replace the `caution` and `warning` ones. 😓 

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [x] I have made my changes in the `docs/sources/next` folder of the documentation.
- [x] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.
- [x] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->
<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->