### PR TITLE
Fix other instances of SQSClient queuesResponse examples

### DIFF
--- a/docs/sources/next/javascript-api/jslib/aws/SQSClient/_index.md
+++ b/docs/sources/next/javascript-api/jslib/aws/SQSClient/_index.md
@@ -55,7 +55,7 @@ const testQueue = 'https://sqs.us-east-1.amazonaws.com/000000000/test-queue';
 export default async function () {
   // If our test queue does not exist, abort the execution.
   const queuesResponse = await sqs.listQueues();
-  if (queuesResponse.queueUrls.filter((q) => q === testQueue).length == 0) {
+  if (queuesResponse.urls.filter((q) => q === testQueue).length == 0) {
     exec.test.abort();
   }
 

--- a/docs/sources/next/javascript-api/jslib/aws/SQSClient/listQueues.md
+++ b/docs/sources/next/javascript-api/jslib/aws/SQSClient/listQueues.md
@@ -49,7 +49,7 @@ export default async function () {
   const queuesResponse = await sqs.listQueues();
 
   // If our test queue does not exist, abort the execution.
-  if (queuesResponse.queueUrls.filter((q) => q === testQueue).length == 0) {
+  if (queuesResponse.urls.filter((q) => q === testQueue).length == 0) {
     exec.test.abort();
   }
 

--- a/docs/sources/next/javascript-api/jslib/aws/SQSClient/sendMessage.md
+++ b/docs/sources/next/javascript-api/jslib/aws/SQSClient/sendMessage.md
@@ -58,7 +58,7 @@ const testQueue = 'https://sqs.us-east-1.amazonaws.com/000000000/test-queue';
 export default async function () {
   // If our test queue does not exist, abort the execution.
   const queuesResponse = await sqs.listQueues();
-  if (queuesResponse.queueUrls.filter((q) => q === testQueue).length == 0) {
+  if (queuesResponse.urls.filter((q) => q === testQueue).length == 0) {
     exec.test.abort();
   }
 

--- a/docs/sources/v0.54.x/javascript-api/jslib/aws/SQSClient/_index.md
+++ b/docs/sources/v0.54.x/javascript-api/jslib/aws/SQSClient/_index.md
@@ -55,7 +55,7 @@ const testQueue = 'https://sqs.us-east-1.amazonaws.com/000000000/test-queue';
 export default async function () {
   // If our test queue does not exist, abort the execution.
   const queuesResponse = await sqs.listQueues();
-  if (queuesResponse.queueUrls.filter((q) => q === testQueue).length == 0) {
+  if (queuesResponse.urls.filter((q) => q === testQueue).length == 0) {
     exec.test.abort();
   }
 

--- a/docs/sources/v0.54.x/javascript-api/jslib/aws/SQSClient/listQueues.md
+++ b/docs/sources/v0.54.x/javascript-api/jslib/aws/SQSClient/listQueues.md
@@ -49,7 +49,7 @@ export default async function () {
   const queuesResponse = await sqs.listQueues();
 
   // If our test queue does not exist, abort the execution.
-  if (queuesResponse.queueUrls.filter((q) => q === testQueue).length == 0) {
+  if (queuesResponse.urls.filter((q) => q === testQueue).length == 0) {
     exec.test.abort();
   }
 

--- a/docs/sources/v0.54.x/javascript-api/jslib/aws/SQSClient/sendMessage.md
+++ b/docs/sources/v0.54.x/javascript-api/jslib/aws/SQSClient/sendMessage.md
@@ -58,7 +58,7 @@ const testQueue = 'https://sqs.us-east-1.amazonaws.com/000000000/test-queue';
 export default async function () {
   // If our test queue does not exist, abort the execution.
   const queuesResponse = await sqs.listQueues();
-  if (queuesResponse.queueUrls.filter((q) => q === testQueue).length == 0) {
+  if (queuesResponse.urls.filter((q) => q === testQueue).length == 0) {
     exec.test.abort();
   }
 


### PR DESCRIPTION
## What?

Fix SQSClient examples that use `queuesResponse.queueUrls` instead of `queuesResponse.urls`.

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [x] I have made my changes in the `docs/sources/next` folder of the documentation.
- [x] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.
- [ ] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->

## Related PR(s)/Issue(s)

Related to https://github.com/grafana/k6-docs/pull/1733/.

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->
<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->