### PR TITLE
Document the `k6 cloud upload` command

### DIFF
--- a/docs/sources/next/misc/archive.md
+++ b/docs/sources/next/misc/archive.md
@@ -83,6 +83,22 @@ from the k6 command-line via the `k6 cloud run script.js` command (similar to `k
 trigger an implicit creation of a k6 archive that is uploaded and distributed to k6 cloud
 load generators for execution.
 
+#### Uploading an archive to k6 Cloud
+
+Under certain scenarios, such as scheduled executions, users might want to upload an archive to k6 Cloud without triggering
+a test execution in the process.
+
+To cater to this use case, the `k6 cloud upload` command was introduced. This command allows users to upload an archive to k6 Cloud
+without triggering a test execution. The command syntax is as follows:
+
+{{< code >}}
+
+```bash
+k6 cloud upload archive.tar
+```
+
+{{< /code >}}
+
 ### Distributed Execution
 
 [k6-operator](https://github.com/grafana/k6-operator#multi-file-tests) can distribute a k6 test across a Kubernetes cluster.

--- a/docs/sources/next/using-k6/k6-options/reference.md
+++ b/docs/sources/next/using-k6/k6-options/reference.md
@@ -1476,7 +1476,13 @@ The possible keys with their meanings and default values:
 | proto               | the protocol to use when connecting with the traces backend                                                            | `grpc`                  |
 | header.`headerName` | adds an additional HTTP header with the provided header name and value to each HTTP request made to the traces backend | N/A                     |
 
-## Upload Only
+## Upload Only (deprecated)
+
+{{< admonition type="caution" >}}
+
+The "Upload Only" option is deprecated and will be removed in a future release. Please use the `k6 cloud upload` command instead.
+
+{{< /admonition >}}
 
 A boolean specifying whether the test should just be uploaded to the cloud, but not run it. Available in `k6 cloud` command.
 

--- a/docs/sources/next/using-k6/k6-options/reference.md
+++ b/docs/sources/next/using-k6/k6-options/reference.md
@@ -1476,11 +1476,11 @@ The possible keys with their meanings and default values:
 | proto               | the protocol to use when connecting with the traces backend                                                            | `grpc`                  |
 | header.`headerName` | adds an additional HTTP header with the provided header name and value to each HTTP request made to the traces backend | N/A                     |
 
-## Upload Only (deprecated)
+## Upload only (deprecated)
 
 {{< admonition type="caution" >}}
 
-The "Upload Only" option is deprecated and will be removed in a future release. Please use the `k6 cloud upload` command instead.
+The "Upload only" option is deprecated and will be removed in a future release. Use the `k6 cloud upload` command instead.
 
 {{< /admonition >}}
 


### PR DESCRIPTION
## What?

This PR documents the newly introduced `k6 cloud upload` command. We also document the "Upload Only" option as deprecated.

I was really unsure where the right place to document this was, please feel free to propose a better place or even move it around. 

## Checklist

- [X] I have used a meaningful title for the PR.
- [X] I have described the changes I've made in the "What?" section above.
- [X] I have performed a self-review of my changes.
- [X] I have run the `npm start` command locally and verified that the changes look good.
- [X] I have made my changes in the `docs/sources/next` folder of the documentation.

## Related PR(s)/Issue(s)

https://github.com/grafana/k6/pull/3949/files#r1767831917