### PR TITLE
Add link to GitHub source code for all jslib libraries

### DIFF
--- a/docs/sources/next/javascript-api/jslib/aws/_index.md
+++ b/docs/sources/next/javascript-api/jslib/aws/_index.md
@@ -13,6 +13,6 @@ The source code for this library can be found in the [grafana/k6-jslib-aws](http
 
 {{< /admonition >}}
 
-The `aws` module is an external JavaScript library helps interact with a subset of AWS services in the context of k6 test scripts.
+The `aws` module is an external JavaScript library that helps interact with a subset of AWS services in the context of k6 test scripts.
 
 {{< section >}}

--- a/docs/sources/next/javascript-api/jslib/aws/_index.md
+++ b/docs/sources/next/javascript-api/jslib/aws/_index.md
@@ -7,4 +7,12 @@ title: aws
 
 <!-- TODO: Add content -->
 
+{{< admonition type="note" >}}
+
+The source code for this library can be found in the [grafana/k6-jslib-aws](https://github.com/grafana/k6-jslib-aws) GitHub repository.
+
+{{< /admonition >}}
+
+The `aws` module is an external JavaScript library helps interact with a subset of AWS services in the context of k6 test scripts.
+
 {{< section >}}

--- a/docs/sources/next/javascript-api/jslib/http-instrumentation-pyroscope/_index.md
+++ b/docs/sources/next/javascript-api/jslib/http-instrumentation-pyroscope/_index.md
@@ -9,7 +9,7 @@ weight: 04
 
 {{< admonition type="note" >}}
 
-The source code for this library can be found in the [grafana/jslib.k6.io](https://github.com/grafana/jslib.k6.io) GitHub repository.
+The source code for this library can be found in the [grafana/jslib.k6.io](https://github.com/grafana/jslib.k6.io/tree/main/lib/http-instrumentation-pyroscope) GitHub repository.
 
 {{< /admonition >}}
 

--- a/docs/sources/next/javascript-api/jslib/http-instrumentation-pyroscope/_index.md
+++ b/docs/sources/next/javascript-api/jslib/http-instrumentation-pyroscope/_index.md
@@ -1,31 +1,35 @@
 ---
 title: HTTP instrumentation for Pyroscope
 menuTitle: http-instrumentation-pyroscope
-description: "k6 Pyroscope instrumentation API"
+description: 'k6 Pyroscope instrumentation API'
 weight: 04
 ---
 
 # HTTP instrumentation for Pyroscope
 
+{{< admonition type="note" >}}
 
-With jslib, you can _instrument_ HTTP requests in a way that lets you tag Grafana Cloud Profiles with relevant information generated from k6 tests.
+The source code for this library can be found in the [grafana/jslib.k6.io](https://github.com/grafana/jslib.k6.io) GitHub repository.
+
+{{< /admonition >}}
+
+The `http-instrumentation-pyroscope` module allows you to _instrument_ HTTP requests in a way that lets you tag Grafana Cloud Profiles with relevant information generated from k6 tests.
 
 ## About baggage header
 
-The _baggage header_ is a standardized HTTP header used to propagate distributed context. The [W3C specification](https://www.w3.org/TR/baggage/) goes into more detail on the specifics, but like many other headers, the baggage header is a list of key-value pairs. 
+The _baggage header_ is a standardized HTTP header used to propagate distributed context. The [W3C specification](https://www.w3.org/TR/baggage/) goes into more detail on the specifics, but like many other headers, the baggage header is a list of key-value pairs.
 
 This module, by default, adds three key-value pairs:
 
-1.  Scenario name
-2.  Name of the request (URL if not set)
-3.  Value of `__ENV.K6_CLOUDRUN_TEST_RUN_ID`, which is set automatically in Grafana Cloud k6.
-
+1. Scenario name
+2. Name of the request (URL if not set)
+3. Value of `__ENV.K6_CLOUDRUN_TEST_RUN_ID`, which is set automatically in Grafana Cloud k6.
 
 ## API
 
-| Class/Function                                                                                                   | Description                                                                                                               |
-| :--------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------ |
-| [instrumentHTTP](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/http-instrumentation-pyroscope/instrumenthttp) | Instruments the k6 http module with baggage header.                                                                 |
+| Class/Function                                                                                                                | Description                                                    |
+| :---------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------- |
+| [instrumentHTTP](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/http-instrumentation-pyroscope/instrumenthttp) | Instruments the k6 http module with baggage header.            |
 | [Client](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/http-instrumentation-pyroscope/client)                 | Configurable Client that exposes instrumented HTTP operations. |
 
 ## Example

--- a/docs/sources/next/javascript-api/jslib/http-instrumentation-tempo/_index.md
+++ b/docs/sources/next/javascript-api/jslib/http-instrumentation-tempo/_index.md
@@ -9,7 +9,7 @@ weight: 04
 
 {{< admonition type="note" >}}
 
-The source code for this library can be found in the [grafana/jslib.k6.io](https://github.com/grafana/jslib.k6.io) GitHub repository.
+The source code for this library can be found in the [grafana/jslib.k6.io](https://github.com/grafana/jslib.k6.io/tree/main/lib/http-instrumentation-tempo/1.0.0) GitHub repository.
 
 {{< /admonition >}}
 

--- a/docs/sources/next/javascript-api/jslib/http-instrumentation-tempo/_index.md
+++ b/docs/sources/next/javascript-api/jslib/http-instrumentation-tempo/_index.md
@@ -7,12 +7,17 @@ weight: 04
 
 # HTTP instrumentation for Tempo
 
-With this jslib, you can _instrument_ HTTP requests so that they emit traces as the test runs. Use it to include a tracing context in HTTP requests, which can then be used by a tracing backend such as [Grafana Tempo](https://grafana.com/docs/grafana-cloud/testing/k6/analyze-results/integration-with-grafana-cloud-traces/).
+{{< admonition type="note" >}}
+
+The source code for this library can be found in the [grafana/jslib.k6.io](https://github.com/grafana/jslib.k6.io) GitHub repository.
+
+{{< /admonition >}}
+
+The `http-instrumentation-tempo` module allows you to _instrument_ HTTP requests so that they emit traces as the test runs. Use it to include a tracing context in HTTP requests, which can then be used by a tracing backend such as [Grafana Tempo](https://grafana.com/docs/grafana-cloud/testing/k6/analyze-results/integration-with-grafana-cloud-traces/).
 
 ## Migration from `k6/experimental/tracing`
 
 This jslib is a drop in replacement, so all you need to migrate to it is to replace `'k6/experimental/tracing'` import with `'https://jslib.k6.io/http-instrumentation-tempo/1.0.0/index.js'`
-
 
 ## About trace contexts
 

--- a/docs/sources/next/javascript-api/jslib/httpx/_index.md
+++ b/docs/sources/next/javascript-api/jslib/httpx/_index.md
@@ -7,25 +7,24 @@ weight: 02
 
 # httpx
 
+{{< admonition type="note" >}}
+
+The source code for this library can be found in the [grafana/k6-jslib-httpx](https://github.com/k6io/k6-jslib-httpx) GitHub repository.
+
+{{< /admonition >}}
+
 The `httpx` module is an external JavaScript library that wraps around the native [k6/http](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-http) module.
-It's a http client with features that are not yet available in the native module.
+It's an HTTP client with features that are not yet available in the native module.
 
-- ability to set http options globally (such as timeout)
-- ability to set default tags and headers that will be used for all requests
-- more user-friendly arguments to request functions (get, post, put take the same arguments)
+- Ability to set HTTP options globally (such as timeout).
+- Ability to set default tags and headers that will be used for all requests.
+- More user-friendly arguments to request functions (get, post, put take the same arguments).
 
-httpx module integrates well with the expect library.
-
-The source code is [on GitHub](https://github.com/k6io/k6-jslib-httpx).
-Please request features and report bugs through [GitHub issues](https://github.com/k6io/k6-jslib-httpx/issues).
+The `httpx` module integrates well with the expect library.
 
 {{< admonition type="caution" >}}
 
-**This library is in active development.**
-
-This library is stable enough to be useful, but pay attention to the new versions released on [jslib.k6.io](https://jslib.k6.io).
-
-This documentation is for the only last version only. If you discover that some of the following doesn't work, you might be using an older version.
+This library is in active development. It's stable enough to be useful, but you can watch the [GitHub repository](https://github.com/k6io/k6-jslib-httpx) to be notified when a new version is released.
 
 {{< /admonition >}}
 

--- a/docs/sources/next/javascript-api/jslib/httpx/_index.md
+++ b/docs/sources/next/javascript-api/jslib/httpx/_index.md
@@ -1,7 +1,6 @@
 ---
-title: "httpx"
-description: "httpx is a wrapper library around the native k6 http module"
-weight: 02
+title: 'httpx'
+description: 'httpx is a wrapper library around the native k6 http module'
 weight: 02
 ---
 

--- a/docs/sources/next/javascript-api/jslib/k6chaijs/_index.md
+++ b/docs/sources/next/javascript-api/jslib/k6chaijs/_index.md
@@ -1,7 +1,6 @@
 ---
-title: "k6chaijs"
-description: "Assertion library for k6"
-weight: 03
+title: 'k6chaijs'
+description: 'Assertion library for k6'
 weight: 03
 ---
 

--- a/docs/sources/next/javascript-api/jslib/k6chaijs/_index.md
+++ b/docs/sources/next/javascript-api/jslib/k6chaijs/_index.md
@@ -7,27 +7,29 @@ weight: 03
 
 # k6chaijs
 
+{{< admonition type="note" >}}
+
+The source code for this library can be found in the [grafana/k6-jslib-k6chaijs](https://github.com/grafana/k6-jslib-k6chaijs) GitHub repository.
+
+{{< /admonition >}}
+
 `k6chaijs` is a library to provide BDD assertions in k6 based on [ChaiJS](https://www.chaijs.com/). You can use `k6chaijs` as an alternative to [check](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6/check) and [group](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6/group).
 
 With this library, you get the following:
 
 - BDD style of assertions for more expressive language
-- chainable assertions
-- more powerful assertions functions such as: `deep`, `nested`, `ordered`, etc.
-- automatic assertion messages
-- [exception handling](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/k6chaijs/error-handling) for better test stability
+- Chainable assertions
+- More powerful assertions functions such as: `deep`, `nested`, `ordered`, etc.
+- Automatic assertion messages
+- [Exception handling](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/k6chaijs/error-handling) for better test stability
 
 ## Installation
 
-There's nothing to install. This library is hosted on [jslib](https://jslib.k6.io/) and can be imported in the k6 script directly.
-
-{{< code >}}
+This library is hosted on [jslib](https://jslib.k6.io/) and can be imported in directly in your k6 script.
 
 ```javascript
 import { describe, expect } from 'https://jslib.k6.io/k6chaijs/4.3.4.3/index.js';
 ```
-
-{{< /code >}}
 
 Alternatively, you can use a copy of this file stored locally. The source code is available on [GitHub](https://github.com/grafana/k6-jslib-k6chaijs).
 

--- a/docs/sources/next/javascript-api/jslib/utils/_index.md
+++ b/docs/sources/next/javascript-api/jslib/utils/_index.md
@@ -6,10 +6,13 @@ weight: 04
 
 # utils
 
-The `utils` module contains number of small utility functions useful in every day load testing.
+{{< admonition type="note" >}}
 
-> ⭐️ Source code available on [GitHub](https://github.com/k6io/k6-jslib-utils).
-> Please request features and report bugs through [GitHub issues](https://github.com/k6io/k6-jslib-utils/issues).
+The source code for this library can be found in the [grafana/k6-jslib-utils](https://github.com/k6io/k6-jslib-utils) GitHub repository.
+
+{{< /admonition >}}
+
+The `utils` module contains number of small utility functions useful in every day load testing.
 
 | Function                                                                                                                                                            | Description                                                                                                                                                                                                                                                                                                                                                                     |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/sources/v0.54.x/javascript-api/jslib/aws/_index.md
+++ b/docs/sources/v0.54.x/javascript-api/jslib/aws/_index.md
@@ -7,4 +7,12 @@ title: aws
 
 <!-- TODO: Add content -->
 
+{{< admonition type="note" >}}
+
+The source code for this library can be found in the [grafana/k6-jslib-aws](https://github.com/grafana/k6-jslib-aws) GitHub repository.
+
+{{< /admonition >}}
+
+The `aws` module is an external JavaScript library that helps interact with a subset of AWS services in the context of k6 test scripts.
+
 {{< section >}}

--- a/docs/sources/v0.54.x/javascript-api/jslib/http-instrumentation-pyroscope/_index.md
+++ b/docs/sources/v0.54.x/javascript-api/jslib/http-instrumentation-pyroscope/_index.md
@@ -7,7 +7,13 @@ weight: 04
 
 # HTTP instrumentation for Pyroscope
 
-With jslib, you can _instrument_ HTTP requests in a way that lets you tag Grafana Cloud Profiles with relevant information generated from k6 tests.
+{{< admonition type="note" >}}
+
+The source code for this library can be found in the [grafana/jslib.k6.io](https://github.com/grafana/jslib.k6.io/tree/main/lib/http-instrumentation-pyroscope) GitHub repository.
+
+{{< /admonition >}}
+
+The `http-instrumentation-pyroscope` module allows you to _instrument_ HTTP requests in a way that lets you tag Grafana Cloud Profiles with relevant information generated from k6 tests.
 
 ## About baggage header
 
@@ -15,9 +21,9 @@ The _baggage header_ is a standardized HTTP header used to propagate distributed
 
 This module, by default, adds three key-value pairs:
 
-1.  Scenario name
-2.  Name of the request (URL if not set)
-3.  Value of `__ENV.K6_CLOUDRUN_TEST_RUN_ID`, which is set automatically in Grafana Cloud k6.
+1. Scenario name
+2. Name of the request (URL if not set)
+3. Value of `__ENV.K6_CLOUDRUN_TEST_RUN_ID`, which is set automatically in Grafana Cloud k6.
 
 ## API
 

--- a/docs/sources/v0.54.x/javascript-api/jslib/http-instrumentation-tempo/_index.md
+++ b/docs/sources/v0.54.x/javascript-api/jslib/http-instrumentation-tempo/_index.md
@@ -7,7 +7,13 @@ weight: 04
 
 # HTTP instrumentation for Tempo
 
-With this jslib, you can _instrument_ HTTP requests so that they emit traces as the test runs. Use it to include a tracing context in HTTP requests, which can then be used by a tracing backend such as [Grafana Tempo](https://grafana.com/docs/grafana-cloud/testing/k6/analyze-results/integration-with-grafana-cloud-traces/).
+{{< admonition type="note" >}}
+
+The source code for this library can be found in the [grafana/jslib.k6.io](https://github.com/grafana/jslib.k6.io/tree/main/lib/http-instrumentation-tempo/1.0.0) GitHub repository.
+
+{{< /admonition >}}
+
+The `http-instrumentation-tempo` module allows you to _instrument_ HTTP requests so that they emit traces as the test runs. Use it to include a tracing context in HTTP requests, which can then be used by a tracing backend such as [Grafana Tempo](https://grafana.com/docs/grafana-cloud/testing/k6/analyze-results/integration-with-grafana-cloud-traces/).
 
 ## Migration from `k6/experimental/tracing`
 

--- a/docs/sources/v0.54.x/javascript-api/jslib/httpx/_index.md
+++ b/docs/sources/v0.54.x/javascript-api/jslib/httpx/_index.md
@@ -1,31 +1,29 @@
 ---
-title: "httpx"
-description: "httpx is a wrapper library around the native k6 http module"
-weight: 02
+title: 'httpx'
+description: 'httpx is a wrapper library around the native k6 http module'
 weight: 02
 ---
 
 # httpx
 
+{{< admonition type="note" >}}
+
+The source code for this library can be found in the [grafana/k6-jslib-httpx](https://github.com/k6io/k6-jslib-httpx) GitHub repository.
+
+{{< /admonition >}}
+
 The `httpx` module is an external JavaScript library that wraps around the native [k6/http](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-http) module.
-It's a http client with features that are not yet available in the native module.
+It's an HTTP client with features that are not yet available in the native module.
 
-- ability to set http options globally (such as timeout)
-- ability to set default tags and headers that will be used for all requests
-- more user-friendly arguments to request functions (get, post, put take the same arguments)
+- Ability to set HTTP options globally (such as timeout).
+- Ability to set default tags and headers that will be used for all requests.
+- More user-friendly arguments to request functions (get, post, put take the same arguments).
 
-httpx module integrates well with the expect library.
-
-The source code is [on GitHub](https://github.com/k6io/k6-jslib-httpx).
-Please request features and report bugs through [GitHub issues](https://github.com/k6io/k6-jslib-httpx/issues).
+The `httpx` module integrates well with the expect library.
 
 {{< admonition type="caution" >}}
 
-**This library is in active development.**
-
-This library is stable enough to be useful, but pay attention to the new versions released on [jslib.k6.io](https://jslib.k6.io).
-
-This documentation is for the only last version only. If you discover that some of the following doesn't work, you might be using an older version.
+This library is in active development. It's stable enough to be useful, but you can watch the [GitHub repository](https://github.com/k6io/k6-jslib-httpx) to be notified when a new version is released.
 
 {{< /admonition >}}
 

--- a/docs/sources/v0.54.x/javascript-api/jslib/k6chaijs/_index.md
+++ b/docs/sources/v0.54.x/javascript-api/jslib/k6chaijs/_index.md
@@ -1,33 +1,34 @@
 ---
-title: "k6chaijs"
-description: "Assertion library for k6"
-weight: 03
+title: 'k6chaijs'
+description: 'Assertion library for k6'
 weight: 03
 ---
 
 # k6chaijs
+
+{{< admonition type="note" >}}
+
+The source code for this library can be found in the [grafana/k6-jslib-k6chaijs](https://github.com/grafana/k6-jslib-k6chaijs) GitHub repository.
+
+{{< /admonition >}}
 
 `k6chaijs` is a library to provide BDD assertions in k6 based on [ChaiJS](https://www.chaijs.com/). You can use `k6chaijs` as an alternative to [check](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6/check) and [group](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6/group).
 
 With this library, you get the following:
 
 - BDD style of assertions for more expressive language
-- chainable assertions
-- more powerful assertions functions such as: `deep`, `nested`, `ordered`, etc.
-- automatic assertion messages
-- [exception handling](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/k6chaijs/error-handling) for better test stability
+- Chainable assertions
+- More powerful assertions functions such as: `deep`, `nested`, `ordered`, etc.
+- Automatic assertion messages
+- [Exception handling](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/k6chaijs/error-handling) for better test stability
 
 ## Installation
 
-There's nothing to install. This library is hosted on [jslib](https://jslib.k6.io/) and can be imported in the k6 script directly.
-
-{{< code >}}
+This library is hosted on [jslib](https://jslib.k6.io/) and can be imported in directly in your k6 script.
 
 ```javascript
 import { describe, expect } from 'https://jslib.k6.io/k6chaijs/4.3.4.3/index.js';
 ```
-
-{{< /code >}}
 
 Alternatively, you can use a copy of this file stored locally. The source code is available on [GitHub](https://github.com/grafana/k6-jslib-k6chaijs).
 

--- a/docs/sources/v0.54.x/javascript-api/jslib/utils/_index.md
+++ b/docs/sources/v0.54.x/javascript-api/jslib/utils/_index.md
@@ -6,10 +6,13 @@ weight: 04
 
 # utils
 
-The `utils` module contains number of small utility functions useful in every day load testing.
+{{< admonition type="note" >}}
 
-> ⭐️ Source code available on [GitHub](https://github.com/k6io/k6-jslib-utils).
-> Please request features and report bugs through [GitHub issues](https://github.com/k6io/k6-jslib-utils/issues).
+The source code for this library can be found in the [grafana/k6-jslib-utils](https://github.com/k6io/k6-jslib-utils) GitHub repository.
+
+{{< /admonition >}}
+
+The `utils` module contains number of small utility functions useful in every day load testing.
 
 | Function                                                                                                                                                            | Description                                                                                                                                                                                                                                                                                                                                                                     |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
## What?

<!-- A description of the changes this PR brings to the documentation. -->

Add an admonition at the top of all jslib libraries _index pages with a link to their GitHub repositories.

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [x] I have made my changes in the `docs/sources/next` folder of the documentation.
- [ ] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.
- [ ] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->