### PR TITLE
Only list extensions available in Grafana k6

### DIFF
--- a/scripts/extension-registry-changed
+++ b/scripts/extension-registry-changed
@@ -6,7 +6,7 @@
 # The script is run by the extension-registry.changed.yml
 # workflow when the extension registry changes.
 #
-# The list of extensions is generated based on https://registry.k6.io/registry.json.
+# The list of extensions is generated based on https://registry.k6.io/product/oss.json.
 #
 # In the docs/sources/next/extensions/explore.md file
 # the content of the <div class="nav-cards"> HTML element
@@ -15,7 +15,7 @@
 set -euf -o pipefail
 
 generate_extension_list_partial() {
-  curl -sL https://registry.k6.io/registry.json |
+  curl -sL https://registry.k6.io/product/oss.json |
     jq -r '
  map(select(.module != "go.k6.io/k6") | { name:.repo.name, url: .repo.url, description: .description } ) |
  sort_by(.name) | map(


### PR DESCRIPTION
## What?

Currently, all extensions in the extension registry are listed in the documentation. In the near future, extensions will be registered that are internal, technological extensions and should not be listed in the public documentation.

This PR allows only those extensions that are (also) available in the Grafana k6 product to be listed.

Use the https://registry.k6.io/product/oss.json endpoint instead of the https://registry.k6.io/registry.json endpoint to generate the list. This endpoint returns the extensions that are available in Grafana k6 (OSS).

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [ ] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

## Related PR(s)/Issue(s)

https://github.com/grafana/k6-docs/issues/1773

Closes #1773

