### PR TITLE
fix: removed conflicting option from nr docker.

### DIFF
--- a/docs/sources/k6/next/results-output/real-time/newrelic.md
+++ b/docs/sources/k6/next/results-output/real-time/newrelic.md
@@ -31,7 +31,7 @@ Run the New Relic integration as a Docker container with this command:
 
 ```bash
 docker run --rm \
-  -d --restart unless-stopped \
+  -d \
   --name newrelic-statsd \
   -h $(hostname) \
   -e NR_ACCOUNT_ID=<NR-ACCOUNT-ID> \

--- a/docs/sources/k6/v0.47.x/results-output/real-time/newrelic.md
+++ b/docs/sources/k6/v0.47.x/results-output/real-time/newrelic.md
@@ -37,7 +37,7 @@ Run the New Relic integration as a Docker container with this command:
 
 ```bash
 docker run --rm \
-  -d --restart unless-stopped \
+  -d \
   --name newrelic-statsd \
   -h $(hostname) \
   -e NR_ACCOUNT_ID=<NR-ACCOUNT-ID> \

--- a/docs/sources/k6/v0.48.x/results-output/real-time/newrelic.md
+++ b/docs/sources/k6/v0.48.x/results-output/real-time/newrelic.md
@@ -37,7 +37,7 @@ Run the New Relic integration as a Docker container with this command:
 
 ```bash
 docker run --rm \
-  -d --restart unless-stopped \
+  -d \
   --name newrelic-statsd \
   -h $(hostname) \
   -e NR_ACCOUNT_ID=<NR-ACCOUNT-ID> \

--- a/docs/sources/k6/v0.49.x/results-output/real-time/newrelic.md
+++ b/docs/sources/k6/v0.49.x/results-output/real-time/newrelic.md
@@ -37,7 +37,7 @@ Run the New Relic integration as a Docker container with this command:
 
 ```bash
 docker run --rm \
-  -d --restart unless-stopped \
+  -d \
   --name newrelic-statsd \
   -h $(hostname) \
   -e NR_ACCOUNT_ID=<NR-ACCOUNT-ID> \

--- a/docs/sources/k6/v0.50.x/results-output/real-time/newrelic.md
+++ b/docs/sources/k6/v0.50.x/results-output/real-time/newrelic.md
@@ -37,7 +37,7 @@ Run the New Relic integration as a Docker container with this command:
 
 ```bash
 docker run --rm \
-  -d --restart unless-stopped \
+  -d \
   --name newrelic-statsd \
   -h $(hostname) \
   -e NR_ACCOUNT_ID=<NR-ACCOUNT-ID> \

--- a/docs/sources/k6/v0.51.x/results-output/real-time/newrelic.md
+++ b/docs/sources/k6/v0.51.x/results-output/real-time/newrelic.md
@@ -37,7 +37,7 @@ Run the New Relic integration as a Docker container with this command:
 
 ```bash
 docker run --rm \
-  -d --restart unless-stopped \
+  -d \
   --name newrelic-statsd \
   -h $(hostname) \
   -e NR_ACCOUNT_ID=<NR-ACCOUNT-ID> \

--- a/docs/sources/k6/v0.52.x/results-output/real-time/newrelic.md
+++ b/docs/sources/k6/v0.52.x/results-output/real-time/newrelic.md
@@ -37,7 +37,7 @@ Run the New Relic integration as a Docker container with this command:
 
 ```bash
 docker run --rm \
-  -d --restart unless-stopped \
+  -d \
   --name newrelic-statsd \
   -h $(hostname) \
   -e NR_ACCOUNT_ID=<NR-ACCOUNT-ID> \

--- a/docs/sources/k6/v0.53.x/results-output/real-time/newrelic.md
+++ b/docs/sources/k6/v0.53.x/results-output/real-time/newrelic.md
@@ -31,7 +31,7 @@ Run the New Relic integration as a Docker container with this command:
 
 ```bash
 docker run --rm \
-  -d --restart unless-stopped \
+  -d \
   --name newrelic-statsd \
   -h $(hostname) \
   -e NR_ACCOUNT_ID=<NR-ACCOUNT-ID> \

--- a/docs/sources/k6/v0.54.x/results-output/real-time/newrelic.md
+++ b/docs/sources/k6/v0.54.x/results-output/real-time/newrelic.md
@@ -31,7 +31,7 @@ Run the New Relic integration as a Docker container with this command:
 
 ```bash
 docker run --rm \
-  -d --restart unless-stopped \
+  -d \
   --name newrelic-statsd \
   -h $(hostname) \
   -e NR_ACCOUNT_ID=<NR-ACCOUNT-ID> \

--- a/src/data/markdown/translated-guides/en/04 Results output/200 Real-time/00 NewRelic.md
+++ b/src/data/markdown/translated-guides/en/04 Results output/200 Real-time/00 NewRelic.md
@@ -34,7 +34,7 @@ Run the New Relic integration as a Docker container with this command:
 
 ```bash
 docker run --rm \
-  -d --restart unless-stopped \
+  -d \
   --name newrelic-statsd \
   -h $(hostname) \
   -e NR_ACCOUNT_ID=<NR-ACCOUNT-ID> \


### PR DESCRIPTION
## What?

* Fixed error when trying to run the docker command for starting NR up to capture metrics.

Error:
```
docker: Conflicting options: --restart and --rm
```

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [x] I have made my changes in the `docs/sources/next` folder of the documentation.
- [x] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.
- [x] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).

## Related PR(s)/Issue(s)
- Closes https://github.com/grafana/k6-docs/pull/1389