### PR TITLE
Update docs structure, rename Configure k6 Intellisense page

### DIFF
--- a/docs/sources/next/get-started/_index.md
+++ b/docs/sources/next/get-started/_index.md
@@ -1,5 +1,5 @@
 ---
-weight: 150
+weight: 175
 title: Get started
 ---
 

--- a/docs/sources/next/set-up/_index.md
+++ b/docs/sources/next/set-up/_index.md
@@ -1,5 +1,5 @@
 ---
-weight: 175
+weight: 150
 title: Set up
 ---
 

--- a/docs/sources/next/set-up/configure-k6-intellisense.md
+++ b/docs/sources/next/set-up/configure-k6-intellisense.md
@@ -36,4 +36,10 @@ $ npm install --save-dev @types/k6
 - [Visual Studio Code - k6 Extension](https://marketplace.visualstudio.com/items?itemName=k6.k6)
 - [IntelliJ IDEA - k6 Plugin](https://plugins.jetbrains.com/plugin/16141-k6)
 - [TypeScript Editor Support](https://github.com/Microsoft/TypeScript/wiki/TypeScript-Editor-Support)
-- [Use TypeScript in k6 scripts](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/javascript-typescript-compatibility-mode/)
+
+## Next steps
+
+Now that you have k6 configured in your code editor, you can:
+
+- Head over to [Running k6](https://grafana.com/docs/k6/<K6_VERSION>/get-started/running-k6/) to learn how to create and run your first test.
+- See how to [use TypeScript in k6 scripts](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/javascript-typescript-compatibility-mode/).

--- a/docs/sources/next/set-up/configure-your-code-editor.md
+++ b/docs/sources/next/set-up/configure-your-code-editor.md
@@ -44,4 +44,4 @@ You can also find k6 code editor extensions for Visual Studio Code and IntelliJ 
 Now that you have k6 configured in your code editor, you can:
 
 - Head over to [Running k6](https://grafana.com/docs/k6/<K6_VERSION>/get-started/running-k6/) to learn how to create and run your first test.
-- Configure your editor for [TypeScript support](https://github.com/Microsoft/TypeScript/wiki/TypeScript-Editor-Support)
+- Configure your editor for [TypeScript support](https://github.com/Microsoft/TypeScript/wiki/TypeScript-Editor-Support).

--- a/docs/sources/next/set-up/configure-your-code-editor.md
+++ b/docs/sources/next/set-up/configure-your-code-editor.md
@@ -43,4 +43,3 @@ $ npm install --save-dev @types/k6
 Now that you have k6 configured in your code editor, you can:
 
 - Head over to [Running k6](https://grafana.com/docs/k6/<K6_VERSION>/get-started/running-k6/) to learn how to create and run your first test.
-- See how to [use TypeScript in k6 scripts](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/javascript-typescript-compatibility-mode/).

--- a/docs/sources/next/set-up/configure-your-code-editor.md
+++ b/docs/sources/next/set-up/configure-your-code-editor.md
@@ -1,13 +1,14 @@
 ---
 aliases:
-  - ./intellisense
+  - ./configure-k6-intellisense # docs/k6/<K6_VERSION>/set-up/configure-k6-intellisense
+  - ./intellisense # docs/k6/<K6_VERSION>/set-up/intellisense
   - ../misc/intellisense # docs/k6/<K6_VERSION>/misc/intellisense
-title: 'Configure k6 IntelliSense'
+title: 'Configure your code editor'
 description: 'k6 has its TypeScript Type Definition that you can configure with your editor to unlock code editing features.'
 weight: 100
 ---
 
-# Configure k6 IntelliSense
+# Configure your code editor
 
 [IntelliSense](https://code.visualstudio.com/docs/editor/intellisense) refers to code editing features like **intelligent code completion** and **quick access to documentation**. These features can significantly improve the developer experience and productivity when working on k6 scripts in your editor of choice. Notable features are:
 

--- a/docs/sources/next/set-up/configure-your-code-editor.md
+++ b/docs/sources/next/set-up/configure-your-code-editor.md
@@ -18,7 +18,7 @@ weight: 100
 
 ![Intellisense enabled in a code editor, showing autocompletion of k6 libraries](/media/docs/k6-oss/intellisense-k6-demo.gif)
 
-## VS Code & IntelliJ
+## Install k6 type definitions
 
 k6 has its [TypeScript Type Definition](https://www.npmjs.com/package/@types/k6) that you can configure with your editor to unlock code editing features.
 
@@ -32,14 +32,16 @@ $ npm init --yes
 $ npm install --save-dev @types/k6
 ```
 
-## Read more
+## Code editor extensions
+
+You can also find k6 code editor extensions for Visual Studio Code and IntelliJ IDEA:
 
 - [Visual Studio Code - k6 Extension](https://marketplace.visualstudio.com/items?itemName=k6.k6)
 - [IntelliJ IDEA - k6 Plugin](https://plugins.jetbrains.com/plugin/16141-k6)
-- [TypeScript Editor Support](https://github.com/Microsoft/TypeScript/wiki/TypeScript-Editor-Support)
 
 ## Next steps
 
 Now that you have k6 configured in your code editor, you can:
 
 - Head over to [Running k6](https://grafana.com/docs/k6/<K6_VERSION>/get-started/running-k6/) to learn how to create and run your first test.
+- Configure your editor for [TypeScript support](https://github.com/Microsoft/TypeScript/wiki/TypeScript-Editor-Support)

--- a/docs/sources/v0.53.x/get-started/_index.md
+++ b/docs/sources/v0.53.x/get-started/_index.md
@@ -1,5 +1,5 @@
 ---
-weight: 150
+weight: 175
 title: Get started
 ---
 

--- a/docs/sources/v0.53.x/set-up/_index.md
+++ b/docs/sources/v0.53.x/set-up/_index.md
@@ -1,5 +1,5 @@
 ---
-weight: 175
+weight: 150
 title: Set up
 ---
 

--- a/docs/sources/v0.53.x/set-up/configure-your-code-editor.md
+++ b/docs/sources/v0.53.x/set-up/configure-your-code-editor.md
@@ -44,4 +44,4 @@ You can also find k6 code editor extensions for Visual Studio Code and IntelliJ 
 Now that you have k6 configured in your code editor, you can:
 
 - Head over to [Running k6](https://grafana.com/docs/k6/<K6_VERSION>/get-started/running-k6/) to learn how to create and run your first test.
-- Configure your editor for [TypeScript support](https://github.com/Microsoft/TypeScript/wiki/TypeScript-Editor-Support)
+- Configure your editor for [TypeScript support](https://github.com/Microsoft/TypeScript/wiki/TypeScript-Editor-Support).

--- a/docs/sources/v0.53.x/set-up/configure-your-code-editor.md
+++ b/docs/sources/v0.53.x/set-up/configure-your-code-editor.md
@@ -1,13 +1,14 @@
 ---
 aliases:
-  - ./intellisense
+  - ./configure-k6-intellisense # docs/k6/<K6_VERSION>/set-up/configure-k6-intellisense
+  - ./intellisense # docs/k6/<K6_VERSION>/set-up/intellisense
   - ../misc/intellisense # docs/k6/<K6_VERSION>/misc/intellisense
-title: 'Configure k6 IntelliSense'
+title: 'Configure your code editor'
 description: 'k6 has its TypeScript Type Definition that you can configure with your editor to unlock code editing features.'
 weight: 100
 ---
 
-# Configure k6 IntelliSense
+# Configure your code editor
 
 [IntelliSense](https://code.visualstudio.com/docs/editor/intellisense) refers to code editing features like **intelligent code completion** and **quick access to documentation**. These features can significantly improve the developer experience and productivity when working on k6 scripts in your editor of choice. Notable features are:
 
@@ -17,7 +18,7 @@ weight: 100
 
 ![Intellisense enabled in a code editor, showing autocompletion of k6 libraries](/media/docs/k6-oss/intellisense-k6-demo.gif)
 
-## VS Code & IntelliJ
+## Install k6 type definitions
 
 k6 has its [TypeScript Type Definition](https://www.npmjs.com/package/@types/k6) that you can configure with your editor to unlock code editing features.
 
@@ -31,9 +32,16 @@ $ npm init --yes
 $ npm install --save-dev @types/k6
 ```
 
-## Read more
+## Code editor extensions
+
+You can also find k6 code editor extensions for Visual Studio Code and IntelliJ IDEA:
 
 - [Visual Studio Code - k6 Extension](https://marketplace.visualstudio.com/items?itemName=k6.k6)
 - [IntelliJ IDEA - k6 Plugin](https://plugins.jetbrains.com/plugin/16141-k6)
-- [TypeScript Editor Support](https://github.com/Microsoft/TypeScript/wiki/TypeScript-Editor-Support)
-- [Use TypeScript in k6 scripts](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/javascript-typescript-compatibility-mode/)
+
+## Next steps
+
+Now that you have k6 configured in your code editor, you can:
+
+- Head over to [Running k6](https://grafana.com/docs/k6/<K6_VERSION>/get-started/running-k6/) to learn how to create and run your first test.
+- Configure your editor for [TypeScript support](https://github.com/Microsoft/TypeScript/wiki/TypeScript-Editor-Support)

--- a/docs/sources/v0.54.x/get-started/_index.md
+++ b/docs/sources/v0.54.x/get-started/_index.md
@@ -1,5 +1,5 @@
 ---
-weight: 150
+weight: 175
 title: Get started
 ---
 

--- a/docs/sources/v0.54.x/set-up/_index.md
+++ b/docs/sources/v0.54.x/set-up/_index.md
@@ -1,5 +1,5 @@
 ---
-weight: 175
+weight: 150
 title: Set up
 ---
 

--- a/docs/sources/v0.54.x/set-up/configure-your-code-editor.md
+++ b/docs/sources/v0.54.x/set-up/configure-your-code-editor.md
@@ -44,4 +44,4 @@ You can also find k6 code editor extensions for Visual Studio Code and IntelliJ 
 Now that you have k6 configured in your code editor, you can:
 
 - Head over to [Running k6](https://grafana.com/docs/k6/<K6_VERSION>/get-started/running-k6/) to learn how to create and run your first test.
-- Configure your editor for [TypeScript support](https://github.com/Microsoft/TypeScript/wiki/TypeScript-Editor-Support)
+- Configure your editor for [TypeScript support](https://github.com/Microsoft/TypeScript/wiki/TypeScript-Editor-Support).

--- a/docs/sources/v0.54.x/set-up/configure-your-code-editor.md
+++ b/docs/sources/v0.54.x/set-up/configure-your-code-editor.md
@@ -1,13 +1,14 @@
 ---
 aliases:
-  - ./intellisense
+  - ./configure-k6-intellisense # docs/k6/<K6_VERSION>/set-up/configure-k6-intellisense
+  - ./intellisense # docs/k6/<K6_VERSION>/set-up/intellisense
   - ../misc/intellisense # docs/k6/<K6_VERSION>/misc/intellisense
-title: 'Configure k6 IntelliSense'
+title: 'Configure your code editor'
 description: 'k6 has its TypeScript Type Definition that you can configure with your editor to unlock code editing features.'
 weight: 100
 ---
 
-# Configure k6 IntelliSense
+# Configure your code editor
 
 [IntelliSense](https://code.visualstudio.com/docs/editor/intellisense) refers to code editing features like **intelligent code completion** and **quick access to documentation**. These features can significantly improve the developer experience and productivity when working on k6 scripts in your editor of choice. Notable features are:
 
@@ -17,7 +18,7 @@ weight: 100
 
 ![Intellisense enabled in a code editor, showing autocompletion of k6 libraries](/media/docs/k6-oss/intellisense-k6-demo.gif)
 
-## VS Code & IntelliJ
+## Install k6 type definitions
 
 k6 has its [TypeScript Type Definition](https://www.npmjs.com/package/@types/k6) that you can configure with your editor to unlock code editing features.
 
@@ -31,9 +32,16 @@ $ npm init --yes
 $ npm install --save-dev @types/k6
 ```
 
-## Read more
+## Code editor extensions
+
+You can also find k6 code editor extensions for Visual Studio Code and IntelliJ IDEA:
 
 - [Visual Studio Code - k6 Extension](https://marketplace.visualstudio.com/items?itemName=k6.k6)
 - [IntelliJ IDEA - k6 Plugin](https://plugins.jetbrains.com/plugin/16141-k6)
-- [TypeScript Editor Support](https://github.com/Microsoft/TypeScript/wiki/TypeScript-Editor-Support)
-- [Use TypeScript in k6 scripts](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/javascript-typescript-compatibility-mode/)
+
+## Next steps
+
+Now that you have k6 configured in your code editor, you can:
+
+- Head over to [Running k6](https://grafana.com/docs/k6/<K6_VERSION>/get-started/running-k6/) to learn how to create and run your first test.
+- Configure your editor for [TypeScript support](https://github.com/Microsoft/TypeScript/wiki/TypeScript-Editor-Support)


### PR DESCRIPTION
## What?

- Move "Set up" section above "Get started"
- Rename "Configure k6 Intellisense" page to "Configure your code editor"
- Add "Next steps" section to "Configure your code editor" page

### Before

<img width="893" alt="Screenshot 2024-10-08 at 3 51 58 PM" src="https://github.com/user-attachments/assets/60c84cab-634b-4681-afc7-02736b052f7a">

### After

<img width="844" alt="Screenshot 2024-10-08 at 3 52 06 PM" src="https://github.com/user-attachments/assets/d8ccebe1-69a8-43ed-aaca-428e7771639e">

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [x] I have made my changes in the `docs/sources/next` folder of the documentation.
- [x] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.
- [x] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->
