### PR TITLE
Use async `check` instead of the sync one

### DIFF
--- a/docs/sources/next/javascript-api/k6-browser/browsercontext/addinitscript.md
+++ b/docs/sources/next/javascript-api/k6-browser/browsercontext/addinitscript.md
@@ -24,7 +24,7 @@ The script is evaluated after the document is created but before any of its scri
 
 ```javascript
 import { browser } from 'k6/browser';
-import { check } from 'k6';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
   scenarios: {
@@ -63,9 +63,8 @@ export default async function () {
     </script>
   </html>`);
 
-  const text = await page.locator('#random').textContent();
-  check(page, {
-    zero: () => text == '0',
+  await check(page.locator('#random'), {
+    'is zero': async random => await random.textContent() == '0'
   });
 
   await page.close();

--- a/docs/sources/next/javascript-api/k6-browser/browsercontext/waitforevent.md
+++ b/docs/sources/next/javascript-api/k6-browser/browsercontext/waitforevent.md
@@ -27,7 +27,7 @@ Waits for the event to fire and returns its value. If a predicate function has b
 <CodeGroup labels={[]}>
 
 ```javascript
-import { browser } from 'k6/x/browser';
+import { browser } from 'k6/browser';
 
 export const options = {
   scenarios: {

--- a/docs/sources/next/javascript-api/k6-browser/elementhandle/_index.md
+++ b/docs/sources/next/javascript-api/k6-browser/elementhandle/_index.md
@@ -50,8 +50,8 @@ weight: 04
 ## Examples
 
 ```javascript
-import { check } from 'k6';
 import { browser } from 'k6/browser';
+import { check } from "https://jslib.k6.io/k6-utils/1.5.0/index.js";
 
 export const options = {
   scenarios: {
@@ -76,16 +76,20 @@ export default async function () {
 
     await Promise.all([page.waitForNavigation(), messagesLink.click()]);
     // Enter login credentials and login
-    await page.$('input[name="login"]').type('admin');
-    await page.$('input[name="password"]').type('123');
+    const login = await page.$('input[name="login"]');
+    await login.type('admin');
+    const password = await page.$('input[name="password"]');
+    await password.type('123');
 
     const submitButton = await page.$('input[type="submit"]');
 
     await Promise.all([page.waitForNavigation(), submitButton.click()]);
-    const text = await page.$('h2');
-    const content = await text.textContent();
-    check(page, {
-      header: () => text == 'Welcome, admin!',
+
+    await check(page, {
+      'header': async p => {
+        const h2 = await p.$('h2');
+        return await h2.textContent() == 'Welcome, admin!';
+      },
     });
   } finally {
     await page.close();
@@ -97,7 +101,7 @@ export default async function () {
 
 ```javascript
 import { browser } from 'k6/browser';
-import { check } from 'k6';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
   scenarios: {
@@ -112,7 +116,7 @@ export const options = {
   },
 };
 
-export default function () {
+export default async function () {
   const page = await browser.newPage();
 
   try {
@@ -128,35 +132,35 @@ export default function () {
     `);
 
     // Check state
-    let el = await page.$('.visible');
-    const isVisible = await el.isVisible();
-
-    el = await page.$('.hidden');
-    const isHidden = await el.isHidden();
-
-    el = await page.$('.editable');
-    const isEditable = await el.isEditable();
-
-    el = await page.$('.enabled');
-    const isEnabled = await el.isEnabled();
-
-    el = await page.$('.disabled');
-    const isDisabled = await el.isDisabled();
-
-    el = await page.$('.checked');
-    const isChecked = await el.isChecked();
-
-    el = await page.$('.unchecked');
-    const isUncheckedChecked = await el.isChecked();
-
-    check(page, {
-      visible: isVisible,
-      hidden: isHidden,
-      editable: isEditable,
-      enabled: isEnabled,
-      disabled: isDisabled,
-      checked: isChecked,
-      unchecked: isUncheckedChecked === false,
+    await check(page, {
+      'is visible': async p => {
+        const e = await p.$('.visible');
+        return e.isVisible();
+      },
+      'is hidden': async p => {
+        const e = await p.$('.hidden');
+        return e.isHidden();
+      },
+      'is editable': async p => {
+        const e = await p.$('.editable');
+        return e.isEditable();
+      },
+      'is enabled': async p => {
+        const e = await p.$('.enabled');
+        return e.isEnabled();
+      },
+      'is disabled': async p => {
+        const e = await p.$('.disabled');
+        return e.isDisabled();
+      },
+      'is checked': async p => {
+        const e = await p.$('.checked');
+        return e.isChecked();
+      },
+      'is unchecked': async p => {
+        const e = await p.$('.unchecked');
+        return await e.isChecked() === false;
+      },
     });
   } finally {
     await page.close();

--- a/docs/sources/next/javascript-api/k6-browser/locator/clear.md
+++ b/docs/sources/next/javascript-api/k6-browser/locator/clear.md
@@ -29,8 +29,8 @@ Clears text boxes and input fields (`input`, `textarea` or `contenteditable` ele
 {{< code >}}
 
 ```javascript
-import { check } from 'k6';
 import { browser } from 'k6/browser';
+import { check } from "https://jslib.k6.io/k6-utils/1.5.0/index.js";
 
 export const options = {
   scenarios: {
@@ -49,26 +49,25 @@ export default async function () {
   const context = await browser.newContext();
   const page = await context.newPage();
 
-  await page.goto('https://test.k6.io/my_messages.php', { waitUntil: 'networkidle' });
-
-  const login = page.locator('input[name="login"]');
-
-  // Fill an input element with some text that we will later clear.
-  await login.type('admin');
-
-  // This checks that the element has been filled with text.
-  let value = await login.inputValue();
-  check(page, {
-    not_empty: (p) => value != '',
+  await page.goto("https://test.k6.io/my_messages.php", {
+    waitUntil: 'networkidle',
   });
 
-  // Now clear the text from the element.
+  // Fill an input element with some text that we will later clear
+  const login = page.locator('input[name="login"]');
+  await login.type('admin');
+
+  // Check that the element has been filled with text
+  await check(login, {
+    'not empty': async lo => await lo.inputValue() != '',
+  });
+
+  // Now clear the text from the element
   await login.clear();
 
-  // This checks that the element is now empty.
-  value = await login.inputValue();
-  check(page, {
-    empty: () => value == '',
+  // Check that the element is now empty
+  await check(login, {
+    empty: async lo => await lo.inputValue() == '',
   });
 
   await page.close();

--- a/docs/sources/next/javascript-api/k6-browser/page/on.md
+++ b/docs/sources/next/javascript-api/k6-browser/page/on.md
@@ -29,7 +29,7 @@ When using the `page.on` method, the page has to be explicitly [closed](https://
 {{< code >}}
 
 ```javascript
-import { browser } from 'k6/x/browser';
+import { browser } from 'k6/browser';
 import { check } from 'k6';
 
 export const options = {

--- a/docs/sources/next/javascript-api/k6-browser/page/throttlenetwork.md
+++ b/docs/sources/next/javascript-api/k6-browser/page/throttlenetwork.md
@@ -33,7 +33,7 @@ To work with the most commonly tested network profiles, import `networkProfiles`
 {{< code >}}
 
 ```javascript
-import { browser, networkProfiles } from 'k6/x/browser';
+import { browser, networkProfiles } from 'k6/browser';
 
 export const options = {
   scenarios: {

--- a/docs/sources/next/javascript-api/k6-browser/page/waitforfunction.md
+++ b/docs/sources/next/javascript-api/k6-browser/page/waitforfunction.md
@@ -33,7 +33,7 @@ Returns when the `pageFunction` returns a truthy value.
 
 ```javascript
 import { browser } from 'k6/browser';
-import { check } from 'k6';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
   scenarios: {
@@ -64,8 +64,10 @@ export default async function () {
       polling: 'mutation',
       timeout: 2000,
     });
-    const innerHTML = await ok.innerHTML();
-    check(ok, { 'waitForFunction successfully resolved': innerHTML == 'Hello' });
+    await check(page, {
+      'waitForFunction successfully resolved': async () =>
+          await ok.innerHTML() == 'Hello'
+    });
   } finally {
     await page.close();
   }

--- a/docs/sources/next/javascript-api/k6-browser/page/waitforfunction.md
+++ b/docs/sources/next/javascript-api/k6-browser/page/waitforfunction.md
@@ -64,8 +64,8 @@ export default async function () {
       polling: 'mutation',
       timeout: 2000,
     });
-    await check(page, {
-      'waitForFunction successfully resolved': async () =>
+    await check(ok, {
+      'waitForFunction successfully resolved': async (ok) =>
           await ok.innerHTML() == 'Hello'
     });
   } finally {

--- a/docs/sources/next/javascript-api/k6-browser/page/waitforloadstate.md
+++ b/docs/sources/next/javascript-api/k6-browser/page/waitforloadstate.md
@@ -48,8 +48,8 @@ Events can be either:
 {{< code >}}
 
 ```javascript
-import { check } from 'k6';
 import { browser } from 'k6/browser';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
   scenarios: {
@@ -65,7 +65,7 @@ export const options = {
 };
 
 export default async function () {
-  const page = await browser.newPage();
+  let page = await browser.newPage();
 
   try {
     await page.goto('https://test.k6.io/my_messages.php');
@@ -76,11 +76,10 @@ export default async function () {
     const submitButton = page.locator('input[type="submit"]');
     await submitButton.click();
 
-    await page.waitForLoadState(); // waits for the default `load` event
+    await page.waitForLoadState('networkidle'); // waits until the `networkidle` event
 
-    const text = await page.locator('h2').textContent();
-    check(page, {
-      header: () => text == 'Welcome, admin!',
+    await check(page.locator('h2'), {
+      'header': async h2 => await h2.textContent() == 'Welcome, admin!'
     });
   } finally {
     await page.close();

--- a/docs/sources/next/javascript-api/k6-browser/page/waitfornavigation.md
+++ b/docs/sources/next/javascript-api/k6-browser/page/waitfornavigation.md
@@ -42,8 +42,8 @@ Events can be either:
 {{< code >}}
 
 ```javascript
-import { check } from 'k6';
 import { browser } from 'k6/browser';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
   scenarios: {
@@ -69,11 +69,13 @@ export default async function () {
 
     const submitButton = page.locator('input[type="submit"]');
 
-    await Promise.all([page.waitForNavigation(), submitButton.click()]);
+    await Promise.all([
+      submitButton.click(),
+      page.waitForNavigation(),
+    ]);
 
-    const text = await page.locator('h2').textContent();
-    check(page, {
-      header: () => text == 'Welcome, admin!',
+    await check(page.locator('h2'), {
+      header: async h2 => await h2.textContent() == 'Welcome, admin!'
     });
   } finally {
     await page.close();

--- a/docs/sources/next/using-k6-browser/_index.md
+++ b/docs/sources/next/using-k6-browser/_index.md
@@ -35,7 +35,7 @@ The main use case for the browser module is to test performance on the browser l
 
 ```javascript
 import { browser } from 'k6/browser';
-import { check } from 'k6';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
   scenarios: {
@@ -68,9 +68,8 @@ export default async function () {
       page.locator('input[type="submit"]').click(),
     ]);
 
-    const header = await page.locator("h2").textContent();
-    check(header, {
-      header: (h) => h == "Welcome, admin!",
+    await check(page.locator("h2"), {
+      'header': async h2 => await h2.textContent() == "Welcome, admin!"
     });
   } finally {
     await page.close();

--- a/docs/sources/next/using-k6-browser/migrating-to-k6-v0-52.md
+++ b/docs/sources/next/using-k6-browser/migrating-to-k6-v0-52.md
@@ -275,7 +275,7 @@ Below is a screenshot of a comparison between a generic browser test in `v0.51` 
 
 ## Working with k6 check
 
-The k6 `check` API will not `await` promises, so calling a function that returns a `Promise`, for example `locator.textContent()`, inside one of the predicates will not work. Instead you can work with [the jslib.k6.io's `check` utility](https://grafana.com/docs/k6/latest/javascript-api/jslib/utils/check/).
+The k6 `check` API will not `await` promises, so calling a function that returns a `Promise`, for example `locator.textContent()`, inside one of the predicates will not work. Instead, you can work with [the jslib.k6.io's `check` utility function](https://grafana.com/docs/k6/latest/javascript-api/jslib/utils/check/).
 
 For example, before:
 

--- a/docs/sources/next/using-k6-browser/recommended-practices/hybrid-approach-to-performance.md
+++ b/docs/sources/next/using-k6-browser/recommended-practices/hybrid-approach-to-performance.md
@@ -86,7 +86,7 @@ export async function checkFrontend() {
   try {
     await page.goto(BASE_URL);
 
-    check(page.locator('h1'), {
+    await check(page.locator('h1'), {
       'header': async lo => await lo.textContent() == 'Looking to break out of your pizza routine?'
     });
 
@@ -185,7 +185,7 @@ export async function checkFrontend() {
 
   try {
     await page.goto(BASE_URL);
-    check(page.locator('h1'), {
+    await check(page.locator('h1'), {
       'header': async lo => await lo.textContent() == 'Looking to break out of your pizza routine?'
     });
 

--- a/docs/sources/next/using-k6-browser/recommended-practices/hybrid-approach-to-performance.md
+++ b/docs/sources/next/using-k6-browser/recommended-practices/hybrid-approach-to-performance.md
@@ -19,10 +19,10 @@ The code below shows an example of combining a browser and HTTP test in a single
 {{< code >}}
 
 ```javascript
-import http from 'k6/http';
-import { check } from 'k6';
 import { browser } from 'k6/browser';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.2.0/index.js';
+import http from 'k6/http';
 
 const BASE_URL = __ENV.BASE_URL || 'https://quickpizza.grafana.com';
 
@@ -86,9 +86,8 @@ export async function checkFrontend() {
   try {
     await page.goto(BASE_URL);
 
-    const header = await page.locator('h1').textContent();
-    check(header, {
-      header: (h) => h == 'Looking to break out of your pizza routine?',
+    check(page.locator('h1'), {
+      'header': async lo => await lo.textContent() == 'Looking to break out of your pizza routine?'
     });
 
     await Promise.all([
@@ -97,9 +96,8 @@ export async function checkFrontend() {
     ]);
     await page.screenshot({ path: `screenshots/${__ITER}.png` });
 
-    const recommendation = await page.locator('div#recommendations').textContent();
-    check(recommendation, {
-      recommendation: (r) => r != '',
+    await check(page.locator('div#recommendations'), {
+      'recommendation': async lo => await lo.textContent() != '',
     });
   } finally {
     await page.close();
@@ -132,10 +130,10 @@ To find out more information about injecting faults to your service, check out t
 {{< code >}}
 
 ```javascript
-import http from 'k6/http';
-import { check } from 'k6';
 import { browser } from 'k6/browser';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 import { ServiceDisruptor } from 'k6/x/disruptor';
+import http from 'k6/http';
 
 const BASE_URL = __ENV.BASE_URL;
 
@@ -188,9 +186,8 @@ export async function checkFrontend() {
 
   try {
     await page.goto(BASE_URL);
-    const header = await page.locator('h1').textContent();
-    check(header, {
-      header: (h) => h == 'Looking to break out of your pizza routine?',
+    check(page.locator('h1'), {
+      'header': async lo => await lo.textContent() == 'Looking to break out of your pizza routine?'
     });
 
     await Promise.all([
@@ -199,9 +196,8 @@ export async function checkFrontend() {
     ]);
     await page.screenshot({ path: `screenshots/${__ITER}.png` });
 
-    const recommendation = await page.locator('div#recommendations').textContent();
-    check(recommendation, {
-      recommendation: (r) => r != '',
+    await check(page.locator('div#recommendations'), {
+      recommendation: async lo => await lo.textContent() != '',
     });
   } finally {
     await page.close();

--- a/docs/sources/next/using-k6-browser/recommended-practices/hybrid-approach-to-performance.md
+++ b/docs/sources/next/using-k6-browser/recommended-practices/hybrid-approach-to-performance.md
@@ -133,7 +133,6 @@ To find out more information about injecting faults to your service, check out t
 import { browser } from 'k6/browser';
 import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 import { ServiceDisruptor } from 'k6/x/disruptor';
-import http from 'k6/http';
 
 const BASE_URL = __ENV.BASE_URL;
 

--- a/docs/sources/next/using-k6-browser/recommended-practices/simulate-user-input-delay.md
+++ b/docs/sources/next/using-k6-browser/recommended-practices/simulate-user-input-delay.md
@@ -89,7 +89,7 @@ export default async function () {
     });
 
     await check(ok, {
-      'waitForFunction successfully resolved': async () => await ok.innerHTML() == 'Hello'
+      'waitForFunction successfully resolved': async (ok) => await ok.innerHTML() == 'Hello'
     });
   } finally {
     await page.close();

--- a/docs/sources/next/using-k6-browser/recommended-practices/simulate-user-input-delay.md
+++ b/docs/sources/next/using-k6-browser/recommended-practices/simulate-user-input-delay.md
@@ -4,6 +4,8 @@ description: 'A guide on how to simulate user input delay.'
 weight: 04
 ---
 
+# Simulating user input delay
+
 We will demonstrate how best to work with `sleep` in `k6` and the various `wait*` prepended methods that are available in `k6/browser` to simulate user input delay, wait for navigations, and wait for element state changes. By the end of this page, you should be able to successfully use the correct API where necessary.
 
 {{< admonition type="note" >}}

--- a/docs/sources/next/using-k6-browser/recommended-practices/simulate-user-input-delay.md
+++ b/docs/sources/next/using-k6-browser/recommended-practices/simulate-user-input-delay.md
@@ -51,7 +51,7 @@ In the browser modules there are various asynchronous APIs that can be used to w
 
 ```javascript
 import { browser } from 'k6/browser';
-import { check } from 'k6';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
   scenarios: {
@@ -86,8 +86,9 @@ export default async function () {
       timeout: 2000,
     });
 
-    const innerHTML = await ok.innerHTML();
-    check(ok, { 'waitForFunction successfully resolved': innerHTML == 'Hello' });
+    await check(ok, {
+      'waitForFunction successfully resolved': async () => await ok.innerHTML() == 'Hello'
+    });
   } finally {
     await page.close();
   }
@@ -103,8 +104,8 @@ export default async function () {
 {{< code >}}
 
 ```javascript
-import { check } from 'k6';
 import { browser } from 'k6/browser';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
   scenarios: {
@@ -147,8 +148,8 @@ It's important to call this in a [Promise.all](https://developer.mozilla.org/en-
 {{< code >}}
 
 ```javascript
-import { check } from 'k6';
 import { browser } from 'k6/browser';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
   scenarios: {
@@ -176,7 +177,10 @@ export default async function () {
 
     // The click action will start a navigation, and the waitForNavigation
     // will help the test wait until the navigation completes.
-    await Promise.all([page.waitForNavigation(), submitButton.click()]);
+    await Promise.all([
+      page.waitForNavigation(),
+      submitButton.click(),
+    ]);
   } finally {
     await page.close();
   }

--- a/docs/sources/next/using-k6-browser/recommended-practices/simulate-user-input-delay.md
+++ b/docs/sources/next/using-k6-browser/recommended-practices/simulate-user-input-delay.md
@@ -107,7 +107,6 @@ export default async function () {
 
 ```javascript
 import { browser } from 'k6/browser';
-import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
   scenarios: {
@@ -151,7 +150,6 @@ It's important to call this in a [Promise.all](https://developer.mozilla.org/en-
 
 ```javascript
 import { browser } from 'k6/browser';
-import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
   scenarios: {

--- a/docs/sources/next/using-k6-browser/running-browser-tests.md
+++ b/docs/sources/next/using-k6-browser/running-browser-tests.md
@@ -228,8 +228,8 @@ To avoid timing errors or other race conditions in your script, if you have acti
 {{< code >}}
 
 ```javascript
-import { check } from 'k6';
 import { browser } from 'k6/browser';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
   scenarios: {
@@ -258,11 +258,13 @@ export default async function () {
 
     const submitButton = page.locator('input[type="submit"]');
 
-    await Promise.all([page.waitForNavigation(), submitButton.click()]);
+    await Promise.all([
+      page.waitForNavigation(),
+      submitButton.click(),
+    ]);
 
-    const header = await page.locator('h2').textContent();
-    check(header, {
-      header: (h) => h == 'Welcome, admin!',
+    await check(page.locator('h2'), {
+      'header': async lo => await lo.textContent() == 'Welcome, admin!'
     });
   } finally {
     await page.close();
@@ -296,7 +298,7 @@ Keep in mind that there is an additional performance overhead when it comes to s
 
 ```javascript
 import { browser } from 'k6/browser';
-import { check } from 'k6';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 import http from 'k6/http';
 
 export const options = {
@@ -329,9 +331,9 @@ export async function browserTest() {
 
     await page.locator('#checkbox1').check();
 
-    const info = await page.locator('#checkbox-info-display').textContent();
-    check(info, {
-      'checkbox is checked': (info) => info === 'Thanks for checking the box',
+    await check(page.locator('#checkbox-info-display'), {
+      'checkbox is checked': async lo =>
+        await lo.textContent() === 'Thanks for checking the box'
     });
   } finally {
     await page.close();

--- a/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/on.md
+++ b/docs/sources/v0.47.x/javascript-api/k6-experimental/browser/page/on.md
@@ -29,7 +29,7 @@ When using the `page.on` method, the page has to be explicitly [closed](https://
 {{< code >}}
 
 ```javascript
-import { browser } from 'k6/x/browser';
+import { browser } from 'k6/experimental/browser';
 import { check } from 'k6';
 
 export const options = {

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/browsercontext/waitforevent.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/browsercontext/waitforevent.md
@@ -27,7 +27,7 @@ Waits for the event to fire and returns its value. If a predicate function has b
 <CodeGroup labels={[]}>
 
 ```javascript
-import { browser } from 'k6/x/browser';
+import { browser } from 'k6/experimental/browser';
 
 export const options = {
   scenarios: {

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/on.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/on.md
@@ -29,7 +29,7 @@ When using the `page.on` method, the page has to be explicitly [closed](https://
 {{< code >}}
 
 ```javascript
-import { browser } from 'k6/x/browser';
+import { browser } from 'k6/experimental/browser';
 import { check } from 'k6';
 
 export const options = {

--- a/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/throttlenetwork.md
+++ b/docs/sources/v0.48.x/javascript-api/k6-experimental/browser/page/throttlenetwork.md
@@ -27,7 +27,7 @@ To work with the most commonly tested network profiles, import `networkProfiles`
 {{< code >}}
 
 ```javascript
-import { browser, networkProfiles } from 'k6/x/browser';
+import { browser, networkProfiles } from 'k6/experimental/browser';
 
 export const options = {
   scenarios: {

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/browsercontext/waitforevent.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/browsercontext/waitforevent.md
@@ -27,7 +27,7 @@ Waits for the event to fire and returns its value. If a predicate function has b
 <CodeGroup labels={[]}>
 
 ```javascript
-import { browser } from 'k6/x/browser';
+import { browser } from 'k6/experimental/browser';
 
 export const options = {
   scenarios: {

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/on.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/on.md
@@ -29,7 +29,7 @@ When using the `page.on` method, the page has to be explicitly [closed](https://
 {{< code >}}
 
 ```javascript
-import { browser } from 'k6/x/browser';
+import { browser } from 'k6/experimental/browser';
 import { check } from 'k6';
 
 export const options = {

--- a/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/throttlenetwork.md
+++ b/docs/sources/v0.49.x/javascript-api/k6-experimental/browser/page/throttlenetwork.md
@@ -27,7 +27,7 @@ To work with the most commonly tested network profiles, import `networkProfiles`
 {{< code >}}
 
 ```javascript
-import { browser, networkProfiles } from 'k6/x/browser';
+import { browser, networkProfiles } from 'k6/experimental/browser';
 
 export const options = {
   scenarios: {

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/browsercontext/waitforevent.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/browsercontext/waitforevent.md
@@ -27,7 +27,7 @@ Waits for the event to fire and returns its value. If a predicate function has b
 <CodeGroup labels={[]}>
 
 ```javascript
-import { browser } from 'k6/x/browser';
+import { browser } from 'k6/experimental/browser';
 
 export const options = {
   scenarios: {

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/on.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/on.md
@@ -29,7 +29,7 @@ When using the `page.on` method, the page has to be explicitly [closed](https://
 {{< code >}}
 
 ```javascript
-import { browser } from 'k6/x/browser';
+import { browser } from 'k6/experimental/browser';
 import { check } from 'k6';
 
 export const options = {

--- a/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/throttlenetwork.md
+++ b/docs/sources/v0.50.x/javascript-api/k6-experimental/browser/page/throttlenetwork.md
@@ -27,7 +27,7 @@ To work with the most commonly tested network profiles, import `networkProfiles`
 {{< code >}}
 
 ```javascript
-import { browser, networkProfiles } from 'k6/x/browser';
+import { browser, networkProfiles } from 'k6/experimental/browser';
 
 export const options = {
   scenarios: {

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/browsercontext/waitforevent.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/browsercontext/waitforevent.md
@@ -27,7 +27,7 @@ Waits for the event to fire and returns its value. If a predicate function has b
 <CodeGroup labels={[]}>
 
 ```javascript
-import { browser } from 'k6/x/browser';
+import { browser } from 'k6/experimental/browser';
 
 export const options = {
   scenarios: {

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/on.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/on.md
@@ -29,7 +29,7 @@ When using the `page.on` method, the page has to be explicitly [closed](https://
 {{< code >}}
 
 ```javascript
-import { browser } from 'k6/x/browser';
+import { browser } from 'k6/experimental/browser';
 import { check } from 'k6';
 
 export const options = {

--- a/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/throttlenetwork.md
+++ b/docs/sources/v0.51.x/javascript-api/k6-experimental/browser/page/throttlenetwork.md
@@ -27,7 +27,7 @@ To work with the most commonly tested network profiles, import `networkProfiles`
 {{< code >}}
 
 ```javascript
-import { browser, networkProfiles } from 'k6/x/browser';
+import { browser, networkProfiles } from 'k6/experimental/browser';
 
 export const options = {
   scenarios: {

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/browsercontext/addinitscript.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/browsercontext/addinitscript.md
@@ -24,7 +24,7 @@ The script is evaluated after the document is created but before any of its scri
 
 ```javascript
 import { browser } from 'k6/browser';
-import { check } from 'k6';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
   scenarios: {
@@ -63,9 +63,8 @@ export default async function () {
     </script>
   </html>`);
 
-  const text = await page.locator('#random').textContent();
-  check(page, {
-    zero: () => text == '0',
+  await check(page.locator('#random'), {
+    'is zero': async random => await random.textContent() == '0'
   });
 
   await page.close();

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/browsercontext/waitforevent.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/browsercontext/waitforevent.md
@@ -18,8 +18,8 @@ Waits for the event to fire and returns its value. If a predicate function has b
 
 ### Returns
 
-| Type            | Description                                                                                                                                                                |
-| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Type            | Description                                                                                                                                                   |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `Promise<Page>` | A Promise that fulfills with a [page](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page) object when the `page` event has been emitted. |
 
 ### Example
@@ -27,7 +27,7 @@ Waits for the event to fire and returns its value. If a predicate function has b
 <CodeGroup labels={[]}>
 
 ```javascript
-import { browser } from 'k6/x/browser';
+import { browser } from 'k6/browser';
 
 export const options = {
   scenarios: {

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/_index.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/elementhandle/_index.md
@@ -50,8 +50,8 @@ weight: 04
 ## Examples
 
 ```javascript
-import { check } from 'k6';
 import { browser } from 'k6/browser';
+import { check } from "https://jslib.k6.io/k6-utils/1.5.0/index.js";
 
 export const options = {
   scenarios: {
@@ -76,16 +76,20 @@ export default async function () {
 
     await Promise.all([page.waitForNavigation(), messagesLink.click()]);
     // Enter login credentials and login
-    await page.$('input[name="login"]').type('admin');
-    await page.$('input[name="password"]').type('123');
+    const login = await page.$('input[name="login"]');
+    await login.type('admin');
+    const password = await page.$('input[name="password"]');
+    await password.type('123');
 
     const submitButton = await page.$('input[type="submit"]');
 
     await Promise.all([page.waitForNavigation(), submitButton.click()]);
-    const text = await page.$('h2');
-    const content = await text.textContent();
-    check(page, {
-      header: () => text == 'Welcome, admin!',
+
+    await check(page, {
+      'header': async p => {
+        const h2 = await p.$('h2');
+        return await h2.textContent() == 'Welcome, admin!';
+      },
     });
   } finally {
     await page.close();
@@ -96,8 +100,8 @@ export default async function () {
 <!-- eslint-skip -->
 
 ```javascript
-import { check } from 'k6';
 import { browser } from 'k6/browser';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
   scenarios: {
@@ -112,7 +116,7 @@ export const options = {
   },
 };
 
-export default function () {
+export default async function () {
   const page = await browser.newPage();
 
   try {
@@ -128,35 +132,35 @@ export default function () {
     `);
 
     // Check state
-    let el = await page.$('.visible');
-    const isVisible = await el.isVisible();
-
-    el = await page.$('.hidden');
-    const isHidden = await el.isHidden();
-
-    el = await page.$('.editable');
-    const isEditable = await el.isEditable();
-
-    el = await page.$('.enabled');
-    const isEnabled = await el.isEnabled();
-
-    el = await page.$('.disabled');
-    const isDisabled = await el.isDisabled();
-
-    el = await page.$('.checked');
-    const isChecked = await el.isChecked();
-
-    el = await page.$('.unchecked');
-    const isUncheckedChecked = await el.isChecked();
-
-    check(page, {
-      visible: isVisible,
-      hidden: isHidden,
-      editable: isEditable,
-      enabled: isEnabled,
-      disabled: isDisabled,
-      checked: isChecked,
-      unchecked: isUncheckedChecked === false,
+    await check(page, {
+      'is visible': async p => {
+        const e = await p.$('.visible');
+        return e.isVisible();
+      },
+      'is hidden': async p => {
+        const e = await p.$('.hidden');
+        return e.isHidden();
+      },
+      'is editable': async p => {
+        const e = await p.$('.editable');
+        return e.isEditable();
+      },
+      'is enabled': async p => {
+        const e = await p.$('.enabled');
+        return e.isEnabled();
+      },
+      'is disabled': async p => {
+        const e = await p.$('.disabled');
+        return e.isDisabled();
+      },
+      'is checked': async p => {
+        const e = await p.$('.checked');
+        return e.isChecked();
+      },
+      'is unchecked': async p => {
+        const e = await p.$('.unchecked');
+        return await e.isChecked() === false;
+      },
     });
   } finally {
     await page.close();

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/locator/clear.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/locator/clear.md
@@ -29,8 +29,8 @@ Clears text boxes and input fields (`input`, `textarea` or `contenteditable` ele
 {{< code >}}
 
 ```javascript
-import { check } from 'k6';
 import { browser } from 'k6/browser';
+import { check } from "https://jslib.k6.io/k6-utils/1.5.0/index.js";
 
 export const options = {
   scenarios: {
@@ -49,26 +49,25 @@ export default async function () {
   const context = await browser.newContext();
   const page = await context.newPage();
 
-  await page.goto('https://test.k6.io/my_messages.php', { waitUntil: 'networkidle' });
-
-  const login = page.locator('input[name="login"]');
-
-  // Fill an input element with some text that we will later clear.
-  await login.type('admin');
-
-  // This checks that the element has been filled with text.
-  let value = await login.inputValue();
-  check(page, {
-    not_empty: (p) => value != '',
+  await page.goto("https://test.k6.io/my_messages.php", {
+    waitUntil: 'networkidle',
   });
 
-  // Now clear the text from the element.
+  // Fill an input element with some text that we will later clear
+  const login = page.locator('input[name="login"]');
+  await login.type('admin');
+
+  // Check that the element has been filled with text
+  await check(login, {
+    'not empty': async lo => await lo.inputValue() != '',
+  });
+
+  // Now clear the text from the element
   await login.clear();
 
-  // This checks that the element is now empty.
-  value = await login.inputValue();
-  check(page, {
-    empty: () => value == '',
+  // Check that the element is now empty
+  await check(login, {
+    empty: async lo => await lo.inputValue() == '',
   });
 
   await page.close();

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/page/on.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/page/on.md
@@ -20,8 +20,8 @@ When using the `page.on` method, the page has to be explicitly [closed](https://
 
 ### Events
 
-| Event     | Description                                                                                                                                                                                                                                                                       |
-| --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Event     | Description                                                                                                                                                                                                                                                          |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `console` | Emitted every time the console API methods are called from within the page JavaScript context. The arguments passed into the handler are defined by the [`ConsoleMessage`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/consolemessage) class. |
 
 ### Example
@@ -29,7 +29,7 @@ When using the `page.on` method, the page has to be explicitly [closed](https://
 {{< code >}}
 
 ```javascript
-import { browser } from 'k6/x/browser';
+import { browser } from 'k6/browser';
 import { check } from 'k6';
 
 export const options = {

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/page/throttlenetwork.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/page/throttlenetwork.md
@@ -33,7 +33,7 @@ To work with the most commonly tested network profiles, import `networkProfiles`
 {{< code >}}
 
 ```javascript
-import { browser, networkProfiles } from 'k6/x/browser';
+import { browser, networkProfiles } from 'k6/browser';
 
 export const options = {
   scenarios: {

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/page/waitforfunction.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/page/waitforfunction.md
@@ -33,7 +33,7 @@ Returns when the `pageFunction` returns a truthy value.
 
 ```javascript
 import { browser } from 'k6/browser';
-import { check } from 'k6';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
   scenarios: {
@@ -64,8 +64,10 @@ export default async function () {
       polling: 'mutation',
       timeout: 2000,
     });
-    const innerHTML = await ok.innerHTML();
-    check(ok, { 'waitForFunction successfully resolved': innerHTML == 'Hello' });
+    await check(page, {
+      'waitForFunction successfully resolved': async () =>
+          await ok.innerHTML() == 'Hello'
+    });
   } finally {
     await page.close();
   }

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/page/waitforfunction.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/page/waitforfunction.md
@@ -64,8 +64,8 @@ export default async function () {
       polling: 'mutation',
       timeout: 2000,
     });
-    await check(page, {
-      'waitForFunction successfully resolved': async () =>
+    await check(ok, {
+      'waitForFunction successfully resolved': async (ok) =>
           await ok.innerHTML() == 'Hello'
     });
   } finally {

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/page/waitforloadstate.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/page/waitforloadstate.md
@@ -48,8 +48,8 @@ Events can be either:
 {{< code >}}
 
 ```javascript
-import { check } from 'k6';
 import { browser } from 'k6/browser';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
   scenarios: {
@@ -65,7 +65,7 @@ export const options = {
 };
 
 export default async function () {
-  const page = await browser.newPage();
+  let page = await browser.newPage();
 
   try {
     await page.goto('https://test.k6.io/my_messages.php');
@@ -76,11 +76,10 @@ export default async function () {
     const submitButton = page.locator('input[type="submit"]');
     await submitButton.click();
 
-    await page.waitForLoadState(); // waits for the default `load` event
+    await page.waitForLoadState('networkidle'); // waits until the `networkidle` event
 
-    const text = await page.locator('h2').textContent();
-    check(page, {
-      header: () => text == 'Welcome, admin!',
+    await check(page.locator('h2'), {
+      'header': async h2 => await h2.textContent() == 'Welcome, admin!'
     });
   } finally {
     await page.close();

--- a/docs/sources/v0.52.x/javascript-api/k6-browser/page/waitfornavigation.md
+++ b/docs/sources/v0.52.x/javascript-api/k6-browser/page/waitfornavigation.md
@@ -42,8 +42,8 @@ Events can be either:
 {{< code >}}
 
 ```javascript
-import { check } from 'k6';
 import { browser } from 'k6/browser';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
   scenarios: {
@@ -69,11 +69,13 @@ export default async function () {
 
     const submitButton = page.locator('input[type="submit"]');
 
-    await Promise.all([page.waitForNavigation(), submitButton.click()]);
+    await Promise.all([
+      submitButton.click(),
+      page.waitForNavigation(),
+    ]);
 
-    const text = await page.locator('h2').textContent();
-    check(page, {
-      header: () => text == 'Welcome, admin!',
+    await check(page.locator('h2'), {
+      header: async h2 => await h2.textContent() == 'Welcome, admin!'
     });
   } finally {
     await page.close();

--- a/docs/sources/v0.52.x/using-k6-browser/_index.md
+++ b/docs/sources/v0.52.x/using-k6-browser/_index.md
@@ -35,7 +35,7 @@ The main use case for the browser module is to test performance on the browser l
 
 ```javascript
 import { browser } from 'k6/browser';
-import { check } from 'k6';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
   scenarios: {
@@ -68,9 +68,8 @@ export default async function () {
       page.locator('input[type="submit"]').click(),
     ]);
 
-    const header = await page.locator("h2").textContent();
-    check(header, {
-      header: (h) => h == "Welcome, admin!",
+    await check(page.locator("h2"), {
+      'header': async h2 => await h2.textContent() == "Welcome, admin!"
     });
   } finally {
     await page.close();

--- a/docs/sources/v0.52.x/using-k6-browser/migrating-to-k6-v0-52.md
+++ b/docs/sources/v0.52.x/using-k6-browser/migrating-to-k6-v0-52.md
@@ -275,7 +275,7 @@ Below is a screenshot of a comparison between a generic browser test in `v0.51` 
 
 ## Working with k6 check
 
-The k6 `check` API will not `await` promises, so calling a function that returns a `Promise`, for example `locator.textContent()`, inside one of the predicates will not work. Instead you can work with [the jslib.k6.io's `check` utility](https://grafana.com/docs/k6/latest/javascript-api/jslib/utils/check/).
+The k6 `check` API will not `await` promises, so calling a function that returns a `Promise`, for example `locator.textContent()`, inside one of the predicates will not work. Instead, you can work with [the jslib.k6.io's `check` utility function](https://grafana.com/docs/k6/latest/javascript-api/jslib/utils/check/).
 
 For example, before:
 

--- a/docs/sources/v0.52.x/using-k6-browser/recommended-practices/hybrid-approach-to-performance.md
+++ b/docs/sources/v0.52.x/using-k6-browser/recommended-practices/hybrid-approach-to-performance.md
@@ -20,8 +20,8 @@ The code below shows an example of combining a browser and HTTP test in a single
 
 ```javascript
 import http from 'k6/http';
-import { check } from 'k6';
 import { browser } from 'k6/browser';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.2.0/index.js';
 
 const BASE_URL = __ENV.BASE_URL || 'https://quickpizza.grafana.com';
@@ -86,9 +86,8 @@ export async function checkFrontend() {
   try {
     await page.goto(BASE_URL);
 
-    const header = await page.locator('h1').textContent();
-    check(header, {
-      header: (h) => h == 'Looking to break out of your pizza routine?',
+    check(page.locator('h1'), {
+      header: async lo => await lo.textContent() == 'Looking to break out of your pizza routine?'
     });
 
     await Promise.all([
@@ -97,9 +96,8 @@ export async function checkFrontend() {
     ]);
     await page.screenshot({ path: `screenshots/${__ITER}.png` });
 
-    const recommendation = await page.locator('div#recommendations').textContent();
-    check(recommendation, {
-      recommendation: (r) => r != '',
+    await check(page.locator('div#recommendations'), {
+      recommendation: async lo => await lo.textContent() != '',
     });
   } finally {
     await page.close();
@@ -188,9 +186,8 @@ export async function checkFrontend() {
 
   try {
     await page.goto(BASE_URL);
-    const header = await page.locator('h1').textContent();
-    check(header, {
-      header: (h) => h == 'Looking to break out of your pizza routine?',
+    check(page.locator('h1'), {
+      header: async lo => await lo.textContent() == 'Looking to break out of your pizza routine?'
     });
 
     await Promise.all([
@@ -199,9 +196,8 @@ export async function checkFrontend() {
     ]);
     await page.screenshot({ path: `screenshots/${__ITER}.png` });
 
-    const recommendation = await page.locator('div#recommendations').textContent();
-    check(recommendation, {
-      recommendation: (r) => r != '',
+    await check(page.locator('div#recommendations'), {
+      recommendation: async lo => await lo.textContent() != '',
     });
   } finally {
     await page.close();

--- a/docs/sources/v0.52.x/using-k6-browser/recommended-practices/hybrid-approach-to-performance.md
+++ b/docs/sources/v0.52.x/using-k6-browser/recommended-practices/hybrid-approach-to-performance.md
@@ -86,7 +86,7 @@ export async function checkFrontend() {
   try {
     await page.goto(BASE_URL);
 
-    check(page.locator('h1'), {
+    await check(page.locator('h1'), {
       'header': async lo => await lo.textContent() == 'Looking to break out of your pizza routine?'
     });
 
@@ -185,7 +185,7 @@ export async function checkFrontend() {
 
   try {
     await page.goto(BASE_URL);
-    check(page.locator('h1'), {
+    await check(page.locator('h1'), {
       'header': async lo => await lo.textContent() == 'Looking to break out of your pizza routine?'
     });
 

--- a/docs/sources/v0.52.x/using-k6-browser/recommended-practices/hybrid-approach-to-performance.md
+++ b/docs/sources/v0.52.x/using-k6-browser/recommended-practices/hybrid-approach-to-performance.md
@@ -19,10 +19,10 @@ The code below shows an example of combining a browser and HTTP test in a single
 {{< code >}}
 
 ```javascript
-import http from 'k6/http';
 import { browser } from 'k6/browser';
 import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.2.0/index.js';
+import http from 'k6/http';
 
 const BASE_URL = __ENV.BASE_URL || 'https://quickpizza.grafana.com';
 
@@ -87,7 +87,7 @@ export async function checkFrontend() {
     await page.goto(BASE_URL);
 
     check(page.locator('h1'), {
-      header: async lo => await lo.textContent() == 'Looking to break out of your pizza routine?'
+      'header': async lo => await lo.textContent() == 'Looking to break out of your pizza routine?'
     });
 
     await Promise.all([
@@ -97,7 +97,7 @@ export async function checkFrontend() {
     await page.screenshot({ path: `screenshots/${__ITER}.png` });
 
     await check(page.locator('div#recommendations'), {
-      recommendation: async lo => await lo.textContent() != '',
+      'recommendation': async lo => await lo.textContent() != '',
     });
   } finally {
     await page.close();
@@ -130,9 +130,8 @@ To find out more information about injecting faults to your service, check out t
 {{< code >}}
 
 ```javascript
-import http from 'k6/http';
-import { check } from 'k6';
 import { browser } from 'k6/browser';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 import { ServiceDisruptor } from 'k6/x/disruptor';
 
 const BASE_URL = __ENV.BASE_URL;
@@ -187,7 +186,7 @@ export async function checkFrontend() {
   try {
     await page.goto(BASE_URL);
     check(page.locator('h1'), {
-      header: async lo => await lo.textContent() == 'Looking to break out of your pizza routine?'
+      'header': async lo => await lo.textContent() == 'Looking to break out of your pizza routine?'
     });
 
     await Promise.all([

--- a/docs/sources/v0.52.x/using-k6-browser/running-browser-tests.md
+++ b/docs/sources/v0.52.x/using-k6-browser/running-browser-tests.md
@@ -228,8 +228,8 @@ To avoid timing errors or other race conditions in your script, if you have acti
 {{< code >}}
 
 ```javascript
-import { check } from 'k6';
 import { browser } from 'k6/browser';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
   scenarios: {
@@ -258,11 +258,13 @@ export default async function () {
 
     const submitButton = page.locator('input[type="submit"]');
 
-    await Promise.all([page.waitForNavigation(), submitButton.click()]);
+    await Promise.all([
+      page.waitForNavigation(),
+      submitButton.click(),
+    ]);
 
-    const header = await page.locator('h2').textContent();
-    check(header, {
-      header: (h) => h == 'Welcome, admin!',
+    await check(page.locator('h2'), {
+      'header': async lo => await lo.textContent() == 'Welcome, admin!'
     });
   } finally {
     await page.close();
@@ -296,7 +298,7 @@ Keep in mind that there is an additional performance overhead when it comes to s
 
 ```javascript
 import { browser } from 'k6/browser';
-import { check } from 'k6';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 import http from 'k6/http';
 
 export const options = {
@@ -329,9 +331,9 @@ export async function browserTest() {
 
     await page.locator('#checkbox1').check();
 
-    const info = await page.locator('#checkbox-info-display').textContent();
-    check(info, {
-      'checkbox is checked': (info) => info === 'Thanks for checking the box',
+    await check(page.locator('#checkbox-info-display'), {
+      'checkbox is checked': async lo =>
+        await lo.textContent() === 'Thanks for checking the box'
     });
   } finally {
     await page.close();

--- a/docs/sources/v0.53.x/javascript-api/k6-browser/browsercontext/addinitscript.md
+++ b/docs/sources/v0.53.x/javascript-api/k6-browser/browsercontext/addinitscript.md
@@ -24,7 +24,7 @@ The script is evaluated after the document is created but before any of its scri
 
 ```javascript
 import { browser } from 'k6/browser';
-import { check } from 'k6';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
   scenarios: {
@@ -63,9 +63,8 @@ export default async function () {
     </script>
   </html>`);
 
-  const text = await page.locator('#random').textContent();
-  check(page, {
-    zero: () => text == '0',
+  await check(page.locator('#random'), {
+    'is zero': async random => await random.textContent() == '0'
   });
 
   await page.close();

--- a/docs/sources/v0.53.x/javascript-api/k6-browser/browsercontext/waitforevent.md
+++ b/docs/sources/v0.53.x/javascript-api/k6-browser/browsercontext/waitforevent.md
@@ -27,7 +27,7 @@ Waits for the event to fire and returns its value. If a predicate function has b
 <CodeGroup labels={[]}>
 
 ```javascript
-import { browser } from 'k6/x/browser';
+import { browser } from 'k6/browser';
 
 export const options = {
   scenarios: {

--- a/docs/sources/v0.53.x/javascript-api/k6-browser/elementhandle/_index.md
+++ b/docs/sources/v0.53.x/javascript-api/k6-browser/elementhandle/_index.md
@@ -50,8 +50,8 @@ weight: 04
 ## Examples
 
 ```javascript
-import { check } from 'k6';
 import { browser } from 'k6/browser';
+import { check } from "https://jslib.k6.io/k6-utils/1.5.0/index.js";
 
 export const options = {
   scenarios: {
@@ -76,16 +76,20 @@ export default async function () {
 
     await Promise.all([page.waitForNavigation(), messagesLink.click()]);
     // Enter login credentials and login
-    await page.$('input[name="login"]').type('admin');
-    await page.$('input[name="password"]').type('123');
+    const login = await page.$('input[name="login"]');
+    await login.type('admin');
+    const password = await page.$('input[name="password"]');
+    await password.type('123');
 
     const submitButton = await page.$('input[type="submit"]');
 
     await Promise.all([page.waitForNavigation(), submitButton.click()]);
-    const text = await page.$('h2');
-    const content = await text.textContent();
-    check(page, {
-      header: () => text == 'Welcome, admin!',
+
+    await check(page, {
+      'header': async p => {
+        const h2 = await p.$('h2');
+        return await h2.textContent() == 'Welcome, admin!';
+      },
     });
   } finally {
     await page.close();
@@ -97,7 +101,7 @@ export default async function () {
 
 ```javascript
 import { browser } from 'k6/browser';
-import { check } from 'k6';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
   scenarios: {
@@ -112,7 +116,7 @@ export const options = {
   },
 };
 
-export default function () {
+export default async function () {
   const page = await browser.newPage();
 
   try {
@@ -128,35 +132,35 @@ export default function () {
     `);
 
     // Check state
-    let el = await page.$('.visible');
-    const isVisible = await el.isVisible();
-
-    el = await page.$('.hidden');
-    const isHidden = await el.isHidden();
-
-    el = await page.$('.editable');
-    const isEditable = await el.isEditable();
-
-    el = await page.$('.enabled');
-    const isEnabled = await el.isEnabled();
-
-    el = await page.$('.disabled');
-    const isDisabled = await el.isDisabled();
-
-    el = await page.$('.checked');
-    const isChecked = await el.isChecked();
-
-    el = await page.$('.unchecked');
-    const isUncheckedChecked = await el.isChecked();
-
-    check(page, {
-      visible: isVisible,
-      hidden: isHidden,
-      editable: isEditable,
-      enabled: isEnabled,
-      disabled: isDisabled,
-      checked: isChecked,
-      unchecked: isUncheckedChecked === false,
+    await check(page, {
+      'is visible': async p => {
+        const e = await p.$('.visible');
+        return e.isVisible();
+      },
+      'is hidden': async p => {
+        const e = await p.$('.hidden');
+        return e.isHidden();
+      },
+      'is editable': async p => {
+        const e = await p.$('.editable');
+        return e.isEditable();
+      },
+      'is enabled': async p => {
+        const e = await p.$('.enabled');
+        return e.isEnabled();
+      },
+      'is disabled': async p => {
+        const e = await p.$('.disabled');
+        return e.isDisabled();
+      },
+      'is checked': async p => {
+        const e = await p.$('.checked');
+        return e.isChecked();
+      },
+      'is unchecked': async p => {
+        const e = await p.$('.unchecked');
+        return await e.isChecked() === false;
+      },
     });
   } finally {
     await page.close();

--- a/docs/sources/v0.53.x/javascript-api/k6-browser/locator/clear.md
+++ b/docs/sources/v0.53.x/javascript-api/k6-browser/locator/clear.md
@@ -29,8 +29,8 @@ Clears text boxes and input fields (`input`, `textarea` or `contenteditable` ele
 {{< code >}}
 
 ```javascript
-import { check } from 'k6';
 import { browser } from 'k6/browser';
+import { check } from "https://jslib.k6.io/k6-utils/1.5.0/index.js";
 
 export const options = {
   scenarios: {
@@ -49,26 +49,25 @@ export default async function () {
   const context = await browser.newContext();
   const page = await context.newPage();
 
-  await page.goto('https://test.k6.io/my_messages.php', { waitUntil: 'networkidle' });
-
-  const login = page.locator('input[name="login"]');
-
-  // Fill an input element with some text that we will later clear.
-  await login.type('admin');
-
-  // This checks that the element has been filled with text.
-  let value = await login.inputValue();
-  check(page, {
-    not_empty: (p) => value != '',
+  await page.goto("https://test.k6.io/my_messages.php", {
+    waitUntil: 'networkidle',
   });
 
-  // Now clear the text from the element.
+  // Fill an input element with some text that we will later clear
+  const login = page.locator('input[name="login"]');
+  await login.type('admin');
+
+  // Check that the element has been filled with text
+  await check(login, {
+    'not empty': async lo => await lo.inputValue() != '',
+  });
+
+  // Now clear the text from the element
   await login.clear();
 
-  // This checks that the element is now empty.
-  value = await login.inputValue();
-  check(page, {
-    empty: () => value == '',
+  // Check that the element is now empty
+  await check(login, {
+    empty: async lo => await lo.inputValue() == '',
   });
 
   await page.close();

--- a/docs/sources/v0.53.x/javascript-api/k6-browser/page/on.md
+++ b/docs/sources/v0.53.x/javascript-api/k6-browser/page/on.md
@@ -29,7 +29,7 @@ When using the `page.on` method, the page has to be explicitly [closed](https://
 {{< code >}}
 
 ```javascript
-import { browser } from 'k6/x/browser';
+import { browser } from 'k6/browser';
 import { check } from 'k6';
 
 export const options = {

--- a/docs/sources/v0.53.x/javascript-api/k6-browser/page/throttlenetwork.md
+++ b/docs/sources/v0.53.x/javascript-api/k6-browser/page/throttlenetwork.md
@@ -33,7 +33,7 @@ To work with the most commonly tested network profiles, import `networkProfiles`
 {{< code >}}
 
 ```javascript
-import { browser, networkProfiles } from 'k6/x/browser';
+import { browser, networkProfiles } from 'k6/browser';
 
 export const options = {
   scenarios: {

--- a/docs/sources/v0.53.x/javascript-api/k6-browser/page/waitforfunction.md
+++ b/docs/sources/v0.53.x/javascript-api/k6-browser/page/waitforfunction.md
@@ -33,7 +33,7 @@ Returns when the `pageFunction` returns a truthy value.
 
 ```javascript
 import { browser } from 'k6/browser';
-import { check } from 'k6';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
   scenarios: {
@@ -64,8 +64,10 @@ export default async function () {
       polling: 'mutation',
       timeout: 2000,
     });
-    const innerHTML = await ok.innerHTML();
-    check(ok, { 'waitForFunction successfully resolved': innerHTML == 'Hello' });
+    await check(page, {
+      'waitForFunction successfully resolved': async () =>
+          await ok.innerHTML() == 'Hello'
+    });
   } finally {
     await page.close();
   }

--- a/docs/sources/v0.53.x/javascript-api/k6-browser/page/waitforfunction.md
+++ b/docs/sources/v0.53.x/javascript-api/k6-browser/page/waitforfunction.md
@@ -64,8 +64,8 @@ export default async function () {
       polling: 'mutation',
       timeout: 2000,
     });
-    await check(page, {
-      'waitForFunction successfully resolved': async () =>
+    await check(ok, {
+      'waitForFunction successfully resolved': async (ok) =>
           await ok.innerHTML() == 'Hello'
     });
   } finally {

--- a/docs/sources/v0.53.x/javascript-api/k6-browser/page/waitforfunction.md
+++ b/docs/sources/v0.53.x/javascript-api/k6-browser/page/waitforfunction.md
@@ -9,20 +9,20 @@ Returns when the `pageFunction` returns a truthy value.
 
 <TableWithNestedRows>
 
-| Parameter       | Type            | Default | Description                                                                                                                                                                                                                                                                                                         |
-| --------------- | --------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| pageFunction    | function        |         | Function to be evaluated in the page context.                                                                                                                                                                                                                                                                       |
-| arg             | string          | `''`    | Optional argument to pass to `pageFunction`                                                                                                                                                                                                                                                                         |
-| options         | object          | `null`  |                                                                                                                                                                                                                                                                                                                     |
-| options.polling | number or `raf` | `raf`   | If `polling` is `'raf'`, then `pageFunction` is constantly executed in `requestAnimationFrame` callback. If `polling` is a number, then it is treated as an interval in milliseconds at which the function would be executed.                                                                                       |
+| Parameter       | Type            | Default | Description                                                                                                                                                                                                                                                                                                                                   |
+| --------------- | --------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| pageFunction    | function        |         | Function to be evaluated in the page context.                                                                                                                                                                                                                                                                                                 |
+| arg             | string          | `''`    | Optional argument to pass to `pageFunction`                                                                                                                                                                                                                                                                                                   |
+| options         | object          | `null`  |                                                                                                                                                                                                                                                                                                                                               |
+| options.polling | number or `raf` | `raf`   | If `polling` is `'raf'`, then `pageFunction` is constantly executed in `requestAnimationFrame` callback. If `polling` is a number, then it is treated as an interval in milliseconds at which the function would be executed.                                                                                                                 |
 | options.timeout | number          | `30000` | Maximum time in milliseconds. Pass `0` to disable the timeout. Default is overridden by the `setDefaultTimeout` option on [BrowserContext](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/browsercontext/) or [Page](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/page/). |
 
 </TableWithNestedRows>
 
 ### Returns
 
-| Type                                                                                              | Description                                       |
-| ------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| Type                                                                                                           | Description                                       |
+| -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
 | Promise<[JSHandle](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-browser/jshandle/)> | The `JSHandle` instance associated with the page. |
 
 ### Example

--- a/docs/sources/v0.53.x/javascript-api/k6-browser/page/waitforloadstate.md
+++ b/docs/sources/v0.53.x/javascript-api/k6-browser/page/waitforloadstate.md
@@ -48,8 +48,8 @@ Events can be either:
 {{< code >}}
 
 ```javascript
-import { check } from 'k6';
 import { browser } from 'k6/browser';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
   scenarios: {
@@ -65,7 +65,7 @@ export const options = {
 };
 
 export default async function () {
-  const page = await browser.newPage();
+  let page = await browser.newPage();
 
   try {
     await page.goto('https://test.k6.io/my_messages.php');
@@ -76,11 +76,10 @@ export default async function () {
     const submitButton = page.locator('input[type="submit"]');
     await submitButton.click();
 
-    await page.waitForLoadState(); // waits for the default `load` event
+    await page.waitForLoadState('networkidle'); // waits until the `networkidle` event
 
-    const text = await page.locator('h2').textContent();
-    check(page, {
-      header: () => text == 'Welcome, admin!',
+    await check(page.locator('h2'), {
+      'header': async h2 => await h2.textContent() == 'Welcome, admin!'
     });
   } finally {
     await page.close();

--- a/docs/sources/v0.53.x/javascript-api/k6-browser/page/waitfornavigation.md
+++ b/docs/sources/v0.53.x/javascript-api/k6-browser/page/waitfornavigation.md
@@ -42,8 +42,8 @@ Events can be either:
 {{< code >}}
 
 ```javascript
-import { check } from 'k6';
 import { browser } from 'k6/browser';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
   scenarios: {
@@ -69,11 +69,13 @@ export default async function () {
 
     const submitButton = page.locator('input[type="submit"]');
 
-    await Promise.all([page.waitForNavigation(), submitButton.click()]);
+    await Promise.all([
+      submitButton.click(),
+      page.waitForNavigation(),
+    ]);
 
-    const text = await page.locator('h2').textContent();
-    check(page, {
-      header: () => text == 'Welcome, admin!',
+    await check(page.locator('h2'), {
+      header: async h2 => await h2.textContent() == 'Welcome, admin!'
     });
   } finally {
     await page.close();

--- a/docs/sources/v0.53.x/using-k6-browser/_index.md
+++ b/docs/sources/v0.53.x/using-k6-browser/_index.md
@@ -35,7 +35,7 @@ The main use case for the browser module is to test performance on the browser l
 
 ```javascript
 import { browser } from 'k6/browser';
-import { check } from 'k6';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
   scenarios: {
@@ -58,16 +58,18 @@ export default async function () {
   const page = await context.newPage();
 
   try {
-    await page.goto('https://test.k6.io/my_messages.php');
+    await page.goto("https://test.k6.io/my_messages.php");
 
-    await page.locator('input[name="login"]').type('admin');
-    await page.locator('input[name="password"]').type('123');
+    await page.locator('input[name="login"]').type("admin");
+    await page.locator('input[name="password"]').type("123");
 
-    await Promise.all([page.waitForNavigation(), page.locator('input[type="submit"]').click()]);
+    await Promise.all([
+      page.waitForNavigation(),
+      page.locator('input[type="submit"]').click(),
+    ]);
 
-    const header = await page.locator('h2').textContent();
-    check(header, {
-      header: (h) => h == 'Welcome, admin!',
+    await check(page.locator("h2"), {
+      'header': async h2 => await h2.textContent() == "Welcome, admin!"
     });
   } finally {
     await page.close();

--- a/docs/sources/v0.53.x/using-k6-browser/migrating-to-k6-v0-52.md
+++ b/docs/sources/v0.53.x/using-k6-browser/migrating-to-k6-v0-52.md
@@ -275,7 +275,7 @@ Below is a screenshot of a comparison between a generic browser test in `v0.51` 
 
 ## Working with k6 check
 
-The k6 `check` API will not `await` promises, so calling a function that returns a `Promise`, for example `locator.textContent()`, inside one of the predicates will not work. Instead you can work with [the jslib.k6.io's `check` utility](https://grafana.com/docs/k6/latest/javascript-api/jslib/utils/check/).
+The k6 `check` API will not `await` promises, so calling a function that returns a `Promise`, for example `locator.textContent()`, inside one of the predicates will not work. Instead, you can work with [the jslib.k6.io's `check` utility function](https://grafana.com/docs/k6/latest/javascript-api/jslib/utils/check/).
 
 For example, before:
 

--- a/docs/sources/v0.53.x/using-k6-browser/recommended-practices/hybrid-approach-to-performance.md
+++ b/docs/sources/v0.53.x/using-k6-browser/recommended-practices/hybrid-approach-to-performance.md
@@ -20,8 +20,8 @@ The code below shows an example of combining a browser and HTTP test in a single
 
 ```javascript
 import http from 'k6/http';
-import { check } from 'k6';
 import { browser } from 'k6/browser';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.2.0/index.js';
 
 const BASE_URL = __ENV.BASE_URL || 'https://quickpizza.grafana.com';
@@ -86,9 +86,8 @@ export async function checkFrontend() {
   try {
     await page.goto(BASE_URL);
 
-    const header = await page.locator('h1').textContent();
-    check(header, {
-      header: (h) => h == 'Looking to break out of your pizza routine?',
+    check(page.locator('h1'), {
+      header: async lo => await lo.textContent() == 'Looking to break out of your pizza routine?'
     });
 
     await Promise.all([
@@ -97,9 +96,8 @@ export async function checkFrontend() {
     ]);
     await page.screenshot({ path: `screenshots/${__ITER}.png` });
 
-    const recommendation = await page.locator('div#recommendations').textContent();
-    check(recommendation, {
-      recommendation: (r) => r != '',
+    await check(page.locator('div#recommendations'), {
+      recommendation: async lo => await lo.textContent() != '',
     });
   } finally {
     await page.close();
@@ -188,9 +186,8 @@ export async function checkFrontend() {
 
   try {
     await page.goto(BASE_URL);
-    const header = await page.locator('h1').textContent();
-    check(header, {
-      header: (h) => h == 'Looking to break out of your pizza routine?',
+    check(page.locator('h1'), {
+      header: async lo => await lo.textContent() == 'Looking to break out of your pizza routine?'
     });
 
     await Promise.all([
@@ -199,9 +196,8 @@ export async function checkFrontend() {
     ]);
     await page.screenshot({ path: `screenshots/${__ITER}.png` });
 
-    const recommendation = await page.locator('div#recommendations').textContent();
-    check(recommendation, {
-      recommendation: (r) => r != '',
+    await check(page.locator('div#recommendations'), {
+      recommendation: async lo => await lo.textContent() != '',
     });
   } finally {
     await page.close();

--- a/docs/sources/v0.53.x/using-k6-browser/recommended-practices/hybrid-approach-to-performance.md
+++ b/docs/sources/v0.53.x/using-k6-browser/recommended-practices/hybrid-approach-to-performance.md
@@ -86,7 +86,7 @@ export async function checkFrontend() {
   try {
     await page.goto(BASE_URL);
 
-    check(page.locator('h1'), {
+    await check(page.locator('h1'), {
       'header': async lo => await lo.textContent() == 'Looking to break out of your pizza routine?'
     });
 
@@ -185,7 +185,7 @@ export async function checkFrontend() {
 
   try {
     await page.goto(BASE_URL);
-    check(page.locator('h1'), {
+    await check(page.locator('h1'), {
       'header': async lo => await lo.textContent() == 'Looking to break out of your pizza routine?'
     });
 

--- a/docs/sources/v0.53.x/using-k6-browser/recommended-practices/hybrid-approach-to-performance.md
+++ b/docs/sources/v0.53.x/using-k6-browser/recommended-practices/hybrid-approach-to-performance.md
@@ -19,10 +19,10 @@ The code below shows an example of combining a browser and HTTP test in a single
 {{< code >}}
 
 ```javascript
-import http from 'k6/http';
 import { browser } from 'k6/browser';
 import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.2.0/index.js';
+import http from 'k6/http';
 
 const BASE_URL = __ENV.BASE_URL || 'https://quickpizza.grafana.com';
 
@@ -87,7 +87,7 @@ export async function checkFrontend() {
     await page.goto(BASE_URL);
 
     check(page.locator('h1'), {
-      header: async lo => await lo.textContent() == 'Looking to break out of your pizza routine?'
+      'header': async lo => await lo.textContent() == 'Looking to break out of your pizza routine?'
     });
 
     await Promise.all([
@@ -97,7 +97,7 @@ export async function checkFrontend() {
     await page.screenshot({ path: `screenshots/${__ITER}.png` });
 
     await check(page.locator('div#recommendations'), {
-      recommendation: async lo => await lo.textContent() != '',
+      'recommendation': async lo => await lo.textContent() != '',
     });
   } finally {
     await page.close();
@@ -130,9 +130,8 @@ To find out more information about injecting faults to your service, check out t
 {{< code >}}
 
 ```javascript
-import http from 'k6/http';
-import { check } from 'k6';
 import { browser } from 'k6/browser';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 import { ServiceDisruptor } from 'k6/x/disruptor';
 
 const BASE_URL = __ENV.BASE_URL;
@@ -187,7 +186,7 @@ export async function checkFrontend() {
   try {
     await page.goto(BASE_URL);
     check(page.locator('h1'), {
-      header: async lo => await lo.textContent() == 'Looking to break out of your pizza routine?'
+      'header': async lo => await lo.textContent() == 'Looking to break out of your pizza routine?'
     });
 
     await Promise.all([

--- a/docs/sources/v0.53.x/using-k6-browser/running-browser-tests.md
+++ b/docs/sources/v0.53.x/using-k6-browser/running-browser-tests.md
@@ -228,8 +228,8 @@ To avoid timing errors or other race conditions in your script, if you have acti
 {{< code >}}
 
 ```javascript
-import { check } from 'k6';
 import { browser } from 'k6/browser';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
   scenarios: {
@@ -258,11 +258,13 @@ export default async function () {
 
     const submitButton = page.locator('input[type="submit"]');
 
-    await Promise.all([page.waitForNavigation(), submitButton.click()]);
+    await Promise.all([
+      page.waitForNavigation(),
+      submitButton.click(),
+    ]);
 
-    const header = await page.locator('h2').textContent();
-    check(header, {
-      header: (h) => h == 'Welcome, admin!',
+    await check(page.locator('h2'), {
+      'header': async lo => await lo.textContent() == 'Welcome, admin!'
     });
   } finally {
     await page.close();
@@ -296,7 +298,7 @@ Keep in mind that there is an additional performance overhead when it comes to s
 
 ```javascript
 import { browser } from 'k6/browser';
-import { check } from 'k6';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 import http from 'k6/http';
 
 export const options = {
@@ -329,9 +331,9 @@ export async function browserTest() {
 
     await page.locator('#checkbox1').check();
 
-    const info = await page.locator('#checkbox-info-display').textContent();
-    check(info, {
-      'checkbox is checked': (info) => info === 'Thanks for checking the box',
+    await check(page.locator('#checkbox-info-display'), {
+      'checkbox is checked': async lo =>
+        await lo.textContent() === 'Thanks for checking the box'
     });
   } finally {
     await page.close();


### PR DESCRIPTION
## What?

We're replacing sync `check` of k6 with the async `check` utility function. Along the way, I've also fixed some small issues I saw.

## Why

Writing concise code can be difficult when using [the k6 `check` function](https://grafana.com/docs/k6/latest/javascript-api/k6/check/) with async code since it doesn't support async APIs. A solution that we have suggested so far is to declare a temporary variable, wait for the value that is to be checked, and then check the result later. However, this approach can clutter the code with single-use declarations and unnecessary variable names, for example:

```javascript
const checked = await p.locator('.checked').isChecked();

check(checked, {
    'checked': c => c,
});
```

To address this limitation, we've added a version of the `check` function to [jslib.k6.io](https://jslib.k6.io/) that makes working with `async`/`await` simpler. The `check` function is a drop-in replacement for the built-in check, with added support for async code. Any `Promise`s will be awaited, and the result is reported once the operation has been completed:

```javascript
// Import the new check function from jslib.k6.io/k6-utils
import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';

// ...

// Use the new check function with async code
check(page, {
    'checked': async p => p.locator('.checked').isChecked(),
});
```

## Related PR(s)/Issue(s)

Closes #1725

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [x] I have made my changes in the `docs/sources/next` folder of the documentation.
- [x] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.