### PR TITLE
Adjust codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,6 @@
-*       @grafana/k6-core @heitortsergent
+# These owners will be the default owners for everything in
+# the repo.
+*       @heitortsergent
+
+# k6-engine (former k6-core) maintain open-source documentation
+/docs/sources/k6 @grafana/k6-core @heitortsergent

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,3 +4,4 @@
 
 # k6-engine (former k6-core) maintain open-source documentation
 /docs/sources/k6 @grafana/k6-core @heitortsergent
+/docs/sources/k6-studio @grafana/k6-Studio @heitortsergent 


### PR DESCRIPTION
<!-- 
Please make sure you have read the contribution guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md as well as the
the code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md before opening a PR.
-->

## What?

Recently, we added k6-core as the code owners to the repository https://github.com/grafana/k6-docs/pull/1802 which made the team reviewers of the all pull requests that are coming to this repo. It's actually not the case, keeping in mind that k6 engine (core) team maintains the open-source documentation mostly.

I believe that version of CODEOWNERS is the correct one.

## Why?

k6-core team started to become reviewers of the PRs for the parts that we don't maintain. 