### PR TITLE
Fix path in Issue template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,8 +23,6 @@ the code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
 - [ ] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
 <!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->
 
-<!-- 2. If updating the documentation for the next release of k6: -->
-- [ ] I have made my changes in the `docs/sources/k6/next` folder of the documentation.
 
 ## Related PR(s)/Issue(s)
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,13 +18,13 @@ the code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
 <!-- Select one of the options below and delete the other -->
 
 <!-- 1. If updating the documentation for the most recent release of k6:  -->
-- [ ] I have made my changes in the `docs/sources/next` folder of the documentation.
-- [ ] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.
+- [ ] I have made my changes in the `docs/sources/k6/next` folder of the documentation.
+- [ ] I have reflected my changes in the `docs/sources/k6/v{most_recent_release}` folder of the documentation.
 - [ ] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
 <!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->
 
 <!-- 2. If updating the documentation for the next release of k6: -->
-- [ ] I have made my changes in the `docs/sources/next` folder of the documentation.
+- [ ] I have made my changes in the `docs/sources/k6/next` folder of the documentation.
 
 ## Related PR(s)/Issue(s)
 


### PR DESCRIPTION
## What?

I believe the paths in the template do not completely reflect the project structure. 

This pull request:
* Changes `docs/sources/*` path to `docs/sources/k6/*`
* Removes the duplication of line `- [ ] I have made my changes in the docs/sources/k6/next folder of the documentation.` (line 26/27)

## Checklist

- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [ ] I have run the `npm start` command locally and verified that the changes look good.
   * I don't think this is needed here
<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [x] I have made my changes in the `.github/pull_request_template.md` folder of the documentation.


## Related PR(s)/Issue(s)

None