### PR TITLE
Replace the 'k6 cloud' references with the new subcommands

### DIFF
--- a/docs/sources/next/get-started/running-k6.md
+++ b/docs/sources/next/get-started/running-k6.md
@@ -14,7 +14,7 @@ Follow along to learn how to:
 4. Ramp the number of requests up and down as the test runs.
 
 With these example snippets, you'll run the test with your machine's resources.
-But, if you have a k6 Cloud account, you can also use the `k6 cloud` command to outsource the test to k6 servers.
+But, if you have a k6 Cloud account, you can also use the `k6 cloud run` command to outsource the test to k6 servers.
 
 ## Before you begin
 
@@ -235,7 +235,7 @@ k6 supports three execution modes to run a k6 test: local, distributed, and clou
 - **Cloud**: the test runs on [Grafana Cloud k6](https://grafana.com/docs/grafana-cloud/testing/k6/get-started/run-cloud-tests-from-the-cli/).
 
   ```bash
-  k6 cloud script.js
+  k6 cloud run script.js
   ```
 
   Additionally, cloud-based solutions can run cloud tests on your [own cloud infrastructure](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/private-load-zone-v2/), and accept the test results from a [local](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/cloud) or [distributed test](https://github.com/grafana/k6-operator#k6-cloud-output).

--- a/docs/sources/next/misc/archive.md
+++ b/docs/sources/next/misc/archive.md
@@ -79,7 +79,7 @@ as needed.
 
 k6 offers a commercial service for running large scale and geographically
 distributed load tests on managed cloud infrastructure. Cloud executed tests are triggered
-from the k6 command-line via the `k6 cloud script.js` command (similar to `k6 run`) which will
+from the k6 command-line via the `k6 cloud run script.js` command (similar to `k6 run`) which will
 trigger an implicit creation of a k6 archive that is uploaded and distributed to k6 cloud
 load generators for execution.
 

--- a/docs/sources/next/results-output/real-time/cloud.md
+++ b/docs/sources/next/results-output/real-time/cloud.md
@@ -12,12 +12,12 @@ When streaming the results to the cloud, the machine - where you execute the k6 
 
 ## Streaming results vs. running on cloud servers
 
-Don't confuse `k6 run --out cloud script.js` (what this page is about) with `k6 cloud script.js`.
+Don't confuse `k6 run --out cloud script.js` (what this page is about) with `k6 cloud run script.js`.
 
 Fundamentally the difference is the machine that the test runs on:
 
 - `k6 run --out cloud` runs k6 locally and streams the results to the cloud.
-- `k6 cloud`, on the other hand, uploads your script to the cloud solution and runs the test on the cloud infrastructure. In this case you'll only see status updates in your CLI.
+- `k6 cloud run`, on the other hand, uploads your script to the cloud solution and runs the test on the cloud infrastructure. In this case you'll only see status updates in your CLI.
 
 In all cases you'll be able to see your test results at [k6 Cloud](https://app.k6.io) or [Grafana Cloud](https://grafana.com/products/cloud/).
 
@@ -34,14 +34,14 @@ so `k6 run --out cloud` will consume VUH or test runs from your subscription.
 
    Assuming you have installed k6, the first step is to log in to the cloud service.
 
-   With the `k6 login cloud` command, you can set up your API token on the k6 machine to authenticate against the cloud service.
+   With the `k6 cloud login` command, you can set up your API token on the k6 machine to authenticate against the cloud service.
 
    Copy your token from [k6 Cloud](https://app.k6.io/account/api-token) or [Grafana Cloud k6](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/tokens-and-cli-authentication/) and pass it as:
 
    {{< code >}}
 
    ```bash
-   $ k6 login cloud --token <YOUR_API_TOKEN>
+   $ k6 cloud login --token <YOUR_API_TOKEN>
    ```
 
    {{< /code >}}
@@ -58,7 +58,7 @@ so `k6 run --out cloud` will consume VUH or test runs from your subscription.
 
    {{< /code >}}
 
-   Alternatively, you could skip the `k6 login cloud` command when passing your API token to the `k6 run` command as:
+   Alternatively, you could skip the `k6 cloud login` command when passing your API token to the `k6 run` command as:
 
    {{< code >}}
 
@@ -131,7 +131,7 @@ Outlier data&mdash;far outside the lower and upper quartiles&mdash; is not aggre
 | `K6_CLOUD_AGGREGATION_OUTLIER_IQR_COEF_LOWER` | How many quartiles below the lower quartile are treated as non-aggregatable outliers (default `1.5`)       |
 | `K6_CLOUD_AGGREGATION_OUTLIER_IQR_COEF_UPPER` | How many quartiles above the upper quartile are treated as non-aggregatable outliers (default `1.3`)       |
 
-> When running a test entirely in the cloud with `k6 cloud`, `k6` will always
+> When running a test entirely in the cloud with `k6 cloud run`, `k6` will always
 > aggregate. For that case the aggregation settings are however set by the
 > cloud infrastructure and are not controllable from the CLI.
 

--- a/docs/sources/next/set-up/set-up-distributed-k6/troubleshooting.md
+++ b/docs/sources/next/set-up/set-up-distributed-k6/troubleshooting.md
@@ -119,10 +119,10 @@ Unlike `TestRun` deployment, when a `PrivateLoadZone` is first created, there ar
 
 ### Running tests in `PrivateLoadZone`
 
-Each time a user runs a test in a PLZ, for example with `k6 cloud script.js`, there is a corresponding `TestRun` being deployed by the k6 Operator. This `TestRun` will be deployed in the same namespace as its `PrivateLoadZone`. If the test is misbehaving, for example, it errors out, or doesn't produce the expected result, then you can check:
+Each time a user runs a test in a PLZ, for example with `k6 cloud run script.js`, there is a corresponding `TestRun` being deployed by the k6 Operator. This `TestRun` will be deployed in the same namespace as its `PrivateLoadZone`. If the test is misbehaving, for example, it errors out, or doesn't produce the expected result, then you can check:
 
 1. If there are any messages in the GCk6 UI.
-2. If there are any messages in the output of the `k6 cloud` command.
+2. If there are any messages in the output of the `k6 cloud run` command.
 3. The resources and their logs, the same way as with a [standalone `TestRun` deployment](#testrun-deployment)
 
 ## Common scenarios

--- a/docs/sources/next/using-k6/environment-variables.md
+++ b/docs/sources/next/using-k6/environment-variables.md
@@ -65,7 +65,7 @@ PS C:\k6> $env:MY_HOSTNAME="test.k6.io"; k6 run script.js
 
 #### ⚠️ Warning
 
-By default, passing system environment variables doesn't work for `k6 archive`, `k6 cloud`, and `k6 inspect`.
+By default, passing system environment variables doesn't work for `k6 archive`, `k6 cloud run`, and `k6 inspect`.
 This is a security measure to avoid the risk of uploading sensitive data to k6 Cloud.
 To override this mode, specify [--include-system-env-vars](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#include-system-env-vars).
 

--- a/docs/sources/next/using-k6/k6-options/reference.md
+++ b/docs/sources/next/using-k6/k6-options/reference.md
@@ -80,7 +80,7 @@ Each option has its own detailed reference in a separate section.
 The following sections detail all available options that you can be specify within a script.
 
 It also documents the equivalent command line flag, environment variables or option when executing `k6 run ...`
-and `k6 cloud ...`, which you can use to override options specified in the code.
+and `k6 cloud run ...`, which you can use to override options specified in the code.
 
 ## Address
 
@@ -106,7 +106,7 @@ The maximum number of simultaneous/parallel connections in total that an
 [`http.batch()`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-http/batch) call in a VU can make. If you have a
 `batch()` call that you've given 20 URLs to and `--batch` is set to 15, then the VU will make 15
 requests right away in parallel and queue the rest, executing them as soon as a previous request is
-done and a slot opens. Available in both the `k6 run` and the `k6 cloud` commands
+done and a slot opens. Available in both the `k6 run` and the `k6 cloud run` commands
 
 | Env        | CLI       | Code / Config file | Default |
 | ---------- | --------- | ------------------ | ------- |
@@ -128,7 +128,7 @@ The maximum number of simultaneous/parallel connections for the same hostname th
 [`http.batch()`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-http/batch) call in a VU can make. If you have a
 `batch()` call that you've given 20 URLs to the _same_ hostname and `--batch-per-host` is set to 5, then the VU will make 5
 requests right away in parallel and queue the rest, executing them as soon as a previous request is
-done and a slot opens. This will not run more request in parallel then the value of `batch`. Available in both the `k6 run` and the `k6 cloud` commands
+done and a slot opens. This will not run more request in parallel then the value of `batch`. Available in both the `k6 run` and the `k6 cloud run` commands
 
 | Env                 | CLI                | Code / Config file | Default |
 | ------------------- | ------------------ | ------------------ | ------- |
@@ -146,7 +146,7 @@ export const options = {
 
 ## Blacklist IP
 
-Blacklist IP ranges from being called. Available in `k6 run` and `k6 cloud` commands.
+Blacklist IP ranges from being called. Available in `k6 run` and `k6 cloud run` commands.
 
 | Env                | CLI              | Code / Config file | Default |
 | ------------------ | ---------------- | ------------------ | ------- |
@@ -167,7 +167,7 @@ export const options = {
 Blocks hostnames based on a list of glob match strings. The pattern matching string can have a single
 `*` at the beginning such as `*.example.com` that will match anything before that such as
 `test.example.com` and `test.test.example.com`.
-Available in `k6 run` and `k6 cloud` commands.
+Available in `k6 run` and `k6 cloud run` commands.
 
 | Env                  | CLI                 | Code / Config file | Default |
 | -------------------- | ------------------- | ------------------ | ------- |
@@ -221,7 +221,7 @@ Default config locations on different operating systems are as follows:
 | macOS      | `${HOME}/Library/Application Support/loadimpact/k6/config.json` |
 | Windows    | `%AppData%/loadimpact/k6/config.json`                           |
 
-Available in `k6 run` and `k6 cloud` commands:
+Available in `k6 run` and `k6 cloud run` commands:
 
 | Env | CLI                            | Code / Config file | Default |
 | --- | ------------------------------ | ------------------ | ------- |
@@ -236,7 +236,7 @@ specify the cloud token inside your config file to authenticate.
 
 ## Console output
 
-Redirects logs logged by `console` methods to the provided output file. Available in `k6 cloud` and `k6 run` commands.
+Redirects logs logged by `console` methods to the provided output file. Available in `k6 cloud run` and `k6 run` commands.
 
 | Env                 | CLI                | Code / Config file | Default |
 | ------------------- | ------------------ | ------------------ | ------- |
@@ -313,7 +313,7 @@ Possible `policy` values are:
 Here are some configuration examples:
 
 ```bash
-K6_DNS="ttl=5m,select=random,policy=preferIPv4" k6 cloud script.js
+K6_DNS="ttl=5m,select=random,policy=preferIPv4" k6 cloud run script.js
 ```
 
 {{< code >}}
@@ -333,7 +333,7 @@ export const options = {
 ## Duration
 
 A string specifying the total duration a test run should be run for. During this time each
-VU will execute the script in a loop. Available in `k6 run` and `k6 cloud` commands.
+VU will execute the script in a loop. Available in `k6 run` and `k6 cloud run` commands.
 
 Together with the [`vus` option](#vus), `duration` is a shortcut for a single [scenario](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/scenarios) with a [constant VUs executor](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/scenarios/executors/constant-vus).
 
@@ -383,7 +383,7 @@ Previously, the `cloud` object was known as `ext.loadimpact`.
 These options specify how to partition the test run and which segment to run.
 If defined, k6 will scale the number of VUs and iterations to be run for that
 segment, which is useful in distributed execution. Available in `k6 run` and
-`k6 cloud` commands.
+`k6 cloud run` commands.
 
 | Env | CLI                            | Code / Config file         | Default |
 | --- | ------------------------------ | -------------------------- | ------- |
@@ -403,11 +403,11 @@ This way one instance could run with `--execution-segment '0:1/4'`, another with
 ## Exit on running
 
 A boolean, specifying whether the script should exit once the test status reaches `running`.
-When running scripts with `k6 cloud` by default scripts will run until the test reaches a finalized status.
+When running scripts with `k6 cloud run` by default scripts will run until the test reaches a finalized status.
 This could be problematic in certain environments (think of Continuous Integration and Delivery pipelines),
 since you'd need to wait until the test ends up in a finalized state.
 
-With this option, you can exit early and let the script run in the background. Available in `k6 cloud` command.
+With this option, you can exit early and let the script run in the background. Available in `k6 cloud run` command.
 
 | Env                  | CLI                 | Code / Config file | Default |
 | -------------------- | ------------------- | ------------------ | ------- |
@@ -416,7 +416,7 @@ With this option, you can exit early and let the script run in the background. A
 {{< code >}}
 
 ```bash
-$ k6 cloud --exit-on-running script.js
+$ k6 cloud run --exit-on-running script.js
 ```
 
 {{< /code >}}
@@ -461,7 +461,7 @@ The preceding code will redirect requests made to `test.k6.io` to `1.2.3.4`, kee
 ## HTTP debug
 
 Log all HTTP requests and responses. Excludes body by default, to include body use
-`--http-debug=full`. Available in `k6 run` and `k6 cloud` commands.
+`--http-debug=full`. Available in `k6 run` and `k6 cloud run` commands.
 
 Read more [here](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/http-debugging).
 
@@ -481,7 +481,7 @@ export const options = {
 
 ## Include system env vars
 
-Pass the real system [environment variables](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/environment-variables) to the runtime. Available in `k6 run` and `k6 cloud` commands.
+Pass the real system [environment variables](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/environment-variables) to the runtime. Available in `k6 run` and `k6 cloud run` commands.
 
 | Env | CLI                         | Code / Config file | Default                                                                                              |
 | --- | --------------------------- | ------------------ | ---------------------------------------------------------------------------------------------------- |
@@ -500,7 +500,7 @@ $ k6 run --include-system-env-vars ~/script.js
 A boolean, true or false. When this option is enabled (set to true), all of the verifications that
 would otherwise be done to establish trust in a server provided TLS certificate will be ignored.
 This only applies to connections created from code, such as HTTP requests.
-Available in `k6 run` and `k6 cloud` commands
+Available in `k6 run` and `k6 cloud run` commands
 
 | Env                           | CLI                          | Code / Config file      | Default |
 | ----------------------------- | ---------------------------- | ----------------------- | ------- |
@@ -518,7 +518,7 @@ export const options = {
 
 ## Iterations
 
-An integer value, specifying the total number of iterations of the `default` function to execute in the test run, as opposed to specifying a duration of time during which the script would run in a loop. Available both in the `k6 run` and `k6 cloud` commands.
+An integer value, specifying the total number of iterations of the `default` function to execute in the test run, as opposed to specifying a duration of time during which the script would run in a loop. Available both in the `k6 run` and `k6 cloud run` commands.
 
 Together with the [`vus` option](#vus), `iterations` is a shortcut for a single [scenario](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/scenarios) with a [shared iterations executor](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/scenarios/executors/shared-iterations).
 
@@ -690,7 +690,7 @@ $ k6 run --log-format raw test.js
 ## Max redirects
 
 The maximum number of HTTP redirects that k6 will follow before giving up on a request and
-erroring out. Available in both the `k6 run` and the `k6 cloud` commands.
+erroring out. Available in both the `k6 run` and the `k6 cloud run` commands.
 
 | Env                | CLI               | Code / Config file | Default |
 | ------------------ | ----------------- | ------------------ | ------- |
@@ -728,7 +728,7 @@ export const options = {
 
 ## No color
 
-A boolean specifying whether colored output is disabled. Available in `k6 run` and `k6 cloud` commands.
+A boolean specifying whether colored output is disabled. Available in `k6 run` and `k6 cloud run` commands.
 
 | Env | CLI          | Code / Config file | Default |
 | --- | ------------ | ------------------ | ------- |
@@ -745,7 +745,7 @@ $ k6 run --no-color script.js
 ## No connection reuse
 
 A boolean, true or false, specifying whether k6 should disable keep-alive connections.
-Available in `k6 run` and `k6 cloud` commands.
+Available in `k6 run` and `k6 cloud run` commands.
 
 | Env                      | CLI                     | Code / Config file  | Default |
 | ------------------------ | ----------------------- | ------------------- | ------- |
@@ -801,7 +801,7 @@ $ k6 run --no-summary ~/script.js
 
 ## No setup
 
-A boolean specifying whether `setup()` function should be run. Available in `k6 cloud` and `k6 run` commands.
+A boolean specifying whether `setup()` function should be run. Available in `k6 cloud run` and `k6 run` commands.
 
 | Env           | CLI          | Code / Config file | Default |
 | ------------- | ------------ | ------------------ | ------- |
@@ -817,7 +817,7 @@ $ k6 run --no-setup script.js
 
 ## No teardown
 
-A boolean specifying whether `teardown()` function should be run. Available in `k6 cloud` and `k6 run` commands.
+A boolean specifying whether `teardown()` function should be run. Available in `k6 cloud run` and `k6 run` commands.
 
 | Env              | CLI             | Code / Config file | Default |
 | ---------------- | --------------- | ------------------ | ------- |
@@ -871,7 +871,7 @@ $ k6 run --no-usage-report ~/script.js
 ## No VU connection reuse
 
 A boolean, true or false, specifying whether k6 should reuse TCP connections between iterations
-of a VU. Available in `k6 run` and `k6 cloud` commands.
+of a VU. Available in `k6 run` and `k6 cloud run` commands.
 
 | Env                         | CLI                        | Code / Config file    | Default |
 | --------------------------- | -------------------------- | --------------------- | ------- |
@@ -890,7 +890,7 @@ export const options = {
 ## Paused
 
 A boolean, true or false, specifying whether the test should start in a paused state. To resume
-a paused state you'd use the `k6 resume` command. Available in `k6 run` and `k6 cloud` commands.
+a paused state you'd use the `k6 resume` command. Available in `k6 run` and `k6 cloud run` commands.
 
 | Env         | CLI              | Code / Config file | Default |
 | ----------- | ---------------- | ------------------ | ------- |
@@ -924,7 +924,7 @@ $ k6 run --profiling-enabled script.js
 
 ## Quiet
 
-A boolean, true or false, that disables the progress update bar on the console output. Available in `k6 run` and `k6 cloud` commands.
+A boolean, true or false, that disables the progress update bar on the console output. Available in `k6 run` and `k6 cloud run` commands.
 
 | Env | CLI             | Code / Config file | Default |
 | --- | --------------- | ------------------ | ------- |
@@ -958,7 +958,7 @@ $ k6 run --out influxdb=http://localhost:8086/k6 script.js
 
 ## RPS
 
-The maximum number of requests to make per second, in total across all VUs. Available in `k6 run` and `k6 cloud` commands.
+The maximum number of requests to make per second, in total across all VUs. Available in `k6 run` and `k6 cloud run` commands.
 
 {{% admonition type="caution" %}}
 
@@ -1002,7 +1002,7 @@ environment variables, tags, and more.
 
 See the [Scenarios](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/scenarios) article for details and more examples.
 
-Available in `k6 run` and `k6 cloud` commands.
+Available in `k6 run` and `k6 cloud run` commands.
 
 | Env | CLI | Code / Config file | Default |
 | --- | --- | ------------------ | ------- |
@@ -1051,7 +1051,7 @@ export const options = {
 
 ## Show logs
 
-A boolean specifying whether the cloud logs are printed out to the terminal. Available in `k6 cloud` command.
+A boolean specifying whether the cloud logs are printed out to the terminal. Available in `k6 cloud run` command.
 
 | Env | CLI           | Code / Config file | Default |
 | --- | ------------- | ------------------ | ------- |
@@ -1060,7 +1060,7 @@ A boolean specifying whether the cloud logs are printed out to the terminal. Ava
 {{< code >}}
 
 ```bash
-$ k6 cloud --show-logs=false script.js
+$ k6 cloud run --show-logs=false script.js
 ```
 
 {{< /code >}}
@@ -1068,7 +1068,7 @@ $ k6 cloud --show-logs=false script.js
 ## Stages
 
 A list of VU `{ target: ..., duration: ... }` objects that specify the target number of VUs to
-ramp up or down to for a specific period. Available in `k6 run` and `k6 cloud` commands.
+ramp up or down to for a specific period. Available in `k6 run` and `k6 cloud run` commands.
 
 It is a shortcut option for a single [scenario](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/scenarios) with a [ramping VUs executor](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/scenarios/executors/ramping-vus). If used together with the [VUs](#vus) option, the `vus` value is used as the `startVUs` option of the executor.
 
@@ -1489,7 +1489,7 @@ This would be useful if you would like to update a given test and run it later. 
 {{< code >}}
 
 ```bash
-$ k6 cloud --upload-only script.js
+$ k6 cloud run --upload-only script.js
 ```
 
 {{< /code >}}


### PR DESCRIPTION
<!-- 
Please make sure you have read the contribution guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md as well as the
the code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md before opening a PR.
-->

## What?

It replaces occurrences of `k6 cloud` (_only the command, not the service name_) with `k6 cloud run`, and `k6 login cloud` with `k6 cloud login`, which are the new subcommands that are (will be) part of [v0.53 release](https://github.com/grafana/k6/pull/3872).

## Checklist

<!-- Please fill in this template: -->
- [X] I have used a meaningful title for the PR.
- [X] I have described the changes I've made in the "What?" section above.
- [X] I have performed a self-review of my changes.
- [X] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [ ] I have made my changes in the `docs/sources/next` folder of the documentation.
- [ ] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.
- [ ] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->

<!-- 2. If updating the documentation for the next release of k6: -->
- [ ] I have made my changes in the `docs/sources/next` folder of the documentation.

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->
<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->