### PR TITLE
Fix lookups for "Edit this page in GitHub" links

### DIFF
--- a/docs/sources/k6-studio/_index.md
+++ b/docs/sources/k6-studio/_index.md
@@ -19,6 +19,18 @@ cards:
       href: ./installation/
       description: Learn how to install k6 Studio.
       height: 24
+cascade:
+  labels:
+    products:
+      - oss
+  breadcrumb_start: 4
+  search_section: Grafana k6 studio
+  search_type: doc
+  public_docs: true
+  github_repo: https://github.com/grafana/k6-docs/
+  github_branch: main
+  github_dir: /docs/sources/k6-studio
+  replace_dir: docs/k6-studio/
 ---
 
 {{< docs/hero-simple key="hero" >}}

--- a/docs/sources/k6-studio/_index.md
+++ b/docs/sources/k6-studio/_index.md
@@ -24,7 +24,7 @@ cascade:
     products:
       - oss
   breadcrumb_start: 4
-  search_section: Grafana k6 studio
+  search_section: Grafana k6 Studio
   search_type: doc
   public_docs: true
   github_repo: https://github.com/grafana/k6-docs/

--- a/docs/sources/k6/_index.md
+++ b/docs/sources/k6/_index.md
@@ -17,7 +17,7 @@ cascade:
   public_docs: true
   github_repo: https://github.com/grafana/k6-docs/
   github_branch: main
-  github_dir: /docs/sources
+  github_dir: /docs/sources/k6
   replace_dir: docs/k6/
   JSLIB_AWS_VERSION: 0.12.3
 versioned: true


### PR DESCRIPTION

## What?
https://raintank-corp.slack.com/archives/C04325A8TTN/p1730286419771249

Chris Bedwell
  4 minutes ago
[@jackzor](https://raintank-corp.slack.com/team/U015CULE0KH)
 I noticed that if I click the 'Suggest an edit in GitHub' links for any of the k6 documentation it all 404s. Presumably something that was missed / overlooked with the migration? :thinking_face:
Example: https://grafana.com/docs/k6/latest/javascript-api/k6-browser/page/locator/

