### PR TITLE
fix: add missing extensions to extensions.json

### DIFF
--- a/src/data/doc-extensions/extensions.json
+++ b/src/data/doc-extensions/extensions.json
@@ -1096,6 +1096,21 @@
       "categories": ["Misc"],
       "tiers": ["Community"],
       "cloudEnabled": false
+    },
+    {
+      "name": "xk6-output-opentelemetry",
+      "description": "Export k6 results in OpenTelemetry format",
+      "url": "https://github.com/grafana/xk6-output-opentelemetry",
+      "logo": "",
+      "author": {
+        "name": "Grafana",
+        "url": "https://github.com/grafana"
+      },
+      "stars": "0",
+      "type": ["Output"],
+      "categories": ["Reporting", "Observability"],
+      "tiers": ["Official"],
+      "cloudEnabled": false
     }
   ]
 }

--- a/src/data/doc-extensions/extensions.json
+++ b/src/data/doc-extensions/extensions.json
@@ -1111,6 +1111,21 @@
       "categories": ["Reporting", "Observability"],
       "tiers": ["Official"],
       "cloudEnabled": false
+    },
+    {
+      "name": "xk6-aws",
+      "description": "Alternative to the official AWS JS Lib that relies on the AWS SDK for Go to interact with Amazon Web Services",
+      "url": "https://github.com/joanlopez/xk6-aws",
+      "logo": "",
+      "author": {
+        "name": "Joan López de la Franca Beltran",
+        "url": "https://github.com/joanlopez"
+      },
+      "stars": "0",
+      "type": ["JavaScript"],
+      "categories": ["Misc"],
+      "tiers": ["Community"],
+      "cloudEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## What?

The grafana/xk6-output-opentelemetry and joanlopez/xk6-aws  extensions were included in the explore.md file but was missing from the extensions.json file. This divergence is corrected by this PR.

This is the last step in the process of moving the extension registry from the grafana/k6-docs repo to the grafana/k6-extension-registry repo. Generation of explore.md is also part of the process, and therefore divergences should be eliminated before moving.

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [ ] I have run the `npm start` command locally and verified that the changes look good.

## Related PR(s)/Issue(s)

https://github.com/grafana/k6-docs/issues/1640

