### PR TITLE
Fix quoting in heredoc

### DIFF
--- a/scripts/extension-registry-changed
+++ b/scripts/extension-registry-changed
@@ -31,7 +31,7 @@ local -r infile="$2"
 
 ed -s "$outfile" <<EOF
 /<div class=.nav-cards.>/+,/<.div>/-d
-/<div class=.nav-cards.>/ r "$infile"
+/<div class=.nav-cards.>/ r $infile
 w
 q
 EOF

--- a/scripts/extension-registry-changed
+++ b/scripts/extension-registry-changed
@@ -1,35 +1,37 @@
 #!/usr/bin/env bash
 
-# This script keeps the list of extensions up to date 
+# This script keeps the list of extensions up to date
 # in the docs/sources/next/extensions/explore.md file.
 #
 # The script is run by the extension-registry.changed.yml
 # workflow when the extension registry changes.
-# 
+#
 # The list of extensions is generated based on https://registry.k6.io/registry.json.
 #
-# In the docs/sources/next/extensions/explore.md file 
+# In the docs/sources/next/extensions/explore.md file
 # the content of the <div class="nav-cards"> HTML element
 # is replaced with the generated extension list.
 
+set -euf -o pipefail
+
 generate_extension_list_partial() {
-curl -sL https://registry.k6.io/registry.json | 
- jq -r '
+  curl -sL https://registry.k6.io/registry.json |
+    jq -r '
  map(select(.module != "go.k6.io/k6") | { name:.repo.name, url: .repo.url, description: .description } ) |
  sort_by(.name) | map(
 "    <a href=\"\(.url)\" target=\"_blank\" class=\"nav-cards__item nav-cards__item--guide\">
         <h4>\(.name)</h4>
         <p>\(.description)</p>
     </a>"
-) | .[] 
+) | .[]
 '
 }
 
 replace_extension_list_partial() {
-local -r outfile="$1"
-local -r infile="$2"
+  local -r outfile="$1"
+  local -r infile="$2"
 
-ed -s "$outfile" <<EOF
+  ed -s "$outfile" <<EOF
 /<div class=.nav-cards.>/+,/<.div>/-d
 /<div class=.nav-cards.>/ r $infile
 w
@@ -40,7 +42,7 @@ EOF
 scriptdir="$(dirname "$(readlink -f "$0")")"
 docfile="$scriptdir/../docs/sources/next/extensions/explore.md"
 
-tmpfile="$(mktemp)"
+tmpfile="$(mktemp /tmp/extension-registry-changed.XXXXXX)"
 
 generate_extension_list_partial > "$tmpfile"
 replace_extension_list_partial "$docfile" "$tmpfile"


### PR DESCRIPTION
I wasn't really thinking when I added the quotes here. With the quotes, `ed` is trying to open a file that has quotes in the name.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com><!-- 
Please make sure you have read the contribution guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md as well as the
the code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md before opening a PR.
-->
