### PR TITLE
Update workflows to use actions that don't need organization secrets

### DIFF
--- a/.github/workflows/publish-technical-documentation.yml
+++ b/.github/workflows/publish-technical-documentation.yml
@@ -1,36 +1,21 @@
-name: "publish-technical-documentation"
+name: publish-technical-documentation
 
 on:
   push:
-    branches: [main]
-    paths: ["docs/sources/**"]
+    branches:
+      - main
+    paths:
+      - "docs/sources/**"
   workflow_dispatch:
 jobs:
   sync:
     if: github.repository == 'grafana/k6-docs'
+    permissions:
+      contents: read
+      id-token: write
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Clone website-sync Action
-        # WEBSITE_SYNC_TOKEN is a fine-grained GitHub Personal Access Token that expires.
-        # It must be regenerated in the grafanabot GitHub account and requires a Grafana organization
-        # GitHub administrator to update the organization secret.
-        # The IT helpdesk can update the organization secret.
-        run: git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.WEBSITE_SYNC_TOKEN }}@github.com/grafana/website-sync ./.github/actions/website-sync
-
-      - name: Publish to website repository (next)
-        uses: ./.github/actions/website-sync
-        id: publish-next
+      - uses: actions/checkout@v4
+      - uses: grafana/writers-toolkit/publish-technical-documentation@publish-technical-documentation/v1
         with:
-          repository: grafana/website
-          branch: master
-          host: github.com
-          # PUBLISH_TO_WEBSITE_TOKEN is a fine-grained GitHub Personal Access Token that expires.
-          # It must be regenerated in the grafanabot GitHub account and requires a Grafana organization
-          # GitHub administrator to update the organization secret.
-          # The IT helpdesk can update the organization secret.
-          github_pat: grafanabot:${{ secrets.PUBLISH_TO_WEBSITE_TOKEN }}
-          source_folder: docs/sources
-          target_folder: content/docs/k6
+          website_directory: content/docs/k6


### PR DESCRIPTION

## What?

Each repository can only have 100 organization secrets and there are now more than 100 in our organization which causes inconsistent behavior.

Some repositories don't have the secrets they need assigned.

These composite actions use secrets stored in Vault that are available to all repositories.

- `publish-technical-documentation-next.yml` has been tested with https://github.com/grafana/writers-toolkit/blob/main/.github/workflows/publish-technical-documentation.yml.
- `publish-technical-documentation-release.yml` has been tested with https://github.com/grafana/backend-enterprise/blob/gem-release-2.13/.github/workflows/publish-technical-documentation-release.yml.

There is some copy-paste involved in the creation of these workflows. Please check:

For `publish-technical-documentation-next.yml`:

- [x] The `on.push` `branches` and `paths` filters are correct for your repository.
- [x] The `jobs.sync.if` repository matches your repository.
- [x] The `jobs.sync.steps[1].with.website_directory` matches the directory you publish to in the website repository.

We'll also need to backport this to any branches where you are maintaining documentation that you want synced to the website.

## Checklist

- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [ ] I have run the `npm start` command locally and verified that the changes look good.

## Related PR(s)/Issue(s)

Closes https://github.com/grafana/technical-documentation/issues/977