### PR TITLE
xk6-faker moved to grafana GitHub organization

### DIFF
--- a/docs/sources/next/extensions/explore.md
+++ b/docs/sources/next/extensions/explore.md
@@ -111,7 +111,7 @@ Use the table to explore the many extensions. Questions? Feel free to join the d
         <h4>xk6-exec</h4>
         <p>Run external commands</p>
     </a>
-    <a href="https://github.com/szkiba/xk6-faker" target="_blank" class="nav-cards__item nav-cards__item--guide">
+    <a href="https://github.com/grafana/xk6-faker" target="_blank" class="nav-cards__item nav-cards__item--guide">
         <h4>xk6-faker</h4>
         <p>Generate random fake data</p>
     </a>

--- a/src/data/doc-extensions/extensions.json
+++ b/src/data/doc-extensions/extensions.json
@@ -409,7 +409,7 @@
     {
       "name": "xk6-faker",
       "description": "Generate random fake data",
-      "url": "https://github.com/szkiba/xk6-faker",
+      "url": "https://github.com/grafana/xk6-faker",
       "logo": "",
       "author": {
         "name": "Iván Szkiba",
@@ -418,7 +418,7 @@
       "stars": "15",
       "type": ["JavaScript"],
       "categories": ["Data"],
-      "tiers": ["Community"],
+      "tiers": ["Official"],
       "cloudEnabled": false
     },
     {


### PR DESCRIPTION
## What?

The `szkiba/xk6-faker` extension has been transferred to the `grafana` GitHub organization: `grafana/xk6-faker`
In addition, it is moved to the `Official` tier instead of the `Community` tier.

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [ ] I have run the `npm start` command locally and verified that the changes look good.

- [x] I have made my changes in the `docs/sources/next` folder of the documentation.

