### PR TITLE
Add import.meta.resolve documentation

### DIFF
--- a/docs/sources/.eslintrc.js
+++ b/docs/sources/.eslintrc.js
@@ -1,12 +1,13 @@
 module.exports = {
   root: true,
   env: {
-    es2017: true,
+    es2022: true,
     commonjs: true,
   },
   parserOptions: {
-    ecmaVersion: '2017',
+    ecmaVersion: '2024',
     sourceType: 'module',
+    requireConfigFile: false, // <== ADD THIS
   },
   extends: ['plugin:mdx/recommended', 'plugin:prettier/recommended'],
   plugins: ['markdown'],

--- a/docs/sources/next/javascript-api/_index.md
+++ b/docs/sources/next/javascript-api/_index.md
@@ -11,6 +11,14 @@ The list of k6 modules natively supported in your k6 scripts.
 
 {{< docs/shared source="k6" lookup="javascript-api/init-context.md" version="<K6_VERSION>" >}}
 
+## Import.meta
+
+`import.meta` is only available in ECMAScript modules, but not CommonJS ones.
+
+| Function                                                                                           | Description                                               |
+| -------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| [import.meta.resolve](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/import.meta/resolve) | resolve path to URL the same way that an ESM import would |
+
 ## k6
 
 {{< docs/shared source="k6" lookup="javascript-api/k6.md" version="<K6_VERSION>" >}}

--- a/docs/sources/next/javascript-api/_index.md
+++ b/docs/sources/next/javascript-api/_index.md
@@ -11,7 +11,7 @@ The list of k6 modules natively supported in your k6 scripts.
 
 {{< docs/shared source="k6" lookup="javascript-api/init-context.md" version="<K6_VERSION>" >}}
 
-## Import.meta
+## import.meta
 
 `import.meta` is only available in ECMAScript modules, but not CommonJS ones.
 

--- a/docs/sources/next/javascript-api/_index.md
+++ b/docs/sources/next/javascript-api/_index.md
@@ -17,7 +17,7 @@ The list of k6 modules natively supported in your k6 scripts.
 
 | Function                                                                                           | Description                                               |
 | -------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
-| [import.meta.resolve](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/import.meta/resolve) | resolve path to URL the same way that an ESM import would |
+| [import.meta.resolve](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/import.meta/resolve) | Resolve the path to URL in the same way that an ESM import does. |
 
 ## k6
 

--- a/docs/sources/next/javascript-api/_index.md
+++ b/docs/sources/next/javascript-api/_index.md
@@ -13,11 +13,7 @@ The list of k6 modules natively supported in your k6 scripts.
 
 ## import.meta
 
-`import.meta` is only available in ECMAScript modules, but not CommonJS ones.
-
-| Function                                                                                           | Description                                               |
-| -------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
-| [import.meta.resolve](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/import.meta/resolve) | Resolve the path to URL in the same way that an ESM import does. |
+{{< docs/shared source="k6" lookup="javascript-api/import.meta.md" version="<K6_VERSION>" >}}
 
 ## k6
 

--- a/docs/sources/next/javascript-api/import.meta/_index.md
+++ b/docs/sources/next/javascript-api/import.meta/_index.md
@@ -1,6 +1,6 @@
 ---
 title: 'import.meta'
-description: 'the ECMAScript import meta property'
+description: 'Details about the ECMAScript import meta property.'
 weight: 20
 ---
 

--- a/docs/sources/next/javascript-api/import.meta/_index.md
+++ b/docs/sources/next/javascript-api/import.meta/_index.md
@@ -4,8 +4,6 @@ description: 'Details about the ECMAScript import meta property.'
 weight: 20
 ---
 
-# import.meta
+## import.meta
 
-| Function                                                                                           | Description                                               |
-| -------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
-| [import.meta.resolve](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/import.meta/resolve) | resolve path to URL the same way that an ESM import would |
+{{< docs/shared source="k6" lookup="javascript-api/import.meta.md" version="<K6_VERSION>" >}}

--- a/docs/sources/next/javascript-api/import.meta/_index.md
+++ b/docs/sources/next/javascript-api/import.meta/_index.md
@@ -1,0 +1,11 @@
+---
+title: 'import.meta'
+description: 'the ECMAScript import meta property'
+weight: 20
+---
+
+# import.meta
+
+| Function                                                                                           | Description                                               |
+| -------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| [import.meta.resolve](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/import.meta/resolve) | resolve path to URL the same way that an ESM import would |

--- a/docs/sources/next/javascript-api/import.meta/resolve.md
+++ b/docs/sources/next/javascript-api/import.meta/resolve.md
@@ -1,21 +1,21 @@
 ---
 title: 'resolve( path )'
-description: 'Resolve a path to a URL strign the same way an import would.'
+description: 'Resolve the path to a URL string in the same way an import statement does.'
 ---
 
 # resolve(path)
 
-Resolve a path to a URL string the same way an import would.
+Resolve a path to a URL string in the same way an import statement does.'
 
-This is useful if you want to provide a path relative to the current module to a function that will use `open` or some other function taking URLs.
+This is useful if you want to provide a path relative to the current module to a function that uses `open` or another function that takes URLs.
 
-This is particularly useful as some functions within k6 are not relative to the same origin, which might lead to seemingly similar paths having very different file being loaded from the filesystem.
+This is particularly useful as some functions within k6 are not relative to the same origin, which might lead to seemingly similar paths having different files being loaded from the filesystem.
 
 For ongoing discussions please see this [issue](https://github.com/grafana/k6/issues/3857).
 
 | Parameter | Type   | Description                |
 | --------- | ------ | -------------------------- |
-| path      | string | a path to a potential file |
+| path      | string | A file path. |
 
 ### Example
 
@@ -25,7 +25,7 @@ For ongoing discussions please see this [issue](https://github.com/grafana/k6/is
 const pdfFile = open(import.meta.resolve('./path/to/file.pdf'), 'b');
 
 export default function () {
-  // this is here to not have an exception if ran in k6
+  // this is here to avoid an exception if run using k6
 }
 ```
 

--- a/docs/sources/next/javascript-api/import.meta/resolve.md
+++ b/docs/sources/next/javascript-api/import.meta/resolve.md
@@ -3,7 +3,7 @@ title: 'resolve( path )'
 description: 'Resolve the path to a URL string in the same way an import statement does.'
 ---
 
-# resolve(path)
+# resolve( path )
 
 Resolve a path to a URL string in the same way an import statement does.'
 
@@ -11,7 +11,7 @@ This is useful if you want to provide a path relative to the current module to a
 
 This is particularly useful as some functions within k6 are not relative to the same origin, which might lead to seemingly similar paths having different files being loaded from the filesystem.
 
-For ongoing discussions please see this [issue](https://github.com/grafana/k6/issues/3857).
+For more details, refer to this [issue](https://github.com/grafana/k6/issues/3857).
 
 | Parameter | Type   | Description                |
 | --------- | ------ | -------------------------- |

--- a/docs/sources/next/javascript-api/import.meta/resolve.md
+++ b/docs/sources/next/javascript-api/import.meta/resolve.md
@@ -1,0 +1,32 @@
+---
+title: 'resolve( path )'
+description: 'Resolve a path to a URL strign the same way an import would.'
+---
+
+# resolve(path)
+
+Resolve a path to a URL string the same way an import would.
+
+This is useful if you want to provide a path relative to the current module to a function that will use `open` or some other function taking URLs.
+
+This is particularly useful as some functions within k6 are not relative to the same origin, which might lead to seemingly similar paths having very different file being loaded from the filesystem.
+
+For ongoing discussions please see this [issue](https://github.com/grafana/k6/issues/3857).
+
+| Parameter | Type   | Description                |
+| --------- | ------ | -------------------------- |
+| path      | string | a path to a potential file |
+
+### Example
+
+{{< code >}}
+
+```javascript
+const pdfFile = open(import.meta.resolve('./path/to/file.pdf'), 'b');
+
+export default function () {
+  // this is here to not have an exception if ran in k6
+}
+```
+
+{{< /code >}}

--- a/docs/sources/next/shared/javascript-api/import.meta.md
+++ b/docs/sources/next/shared/javascript-api/import.meta.md
@@ -1,0 +1,9 @@
+---
+title: 'javascript-api/import.meta'
+---
+
+`import.meta` is only available in ECMAScript modules, but not CommonJS ones.
+
+| Function                                                                                           | Description                                               |
+| -------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| [import.meta.resolve](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/import.meta/resolve) | resolve path to URL the same way that an ESM import would |


### PR DESCRIPTION
## What?

Add documentation for https://github.com/grafana/k6/pull/3873 and fix eslint to support it.
## Checklist

<!-- Please fill in this template: -->
- [ ] I have used a meaningful title for the PR.
- [ ] I have described the changes I've made in the "What?" section above.
- [ ] I have performed a self-review of my changes.
- [ ] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [ ] I have made my changes in the `docs/sources/next` folder of the documentation.
- [ ] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.
- [ ] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->

<!-- 2. If updating the documentation for the next release of k6: -->
- [ ] I have made my changes in the `docs/sources/next` folder of the documentation.

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->
<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->