### PR TITLE
Documents that setup timeout accepts only positive values

### DIFF
--- a/docs/sources/next/using-k6/k6-options/reference.md
+++ b/docs/sources/next/using-k6/k6-options/reference.md
@@ -1033,7 +1033,7 @@ export const options = {
 
 ## Setup timeout
 
-Specify how long the `setup()` function is allow to run before it's terminated and the test fails.
+Specify how long the `setup()` function is allow to run before it's terminated and the test fails. If defined the value must be positive.
 
 | Env                | CLI | Code / Config file | Default |
 | ------------------ | --- | ------------------ | ------- |

--- a/docs/sources/next/using-k6/k6-options/reference.md
+++ b/docs/sources/next/using-k6/k6-options/reference.md
@@ -1033,7 +1033,7 @@ export const options = {
 
 ## Setup timeout
 
-Specify how long the `setup()` function is allow to run before it's terminated and the test fails. If defined the value must be positive.
+Specify how long the `setup()` function can run before it's terminated and the test fails. If defined, the value must be positive.
 
 | Env                | CLI | Code / Config file | Default |
 | ------------------ | --- | ------------------ | ------- |


### PR DESCRIPTION
<!-- 
Please make sure you have read the contribution guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md as well as the
the code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md before opening a PR.
-->

## What?

In the upcoming v0.54, the setup timeout option gets the validation and starts to accept only positive (>0s) values.

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [ ] I have performed a self-review of my changes.
- [ ] I have run the `npm start` command locally and verified that the changes look good.
- [x] I have made my changes in the `docs/sources/next` folder of the documentation.

## Related PR(s)/Issue(s)

https://github.com/grafana/k6/pull/3898

<!-- Thanks for your contribution! 🙏🏼 -->