### PR TITLE
Update references to docs/sources/ to include /k6

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,13 +18,13 @@ the code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
 <!-- Select one of the options below and delete the other -->
 
 <!-- 1. If updating the documentation for the most recent release of k6:  -->
-- [ ] I have made my changes in the `docs/sources/next` folder of the documentation.
-- [ ] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.
+- [ ] I have made my changes in the `docs/sources/k6/next` folder of the documentation.
+- [ ] I have reflected my changes in the `docs/sources/k6/v{most_recent_release}` folder of the documentation.
 - [ ] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
 <!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->
 
 <!-- 2. If updating the documentation for the next release of k6: -->
-- [ ] I have made my changes in the `docs/sources/next` folder of the documentation.
+- [ ] I have made my changes in the `docs/sources/k6/next` folder of the documentation.
 
 ## Related PR(s)/Issue(s)
 

--- a/CONTRIBUTING/README.md
+++ b/CONTRIBUTING/README.md
@@ -81,8 +81,8 @@ Depending on the type of update you need to make, you'll want to make updates to
 
 If you're making any updates or fixes that apply to the latest version of k6, you'll need to:
 
-- Update the Markdown files in the `docs/sources/next` folder.
-- Update the Markdown files in the `docs/sources/v{LATEST_VERSION}` folder.
+- Update the Markdown files in the `docs/sources/k6/next` folder.
+- Update the Markdown files in the `docs/sources/k6/v{LATEST_VERSION}` folder.
   - You can do this manually or by using the [`apply-patch`](../scripts/apply-patch) script from the `scripts` folder. Refer to the [Use the `apply-patch` script](#use-the-apply-patch-script) section for more details.
 
 This is to make sure that any changes you make are also brought over to the next major release version of k6.
@@ -93,7 +93,7 @@ This is to make sure that any changes you make are also brought over to the next
 
 If you're making any updates or fixes that only apply to the next major release of k6, you'll need to:
 
-- Update the Markdown files in the `docs/sources/next` folder.
+- Update the Markdown files in the `docs/sources/k6/next` folder.
 
 Once you make any changes and open a PR, and that PR is reviewed, you can merge it without having to worry about those changes showing up in the `latest` version of the docs. The `latest` version will always display the highest numbered version folder of the docs.
 
@@ -107,16 +107,16 @@ To use the script, make sure you're in the root of the k6-docs folder and run:
 scripts/apply-patch <COMMIT> <SOURCE> <DESTINATION>
 ```
 
-For example, if you'd like to apply the changes from your last commit, from the `docs/sources/next` folder to the `docs/sources/v0.47.x`, you can run:
+For example, if you'd like to apply the changes from your last commit, from the `docs/sources/k6/next` folder to the `docs/sources/k6/v0.47.x`, you can run:
 
 ```bash
-scripts/apply-patch HEAD~ docs/sources/next docs/sources/v0.47.x
+scripts/apply-patch HEAD~ docs/sources/k6/next docs/sources/k6/v0.47.x
 ```
 
 Or if you'd like to apply the changes from your previous three commits, you can run:
 
 ```bash
-scripts/apply-patch HEAD~3 docs/sources/next docs/sources/v0.47.x
+scripts/apply-patch HEAD~3 docs/sources/k6/next docs/sources/k6/v0.47.x
 ```
 
 ### Style guides


### PR DESCRIPTION
## What?

Update references in PR template and CONTRIBUTING guide to point to new docs path: `docs/sources/k6/{VERSION}`.

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.
