### PR TITLE
Add alias from k6-experimental/browser to k6-browser

### DIFF
--- a/docs/sources/k6/next/javascript-api/k6-browser/_index.md
+++ b/docs/sources/k6/next/javascript-api/k6-browser/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - ./k6-experimental/browser # docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser
 title: 'k6/browser'
 description: 'An overview of the browser-level APIs from browser module.'
 weight: 02

--- a/docs/sources/k6/v0.54.x/javascript-api/k6-browser/_index.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/k6-browser/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - ./k6-experimental/browser # docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser
 title: 'k6/browser'
 description: 'An overview of the browser-level APIs from browser module.'
 weight: 02

--- a/docs/sources/k6/v0.55.x/javascript-api/k6-browser/_index.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/k6-browser/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - ./k6-experimental/browser # docs/k6/<K6_VERSION>/javascript-api/k6-experimental/browser
 title: 'k6/browser'
 description: 'An overview of the browser-level APIs from browser module.'
 weight: 02


### PR DESCRIPTION
## What?

This adds a redirect from https://grafana.com/docs/k6/latest/javascript-api/k6-experimental/browser/ to https://grafana.com/docs/k6/latest/javascript-api/k6-browser/. The broken link was reported by @tom-miseur. 🙇 

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [x] I have made my changes in the `docs/sources/next` folder of the documentation.
- [x] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.
- [x] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->