### PR TITLE
Modify fs/streams/csv docs to reflect top-level await support

### DIFF
--- a/docs/sources/k6/next/javascript-api/k6-experimental/csv/Options.md
+++ b/docs/sources/k6/next/javascript-api/k6-experimental/csv/Options.md
@@ -25,17 +25,13 @@ The `Options` object describes the configuration available for the operation of 
 import { open } from 'k6/experimental/fs';
 import csv from 'k6/experimental/csv';
 
-let file;
-let parser;
-(async function () {
-  file = await open('data.csv');
-  parser = new csv.Parser(file, {
-    delimiter: ',',
-    skipFirstLine: true,
-    fromLine: 2,
-    toLine: 8,
-  });
-})();
+const file = await open('data.csv');
+const parser = new csv.Parser(file, {
+  delimiter: ',',
+  skipFirstLine: true,
+  fromLine: 2,
+  toLine: 8,
+});
 
 export default async function () {
   // The `next` method attempts to read the next row from the CSV file.

--- a/docs/sources/k6/next/javascript-api/k6-experimental/csv/Parser.md
+++ b/docs/sources/k6/next/javascript-api/k6-experimental/csv/Parser.md
@@ -64,12 +64,8 @@ export const options = {
   iterations: 10,
 };
 
-let file;
-let parser;
-(async function () {
-  file = await open('data.csv');
-  parser = new csv.Parser(file, { skipFirstLine: true });
-})();
+const file = await open('data.csv');
+const parser = new csv.Parser(file, { skipFirstLine: true });
 
 export default async function () {
   // The `next` method attempts to read the next row from the CSV file.

--- a/docs/sources/k6/next/javascript-api/k6-experimental/csv/_index.md
+++ b/docs/sources/k6/next/javascript-api/k6-experimental/csv/_index.md
@@ -52,15 +52,11 @@ export const options = {
   iterations: 10,
 };
 
-let file;
-let csvRecords;
-(async function () {
-  file = await open('data.csv');
+const file = await open('data.csv');
 
-  // The `csv.parse` function consumes the entire file at once and returns
-  // the parsed records as a `SharedArray` object.
-  csvRecords = await csv.parse(file, { delimiter: ',' });
-})();
+// The `csv.parse` function consumes the entire file at once and returns
+// the parsed records as a `SharedArray` object.
+const csvRecords = await csv.parse(file, { delimiter: ',' });
 
 export default async function () {
   // `csvRecords` is a `SharedArray`. Each element is a record from the CSV file, represented as an array
@@ -85,12 +81,11 @@ export const options = {
   iterations: 10,
 };
 
-let file;
-let parser;
-(async function () {
-  file = await open('data.csv');
-  parser = new csv.Parser(file);
-})();
+const file = await open('data.csv');
+
+// The `csv.parse` function consumes the entire file at once and returns
+// the parsed records as a `SharedArray` object.
+const parser = new csv.Parser(file);
 
 export default async function () {
   // The parser `next` method attempts to read the next row from the CSV file.

--- a/docs/sources/k6/next/javascript-api/k6-experimental/csv/parse.md
+++ b/docs/sources/k6/next/javascript-api/k6-experimental/csv/parse.md
@@ -55,15 +55,11 @@ export const options = {
   iterations: 10,
 };
 
-let file;
-let csvRecords;
-(async function () {
-  file = await open('data.csv');
+const file = await open('data.csv');
 
-  // The `csv.parse` function consumes the entire file at once and returns
-  // the parsed records as a `SharedArray` object.
-  csvRecords = await csv.parse(file, { skipFirstLine: true });
-})();
+// The `csv.parse` function consumes the entire file at once and returns
+// the parsed records as a `SharedArray` object.
+const csvRecords = await csv.parse(file, { skipFirstLine: true });
 
 export default async function () {
   // `csvRecords` is a `SharedArray`. Each element is a record from the CSV file, represented as an array

--- a/docs/sources/k6/next/javascript-api/k6-experimental/fs/FileInfo.md
+++ b/docs/sources/k6/next/javascript-api/k6-experimental/fs/FileInfo.md
@@ -22,10 +22,7 @@ The `FileInfo` class represents information about a [file](https://grafana.com/d
 ```javascript
 import { open, SeekMode } from 'k6/experimental/fs';
 
-let file;
-(async function () {
-  file = await open('bonjour.txt');
-})();
+const file = await open('bonjour.txt');
 
 export default async function () {
   // Retrieve information about the file

--- a/docs/sources/k6/next/javascript-api/k6-experimental/fs/SeekMode.md
+++ b/docs/sources/k6/next/javascript-api/k6-experimental/fs/SeekMode.md
@@ -23,10 +23,7 @@ The `SeekMode` enum specifies the position from which to [seek](https://grafana.
 ```javascript
 import { open, SeekMode } from 'k6/experimental/fs';
 
-let file;
-(async function () {
-  file = await open('bonjour.txt');
-})();
+const file = await open('bonjour.txt');
 
 export default async function () {
   // Seek 6 bytes from the start of the file

--- a/docs/sources/k6/next/javascript-api/k6-experimental/fs/_index.md
+++ b/docs/sources/k6/next/javascript-api/k6-experimental/fs/_index.md
@@ -35,14 +35,7 @@ The module exports functions and objects to interact with the file system:
 ```javascript
 import { open, SeekMode } from 'k6/experimental/fs';
 
-// k6 doesn't support async in the init context. We use a top-level async function for `await`.
-//
-// Each Virtual User gets its own `file` copy.
-// So, operations like `seek` or `read` won't impact other VUs.
-let file;
-(async function () {
-  file = await open('bonjour.txt');
-})();
+const file = await open('bonjour.txt');
 
 export default async function () {
   // Seek to the beginning of the file

--- a/docs/sources/k6/next/javascript-api/k6-experimental/fs/file/_index.md
+++ b/docs/sources/k6/next/javascript-api/k6-experimental/fs/file/_index.md
@@ -29,10 +29,7 @@ The `File` class represents a file with methods for reading, seeking, and obtain
 ```javascript
 import { open, SeekMode } from 'k6/experimental/fs';
 
-let file;
-(async function () {
-  file = await open('bonjour.txt');
-})();
+const file = await open('bonjour.txt');
 
 export default async function () {
   // Seek to the beginning of the file

--- a/docs/sources/k6/next/javascript-api/k6-experimental/fs/file/read.md
+++ b/docs/sources/k6/next/javascript-api/k6-experimental/fs/file/read.md
@@ -31,10 +31,7 @@ In the following example, we open a file and read it in chunks of 128 bytes unti
 ```javascript
 import { open, SeekMode } from 'k6/experimental/fs';
 
-let file;
-(async function () {
-  file = await open('bonjour.txt');
-})();
+const file = await open('bonjour.txt');
 
 export default async function () {
   // Seek to the beginning of the file

--- a/docs/sources/k6/next/javascript-api/k6-experimental/fs/file/seek.md
+++ b/docs/sources/k6/next/javascript-api/k6-experimental/fs/file/seek.md
@@ -32,10 +32,7 @@ A [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Gl
 ```javascript
 import { open, SeekMode } from 'k6/experimental/fs';
 
-let file;
-(async function () {
-  file = await open('bonjour.txt');
-})();
+const file = await open('bonjour.txt');
 
 export default async function () {
   // Seek 6 bytes from the start of the file

--- a/docs/sources/k6/next/javascript-api/k6-experimental/fs/file/stat.md
+++ b/docs/sources/k6/next/javascript-api/k6-experimental/fs/file/stat.md
@@ -19,10 +19,7 @@ A [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Gl
 ```javascript
 import { open, SeekMode } from 'k6/experimental/fs';
 
-let file;
-(async function () {
-  file = await open('bonjour.txt');
-})();
+const file = await open('bonjour.txt');
 
 export default async function () {
   // About information about the file

--- a/docs/sources/k6/next/javascript-api/k6-experimental/fs/open.md
+++ b/docs/sources/k6/next/javascript-api/k6-experimental/fs/open.md
@@ -8,21 +8,6 @@ weight: 20
 
 The `open` function opens a file and returns a promise that resolves to a [File](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/fs/file) instance. Unlike the traditional [open](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/init-context/open/) function, which loads a file multiple times into memory, the filesystem module reduces memory usage by loading the file as little possible, and sharing the same memory space between all VUs. This approach reduces the risk of encountering out-of-memory errors, especially in load tests involving large files.
 
-### Asynchronous nature
-
-It's important to note that `open` is asynchronous and returns a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). Due to k6's current limitation with the Init context (which doesn't support asynchronous functions directly), you need to use an asynchronous wrapper like this:
-
-{{< code >}}
-
-```javascript
-let file;
-(async function () {
-  file = await open('bonjour.txt');
-})();
-```
-
-{{< /code >}}
-
 ## Parameters
 
 | Parameter | Type   | Description                                                                          |
@@ -44,10 +29,7 @@ import { open } from 'k6/experimental/fs';
 //
 // Each Virtual User gets its own `file` copy.
 // So, operations like `seek` or `read` won't impact other VUs.
-let file;
-(async function () {
-  file = await open('bonjour.txt');
-})();
+const file = await open('bonjour.txt');
 
 export default async function () {
   // About information about the file

--- a/docs/sources/k6/next/javascript-api/k6-experimental/streams/_index.md
+++ b/docs/sources/k6/next/javascript-api/k6-experimental/streams/_index.md
@@ -18,7 +18,7 @@ With the Streams API support in k6, you can start processing raw data with Javas
 
 ## API Overview
 
-| Class                                                                                                           | Description                           |
+| Class                                                                                                            | Description                           |
 | ---------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
 | [ReadableStream](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/streams/readablestream) | Represents a readable stream of data. |
 
@@ -31,10 +31,7 @@ import { open } from 'k6/experimental/fs';
 import { ReadableStream } from 'k6/experimental/streams';
 
 // Open a csv file containing the data to be read
-let file;
-(async function () {
-  file = await open('./data.csv');
-})();
+const file = await open('./data.csv');
 
 export default async function () {
   let lineReaderState;

--- a/docs/sources/k6/next/javascript-api/k6-experimental/streams/readablestreamdefaultcontroller/enqueue.md
+++ b/docs/sources/k6/next/javascript-api/k6-experimental/streams/readablestreamdefaultcontroller/enqueue.md
@@ -29,10 +29,7 @@ import { open } from 'k6/experimental/fs';
 import { ReadableStream } from 'k6/experimental/streams';
 
 // Open a csv file containing the data to be read
-let file;
-(async function () {
-  file = await open('./data.csv');
-})();
+const file = await open('./data.csv');
 
 export default async function () {
   let lineReaderState;


### PR DESCRIPTION
## What?

This PR modifies the documentation of the fs/streams/csv modules to reflect the availability of top-level (init context) support for the `await` keyword.

## Checklist

<!-- Please fill in this template: -->
- [X] I have used a meaningful title for the PR.
- [X] I have described the changes I've made in the "What?" section above.
- [X] I have performed a self-review of my changes.
- [X] I have run the `npm start` command locally and verified that the changes look good.
- [X] I have made my changes in the `docs/sources/next` folder of the documentation.

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->
<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->