### PR TITLE
Fix example for redis spop function

### DIFF
--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/client-spop.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/client-spop.md
@@ -9,15 +9,15 @@ Removes and returns a random element from the set value stored at `key`.
 
 ### Parameters
 
-| Parameter | Type   | Description                                    |
-| :-------- | :----- | :--------------------------------------------- |
-| `key`     | string | key holding the set to get a random member of. |
+| Parameter | Type   | Description                                              |
+| :-------- | :----- | :------------------------------------------------------- |
+| `key`     | string | The key value holding the set to get a random member of. |
 
 ### Returns
 
-| Type              | Resolves with                                                | Rejected when                                                     |
-| :---------------- | :----------------------------------------------------------- | :---------------------------------------------------------------- |
-| `Promise<string>` | On success, the promise resolves to the returned set member. | If the set does not exist, the promise is rejected with an error. |
+| Type              | Resolves with                                                | Rejected when                                                    |
+| :---------------- | :----------------------------------------------------------- | :--------------------------------------------------------------- |
+| `Promise<string>` | On success, the promise resolves to the returned set member. | If the set doesn't exist, the promise is rejected with an error. |
 
 ### Example
 
@@ -32,7 +32,8 @@ const redisClient = new redis.Client('redis://localhost:6379');
 export default async function () {
   await redisClient.sadd('myset', 'foo');
   await redisClient.sadd('myset', 'bar');
-  await redisClient.spop('myset', 'foo');
+  await redisClient.spop('myset');
+
   const members = await redisClient.smembers('myset');
   if (members.length !== 1) {
     throw new Error('sismember should have length 1');

--- a/docs/sources/next/javascript-api/k6-experimental/redis/client/client-srandmember.md
+++ b/docs/sources/next/javascript-api/k6-experimental/redis/client/client-srandmember.md
@@ -9,15 +9,15 @@ Returns a random element from the set value stored at `key`.
 
 ### Parameters
 
-| Parameter | Type   | Description                                    |
-| :-------- | :----- | :--------------------------------------------- |
-| `key`     | string | key holding the set to get a random member of. |
+| Parameter | Type   | Description                                              |
+| :-------- | :----- | :------------------------------------------------------- |
+| `key`     | string | The key value holding the set to get a random member of. |
 
 ### Returns
 
-| Type              | Resolves with                                                     | Rejected when                                                     |
-| :---------------- | :---------------------------------------------------------------- | :---------------------------------------------------------------- |
-| `Promise<string>` | On success, the promise resolves with the selected random member. | If the set does not exist, the promise is rejected with an error. |
+| Type              | Resolves with                                                     | Rejected when                                                    |
+| :---------------- | :---------------------------------------------------------------- | :--------------------------------------------------------------- |
+| `Promise<string>` | On success, the promise resolves with the selected random member. | If the set doesn't exist, the promise is rejected with an error. |
 
 ### Example
 
@@ -32,11 +32,10 @@ const redisClient = new redis.Client('redis://localhost:6379');
 export default async function () {
   await redisClient.sadd('myset', 'foo');
   await redisClient.sadd('myset', 'bar');
-  await redisClient.spop('myset', 'foo');
 
-  const members = await redisClient.smembers('myset');
-  if (members.length !== 1) {
-    throw new Error('sismember should have length 1');
+  const randomMember = await redisClient.srandmember('myset');
+  if (randomMember !== 'foo' && randomMember !== 'bar') {
+    throw new Error('randomMember should be equal to "foo" or "bar"');
   }
 }
 ```


### PR DESCRIPTION
## What?

Fix a couple of code examples for the Redis `spop` and `srandmember` functions.

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [x] I have made my changes in the `docs/sources/next` folder of the documentation.
- [ ] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.
- [ ] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->
<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->