### PR TITLE
Update group page to include link to utils check function

### DIFF
--- a/docs/sources/k6/next/javascript-api/k6/group.md
+++ b/docs/sources/k6/next/javascript-api/k6/group.md
@@ -6,6 +6,12 @@ description: 'Runs code inside a group. Used to organize results in a test.'
 
 # group( name, fn )
 
+{{< admonition type="note" >}}
+
+For details about using the `check()` function with async values, refer to the jslib utils [check](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/utils/check/).
+
+{{< /admonition >}}
+
 Run code inside a group. Groups are used to organize results in a test.
 
 | Parameter | Type     | Description                                            |
@@ -19,18 +25,20 @@ Run code inside a group. Groups are used to organize results in a test.
 | ---- | ------------------------- |
 | any  | The return value of _fn_. |
 
+## Limitations
+
 {{< admonition type="warning" >}}
 
 Avoid using `group` with async functions or asynchronous code.
-If you do, k6 might apply tags in a way that is unreliable or unintuitive.
-
-If you start promise chains or even use `await` within `group`, some code within the group will be waited for and tagged with the proper `group` tag, but others won't be.
-
-To avoid confusion, `async` functions are forbidden as `group()` arguments. This still lets users make and chain promises within a group, but doing so is unsupported and not recommended.
-
-For more information, refer to [k6 #2728](https://github.com/grafana/k6/issues/2728), which tracks possible solutions and provides detailed explanations.
+If you do, k6 might apply tags in an unreliable or unintuitive way.
 
 {{< /admonition >}}
+
+If you start promise chains or use `await` within `group`, some code within the group will be waited for and tagged with the proper `group` tag, but others won't be.
+
+To avoid confusion, `async` functions are forbidden as `group()` arguments. That still lets users make and chain promises within a group, but doing so is unsupported and not recommended.
+
+For more information, refer to [k6 #2728](https://github.com/grafana/k6/issues/2728), which tracks possible solutions and provides detailed explanations.
 
 ### Example
 

--- a/docs/sources/k6/next/javascript-api/k6/group.md
+++ b/docs/sources/k6/next/javascript-api/k6/group.md
@@ -1,7 +1,6 @@
 ---
 title: 'group( name, fn )'
 description: 'Runs code inside a group. Used to organize results in a test.'
-description: 'Runs code inside a group. Used to organize results in a test.'
 ---
 
 # group( name, fn )

--- a/docs/sources/k6/v0.53.x/javascript-api/k6/group.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/k6/group.md
@@ -1,10 +1,15 @@
 ---
 title: 'group( name, fn )'
 description: 'Runs code inside a group. Used to organize results in a test.'
-description: 'Runs code inside a group. Used to organize results in a test.'
 ---
 
 # group( name, fn )
+
+{{< admonition type="note" >}}
+
+For details about using the `check()` function with async values, refer to the jslib utils [check](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/utils/check/).
+
+{{< /admonition >}}
 
 Run code inside a group. Groups are used to organize results in a test.
 
@@ -19,18 +24,20 @@ Run code inside a group. Groups are used to organize results in a test.
 | ---- | ------------------------- |
 | any  | The return value of _fn_. |
 
+## Limitations
+
 {{< admonition type="warning" >}}
 
 Avoid using `group` with async functions or asynchronous code.
-If you do, k6 might apply tags in a way that is unreliable or unintuitive.
-
-If you start promise chains or even use `await` within `group`, some code within the group will be waited for and tagged with the proper `group` tag, but others won't be.
-
-To avoid confusion, `async` functions are forbidden as `group()` arguments. This still lets users make and chain promises within a group, but doing so is unsupported and not recommended.
-
-For more information, refer to [k6 #2728](https://github.com/grafana/k6/issues/2728), which tracks possible solutions and provides detailed explanations.
+If you do, k6 might apply tags in an unreliable or unintuitive way.
 
 {{< /admonition >}}
+
+If you start promise chains or use `await` within `group`, some code within the group will be waited for and tagged with the proper `group` tag, but others won't be.
+
+To avoid confusion, `async` functions are forbidden as `group()` arguments. That still lets users make and chain promises within a group, but doing so is unsupported and not recommended.
+
+For more information, refer to [k6 #2728](https://github.com/grafana/k6/issues/2728), which tracks possible solutions and provides detailed explanations.
 
 ### Example
 

--- a/docs/sources/k6/v0.54.x/javascript-api/k6/group.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/k6/group.md
@@ -1,10 +1,15 @@
 ---
 title: 'group( name, fn )'
 description: 'Runs code inside a group. Used to organize results in a test.'
-description: 'Runs code inside a group. Used to organize results in a test.'
 ---
 
 # group( name, fn )
+
+{{< admonition type="note" >}}
+
+For details about using the `check()` function with async values, refer to the jslib utils [check](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/utils/check/).
+
+{{< /admonition >}}
 
 Run code inside a group. Groups are used to organize results in a test.
 
@@ -19,18 +24,20 @@ Run code inside a group. Groups are used to organize results in a test.
 | ---- | ------------------------- |
 | any  | The return value of _fn_. |
 
+## Limitations
+
 {{< admonition type="warning" >}}
 
 Avoid using `group` with async functions or asynchronous code.
-If you do, k6 might apply tags in a way that is unreliable or unintuitive.
-
-If you start promise chains or even use `await` within `group`, some code within the group will be waited for and tagged with the proper `group` tag, but others won't be.
-
-To avoid confusion, `async` functions are forbidden as `group()` arguments. This still lets users make and chain promises within a group, but doing so is unsupported and not recommended.
-
-For more information, refer to [k6 #2728](https://github.com/grafana/k6/issues/2728), which tracks possible solutions and provides detailed explanations.
+If you do, k6 might apply tags in an unreliable or unintuitive way.
 
 {{< /admonition >}}
+
+If you start promise chains or use `await` within `group`, some code within the group will be waited for and tagged with the proper `group` tag, but others won't be.
+
+To avoid confusion, `async` functions are forbidden as `group()` arguments. That still lets users make and chain promises within a group, but doing so is unsupported and not recommended.
+
+For more information, refer to [k6 #2728](https://github.com/grafana/k6/issues/2728), which tracks possible solutions and provides detailed explanations.
 
 ### Example
 


### PR DESCRIPTION
## What?

The group link is referenced from a k6 error message when using the check function with async. This PR includes a link to where users can find the correct information about using the jslib utils check function.

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [x] I have made my changes in the `docs/sources/next` folder of the documentation.
- [ ] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.
- [ ] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->