### PR TITLE
Add sleep and page.waitForTimeout doc to v0.52 & v0.53

### DIFF
--- a/docs/sources/next/using-k6-browser/recommended-practices/_index.md
+++ b/docs/sources/next/using-k6-browser/recommended-practices/_index.md
@@ -11,4 +11,4 @@ This section presents some examples and recommended practices when working with 
 - [Hybrid approach to performance](https://grafana.com/docs/k6/<K6_VERSION>/using-k6-browser/recommended-practices/hybrid-approach-to-performance)
 - [Page object model pattern](https://grafana.com/docs/k6/<K6_VERSION>/using-k6-browser/recommended-practices/page-object-model-pattern)
 - [Selecting elements](https://grafana.com/docs/k6/<K6_VERSION>/using-k6-browser/recommended-practices/selecting-elements)
-- [Simulating user input delay](https://grafana.com/docs/k6/<K6_VERSION>/using-k6-browser/recommended-practices/simulate-user-input-delay)
+- [Simulate user input delay](https://grafana.com/docs/k6/<K6_VERSION>/using-k6-browser/recommended-practices/simulate-user-input-delay)

--- a/docs/sources/next/using-k6-browser/recommended-practices/simulate-user-input-delay.md
+++ b/docs/sources/next/using-k6-browser/recommended-practices/simulate-user-input-delay.md
@@ -6,7 +6,7 @@ weight: 04
 
 # Simulate user input delay
 
-We will demonstrate how best to work with `sleep` in `k6` and the various `wait*` prepended methods that are available in `k6/browser` to simulate user input delay, wait for navigations, and wait for element state changes. By the end of this page, you should be able to successfully use the correct API where necessary.
+On this page, you'll learn how to best work with `sleep` in `k6` and the various `wait*` prepended methods available in `k6/browser` to simulate user input delay, wait for navigations, and wait for element state changes. By the end of this page, you should be able to successfully use the correct API where necessary.
 
 {{< admonition type="note" >}}
 
@@ -88,7 +88,7 @@ export default async function () {
     });
 
     await check(ok, {
-      'waitForFunction successfully resolved': async (ok) => await ok.innerHTML() == 'Hello'
+      'waitForFunction successfully resolved': async (ok) => (await ok.innerHTML()) == 'Hello',
     });
   } finally {
     await page.close();
@@ -176,10 +176,7 @@ export default async function () {
 
     // The click action will start a navigation, and the waitForNavigation
     // will help the test wait until the navigation completes.
-    await Promise.all([
-      page.waitForNavigation(),
-      submitButton.click(),
-    ]);
+    await Promise.all([page.waitForNavigation(), submitButton.click()]);
   } finally {
     await page.close();
   }

--- a/docs/sources/next/using-k6-browser/recommended-practices/simulate-user-input-delay.md
+++ b/docs/sources/next/using-k6-browser/recommended-practices/simulate-user-input-delay.md
@@ -1,10 +1,10 @@
 ---
-title: 'Simulating user input delay'
+title: 'Simulate user input delay'
 description: 'A guide on how to simulate user input delay.'
 weight: 04
 ---
 
-# Simulating user input delay
+# Simulate user input delay
 
 We will demonstrate how best to work with `sleep` in `k6` and the various `wait*` prepended methods that are available in `k6/browser` to simulate user input delay, wait for navigations, and wait for element state changes. By the end of this page, you should be able to successfully use the correct API where necessary.
 
@@ -19,15 +19,14 @@ While using the `sleep` or `page.waitForTimeout` functions to wait for element s
 [sleep](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6/sleep) is a first class function built into k6. It's main use is to _"suspend VU execution for the specified duration"_ which is most useful when you want to simulate user input delay, such as:
 
 - Navigating to a page.
-- Sleeping for a 1 second, which is to simulate a user looking for a specific element on the page.
+- Sleeping for one second to simulate a user looking for a specific element on the page.
 - Clicking on the element.
-- etc.
 
 {{< admonition type="warning" >}}
 
-`sleep` is a synchronous function that blocks the JS event loop, which means that all asynchronous work will also be suspended until the `sleep` completes.
+`sleep` is a synchronous function that blocks the JavaScript event loop, which means that all asynchronous work will also be suspended until `sleep` completes.
 
-The browser module predominantly provides asynchronous APIs, and so it's best to avoid working with `sleep`, and instead **we recommend you use [page.waitForTimeout](#pagewaitfortimeout)**.
+The browser module predominantly provides asynchronous APIs, so it's best to avoid working with `sleep`. Instead, _use the [page.waitForTimeout](#pagewaitfortimeout) function_.
 
 {{< /admonition >}}
 
@@ -35,17 +34,17 @@ The browser module predominantly provides asynchronous APIs, and so it's best to
 
 In the browser modules there are various asynchronous APIs that can be used to wait for certain states:
 
-| Method                                           | Description                                                                   |
-| ------------------------------------------------ | ----------------------------------------------------------------------------- |
-| [page.waitForFunction](#pagewaitforfunction)     | Waits for the given function to return a truthy value.                        |
-| [page.waitForLoadState](#pagewaitforloadstate)   | Waits for the specified page life cycle event.                                |
-| [page.waitForNavigation](#pagewaitfornavigation) | Waits for the navigation to complete after one starts.                        |
-| [locator.waitFor](#locatorwaitfor)               | Wait for the element to be in a particular state.                             |
-| [page.waitForTimeout](#pagewaitfortimeout)       | Waits the given time. **Use this instead of `sleep` in your frontend tests.** |
+| Method                                           | Description                                                                 |
+| ------------------------------------------------ | --------------------------------------------------------------------------- |
+| [page.waitForFunction](#pagewaitforfunction)     | Waits for the given function to return a truthy value.                      |
+| [page.waitForLoadState](#pagewaitforloadstate)   | Waits for the specified page life cycle event.                              |
+| [page.waitForNavigation](#pagewaitfornavigation) | Waits for the navigation to complete after one starts.                      |
+| [locator.waitFor](#locatorwaitfor)               | Wait for the element to be in a particular state.                           |
+| [page.waitForTimeout](#pagewaitfortimeout)       | Waits the given time. _Use this instead of `sleep` in your frontend tests_. |
 
 ## page.waitForFunction
 
-[page.waitForFunction](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/waitforfunction) is useful when you want more control over when a test progresses with a javascript function that returns true when a condition (or many conditions) is met. It can be used to poll for changes in the dom or non dom elements and variables.
+[page.waitForFunction](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/waitforfunction) is useful when you want more control over when a test progresses with a javascript function that returns true when a condition (or many conditions) is met. It can be used to poll for changes in the DOM or non-DOM elements and variables.
 
 {{< code >}}
 
@@ -101,7 +100,7 @@ export default async function () {
 
 ## page.waitForLoadState
 
-[page.waitForLoadState](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/waitforloadstate) is useful when there’s no explicit navigation, but you need to wait for the page or network to settle. This is mainly used when working with single page applications or when no full page reloads happen.
+[page.waitForLoadState](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/waitforloadstate) is useful when there’s no explicit navigation, but you need to wait for the page or network to settle. This is mainly used when working with single-page applications or when no full page reloads happen.
 
 {{< code >}}
 
@@ -142,7 +141,7 @@ export default async function () {
 
 ## page.waitForNavigation
 
-[page.waitForNavigation](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/waitfornavigation) is a very useful API when performing other actions that could start a page navigation, and they don't automatically wait for a navigation to end. Usually you'll find it in our examples with a `click` API call. Note that [goto](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/goto) is an example of an API that **doesn't** require `waitForNavigation` since it will automatically wait for the navigation to complete before returning.
+[page.waitForNavigation](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/waitfornavigation) is a very useful API when performing other actions that could start a page navigation, and they don't automatically wait for the navigation to end. Usually, you'll find it in our examples with a `click` API call. Note that [goto](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/goto) is an example of an API that _doesn't_ require `waitForNavigation` since it will automatically wait for the navigation to complete before returning.
 
 It's important to call this in a [Promise.all](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all) along with the API that will cause the navigation to start.
 
@@ -191,7 +190,7 @@ export default async function () {
 
 ## locator.waitFor
 
-[locator.waitFor](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/waitfor/) will wait until the element meets the waiting criteria. It's useful when dealing with dynamic websites where elements may take time to appear or change state (they might load after some delay due to async calls, JavaScript execution, etc.).
+[locator.waitFor](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/waitfor/) will wait until the element meets the waiting criteria. It's useful when dealing with dynamic websites where elements may take time to appear or change state. For example, if elements load after some delay due to async calls, or because of slow JavaScript execution.
 
 {{< code >}}
 
@@ -226,7 +225,7 @@ export default async function () {
 
 ## page.waitForTimeout
 
-[page.waitForTimeout](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/waitfortimeout) will wait the given amount of time. It's functionally the same as k6's [sleep](#What-is-`sleep`) but it is asynchronous which means it will not block the event loop, thus allowing the background tasks to continue to be worked on. We're also planning on instruementing it with tracing to then allow us visualize it in the timeline in grafana cloud k6.
+[page.waitForTimeout](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/waitfortimeout) will wait the given amount of time. It's functionally the same as k6's [sleep](#What-is-`sleep`), but it's asynchronous, which means it will not block the event loop and allows the background tasks to continue to be worked on.
 
 {{< code >}}
 

--- a/docs/sources/v0.52.x/using-k6-browser/recommended-practices/_index.md
+++ b/docs/sources/v0.52.x/using-k6-browser/recommended-practices/_index.md
@@ -11,4 +11,4 @@ This section presents some examples and recommended practices when working with 
 - [Hybrid approach to performance](https://grafana.com/docs/k6/<K6_VERSION>/using-k6-browser/recommended-practices/hybrid-approach-to-performance)
 - [Page object model pattern](https://grafana.com/docs/k6/<K6_VERSION>/using-k6-browser/recommended-practices/page-object-model-pattern)
 - [Selecting elements](https://grafana.com/docs/k6/<K6_VERSION>/using-k6-browser/recommended-practices/selecting-elements)
-- [Simulating user input delay](https://grafana.com/docs/k6/<K6_VERSION>/using-k6-browser/recommended-practices/simulate-user-input-delay)
+- [Simulate user input delay](https://grafana.com/docs/k6/<K6_VERSION>/using-k6-browser/recommended-practices/simulate-user-input-delay)

--- a/docs/sources/v0.52.x/using-k6-browser/recommended-practices/_index.md
+++ b/docs/sources/v0.52.x/using-k6-browser/recommended-practices/_index.md
@@ -11,3 +11,4 @@ This section presents some examples and recommended practices when working with 
 - [Hybrid approach to performance](https://grafana.com/docs/k6/<K6_VERSION>/using-k6-browser/recommended-practices/hybrid-approach-to-performance)
 - [Page object model pattern](https://grafana.com/docs/k6/<K6_VERSION>/using-k6-browser/recommended-practices/page-object-model-pattern)
 - [Selecting elements](https://grafana.com/docs/k6/<K6_VERSION>/using-k6-browser/recommended-practices/selecting-elements)
+- [Simulating user input delay](https://grafana.com/docs/k6/<K6_VERSION>/using-k6-browser/recommended-practices/simulate-user-input-delay)

--- a/docs/sources/v0.52.x/using-k6-browser/recommended-practices/simulate-user-input-delay.md
+++ b/docs/sources/v0.52.x/using-k6-browser/recommended-practices/simulate-user-input-delay.md
@@ -1,0 +1,261 @@
+---
+title: 'Simulating user input delay'
+description: 'A guide on how to simulate user input delay.'
+weight: 04
+---
+
+We will demonstrate how best to work with `sleep` in `k6` and the various `wait*` prepended methods that are available in `k6/browser` to simulate user input delay, wait for navigations, and wait for element state changes. By the end of this page, you should be able to successfully use the correct API where necessary.
+
+{{< admonition type="note" >}}
+
+While using the `sleep` or `page.waitForTimeout` functions to wait for element state changes may seem helpful, it's best to avoid them to prevent flakey tests. Instead, it's better to use the other `wait*` prepended methods listed on this page.
+
+{{< /admonition >}}
+
+# What is `sleep`?
+
+[sleep](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6/sleep) is a first class function built into k6. It's main use is to _"suspend VU execution for the specified duration"_ which is most useful when you want to simulate user input delay, such as:
+
+- Navigating to a page.
+- Sleeping for a 1 second, which is to simulate a user looking for a specific element on the page.
+- Clicking on the element.
+- etc.
+
+{{< admonition type="warning" >}}
+
+`sleep` is a synchronous function that blocks the JS event loop, which means that all asynchronous work will also be suspended until the `sleep` completes.
+
+The browser module predominantly provides asynchronous APIs, and so it's best to avoid working with `sleep`, and instead **we recommend you use [page.waitForTimeout](#pagewaitfortimeout)**.
+
+{{< /admonition >}}
+
+# What is `wait*`?
+
+In the browser modules there are various asynchronous APIs that can be used to wait for certain states:
+
+| Method                                           | Description                                                                   |
+| ------------------------------------------------ | ----------------------------------------------------------------------------- |
+| [page.waitForFunction](#pagewaitforfunction)     | Waits for the given function to return a truthy value.                        |
+| [page.waitForLoadState](#pagewaitforloadstate)   | Waits for the specified page life cycle event.                                |
+| [page.waitForNavigation](#pagewaitfornavigation) | Waits for the navigation to complete after one starts.                        |
+| [locator.waitFor](#locatorwaitfor)               | Wait for the element to be in a particular state.                             |
+| [page.waitForTimeout](#pagewaitfortimeout)       | Waits the given time. **Use this instead of `sleep` in your frontend tests.** |
+
+## page.waitForFunction
+
+[page.waitForFunction](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/waitforfunction) is useful when you want more control over when a test progresses with a javascript function that returns true when a condition (or many conditions) is met. It can be used to poll for changes in the dom or non dom elements and variables.
+
+{{< code >}}
+
+<!-- eslint-skip-->
+
+```javascript
+import { browser } from 'k6/browser';
+import { check } from 'k6';
+
+export const options = {
+  scenarios: {
+    browser: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+          type: 'chromium',
+        },
+      },
+    },
+  },
+};
+
+export default async function () {
+  const page = await browser.newPage();
+
+  try {
+    // Setting up the example that will mutate the h1 element by setting the
+    // h1 elements text value to "Hello".
+    await page.evaluate(() => {
+      setTimeout(() => {
+        const el = document.createElement('h1');
+        el.innerHTML = 'Hello';
+        document.body.appendChild(el);
+      }, 1000);
+    });
+
+    // Waiting until the h1 element has mutated.
+    const ok = await page.waitForFunction("document.querySelector('h1')", {
+      polling: 'mutation',
+      timeout: 2000,
+    });
+
+    const innerHTML = await ok.innerHTML();
+    check(ok, { 'waitForFunction successfully resolved': innerHTML == 'Hello' });
+  } finally {
+    await page.close();
+  }
+}
+```
+
+{{< /code >}}
+
+## page.waitForLoadState
+
+[page.waitForLoadState](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/waitforloadstate) is useful when there’s no explicit navigation, but you need to wait for the page or network to settle. This is mainly used when working with single page applications or when no full page reloads happen.
+
+{{< code >}}
+
+```javascript
+import { check } from 'k6';
+import { browser } from 'k6/browser';
+
+export const options = {
+  scenarios: {
+    browser: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+          type: 'chromium',
+        },
+      },
+    },
+  },
+};
+
+export default async function () {
+  const page = await browser.newPage();
+
+  try {
+    // Goto a SPA
+    await page.goto('<url>');
+
+    // ... perform some actions that reload part of the page.
+
+    // waits for the default `load` event.
+    await page.waitForLoadState();
+  } finally {
+    await page.close();
+  }
+}
+```
+
+{{< /code >}}
+
+## page.waitForNavigation
+
+[page.waitForNavigation](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/waitfornavigation) is a very useful API when performing other actions that could start a page navigation, and they don't automatically wait for a navigation to end. Usually you'll find it in our examples with a `click` API call. Note that [goto](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/goto) is an example of an API that **doesn't** require `waitForNavigation` since it will automatically wait for the navigation to complete before returning.
+
+It's important to call this in a [Promise.all](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all) along with the API that will cause the navigation to start.
+
+{{< code >}}
+
+```javascript
+import { check } from 'k6';
+import { browser } from 'k6/browser';
+
+export const options = {
+  scenarios: {
+    browser: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+          type: 'chromium',
+        },
+      },
+    },
+  },
+};
+
+export default async function () {
+  const page = await browser.newPage();
+
+  try {
+    await page.goto('https://test.k6.io/my_messages.php');
+
+    await page.locator('input[name="login"]').type('admin');
+    await page.locator('input[name="password"]').type('123');
+
+    const submitButton = page.locator('input[type="submit"]');
+
+    // The click action will start a navigation, and the waitForNavigation
+    // will help the test wait until the navigation completes.
+    await Promise.all([page.waitForNavigation(), submitButton.click()]);
+  } finally {
+    await page.close();
+  }
+}
+```
+
+{{< /code >}}
+
+## locator.waitFor
+
+[locator.waitFor](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/waitfor/) will wait until the element meets the waiting criteria. It's useful when dealing with dynamic websites where elements may take time to appear or change state (they might load after some delay due to async calls, JavaScript execution, etc.).
+
+{{< code >}}
+
+```js
+import { browser } from 'k6/browser';
+
+export const options = {
+  scenarios: {
+    browser: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+          type: 'chromium',
+        },
+      },
+    },
+  },
+};
+
+export default async function () {
+  const page = await browser.newPage();
+
+  await page.goto('https://test.k6.io/browser.php');
+  const text = page.locator('#input-text-hidden');
+  await text.waitFor({
+    state: 'hidden',
+  });
+}
+```
+
+{{< /code >}}
+
+## page.waitForTimeout
+
+[page.waitForTimeout](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/waitfortimeout) will wait the given amount of time. It's functionally the same as k6's [sleep](#What-is-`sleep`) but it is asynchronous which means it will not block the event loop, thus allowing the background tasks to continue to be worked on. We're also planning on instruementing it with tracing to then allow us visualize it in the timeline in grafana cloud k6.
+
+{{< code >}}
+
+```js
+import { browser } from 'k6/browser';
+
+export const options = {
+  scenarios: {
+    browser: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+          type: 'chromium',
+        },
+      },
+    },
+  },
+};
+
+export default async function () {
+  const page = await browser.newPage();
+
+  try {
+    await page.goto('https://test.k6.io');
+
+    // Slow the test down to mimic a user looking for the element on the page.
+    await page.waitForTimeout(1000);
+
+    // ... perform the next action
+  } finally {
+    await page.close();
+  }
+}
+```
+
+{{< /code >}}

--- a/docs/sources/v0.52.x/using-k6-browser/recommended-practices/simulate-user-input-delay.md
+++ b/docs/sources/v0.52.x/using-k6-browser/recommended-practices/simulate-user-input-delay.md
@@ -34,12 +34,12 @@ The browser module predominantly provides asynchronous APIs, so it's best to avo
 
 In the browser modules there are various asynchronous APIs that can be used to wait for certain states:
 
-| Method                                           | Description                                                                   |
-| ------------------------------------------------ | ----------------------------------------------------------------------------- |
-| [page.waitForFunction](#pagewaitforfunction)     | Waits for the given function to return a truthy value.                        |
-| [page.waitForLoadState](#pagewaitforloadstate)   | Waits for the specified page life cycle event.                                |
-| [page.waitForNavigation](#pagewaitfornavigation) | Waits for the navigation to complete after one starts.                        |
-| [locator.waitFor](#locatorwaitfor)               | Wait for the element to be in a particular state.                             |
+| Method                                           | Description                                                                 |
+| ------------------------------------------------ | --------------------------------------------------------------------------- |
+| [page.waitForFunction](#pagewaitforfunction)     | Waits for the given function to return a truthy value.                      |
+| [page.waitForLoadState](#pagewaitforloadstate)   | Waits for the specified page life cycle event.                              |
+| [page.waitForNavigation](#pagewaitfornavigation) | Waits for the navigation to complete after one starts.                      |
+| [locator.waitFor](#locatorwaitfor)               | Wait for the element to be in a particular state.                           |
 | [page.waitForTimeout](#pagewaitfortimeout)       | Waits the given time. _Use this instead of `sleep` in your frontend tests_. |
 
 ## page.waitForFunction
@@ -52,7 +52,7 @@ In the browser modules there are various asynchronous APIs that can be used to w
 
 ```javascript
 import { browser } from 'k6/browser';
-import { check } from 'k6';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
   scenarios: {
@@ -87,8 +87,9 @@ export default async function () {
       timeout: 2000,
     });
 
-    const innerHTML = await ok.innerHTML();
-    check(ok, { 'waitForFunction successfully resolved': innerHTML == 'Hello' });
+    await check(ok, {
+      'waitForFunction successfully resolved': async (ok) => (await ok.innerHTML()) == 'Hello',
+    });
   } finally {
     await page.close();
   }
@@ -104,7 +105,6 @@ export default async function () {
 {{< code >}}
 
 ```javascript
-import { check } from 'k6';
 import { browser } from 'k6/browser';
 
 export const options = {
@@ -148,7 +148,6 @@ It's important to call this in a [Promise.all](https://developer.mozilla.org/en-
 {{< code >}}
 
 ```javascript
-import { check } from 'k6';
 import { browser } from 'k6/browser';
 
 export const options = {

--- a/docs/sources/v0.52.x/using-k6-browser/recommended-practices/simulate-user-input-delay.md
+++ b/docs/sources/v0.52.x/using-k6-browser/recommended-practices/simulate-user-input-delay.md
@@ -1,10 +1,12 @@
 ---
-title: 'Simulating user input delay'
+title: 'Simulate user input delay'
 description: 'A guide on how to simulate user input delay.'
 weight: 04
 ---
 
-We will demonstrate how best to work with `sleep` in `k6` and the various `wait*` prepended methods that are available in `k6/browser` to simulate user input delay, wait for navigations, and wait for element state changes. By the end of this page, you should be able to successfully use the correct API where necessary.
+# Simulate user input delay
+
+On this page, you'll learn how to best work with `sleep` in `k6` and the various `wait*` prepended methods available in `k6/browser` to simulate user input delay, wait for navigations, and wait for element state changes. By the end of this page, you should be able to successfully use the correct API where necessary.
 
 {{< admonition type="note" >}}
 
@@ -17,15 +19,14 @@ While using the `sleep` or `page.waitForTimeout` functions to wait for element s
 [sleep](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6/sleep) is a first class function built into k6. It's main use is to _"suspend VU execution for the specified duration"_ which is most useful when you want to simulate user input delay, such as:
 
 - Navigating to a page.
-- Sleeping for a 1 second, which is to simulate a user looking for a specific element on the page.
+- Sleeping for one second to simulate a user looking for a specific element on the page.
 - Clicking on the element.
-- etc.
 
 {{< admonition type="warning" >}}
 
-`sleep` is a synchronous function that blocks the JS event loop, which means that all asynchronous work will also be suspended until the `sleep` completes.
+`sleep` is a synchronous function that blocks the JavaScript event loop, which means that all asynchronous work will also be suspended until `sleep` completes.
 
-The browser module predominantly provides asynchronous APIs, and so it's best to avoid working with `sleep`, and instead **we recommend you use [page.waitForTimeout](#pagewaitfortimeout)**.
+The browser module predominantly provides asynchronous APIs, so it's best to avoid working with `sleep`. Instead, _use the [page.waitForTimeout](#pagewaitfortimeout) function_.
 
 {{< /admonition >}}
 
@@ -39,11 +40,11 @@ In the browser modules there are various asynchronous APIs that can be used to w
 | [page.waitForLoadState](#pagewaitforloadstate)   | Waits for the specified page life cycle event.                                |
 | [page.waitForNavigation](#pagewaitfornavigation) | Waits for the navigation to complete after one starts.                        |
 | [locator.waitFor](#locatorwaitfor)               | Wait for the element to be in a particular state.                             |
-| [page.waitForTimeout](#pagewaitfortimeout)       | Waits the given time. **Use this instead of `sleep` in your frontend tests.** |
+| [page.waitForTimeout](#pagewaitfortimeout)       | Waits the given time. _Use this instead of `sleep` in your frontend tests_. |
 
 ## page.waitForFunction
 
-[page.waitForFunction](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/waitforfunction) is useful when you want more control over when a test progresses with a javascript function that returns true when a condition (or many conditions) is met. It can be used to poll for changes in the dom or non dom elements and variables.
+[page.waitForFunction](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/waitforfunction) is useful when you want more control over when a test progresses with a javascript function that returns true when a condition (or many conditions) is met. It can be used to poll for changes in the DOM or non-DOM elements and variables.
 
 {{< code >}}
 
@@ -98,7 +99,7 @@ export default async function () {
 
 ## page.waitForLoadState
 
-[page.waitForLoadState](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/waitforloadstate) is useful when there’s no explicit navigation, but you need to wait for the page or network to settle. This is mainly used when working with single page applications or when no full page reloads happen.
+[page.waitForLoadState](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/waitforloadstate) is useful when there’s no explicit navigation, but you need to wait for the page or network to settle. This is mainly used when working with single-page applications or when no full page reloads happen.
 
 {{< code >}}
 
@@ -140,7 +141,7 @@ export default async function () {
 
 ## page.waitForNavigation
 
-[page.waitForNavigation](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/waitfornavigation) is a very useful API when performing other actions that could start a page navigation, and they don't automatically wait for a navigation to end. Usually you'll find it in our examples with a `click` API call. Note that [goto](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/goto) is an example of an API that **doesn't** require `waitForNavigation` since it will automatically wait for the navigation to complete before returning.
+[page.waitForNavigation](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/waitfornavigation) is a very useful API when performing other actions that could start a page navigation, and they don't automatically wait for the navigation to end. Usually, you'll find it in our examples with a `click` API call. Note that [goto](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/goto) is an example of an API that _doesn't_ require `waitForNavigation` since it will automatically wait for the navigation to complete before returning.
 
 It's important to call this in a [Promise.all](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all) along with the API that will cause the navigation to start.
 
@@ -187,7 +188,7 @@ export default async function () {
 
 ## locator.waitFor
 
-[locator.waitFor](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/waitfor/) will wait until the element meets the waiting criteria. It's useful when dealing with dynamic websites where elements may take time to appear or change state (they might load after some delay due to async calls, JavaScript execution, etc.).
+[locator.waitFor](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/waitfor/) will wait until the element meets the waiting criteria. It's useful when dealing with dynamic websites where elements may take time to appear or change state. For example, if elements load after some delay due to async calls, or because of slow JavaScript execution.
 
 {{< code >}}
 
@@ -222,7 +223,7 @@ export default async function () {
 
 ## page.waitForTimeout
 
-[page.waitForTimeout](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/waitfortimeout) will wait the given amount of time. It's functionally the same as k6's [sleep](#What-is-`sleep`) but it is asynchronous which means it will not block the event loop, thus allowing the background tasks to continue to be worked on. We're also planning on instruementing it with tracing to then allow us visualize it in the timeline in grafana cloud k6.
+[page.waitForTimeout](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/waitfortimeout) will wait the given amount of time. It's functionally the same as k6's [sleep](#What-is-`sleep`), but it's asynchronous, which means it will not block the event loop and allows the background tasks to continue to be worked on.
 
 {{< code >}}
 

--- a/docs/sources/v0.53.x/using-k6-browser/recommended-practices/_index.md
+++ b/docs/sources/v0.53.x/using-k6-browser/recommended-practices/_index.md
@@ -11,4 +11,4 @@ This section presents some examples and recommended practices when working with 
 - [Hybrid approach to performance](https://grafana.com/docs/k6/<K6_VERSION>/using-k6-browser/recommended-practices/hybrid-approach-to-performance)
 - [Page object model pattern](https://grafana.com/docs/k6/<K6_VERSION>/using-k6-browser/recommended-practices/page-object-model-pattern)
 - [Selecting elements](https://grafana.com/docs/k6/<K6_VERSION>/using-k6-browser/recommended-practices/selecting-elements)
-- [Simulating user input delay](https://grafana.com/docs/k6/<K6_VERSION>/using-k6-browser/recommended-practices/simulate-user-input-delay)
+- [Simulate user input delay](https://grafana.com/docs/k6/<K6_VERSION>/using-k6-browser/recommended-practices/simulate-user-input-delay)

--- a/docs/sources/v0.53.x/using-k6-browser/recommended-practices/_index.md
+++ b/docs/sources/v0.53.x/using-k6-browser/recommended-practices/_index.md
@@ -11,3 +11,4 @@ This section presents some examples and recommended practices when working with 
 - [Hybrid approach to performance](https://grafana.com/docs/k6/<K6_VERSION>/using-k6-browser/recommended-practices/hybrid-approach-to-performance)
 - [Page object model pattern](https://grafana.com/docs/k6/<K6_VERSION>/using-k6-browser/recommended-practices/page-object-model-pattern)
 - [Selecting elements](https://grafana.com/docs/k6/<K6_VERSION>/using-k6-browser/recommended-practices/selecting-elements)
+- [Simulating user input delay](https://grafana.com/docs/k6/<K6_VERSION>/using-k6-browser/recommended-practices/simulate-user-input-delay)

--- a/docs/sources/v0.53.x/using-k6-browser/recommended-practices/simulate-user-input-delay.md
+++ b/docs/sources/v0.53.x/using-k6-browser/recommended-practices/simulate-user-input-delay.md
@@ -52,7 +52,7 @@ In the browser modules there are various asynchronous APIs that can be used to w
 
 ```javascript
 import { browser } from 'k6/browser';
-import { check } from 'k6';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
   scenarios: {
@@ -87,8 +87,9 @@ export default async function () {
       timeout: 2000,
     });
 
-    const innerHTML = await ok.innerHTML();
-    check(ok, { 'waitForFunction successfully resolved': innerHTML == 'Hello' });
+    await check(ok, {
+      'waitForFunction successfully resolved': async (ok) => (await ok.innerHTML()) == 'Hello',
+    });
   } finally {
     await page.close();
   }
@@ -104,7 +105,6 @@ export default async function () {
 {{< code >}}
 
 ```javascript
-import { check } from 'k6';
 import { browser } from 'k6/browser';
 
 export const options = {
@@ -148,7 +148,6 @@ It's important to call this in a [Promise.all](https://developer.mozilla.org/en-
 {{< code >}}
 
 ```javascript
-import { check } from 'k6';
 import { browser } from 'k6/browser';
 
 export const options = {

--- a/docs/sources/v0.53.x/using-k6-browser/recommended-practices/simulate-user-input-delay.md
+++ b/docs/sources/v0.53.x/using-k6-browser/recommended-practices/simulate-user-input-delay.md
@@ -1,10 +1,12 @@
 ---
-title: 'Simulating user input delay'
+title: 'Simulate user input delay'
 description: 'A guide on how to simulate user input delay.'
 weight: 04
 ---
 
-We will demonstrate how best to work with `sleep` in `k6` and the various `wait*` prepended methods that are available in `k6/browser` to simulate user input delay, wait for navigations, and wait for element state changes. By the end of this page, you should be able to successfully use the correct API where necessary.
+# Simulate user input delay
+
+On this page, you'll learn how to best work with `sleep` in `k6` and the various `wait*` prepended methods available in `k6/browser` to simulate user input delay, wait for navigations, and wait for element state changes. By the end of this page, you should be able to successfully use the correct API where necessary.
 
 {{< admonition type="note" >}}
 
@@ -17,15 +19,14 @@ While using the `sleep` or `page.waitForTimeout` functions to wait for element s
 [sleep](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6/sleep) is a first class function built into k6. It's main use is to _"suspend VU execution for the specified duration"_ which is most useful when you want to simulate user input delay, such as:
 
 - Navigating to a page.
-- Sleeping for a 1 second, which is to simulate a user looking for a specific element on the page.
+- Sleeping for one second to simulate a user looking for a specific element on the page.
 - Clicking on the element.
-- etc.
 
 {{< admonition type="warning" >}}
 
-`sleep` is a synchronous function that blocks the JS event loop, which means that all asynchronous work will also be suspended until the `sleep` completes.
+`sleep` is a synchronous function that blocks the JavaScript event loop, which means that all asynchronous work will also be suspended until `sleep` completes.
 
-The browser module predominantly provides asynchronous APIs, and so it's best to avoid working with `sleep`, and instead **we recommend you use [page.waitForTimeout](#pagewaitfortimeout)**.
+The browser module predominantly provides asynchronous APIs, so it's best to avoid working with `sleep`. Instead, _use the [page.waitForTimeout](#pagewaitfortimeout) function_.
 
 {{< /admonition >}}
 
@@ -33,17 +34,17 @@ The browser module predominantly provides asynchronous APIs, and so it's best to
 
 In the browser modules there are various asynchronous APIs that can be used to wait for certain states:
 
-| Method                                           | Description                                                                   |
-| ------------------------------------------------ | ----------------------------------------------------------------------------- |
-| [page.waitForFunction](#pagewaitforfunction)     | Waits for the given function to return a truthy value.                        |
-| [page.waitForLoadState](#pagewaitforloadstate)   | Waits for the specified page life cycle event.                                |
-| [page.waitForNavigation](#pagewaitfornavigation) | Waits for the navigation to complete after one starts.                        |
-| [locator.waitFor](#locatorwaitfor)               | Wait for the element to be in a particular state.                             |
-| [page.waitForTimeout](#pagewaitfortimeout)       | Waits the given time. **Use this instead of `sleep` in your frontend tests.** |
+| Method                                           | Description                                                                 |
+| ------------------------------------------------ | --------------------------------------------------------------------------- |
+| [page.waitForFunction](#pagewaitforfunction)     | Waits for the given function to return a truthy value.                      |
+| [page.waitForLoadState](#pagewaitforloadstate)   | Waits for the specified page life cycle event.                              |
+| [page.waitForNavigation](#pagewaitfornavigation) | Waits for the navigation to complete after one starts.                      |
+| [locator.waitFor](#locatorwaitfor)               | Wait for the element to be in a particular state.                           |
+| [page.waitForTimeout](#pagewaitfortimeout)       | Waits the given time. _Use this instead of `sleep` in your frontend tests_. |
 
 ## page.waitForFunction
 
-[page.waitForFunction](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/waitforfunction) is useful when you want more control over when a test progresses with a javascript function that returns true when a condition (or many conditions) is met. It can be used to poll for changes in the dom or non dom elements and variables.
+[page.waitForFunction](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/waitforfunction) is useful when you want more control over when a test progresses with a javascript function that returns true when a condition (or many conditions) is met. It can be used to poll for changes in the DOM or non-DOM elements and variables.
 
 {{< code >}}
 
@@ -98,7 +99,7 @@ export default async function () {
 
 ## page.waitForLoadState
 
-[page.waitForLoadState](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/waitforloadstate) is useful when there’s no explicit navigation, but you need to wait for the page or network to settle. This is mainly used when working with single page applications or when no full page reloads happen.
+[page.waitForLoadState](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/waitforloadstate) is useful when there’s no explicit navigation, but you need to wait for the page or network to settle. This is mainly used when working with single-page applications or when no full page reloads happen.
 
 {{< code >}}
 
@@ -140,7 +141,7 @@ export default async function () {
 
 ## page.waitForNavigation
 
-[page.waitForNavigation](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/waitfornavigation) is a very useful API when performing other actions that could start a page navigation, and they don't automatically wait for a navigation to end. Usually you'll find it in our examples with a `click` API call. Note that [goto](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/goto) is an example of an API that **doesn't** require `waitForNavigation` since it will automatically wait for the navigation to complete before returning.
+[page.waitForNavigation](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/waitfornavigation) is a very useful API when performing other actions that could start a page navigation, and they don't automatically wait for the navigation to end. Usually, you'll find it in our examples with a `click` API call. Note that [goto](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/goto) is an example of an API that _doesn't_ require `waitForNavigation` since it will automatically wait for the navigation to complete before returning.
 
 It's important to call this in a [Promise.all](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all) along with the API that will cause the navigation to start.
 
@@ -187,7 +188,7 @@ export default async function () {
 
 ## locator.waitFor
 
-[locator.waitFor](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/waitfor/) will wait until the element meets the waiting criteria. It's useful when dealing with dynamic websites where elements may take time to appear or change state (they might load after some delay due to async calls, JavaScript execution, etc.).
+[locator.waitFor](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/waitfor/) will wait until the element meets the waiting criteria. It's useful when dealing with dynamic websites where elements may take time to appear or change state. For example, if elements load after some delay due to async calls, or because of slow JavaScript execution.
 
 {{< code >}}
 
@@ -222,7 +223,7 @@ export default async function () {
 
 ## page.waitForTimeout
 
-[page.waitForTimeout](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/waitfortimeout) will wait the given amount of time. It's functionally the same as k6's [sleep](#What-is-`sleep`) but it is asynchronous which means it will not block the event loop, thus allowing the background tasks to continue to be worked on. We're also planning on instruementing it with tracing to then allow us visualize it in the timeline in grafana cloud k6.
+[page.waitForTimeout](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/waitfortimeout) will wait the given amount of time. It's functionally the same as k6's [sleep](#What-is-`sleep`), but it's asynchronous, which means it will not block the event loop and allows the background tasks to continue to be worked on.
 
 {{< code >}}
 

--- a/docs/sources/v0.53.x/using-k6-browser/recommended-practices/simulate-user-input-delay.md
+++ b/docs/sources/v0.53.x/using-k6-browser/recommended-practices/simulate-user-input-delay.md
@@ -1,0 +1,261 @@
+---
+title: 'Simulating user input delay'
+description: 'A guide on how to simulate user input delay.'
+weight: 04
+---
+
+We will demonstrate how best to work with `sleep` in `k6` and the various `wait*` prepended methods that are available in `k6/browser` to simulate user input delay, wait for navigations, and wait for element state changes. By the end of this page, you should be able to successfully use the correct API where necessary.
+
+{{< admonition type="note" >}}
+
+While using the `sleep` or `page.waitForTimeout` functions to wait for element state changes may seem helpful, it's best to avoid them to prevent flakey tests. Instead, it's better to use the other `wait*` prepended methods listed on this page.
+
+{{< /admonition >}}
+
+# What is `sleep`?
+
+[sleep](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6/sleep) is a first class function built into k6. It's main use is to _"suspend VU execution for the specified duration"_ which is most useful when you want to simulate user input delay, such as:
+
+- Navigating to a page.
+- Sleeping for a 1 second, which is to simulate a user looking for a specific element on the page.
+- Clicking on the element.
+- etc.
+
+{{< admonition type="warning" >}}
+
+`sleep` is a synchronous function that blocks the JS event loop, which means that all asynchronous work will also be suspended until the `sleep` completes.
+
+The browser module predominantly provides asynchronous APIs, and so it's best to avoid working with `sleep`, and instead **we recommend you use [page.waitForTimeout](#pagewaitfortimeout)**.
+
+{{< /admonition >}}
+
+# What is `wait*`?
+
+In the browser modules there are various asynchronous APIs that can be used to wait for certain states:
+
+| Method                                           | Description                                                                   |
+| ------------------------------------------------ | ----------------------------------------------------------------------------- |
+| [page.waitForFunction](#pagewaitforfunction)     | Waits for the given function to return a truthy value.                        |
+| [page.waitForLoadState](#pagewaitforloadstate)   | Waits for the specified page life cycle event.                                |
+| [page.waitForNavigation](#pagewaitfornavigation) | Waits for the navigation to complete after one starts.                        |
+| [locator.waitFor](#locatorwaitfor)               | Wait for the element to be in a particular state.                             |
+| [page.waitForTimeout](#pagewaitfortimeout)       | Waits the given time. **Use this instead of `sleep` in your frontend tests.** |
+
+## page.waitForFunction
+
+[page.waitForFunction](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/waitforfunction) is useful when you want more control over when a test progresses with a javascript function that returns true when a condition (or many conditions) is met. It can be used to poll for changes in the dom or non dom elements and variables.
+
+{{< code >}}
+
+<!-- eslint-skip-->
+
+```javascript
+import { browser } from 'k6/browser';
+import { check } from 'k6';
+
+export const options = {
+  scenarios: {
+    browser: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+          type: 'chromium',
+        },
+      },
+    },
+  },
+};
+
+export default async function () {
+  const page = await browser.newPage();
+
+  try {
+    // Setting up the example that will mutate the h1 element by setting the
+    // h1 elements text value to "Hello".
+    await page.evaluate(() => {
+      setTimeout(() => {
+        const el = document.createElement('h1');
+        el.innerHTML = 'Hello';
+        document.body.appendChild(el);
+      }, 1000);
+    });
+
+    // Waiting until the h1 element has mutated.
+    const ok = await page.waitForFunction("document.querySelector('h1')", {
+      polling: 'mutation',
+      timeout: 2000,
+    });
+
+    const innerHTML = await ok.innerHTML();
+    check(ok, { 'waitForFunction successfully resolved': innerHTML == 'Hello' });
+  } finally {
+    await page.close();
+  }
+}
+```
+
+{{< /code >}}
+
+## page.waitForLoadState
+
+[page.waitForLoadState](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/waitforloadstate) is useful when there’s no explicit navigation, but you need to wait for the page or network to settle. This is mainly used when working with single page applications or when no full page reloads happen.
+
+{{< code >}}
+
+```javascript
+import { check } from 'k6';
+import { browser } from 'k6/browser';
+
+export const options = {
+  scenarios: {
+    browser: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+          type: 'chromium',
+        },
+      },
+    },
+  },
+};
+
+export default async function () {
+  const page = await browser.newPage();
+
+  try {
+    // Goto a SPA
+    await page.goto('<url>');
+
+    // ... perform some actions that reload part of the page.
+
+    // waits for the default `load` event.
+    await page.waitForLoadState();
+  } finally {
+    await page.close();
+  }
+}
+```
+
+{{< /code >}}
+
+## page.waitForNavigation
+
+[page.waitForNavigation](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/waitfornavigation) is a very useful API when performing other actions that could start a page navigation, and they don't automatically wait for a navigation to end. Usually you'll find it in our examples with a `click` API call. Note that [goto](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/goto) is an example of an API that **doesn't** require `waitForNavigation` since it will automatically wait for the navigation to complete before returning.
+
+It's important to call this in a [Promise.all](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all) along with the API that will cause the navigation to start.
+
+{{< code >}}
+
+```javascript
+import { check } from 'k6';
+import { browser } from 'k6/browser';
+
+export const options = {
+  scenarios: {
+    browser: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+          type: 'chromium',
+        },
+      },
+    },
+  },
+};
+
+export default async function () {
+  const page = await browser.newPage();
+
+  try {
+    await page.goto('https://test.k6.io/my_messages.php');
+
+    await page.locator('input[name="login"]').type('admin');
+    await page.locator('input[name="password"]').type('123');
+
+    const submitButton = page.locator('input[type="submit"]');
+
+    // The click action will start a navigation, and the waitForNavigation
+    // will help the test wait until the navigation completes.
+    await Promise.all([page.waitForNavigation(), submitButton.click()]);
+  } finally {
+    await page.close();
+  }
+}
+```
+
+{{< /code >}}
+
+## locator.waitFor
+
+[locator.waitFor](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/locator/waitfor/) will wait until the element meets the waiting criteria. It's useful when dealing with dynamic websites where elements may take time to appear or change state (they might load after some delay due to async calls, JavaScript execution, etc.).
+
+{{< code >}}
+
+```js
+import { browser } from 'k6/browser';
+
+export const options = {
+  scenarios: {
+    browser: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+          type: 'chromium',
+        },
+      },
+    },
+  },
+};
+
+export default async function () {
+  const page = await browser.newPage();
+
+  await page.goto('https://test.k6.io/browser.php');
+  const text = page.locator('#input-text-hidden');
+  await text.waitFor({
+    state: 'hidden',
+  });
+}
+```
+
+{{< /code >}}
+
+## page.waitForTimeout
+
+[page.waitForTimeout](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/waitfortimeout) will wait the given amount of time. It's functionally the same as k6's [sleep](#What-is-`sleep`) but it is asynchronous which means it will not block the event loop, thus allowing the background tasks to continue to be worked on. We're also planning on instruementing it with tracing to then allow us visualize it in the timeline in grafana cloud k6.
+
+{{< code >}}
+
+```js
+import { browser } from 'k6/browser';
+
+export const options = {
+  scenarios: {
+    browser: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+          type: 'chromium',
+        },
+      },
+    },
+  },
+};
+
+export default async function () {
+  const page = await browser.newPage();
+
+  try {
+    await page.goto('https://test.k6.io');
+
+    // Slow the test down to mimic a user looking for the element on the page.
+    await page.waitForTimeout(1000);
+
+    // ... perform the next action
+  } finally {
+    await page.close();
+  }
+}
+```
+
+{{< /code >}}


### PR DESCRIPTION
<!-- 
Please make sure you have read the contribution guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md as well as the
the code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md before opening a PR.
-->

## What?

Add `sleep` and `page.waitForTimeout` doc to v0.52 & v0.53. It's a new recommended best practice doc for the browser module.

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [x] I have made my changes in the `docs/sources/next` folder of the documentation.
- [x] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.
- [x] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->
<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
Updates: https://github.com/grafana/k6-docs/issues/1719