### PR TITLE
Fix path to extension registry output file

### DIFF
--- a/scripts/extension-registry-changed
+++ b/scripts/extension-registry-changed
@@ -40,7 +40,7 @@ EOF
 }
 
 scriptdir="$(dirname "$(readlink -f "$0")")"
-docfile="$scriptdir/../docs/sources/next/extensions/explore.md"
+docfile="$scriptdir/../docs/sources/k6/next/extensions/explore.md"
 
 tmpfile="$(mktemp /tmp/extension-registry-changed.XXXXXX)"
 


### PR DESCRIPTION
It was moved in https://github.com/grafana/k6-docs/pull/1781 and the script has been failing in https://github.com/grafana/k6-docs/actions/workflows/extension-registry-changed.yml since then.

Thanks to @heitortsergent for spotting the failing workflow.