### PR TITLE
Added example for running specific scenario via cli

### DIFF
--- a/docs/sources/k6/next/using-k6/scenarios/advanced-examples.md
+++ b/docs/sources/k6/next/using-k6/scenarios/advanced-examples.md
@@ -204,9 +204,9 @@ export function apitest() {
 
 ## Run specific scenario via environment variable
 
-Utilizing an [environment variable](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/environment-variables/#environment-variables) and a bit of code, you can run a specific scenario via command line as opposed to running all configured scenarios. By default, [k6 runs all scenarios listed in a file](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/scenarios/#scenarios).
+k6 runs all [scenarios](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/scenarios/#scenarios) listed in a test script by default. But, with some small code changes and using [environment variables](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/environment-variables/#environment-variables), you can tell k6 to only run a specific scenario via the command-line.
 
-The following provides an example of how to add the ability to run a specific scenario among multiple configured scenarios:
+The following example shows a test script that uses a `SCENARIO` environment variable, if it exists, to choose which scenario to execute:
 {{< code >}}
 
 ```javascript
@@ -229,7 +229,7 @@ const scenarios = {
 
 const { SCENARIO } = __ENV;
 export const options = {
-  // if a scenario is supplied via cli env, then run that scenario. Otherwise, run like normal
+  // if a scenario is passed via a CLI env variable, then run that scenario. Otherwise, run
   // using the pre-configured scenarios above.
   scenarios: SCENARIO ? { [SCENARIO]: scenarios[SCENARIO] } : scenarios,
   discardResponseBodies: true,
@@ -245,7 +245,7 @@ export default function () {
 
 {{< /code >}}
 
-Alternatively, slightly modifying this approach, it can instead be used as a skip feature. Reading from the custom environment variable allows calling a specific scenario via command line:
+Then from the command line, you could run the test script and only execute the `my_web_test` scenario by running:
 
 {{< code >}}
 

--- a/docs/sources/k6/v0.47.x/using-k6/scenarios/advanced-examples.md
+++ b/docs/sources/k6/v0.47.x/using-k6/scenarios/advanced-examples.md
@@ -204,9 +204,9 @@ export function apitest() {
 
 ## Run specific scenario via environment variable
 
-Utilizing an [environment variable](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/environment-variables/#environment-variables) and a bit of code, you can run a specific scenario via command line as opposed to running all configured scenarios. By default, [k6 runs all scenarios listed in a file](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/scenarios/#scenarios).
+k6 runs all [scenarios](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/scenarios/#scenarios) listed in a test script by default. But, with some small code changes and using [environment variables](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/environment-variables/#environment-variables), you can tell k6 to only run a specific scenario via the command-line.
 
-The following provides an example of how to add the ability to run a specific scenario among multiple configured scenarios:
+The following example shows a test script that uses a `SCENARIO` environment variable, if it exists, to choose which scenario to execute:
 {{< code >}}
 
 ```javascript
@@ -229,7 +229,7 @@ const scenarios = {
 
 const { SCENARIO } = __ENV;
 export const options = {
-  // if a scenario is supplied via cli env, then run that scenario. Otherwise, run like normal
+  // if a scenario is passed via a CLI env variable, then run that scenario. Otherwise, run
   // using the pre-configured scenarios above.
   scenarios: SCENARIO ? { [SCENARIO]: scenarios[SCENARIO] } : scenarios,
   discardResponseBodies: true,
@@ -245,7 +245,7 @@ export default function () {
 
 {{< /code >}}
 
-Alternatively, slightly modifying this approach, it can instead be used as a skip feature. Reading from the custom environment variable allows calling a specific scenario via command line:
+Then from the command line, you could run the test script and only execute the `my_web_test` scenario by running:
 
 {{< code >}}
 

--- a/docs/sources/k6/v0.48.x/using-k6/scenarios/advanced-examples.md
+++ b/docs/sources/k6/v0.48.x/using-k6/scenarios/advanced-examples.md
@@ -204,9 +204,9 @@ export function apitest() {
 
 ## Run specific scenario via environment variable
 
-Utilizing an [environment variable](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/environment-variables/#environment-variables) and a bit of code, you can run a specific scenario via command line as opposed to running all configured scenarios. By default, [k6 runs all scenarios listed in a file](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/scenarios/#scenarios).
+k6 runs all [scenarios](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/scenarios/#scenarios) listed in a test script by default. But, with some small code changes and using [environment variables](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/environment-variables/#environment-variables), you can tell k6 to only run a specific scenario via the command-line.
 
-The following provides an example of how to add the ability to run a specific scenario among multiple configured scenarios:
+The following example shows a test script that uses a `SCENARIO` environment variable, if it exists, to choose which scenario to execute:
 {{< code >}}
 
 ```javascript
@@ -229,7 +229,7 @@ const scenarios = {
 
 const { SCENARIO } = __ENV;
 export const options = {
-  // if a scenario is supplied via cli env, then run that scenario. Otherwise, run like normal
+  // if a scenario is passed via a CLI env variable, then run that scenario. Otherwise, run
   // using the pre-configured scenarios above.
   scenarios: SCENARIO ? { [SCENARIO]: scenarios[SCENARIO] } : scenarios,
   discardResponseBodies: true,
@@ -245,7 +245,7 @@ export default function () {
 
 {{< /code >}}
 
-Alternatively, slightly modifying this approach, it can instead be used as a skip feature. Reading from the custom environment variable allows calling a specific scenario via command line:
+Then from the command line, you could run the test script and only execute the `my_web_test` scenario by running:
 
 {{< code >}}
 

--- a/docs/sources/k6/v0.49.x/using-k6/scenarios/advanced-examples.md
+++ b/docs/sources/k6/v0.49.x/using-k6/scenarios/advanced-examples.md
@@ -204,9 +204,9 @@ export function apitest() {
 
 ## Run specific scenario via environment variable
 
-Utilizing an [environment variable](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/environment-variables/#environment-variables) and a bit of code, you can run a specific scenario via command line as opposed to running all configured scenarios. By default, [k6 runs all scenarios listed in a file](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/scenarios/#scenarios).
+k6 runs all [scenarios](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/scenarios/#scenarios) listed in a test script by default. But, with some small code changes and using [environment variables](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/environment-variables/#environment-variables), you can tell k6 to only run a specific scenario via the command-line.
 
-The following provides an example of how to add the ability to run a specific scenario among multiple configured scenarios:
+The following example shows a test script that uses a `SCENARIO` environment variable, if it exists, to choose which scenario to execute:
 {{< code >}}
 
 ```javascript
@@ -229,7 +229,7 @@ const scenarios = {
 
 const { SCENARIO } = __ENV;
 export const options = {
-  // if a scenario is supplied via cli env, then run that scenario. Otherwise, run like normal
+  // if a scenario is passed via a CLI env variable, then run that scenario. Otherwise, run
   // using the pre-configured scenarios above.
   scenarios: SCENARIO ? { [SCENARIO]: scenarios[SCENARIO] } : scenarios,
   discardResponseBodies: true,
@@ -245,7 +245,7 @@ export default function () {
 
 {{< /code >}}
 
-Alternatively, slightly modifying this approach, it can instead be used as a skip feature. Reading from the custom environment variable allows calling a specific scenario via command line:
+Then from the command line, you could run the test script and only execute the `my_web_test` scenario by running:
 
 {{< code >}}
 

--- a/docs/sources/k6/v0.50.x/using-k6/scenarios/advanced-examples.md
+++ b/docs/sources/k6/v0.50.x/using-k6/scenarios/advanced-examples.md
@@ -204,9 +204,9 @@ export function apitest() {
 
 ## Run specific scenario via environment variable
 
-Utilizing an [environment variable](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/environment-variables/#environment-variables) and a bit of code, you can run a specific scenario via command line as opposed to running all configured scenarios. By default, [k6 runs all scenarios listed in a file](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/scenarios/#scenarios).
+k6 runs all [scenarios](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/scenarios/#scenarios) listed in a test script by default. But, with some small code changes and using [environment variables](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/environment-variables/#environment-variables), you can tell k6 to only run a specific scenario via the command-line.
 
-The following provides an example of how to add the ability to run a specific scenario among multiple configured scenarios:
+The following example shows a test script that uses a `SCENARIO` environment variable, if it exists, to choose which scenario to execute:
 {{< code >}}
 
 ```javascript
@@ -229,7 +229,7 @@ const scenarios = {
 
 const { SCENARIO } = __ENV;
 export const options = {
-  // if a scenario is supplied via cli env, then run that scenario. Otherwise, run like normal
+  // if a scenario is passed via a CLI env variable, then run that scenario. Otherwise, run
   // using the pre-configured scenarios above.
   scenarios: SCENARIO ? { [SCENARIO]: scenarios[SCENARIO] } : scenarios,
   discardResponseBodies: true,
@@ -245,7 +245,7 @@ export default function () {
 
 {{< /code >}}
 
-Alternatively, slightly modifying this approach, it can instead be used as a skip feature. Reading from the custom environment variable allows calling a specific scenario via command line:
+Then from the command line, you could run the test script and only execute the `my_web_test` scenario by running:
 
 {{< code >}}
 

--- a/docs/sources/k6/v0.51.x/using-k6/scenarios/advanced-examples.md
+++ b/docs/sources/k6/v0.51.x/using-k6/scenarios/advanced-examples.md
@@ -204,9 +204,9 @@ export function apitest() {
 
 ## Run specific scenario via environment variable
 
-Utilizing an [environment variable](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/environment-variables/#environment-variables) and a bit of code, you can run a specific scenario via command line as opposed to running all configured scenarios. By default, [k6 runs all scenarios listed in a file](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/scenarios/#scenarios).
+k6 runs all [scenarios](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/scenarios/#scenarios) listed in a test script by default. But, with some small code changes and using [environment variables](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/environment-variables/#environment-variables), you can tell k6 to only run a specific scenario via the command-line.
 
-The following provides an example of how to add the ability to run a specific scenario among multiple configured scenarios:
+The following example shows a test script that uses a `SCENARIO` environment variable, if it exists, to choose which scenario to execute:
 {{< code >}}
 
 ```javascript
@@ -229,7 +229,7 @@ const scenarios = {
 
 const { SCENARIO } = __ENV;
 export const options = {
-  // if a scenario is supplied via cli env, then run that scenario. Otherwise, run like normal
+  // if a scenario is passed via a CLI env variable, then run that scenario. Otherwise, run
   // using the pre-configured scenarios above.
   scenarios: SCENARIO ? { [SCENARIO]: scenarios[SCENARIO] } : scenarios,
   discardResponseBodies: true,
@@ -245,7 +245,7 @@ export default function () {
 
 {{< /code >}}
 
-Alternatively, slightly modifying this approach, it can instead be used as a skip feature. Reading from the custom environment variable allows calling a specific scenario via command line:
+Then from the command line, you could run the test script and only execute the `my_web_test` scenario by running:
 
 {{< code >}}
 

--- a/docs/sources/k6/v0.52.x/using-k6/scenarios/advanced-examples.md
+++ b/docs/sources/k6/v0.52.x/using-k6/scenarios/advanced-examples.md
@@ -204,9 +204,9 @@ export function apitest() {
 
 ## Run specific scenario via environment variable
 
-Utilizing an [environment variable](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/environment-variables/#environment-variables) and a bit of code, you can run a specific scenario via command line as opposed to running all configured scenarios. By default, [k6 runs all scenarios listed in a file](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/scenarios/#scenarios).
+k6 runs all [scenarios](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/scenarios/#scenarios) listed in a test script by default. But, with some small code changes and using [environment variables](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/environment-variables/#environment-variables), you can tell k6 to only run a specific scenario via the command-line.
 
-The following provides an example of how to add the ability to run a specific scenario among multiple configured scenarios:
+The following example shows a test script that uses a `SCENARIO` environment variable, if it exists, to choose which scenario to execute:
 {{< code >}}
 
 ```javascript
@@ -229,7 +229,7 @@ const scenarios = {
 
 const { SCENARIO } = __ENV;
 export const options = {
-  // if a scenario is supplied via cli env, then run that scenario. Otherwise, run like normal
+  // if a scenario is passed via a CLI env variable, then run that scenario. Otherwise, run
   // using the pre-configured scenarios above.
   scenarios: SCENARIO ? { [SCENARIO]: scenarios[SCENARIO] } : scenarios,
   discardResponseBodies: true,
@@ -245,7 +245,7 @@ export default function () {
 
 {{< /code >}}
 
-Alternatively, slightly modifying this approach, it can instead be used as a skip feature. Reading from the custom environment variable allows calling a specific scenario via command line:
+Then from the command line, you could run the test script and only execute the `my_web_test` scenario by running:
 
 {{< code >}}
 

--- a/docs/sources/k6/v0.53.x/using-k6/scenarios/advanced-examples.md
+++ b/docs/sources/k6/v0.53.x/using-k6/scenarios/advanced-examples.md
@@ -204,9 +204,9 @@ export function apitest() {
 
 ## Run specific scenario via environment variable
 
-Utilizing an [environment variable](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/environment-variables/#environment-variables) and a bit of code, you can run a specific scenario via command line as opposed to running all configured scenarios. By default, [k6 runs all scenarios listed in a file](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/scenarios/#scenarios).
+k6 runs all [scenarios](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/scenarios/#scenarios) listed in a test script by default. But, with some small code changes and using [environment variables](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/environment-variables/#environment-variables), you can tell k6 to only run a specific scenario via the command-line.
 
-The following provides an example of how to add the ability to run a specific scenario among multiple configured scenarios:
+The following example shows a test script that uses a `SCENARIO` environment variable, if it exists, to choose which scenario to execute:
 {{< code >}}
 
 ```javascript
@@ -229,7 +229,7 @@ const scenarios = {
 
 const { SCENARIO } = __ENV;
 export const options = {
-  // if a scenario is supplied via cli env, then run that scenario. Otherwise, run like normal
+  // if a scenario is passed via a CLI env variable, then run that scenario. Otherwise, run
   // using the pre-configured scenarios above.
   scenarios: SCENARIO ? { [SCENARIO]: scenarios[SCENARIO] } : scenarios,
   discardResponseBodies: true,
@@ -245,7 +245,7 @@ export default function () {
 
 {{< /code >}}
 
-Alternatively, slightly modifying this approach, it can instead be used as a skip feature. Reading from the custom environment variable allows calling a specific scenario via command line:
+Then from the command line, you could run the test script and only execute the `my_web_test` scenario by running:
 
 {{< code >}}
 

--- a/docs/sources/k6/v0.54.x/using-k6/scenarios/advanced-examples.md
+++ b/docs/sources/k6/v0.54.x/using-k6/scenarios/advanced-examples.md
@@ -204,9 +204,9 @@ export function apitest() {
 
 ## Run specific scenario via environment variable
 
-Utilizing an [environment variable](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/environment-variables/#environment-variables) and a bit of code, you can run a specific scenario via command line as opposed to running all configured scenarios. By default, [k6 runs all scenarios listed in a file](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/scenarios/#scenarios).
+k6 runs all [scenarios](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/scenarios/#scenarios) listed in a test script by default. But, with some small code changes and using [environment variables](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/environment-variables/#environment-variables), you can tell k6 to only run a specific scenario via the command-line.
 
-The following provides an example of how to add the ability to run a specific scenario among multiple configured scenarios:
+The following example shows a test script that uses a `SCENARIO` environment variable, if it exists, to choose which scenario to execute:
 {{< code >}}
 
 ```javascript
@@ -229,7 +229,7 @@ const scenarios = {
 
 const { SCENARIO } = __ENV;
 export const options = {
-  // if a scenario is supplied via cli env, then run that scenario. Otherwise, run like normal
+  // if a scenario is passed via a CLI env variable, then run that scenario. Otherwise, run
   // using the pre-configured scenarios above.
   scenarios: SCENARIO ? { [SCENARIO]: scenarios[SCENARIO] } : scenarios,
   discardResponseBodies: true,
@@ -245,7 +245,7 @@ export default function () {
 
 {{< /code >}}
 
-Alternatively, slightly modifying this approach, it can instead be used as a skip feature. Reading from the custom environment variable allows calling a specific scenario via command line:
+Then from the command line, you could run the test script and only execute the `my_web_test` scenario by running:
 
 {{< code >}}
 


### PR DESCRIPTION
## Why?
On a number of occasions I have found colleagues wanting to run a specific scenario of a given test script. Early on I saw folks would just comment things out to get to the behavior they wanted or would start nesting scripts and fanning tests out.

## What?
- Added an example to the scenario section outlining how to effectively use an environment variable to run a specific scenario among a group.
- Tested example in all versions that it works as expected.

![image](https://github.com/user-attachments/assets/26baa2d6-d108-44f6-a7c0-c5c4de67079a)

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [x] I have made my changes in the `docs/sources/next` folder of the documentation.
- [x] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.
- [x] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).

## Related PR(s)/Issue(s)

- https://github.com/grafana/k6/issues/2780