### PR TITLE
Add a "Write your first test" page to the Get Started section

### DIFF
--- a/docs/sources/next/get-started/write-your-first-test.md
+++ b/docs/sources/next/get-started/write-your-first-test.md
@@ -1,0 +1,74 @@
+---
+title: 'Write your first test'
+description: 'Follow along to learn how to write your first k6 test script.'
+weight: 02
+---
+
+# Write your first test
+
+k6 is a reliability testing tool. It helps developers simulate realistic user behavior and test how their systems behaves as a result. Writing tests in k6 allows you to identify issues such as slow response times or system failures before they occur in production.
+
+The goal of your test can vary. You might want to check performance, reliability, or scalability. Depending on your goal, your script may need different configurations, such as simulating many users, or running tests for a long time. (For more details, see our documentation on [reliability testing types](https://grafana.com/docs/k6/<K6_VERSION>/testing-guides/)).
+
+k6 uses JavaScript (or [TypeScript](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/javascript-typescript-compatibility-mode/#experimental-enhanced-mode)) to define the test's behavior. This makes it accessible to many developers. By writing scripts, you control what the test does and how it behaves.
+
+Follow along your first test script, and start testing the reliability of your application.
+
+## Before you start
+
+To write k6 scripts, basic knowledge of JavaScript or TypeScript is recommended. If you’re not familiar with these languages, you can use [k6 Studio](https://grafana.com/docs/k6/<K6_VERSION>/k6-studio/) to automatically generate tests without writing code, or any of our [test authoring methods](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-authoring/).
+
+Make sure k6 is installed on your system. If it’s not, follow our [set up guide](https://grafana.com/docs/k6/<K6_VERSION>/set-up/).
+
+Finally, you’ll also need a code editor to write your scripts. We recommend using VS Code or any other editor you’re comfortable with. See our [guide for setting up your editor](https://grafana.com/docs/k6/<K6_VERSION>/set-up/configure-your-code-editor/) for more details.
+
+## Basic structure of a k6 test
+
+Every k6 test script follows a basic structure, revolving around a few core components:
+
+1. **Default function**: This is where the test logic resides. It defines what your test will do and how it will behave during execution.
+2. **Imports**: You can import additional [k6 modules](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/) or [JavaScript libraries (jslibs)](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/) to extend your script’s functionality, such as making HTTP requests or simulating browser interactions. Note that k6 is not built upon NodeJS, and uses instead its own JavaScript runtime, and although it might be compatible with some npm modules, we do not guarantee it.
+3. **Options (optional)**: Enable you to configure the test conditions, like defining the number of virtual users, test duration, or setting performance thresholds. See our [options documentation](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/) for more details.
+4. **Lifecycle functions (optional)**: These allow you to write code that will be run before and after the test, such as setting up test data or processing results.
+
+### Writing your first test script
+
+Let’s walk through creating a simple test:
+
+1. **Create the test file**: Open your code editor and create a new file named `test.js`.
+2. **Write a basic test**: Here’s a simple script that makes a GET request to a URL and simulates waiting between requests.
+
+   ```javascript
+   // Import k6 modules exposing additional functionality such as performing
+   // HTTP requests and introducing delays.
+   import http from 'k6/http';
+   import { sleep } from 'k6';
+
+   // The default exported function is gonna be picked up by k6 as the entry point
+   // for the test script. It will be executed repeated in "iterations" for the whole
+   // duration of the test.
+   export default function () {
+     // Make a GET request to the target URL
+     http.get('https://test-api.k6.io');
+
+     // Sleep for 1 second to simulate real-world usage
+     sleep(1);
+   }
+   ```
+
+3. **Explanation**:
+   - The http module is used to make HTTP requests, in this case, a simple GET request to `https://test-api.k6.io`. You can replace this with your own API or website URL.
+   - The `sleep(1)` function pauses for 1 second after each request, mimicking real-world user behavior where not every action happens instantly.
+
+### Going a bit further
+
+Once you’re comfortable with this basic script, there are many ways to extend its functionality:
+
+1. _Multiple requests_: You can add more `http.get()` or `http.post()` requests to simulate more complex user flows.
+2. _Using TypeScript_: If you prefer TypeScript, k6 supports it too. You can learn more in our [TypeScript guide](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/javascript-typescript-compatibility-mode/#experimental-enhanced-mode).
+3. _Thresholds, checks, and metrics_: You can add conditions to monitor performance. For example, you can set thresholds to ensure the response time doesn’t exceed a certain limit. Learn more about thresholds and checks in our documentation.
+4. _Browser tests_: You can use the browser module to simulate user interactions like clicking buttons or filling out forms. This is useful for testing web applications. Learn more about browser tests in our [documentation](https://grafana.com/docs/k6/<K6_VERSION>/using-k6-browser/).
+
+## Next Steps
+
+Now that you’ve written your first k6 test script, it’s time to run it. Head over to the [Running k6](https://grafana.com/docs/k6/<K6_VERSION>/get-started/running-k6/) page to learn how to execute your script and view the results.

--- a/docs/sources/next/get-started/write-your-first-test.md
+++ b/docs/sources/next/get-started/write-your-first-test.md
@@ -1,6 +1,6 @@
 ---
 title: 'Write your first test'
-description: 'Follow along to learn how to write your first k6 test script.'
+description: 'Learn how to write your first k6 test script.'
 weight: 02
 ---
 

--- a/docs/sources/next/get-started/write-your-first-test.md
+++ b/docs/sources/next/get-started/write-your-first-test.md
@@ -8,38 +8,42 @@ weight: 02
 
 k6 is a reliability testing tool. It helps developers simulate realistic user behavior and test how their systems behave as a result. Writing tests in k6 allows you to identify potential issues, such as slow response times or system failures, before they occur in production.
 
-The goal of your test can vary. You might want to check performance, reliability, or scalability. Depending on your goal, your script may need different configurations, such as simulating many users, or running tests for a long time. (For more details, see our documentation on [reliability testing types](https://grafana.com/docs/k6/<K6_VERSION>/testing-guides/)).
+The goal of your test can vary. You might want to check performance, reliability, or scalability. Depending on your goal, your script may need different configurations, such as simulating many users, or running tests for a long time.
 
-k6 tests are written using the JavaScript (or [TypeScript](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/javascript-typescript-compatibility-mode/#experimental-enhanced-mode)) programming language, making it accessible to developers, and easy to integrate in existing codebases and projects. By writing k6 test scripts, you control what the k6 does, the action it performs, and how it behaves.
+k6 tests are written using the JavaScript or TypeScript programming language, making it accessible to developers, and easy to integrate in existing codebases and projects. By writing k6 test scripts, you control what the k6 does, the action it performs, and how it behaves.
 
 Follow along and learn how to write your first test script, and start testing the reliability of your application.
 
 ## Before you start
 
-To write k6 scripts, basic knowledge of JavaScript or TypeScript is recommended. If you're unfamiliar with these languages, check out [k6 Studio](https://grafana.com/docs/k6/<K6_VERSION>/k6-studio/), which helps users generate tests without writing code. Alternatively, explore our [test authoring methods](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-authoring/).
+To write k6 scripts, you'll need:
 
-Make sure k6 is installed on your system by following our [set up guide](https://grafana.com/docs/k6/<K6_VERSION>/set-up/).
-
-Finally, you’ll also need a code editor to write your scripts. k6 is well supported in editors such as [Visual Studio Code](https://code.visualstudio.com/) and [JetBrains editors](https://www.jetbrains.com/), see our [guide for setting up your editor](https://grafana.com/docs/k6/<K6_VERSION>/set-up/configure-your-code-editor/) for more details.
+- A basic knowledge of JavaScript or TypeScript.
+  - If you're unfamiliar with these languages, check out [k6 Studio](https://grafana.com/docs/k6/<K6_VERSION>/k6-studio/), which helps users generate tests without writing code. Alternatively, explore our [test authoring methods](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-authoring/).
+- [Install k6](https://grafana.com/docs/k6/<K6_VERSION>/set-up/) in your machine.
+- A code editor to write your scripts, such as [Visual Studio Code](https://code.visualstudio.com/) or [JetBrains editors](https://www.jetbrains.com/).
+  - Refer to [Configure your code editor](https://grafana.com/docs/k6/<K6_VERSION>/set-up/configure-your-code-editor/) to learn how to enable auto-completion and other features.
 
 ## Basic structure of a k6 test
 
 For k6 to be able to interpret and execute your test, every k6 script follows a common structure, revolving around a few core components:
 
 1. **Default function**: This is where the test logic resides. It defines what your test will do and how it will behave during execution. It should be exported as the default function in your script.
-2. **Imports**: You can import additional [k6 modules](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/) or [JavaScript libraries (jslibs)](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/) to extend your script’s functionality, such as making HTTP requests or simulating browser interactions. Note that k6 is not built upon NodeJS, and instead uses its own JavaScript runtime. Compatibility with some npm modules may vary.
-3. **Options (optional)**: Enable you to configure the execution of the test, such as defining the number of virtual users, the test duration, or setting performance thresholds. See our [options documentation](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/) for more details.
+2. **Imports**: You can import additional [k6 modules](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/) or [JavaScript libraries (jslibs)](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/) to extend your script’s functionality, such as making HTTP requests or simulating browser interactions. Note that k6 is not built upon Node.js, and instead uses its own JavaScript runtime. Compatibility with some npm modules may vary.
+3. **Options (optional)**: Enable you to configure the execution of the test, such as defining the number of virtual users, the test duration, or setting performance thresholds. Refer to [Options](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/) for more details.
 4. **Lifecycle operations (optional)**: Because your test might need run code before and/or after the execution of the test logic, [lifecycle operations](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/) allow you to write code, either as predefined functions, or within specific code scopes, that will be executed at different stages of the test execution.
 
 ### Writing your first test script
 
 Let’s walk through creating a simple test which performs 10 `GET` HTTP requests to a URL and waits for 1 second between requests. This script will help you understand the basic structure of a k6 test script.
 
-1. **Create a test file**: A test file can be named anything you like, and live wherever you see fit in your project, but it should have a `.js` or `.ts` extension. In this example, we'll define a JavaScript file, and call it `my-first-test.js`.
+1. **Create a test file**: A test file can be named anything you like, and live wherever you see fit in your project, but it should have a `.js` or `.ts` extension. In this example, create a JavaScript file named `my-first-test.js`. Open your terminal and run the following command:
+
    ```bash
    touch my-first-test.js
    ```
-2. **Import k6 modules**: As our end goal here is to perform HTTP requests, import the k6 `http` module at the top of the file. Furthermore, as we want to simulate a real-world scenario, we'll also import the `sleep` function from the `k6` module.
+
+2. **Import k6 modules**: As the end goal here is to perform HTTP requests, import the k6 `http` module at the top of the file. To help simulate a real-world scenario, import the `sleep` function from the `k6` module as well.
 
    ```javascript
    // Import the http module to make HTTP requests. From this point, you can use `http` methods to make HTTP requests.
@@ -49,7 +53,7 @@ Let’s walk through creating a simple test which performs 10 `GET` HTTP request
    import { sleep } from 'k6';
    ```
 
-3. **Define options**: As we aim to perform 10 HTTP requests, we will define an options block to configure the test execution. In this case, we will set the number of iterations to 10 to instruct k6 to execute our default function 10 times. Right beneath the imports, add the following code:
+3. **Define options**: To perform 10 HTTP requests, define an options block to configure the test execution. In this case, set the number of iterations to 10 to instruct k6 to execute the default function 10 times. Right beneath the imports, add the following code:
 
    ```javascript
    import http from 'k6/http';
@@ -61,7 +65,7 @@ Let’s walk through creating a simple test which performs 10 `GET` HTTP request
    };
    ```
 
-4. **Define a default exported function to hold our test logic**: The default exported function is the entry point for the test script. It will be executed repeatedly the number of times we defined with the `iterations` option. In this function, we will make a `GET` request to a URL and introduce a 1-second delay between requests. Add the following code to your script:
+4. **Define a default function**: The default exported function is the entry point for the test script. It will be executed repeatedly the number of times you define with the `iterations` option. In this function, make a `GET` request to a URL and introduce a 1-second delay between requests. Add the following code to your script:
 
    ```javascript
    import http from 'k6/http';
@@ -71,7 +75,7 @@ Let’s walk through creating a simple test which performs 10 `GET` HTTP request
      iterations: 10,
    };
 
-   // The default exported function is gonna be picked up by k6 as the entry point for the test script. It will be executed repeated in "iterations" for the whole duration of the test.
+   // The default exported function is gonna be picked up by k6 as the entry point for the test script. It will be executed repeatedly in "iterations" for the whole duration of the test.
    export default function () {
      // Make a GET request to the target URL
      http.get('https://test-api.k6.io');
@@ -81,17 +85,17 @@ Let’s walk through creating a simple test which performs 10 `GET` HTTP request
    }
    ```
 
-### Going a bit further
+### Extending your script
 
-Once comfortable with this basic script, you can extend its functionality in many ways. Here are a few ideas to get you started:
+After you're comfortable with this basic script, you can extend its functionality in many ways. Here are a few ideas to get you started:
 
-1. _Multiple requests_: You can add more `http.get()` or `http.post()` requests to simulate more complex user flows.
-2. _Using TypeScript_: If you prefer TypeScript, k6 supports it too. You can learn more in our [TypeScript guide](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/javascript-typescript-compatibility-mode/#experimental-enhanced-mode).
-3. _Thresholds, checks, and metrics_: You can add conditions to monitor performance. For example, you can set thresholds to ensure the response time doesn’t exceed a certain limit. Learn more about thresholds and checks in our documentation.
-4. _Browser tests_: Use the browser module to simulate user interactions like clicking buttons or filling out forms. This is useful for testing web applications. Learn more about browser tests in our [documentation](https://grafana.com/docs/k6/<K6_VERSION>/using-k6-browser/).
+1. **Multiple requests**: You can add more `http.get()` or `http.post()` requests to simulate complex user flows.
+2. **Using TypeScript**: If you prefer TypeScript, k6 also supports it. You can learn more in our [TypeScript guide](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/javascript-typescript-compatibility-mode/#experimental-enhanced-mode).
+3. **Thresholds, checks, and metrics**: You can add conditions to monitor performance. For example, you can set thresholds to ensure the response time doesn’t exceed a certain limit. Refer to [Thresholds](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/thresholds/) and [Checks](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/checks/) for more details.
+4. **Browser tests**: Use the browser module to simulate user interactions like clicking buttons or filling out forms. This is useful for testing web applications. Refer to  [Using k6 browser](https://grafana.com/docs/k6/<K6_VERSION>/using-k6-browser/) for more details.
 
-Furthermore, to speed up the process of putting together a k6 test script in the future, you can use the k6 to generate a basic script like the one we've written above using the `k6 new` command. Try it out!
+You can also use the `k6 new` command to speed up the process of putting together a k6 test script when you're testing a new service or application. Try it out!
 
-## Next Steps
+## Next steps
 
-Now that you’ve written your first k6 test script, it’s time to run it. Visit our [Running k6](https://grafana.com/docs/k6/<K6_VERSION>/get-started/running-k6/) page to learn how to execute your script and analyze the results.
+Now that you’ve written your first k6 test script, it’s time to run it. Refer to [Running k6](https://grafana.com/docs/k6/<K6_VERSION>/get-started/running-k6/) to learn how to execute your script and analyze the results.

--- a/docs/sources/next/get-started/write-your-first-test.md
+++ b/docs/sources/next/get-started/write-your-first-test.md
@@ -31,7 +31,7 @@ For k6 to be able to interpret and execute your test, every k6 script follows a 
 1. **Default function**: This is where the test logic resides. It defines what your test will do and how it will behave during execution. It should be exported as the default function in your script.
 2. **Imports**: You can import additional [k6 modules](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/) or [JavaScript libraries (jslibs)](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/) to extend your script’s functionality, such as making HTTP requests or simulating browser interactions. Note that k6 is not built upon Node.js, and instead uses its own JavaScript runtime. Compatibility with some npm modules may vary.
 3. **Options (optional)**: Enable you to configure the execution of the test, such as defining the number of virtual users, the test duration, or setting performance thresholds. Refer to [Options](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/) for more details.
-4. **Lifecycle operations (optional)**: Because your test might need run code before and/or after the execution of the test logic, [lifecycle operations](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/) allow you to write code, either as predefined functions, or within specific code scopes, that will be executed at different stages of the test execution.
+4. **Lifecycle operations (optional)**: Because your test might need to run code before and/or after the execution of the test logic, such as parsing data from a file, or download an object from Amazon S3, [lifecycle operations](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/) allow you to write code, either as predefined functions or within specific code scopes, that will be executed at different stages of the test execution.
 
 ### Writing your first test script
 
@@ -92,7 +92,7 @@ After you're comfortable with this basic script, you can extend its functionalit
 1. **Multiple requests**: You can add more `http.get()` or `http.post()` requests to simulate complex user flows.
 2. **Using TypeScript**: If you prefer TypeScript, k6 also supports it. You can learn more in our [TypeScript guide](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/javascript-typescript-compatibility-mode/#experimental-enhanced-mode).
 3. **Thresholds, checks, and metrics**: You can add conditions to monitor performance. For example, you can set thresholds to ensure the response time doesn’t exceed a certain limit. Refer to [Thresholds](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/thresholds/) and [Checks](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/checks/) for more details.
-4. **Browser tests**: Use the browser module to simulate user interactions like clicking buttons or filling out forms. This is useful for testing web applications. Refer to  [Using k6 browser](https://grafana.com/docs/k6/<K6_VERSION>/using-k6-browser/) for more details.
+4. **Browser tests**: Use the browser module to simulate user interactions like clicking buttons or filling out forms. This is useful for testing web applications. Refer to [Using k6 browser](https://grafana.com/docs/k6/<K6_VERSION>/using-k6-browser/) for more details.
 
 You can also use the `k6 new` command to speed up the process of putting together a k6 test script when you're testing a new service or application. Try it out!
 

--- a/docs/sources/next/get-started/write-your-first-test.md
+++ b/docs/sources/next/get-started/write-your-first-test.md
@@ -6,47 +6,72 @@ weight: 02
 
 # Write your first test
 
-k6 is a reliability testing tool. It helps developers simulate realistic user behavior and test how their systems behaves as a result. Writing tests in k6 allows you to identify issues such as slow response times or system failures before they occur in production.
+k6 is a reliability testing tool. It helps developers simulate realistic user behavior and test how their systems behave as a result. Writing tests in k6 allows you to identify potential issues, such as slow response times or system failures, before they occur in production.
 
 The goal of your test can vary. You might want to check performance, reliability, or scalability. Depending on your goal, your script may need different configurations, such as simulating many users, or running tests for a long time. (For more details, see our documentation on [reliability testing types](https://grafana.com/docs/k6/<K6_VERSION>/testing-guides/)).
 
-k6 uses JavaScript (or [TypeScript](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/javascript-typescript-compatibility-mode/#experimental-enhanced-mode)) to define the test's behavior. This makes it accessible to many developers. By writing scripts, you control what the test does and how it behaves.
+k6 tests are written using the JavaScript (or [TypeScript](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/javascript-typescript-compatibility-mode/#experimental-enhanced-mode)) programming language, making it accessible to developers, and easy to integrate in existing codebases and projects. By writing k6 test scripts, you control what the k6 does, the action it performs, and how it behaves.
 
-Follow along your first test script, and start testing the reliability of your application.
+Follow along and learn how to write your first test script, and start testing the reliability of your application.
 
 ## Before you start
 
-To write k6 scripts, basic knowledge of JavaScript or TypeScript is recommended. If you’re not familiar with these languages, you can use [k6 Studio](https://grafana.com/docs/k6/<K6_VERSION>/k6-studio/) to automatically generate tests without writing code, or any of our [test authoring methods](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-authoring/).
+To write k6 scripts, basic knowledge of JavaScript or TypeScript is recommended. If you're unfamiliar with these languages, check out [k6 Studio](https://grafana.com/docs/k6/<K6_VERSION>/k6-studio/), which helps users generate tests without writing code. Alternatively, explore our [test authoring methods](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-authoring/).
 
-Make sure k6 is installed on your system. If it’s not, follow our [set up guide](https://grafana.com/docs/k6/<K6_VERSION>/set-up/).
+Make sure k6 is installed on your system by following our [set up guide](https://grafana.com/docs/k6/<K6_VERSION>/set-up/).
 
-Finally, you’ll also need a code editor to write your scripts. We recommend using VS Code or any other editor you’re comfortable with. See our [guide for setting up your editor](https://grafana.com/docs/k6/<K6_VERSION>/set-up/configure-your-code-editor/) for more details.
+Finally, you’ll also need a code editor to write your scripts. k6 is well supported in editors such as [Visual Studio Code](https://code.visualstudio.com/) and [JetBrains editors](https://www.jetbrains.com/), see our [guide for setting up your editor](https://grafana.com/docs/k6/<K6_VERSION>/set-up/configure-your-code-editor/) for more details.
 
 ## Basic structure of a k6 test
 
-Every k6 test script follows a basic structure, revolving around a few core components:
+For k6 to be able to interpret and execute your test, every k6 script follows a common structure, revolving around a few core components:
 
-1. **Default function**: This is where the test logic resides. It defines what your test will do and how it will behave during execution.
-2. **Imports**: You can import additional [k6 modules](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/) or [JavaScript libraries (jslibs)](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/) to extend your script’s functionality, such as making HTTP requests or simulating browser interactions. Note that k6 is not built upon NodeJS, and uses instead its own JavaScript runtime, and although it might be compatible with some npm modules, we do not guarantee it.
-3. **Options (optional)**: Enable you to configure the test conditions, like defining the number of virtual users, test duration, or setting performance thresholds. See our [options documentation](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/) for more details.
-4. **Lifecycle functions (optional)**: These allow you to write code that will be run before and after the test, such as setting up test data or processing results.
+1. **Default function**: This is where the test logic resides. It defines what your test will do and how it will behave during execution. It should be exported as the default function in your script.
+2. **Imports**: You can import additional [k6 modules](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/) or [JavaScript libraries (jslibs)](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/) to extend your script’s functionality, such as making HTTP requests or simulating browser interactions. Note that k6 is not built upon NodeJS, and instead uses its own JavaScript runtime. Compatibility with some npm modules may vary.
+3. **Options (optional)**: Enable you to configure the execution of the test, such as defining the number of virtual users, the test duration, or setting performance thresholds. See our [options documentation](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/) for more details.
+4. **Lifecycle operations (optional)**: Because your test might need run code before and/or after the execution of the test logic, [lifecycle operations](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/) allow you to write code, either as predefined functions, or within specific code scopes, that will be executed at different stages of the test execution.
 
 ### Writing your first test script
 
-Let’s walk through creating a simple test:
+Let’s walk through creating a simple test which performs 10 `GET` HTTP requests to a URL and waits for 1 second between requests. This script will help you understand the basic structure of a k6 test script.
 
-1. **Create the test file**: Open your code editor and create a new file named `test.js`.
-2. **Write a basic test**: Here’s a simple script that makes a GET request to a URL and simulates waiting between requests.
+1. **Create a test file**: A test file can be named anything you like, and live wherever you see fit in your project, but it should have a `.js` or `.ts` extension. In this example, we'll define a JavaScript file, and call it `my-first-test.js`.
+   ```bash
+   touch my-first-test.js
+   ```
+2. **Import k6 modules**: As our end goal here is to perform HTTP requests, import the k6 `http` module at the top of the file. Furthermore, as we want to simulate a real-world scenario, we'll also import the `sleep` function from the `k6` module.
 
    ```javascript
-   // Import k6 modules exposing additional functionality such as performing
-   // HTTP requests and introducing delays.
+   // Import the http module to make HTTP requests. From this point, you can use `http` methods to make HTTP requests.
+   import http from 'k6/http';
+
+   // Import the sleep function to introduce delays. From this point, you can use the `sleep` function to introduce delays in your test script.
+   import { sleep } from 'k6';
+   ```
+
+3. **Define options**: As we aim to perform 10 HTTP requests, we will define an options block to configure the test execution. In this case, we will set the number of iterations to 10 to instruct k6 to execute our default function 10 times. Right beneath the imports, add the following code:
+
+   ```javascript
    import http from 'k6/http';
    import { sleep } from 'k6';
 
-   // The default exported function is gonna be picked up by k6 as the entry point
-   // for the test script. It will be executed repeated in "iterations" for the whole
-   // duration of the test.
+   export const options = {
+     // Define the number of iterations for the test
+     iterations: 10,
+   };
+   ```
+
+4. **Define a default exported function to hold our test logic**: The default exported function is the entry point for the test script. It will be executed repeatedly the number of times we defined with the `iterations` option. In this function, we will make a `GET` request to a URL and introduce a 1-second delay between requests. Add the following code to your script:
+
+   ```javascript
+   import http from 'k6/http';
+   import { sleep } from 'k6';
+
+   export const options = {
+     iterations: 10,
+   };
+
+   // The default exported function is gonna be picked up by k6 as the entry point for the test script. It will be executed repeated in "iterations" for the whole duration of the test.
    export default function () {
      // Make a GET request to the target URL
      http.get('https://test-api.k6.io');
@@ -56,19 +81,17 @@ Let’s walk through creating a simple test:
    }
    ```
 
-3. **Explanation**:
-   - The http module is used to make HTTP requests, in this case, a simple GET request to `https://test-api.k6.io`. You can replace this with your own API or website URL.
-   - The `sleep(1)` function pauses for 1 second after each request, mimicking real-world user behavior where not every action happens instantly.
-
 ### Going a bit further
 
-Once you’re comfortable with this basic script, there are many ways to extend its functionality:
+Once comfortable with this basic script, you can extend its functionality in many ways. Here are a few ideas to get you started:
 
 1. _Multiple requests_: You can add more `http.get()` or `http.post()` requests to simulate more complex user flows.
 2. _Using TypeScript_: If you prefer TypeScript, k6 supports it too. You can learn more in our [TypeScript guide](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/javascript-typescript-compatibility-mode/#experimental-enhanced-mode).
 3. _Thresholds, checks, and metrics_: You can add conditions to monitor performance. For example, you can set thresholds to ensure the response time doesn’t exceed a certain limit. Learn more about thresholds and checks in our documentation.
-4. _Browser tests_: You can use the browser module to simulate user interactions like clicking buttons or filling out forms. This is useful for testing web applications. Learn more about browser tests in our [documentation](https://grafana.com/docs/k6/<K6_VERSION>/using-k6-browser/).
+4. _Browser tests_: Use the browser module to simulate user interactions like clicking buttons or filling out forms. This is useful for testing web applications. Learn more about browser tests in our [documentation](https://grafana.com/docs/k6/<K6_VERSION>/using-k6-browser/).
+
+Furthermore, to speed up the process of putting together a k6 test script in the future, you can use the k6 to generate a basic script like the one we've written above using the `k6 new` command. Try it out!
 
 ## Next Steps
 
-Now that you’ve written your first k6 test script, it’s time to run it. Head over to the [Running k6](https://grafana.com/docs/k6/<K6_VERSION>/get-started/running-k6/) page to learn how to execute your script and view the results.
+Now that you’ve written your first k6 test script, it’s time to run it. Visit our [Running k6](https://grafana.com/docs/k6/<K6_VERSION>/get-started/running-k6/) page to learn how to execute your script and analyze the results.


### PR DESCRIPTION
## What?

As we agreed during our latest meetup, this PR adds a "Write your first test" page to the Getting Started section.

It aims to cover a gap between installing k6, and "Running k6", as we realised we had not introduced users to scripting in the logical flow yet. This PR aims to bridge that gap, and links to a lot of useful resources users might find useful on their onboarding experience with k6.

@heitortsergent this is really a draft on my side, you should feel free to propose whatever you see fit 👍🏻 Also, I've noticed we have some pages in our documentation which might repeat this information, we might want to also reorganize/regroup it somehow 🙇🏻 

## Checklist

<!-- Please fill in this template: -->
- [X] I have used a meaningful title for the PR.
- [X] I have described the changes I've made in the "What?" section above.
- [X] I have performed a self-review of my changes.
- [X] I have run the `npm start` command locally and verified that the changes look good.
- [X] I have made my changes in the `docs/sources/next` folder of the documentation.
