### PR TITLE
Update running-k6.md - removed extra "run" arg in cloud k6 bash command

### DIFF
--- a/docs/sources/v0.53.x/get-started/running-k6.md
+++ b/docs/sources/v0.53.x/get-started/running-k6.md
@@ -235,7 +235,7 @@ k6 supports three execution modes to run a k6 test: local, distributed, and clou
 - **Cloud**: the test runs on [Grafana Cloud k6](https://grafana.com/docs/grafana-cloud/testing/k6/get-started/run-cloud-tests-from-the-cli/).
 
   ```bash
-  k6 cloud run script.js
+  k6 cloud script.js
   ```
 
   Additionally, cloud-based solutions can run cloud tests on your [own cloud infrastructure](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/private-load-zone-v2/), and accept the test results from a [local](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/cloud) or [distributed test](https://github.com/grafana/k6-operator#k6-cloud-output).


### PR DESCRIPTION
Cloud: the test runs on Grafana Cloud k6 command is incorrect.

## What?
`k6 cloud run script.js` gives following error:
ERRO[0000] accepts 1 arg(s), received 2: arg should either be "-", if reading script from stdin, or a path to a script file 

correct command to test run on Cloud k6 should exclude the arg `run` with only:
`k6 cloud script.js`

## Checklist
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.

- [x] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.