### PR TITLE
Fix json example in url grouping docs

### DIFF
--- a/docs/sources/next/using-k6/http-requests.md
+++ b/docs/sources/next/using-k6/http-requests.md
@@ -165,6 +165,8 @@ That code would produce JSON output like this:
 {{< code >}}
 
 ```json
+// For http://example.com/1, note that the url is not present in the JSON.
+
 {
     "type":"Point",
     "metric":"http_req_duration",
@@ -175,12 +177,12 @@ That code would produce JSON output like this:
             "method":"GET",
             "name":"PostsItemURL",
             "status":"200",
-            "url":"http://example.com/1"
+            "url":"PostsItemURL"
         }
     }
 }
 
-// and
+// and for http://example.com/2
 
 {
     "type":"Point",
@@ -192,7 +194,7 @@ That code would produce JSON output like this:
             "method":"GET",
             "name":"PostsItemURL",
             "status":"200",
-            "url":"http://example.com/2"
+            "url":"PostsItemURL"
         }
     }
 }

--- a/docs/sources/v0.47.x/using-k6/http-requests.md
+++ b/docs/sources/v0.47.x/using-k6/http-requests.md
@@ -158,6 +158,8 @@ That code would produce JSON output like this:
 {{< code >}}
 
 ```json
+// For http://example.com/1, note that the url is not present in the JSON.
+
 {
     "type":"Point",
     "metric":"http_req_duration",
@@ -168,12 +170,12 @@ That code would produce JSON output like this:
             "method":"GET",
             "name":"PostsItemURL",
             "status":"200",
-            "url":"http://example.com/1"
+            "url":"PostsItemURL"
         }
     }
 }
 
-// and
+// and for http://example.com/2
 
 {
     "type":"Point",
@@ -185,7 +187,7 @@ That code would produce JSON output like this:
             "method":"GET",
             "name":"PostsItemURL",
             "status":"200",
-            "url":"http://example.com/2"
+            "url":"PostsItemURL"
         }
     }
 }

--- a/docs/sources/v0.48.x/using-k6/http-requests.md
+++ b/docs/sources/v0.48.x/using-k6/http-requests.md
@@ -158,6 +158,8 @@ That code would produce JSON output like this:
 {{< code >}}
 
 ```json
+// For http://example.com/1, note that the url is not present in the JSON.
+
 {
     "type":"Point",
     "metric":"http_req_duration",
@@ -168,12 +170,12 @@ That code would produce JSON output like this:
             "method":"GET",
             "name":"PostsItemURL",
             "status":"200",
-            "url":"http://example.com/1"
+            "url":"PostsItemURL"
         }
     }
 }
 
-// and
+// and for http://example.com/2
 
 {
     "type":"Point",
@@ -185,7 +187,7 @@ That code would produce JSON output like this:
             "method":"GET",
             "name":"PostsItemURL",
             "status":"200",
-            "url":"http://example.com/2"
+            "url":"PostsItemURL"
         }
     }
 }

--- a/docs/sources/v0.49.x/using-k6/http-requests.md
+++ b/docs/sources/v0.49.x/using-k6/http-requests.md
@@ -158,6 +158,8 @@ That code would produce JSON output like this:
 {{< code >}}
 
 ```json
+// For http://example.com/1, note that the url is not present in the JSON.
+
 {
     "type":"Point",
     "metric":"http_req_duration",
@@ -168,12 +170,12 @@ That code would produce JSON output like this:
             "method":"GET",
             "name":"PostsItemURL",
             "status":"200",
-            "url":"http://example.com/1"
+            "url":"PostsItemURL"
         }
     }
 }
 
-// and
+// and for http://example.com/2
 
 {
     "type":"Point",
@@ -185,7 +187,7 @@ That code would produce JSON output like this:
             "method":"GET",
             "name":"PostsItemURL",
             "status":"200",
-            "url":"http://example.com/2"
+            "url":"PostsItemURL"
         }
     }
 }

--- a/docs/sources/v0.50.x/using-k6/http-requests.md
+++ b/docs/sources/v0.50.x/using-k6/http-requests.md
@@ -158,6 +158,8 @@ That code would produce JSON output like this:
 {{< code >}}
 
 ```json
+// For http://example.com/1, note that the url is not present in the JSON.
+
 {
     "type":"Point",
     "metric":"http_req_duration",
@@ -168,12 +170,12 @@ That code would produce JSON output like this:
             "method":"GET",
             "name":"PostsItemURL",
             "status":"200",
-            "url":"http://example.com/1"
+            "url":"PostsItemURL"
         }
     }
 }
 
-// and
+// and for http://example.com/2
 
 {
     "type":"Point",
@@ -185,7 +187,7 @@ That code would produce JSON output like this:
             "method":"GET",
             "name":"PostsItemURL",
             "status":"200",
-            "url":"http://example.com/2"
+            "url":"PostsItemURL"
         }
     }
 }

--- a/docs/sources/v0.51.x/using-k6/http-requests.md
+++ b/docs/sources/v0.51.x/using-k6/http-requests.md
@@ -158,6 +158,8 @@ That code would produce JSON output like this:
 {{< code >}}
 
 ```json
+// For http://example.com/1, note that the url is not present in the JSON.
+
 {
     "type":"Point",
     "metric":"http_req_duration",
@@ -168,12 +170,12 @@ That code would produce JSON output like this:
             "method":"GET",
             "name":"PostsItemURL",
             "status":"200",
-            "url":"http://example.com/1"
+            "url":"PostsItemURL"
         }
     }
 }
 
-// and
+// and for http://example.com/2
 
 {
     "type":"Point",
@@ -185,7 +187,7 @@ That code would produce JSON output like this:
             "method":"GET",
             "name":"PostsItemURL",
             "status":"200",
-            "url":"http://example.com/2"
+            "url":"PostsItemURL"
         }
     }
 }

--- a/docs/sources/v0.52.x/using-k6/http-requests.md
+++ b/docs/sources/v0.52.x/using-k6/http-requests.md
@@ -165,6 +165,8 @@ That code would produce JSON output like this:
 {{< code >}}
 
 ```json
+// For http://example.com/1, note that the url is not present in the JSON.
+
 {
     "type":"Point",
     "metric":"http_req_duration",
@@ -175,12 +177,12 @@ That code would produce JSON output like this:
             "method":"GET",
             "name":"PostsItemURL",
             "status":"200",
-            "url":"http://example.com/1"
+            "url":"PostsItemURL"
         }
     }
 }
 
-// and
+// and for http://example.com/2
 
 {
     "type":"Point",
@@ -192,7 +194,7 @@ That code would produce JSON output like this:
             "method":"GET",
             "name":"PostsItemURL",
             "status":"200",
-            "url":"http://example.com/2"
+            "url":"PostsItemURL"
         }
     }
 }

--- a/docs/sources/v0.53.x/using-k6/http-requests.md
+++ b/docs/sources/v0.53.x/using-k6/http-requests.md
@@ -165,6 +165,8 @@ That code would produce JSON output like this:
 {{< code >}}
 
 ```json
+// For http://example.com/1, note that the url is not present in the JSON.
+
 {
     "type":"Point",
     "metric":"http_req_duration",
@@ -175,12 +177,12 @@ That code would produce JSON output like this:
             "method":"GET",
             "name":"PostsItemURL",
             "status":"200",
-            "url":"http://example.com/1"
+            "url":"PostsItemURL"
         }
     }
 }
 
-// and
+// and for http://example.com/2
 
 {
     "type":"Point",
@@ -192,7 +194,7 @@ That code would produce JSON output like this:
             "method":"GET",
             "name":"PostsItemURL",
             "status":"200",
-            "url":"http://example.com/2"
+            "url":"PostsItemURL"
         }
     }
 }

--- a/docs/sources/v0.54.x/using-k6/http-requests.md
+++ b/docs/sources/v0.54.x/using-k6/http-requests.md
@@ -165,6 +165,8 @@ That code would produce JSON output like this:
 {{< code >}}
 
 ```json
+// For http://example.com/1, note that the url is not present in the JSON.
+
 {
     "type":"Point",
     "metric":"http_req_duration",
@@ -175,12 +177,12 @@ That code would produce JSON output like this:
             "method":"GET",
             "name":"PostsItemURL",
             "status":"200",
-            "url":"http://example.com/1"
+            "url":"PostsItemURL"
         }
     }
 }
 
-// and
+// and for http://example.com/2
 
 {
     "type":"Point",
@@ -192,7 +194,7 @@ That code would produce JSON output like this:
             "method":"GET",
             "name":"PostsItemURL",
             "status":"200",
-            "url":"http://example.com/2"
+            "url":"PostsItemURL"
         }
     }
 }

--- a/src/data/markdown/translated-guides/en/02 Using k6/01 HTTP requests.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/01 HTTP requests.md
@@ -156,6 +156,8 @@ That code would produce JSON output like this:
 <CodeGroup labels={[ ]} lineNumbers={[true]}>
 
 ```json
+// For http://example.com/1, note that the url is not present in the JSON.
+
 {
     "type":"Point",
     "metric":"http_req_duration",
@@ -166,12 +168,12 @@ That code would produce JSON output like this:
             "method":"GET",
             "name":"PostsItemURL",
             "status":"200",
-            "url":"http://example.com/1"
+            "url":"PostsItemURL"
         }
     }
 }
 
-// and
+// and for http://example.com/2
 
 {
     "type":"Point",
@@ -183,7 +185,7 @@ That code would produce JSON output like this:
             "method":"GET",
             "name":"PostsItemURL",
             "status":"200",
-            "url":"http://example.com/2"
+            "url":"PostsItemURL"
         }
     }
 }


### PR DESCRIPTION
<!-- 
Please make sure you have read the contribution guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md as well as the
the code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md before opening a PR.
-->

## What?

The url value in the json should be the same as name when the url grouping is applied.

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [x] I have made my changes in the `docs/sources/next` folder of the documentation.
- [x] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.
- [x] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->
<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->