### PR TITLE
xk6-banner extension registration

### DIFF
--- a/docs/sources/next/extensions/explore.md
+++ b/docs/sources/next/extensions/explore.md
@@ -39,6 +39,10 @@ Use the table to explore the many extensions. Questions? Feel free to join the d
         <h4>xk6-aws</h4>
         <p>Alternative to the official AWS JS Lib that relies on the AWS SDK for Go to interact with Amazon Web Services</p>
     </a>
+    <a href="https://gitlab.com/szkiba/xk6-banner" target="_blank" class="nav-cards__item nav-cards__item--guide">
+        <h4>xk6-banner</h4>
+        <p>Print ASCII art banner from k6 test</p>
+    </a>
     <a href="https://github.com/anycable/xk6-cable" target="_blank" class="nav-cards__item nav-cards__item--guide">
         <h4>xk6-cable</h4>
         <p>Test Action Cable and AnyCable functionality</p>

--- a/src/data/doc-extensions/extensions.json
+++ b/src/data/doc-extensions/extensions.json
@@ -1081,6 +1081,21 @@
       "categories": ["Protocol"],
       "tiers": ["Community"],
       "cloudEnabled": false
+    },
+    {
+      "name": "xk6-banner",
+      "description": "Print ASCII art banner from k6 test",
+      "url": "https://gitlab.com/szkiba/xk6-banner",
+      "logo": "",
+      "author": {
+        "name": "Ivan Szkiba",
+        "url": "https://gitlab.com/szkiba"
+      },
+      "stars": "0",
+      "type": ["JavaScript"],
+      "categories": ["Misc"],
+      "tiers": ["Community"],
+      "cloudEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## What?

This PR contains the registration of the xk6-banner extension.
The [xk6-banner](https://gitlab.com/szkiba/xk6-banner) extension is interesting not because of its function, but because it is the first extension hosted on GitLab. As a result, it is suitable for testing extension-related tooling in the case of extensions hosted on GitLab.

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [ ] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 2. If updating the documentation for the next release of k6: -->
- [x] I have made my changes in the `docs/sources/next` folder of the documentation.

