### PR TITLE
Add links to k6 Studio and Grafana Cloud k6 docs

### DIFF
--- a/docs/sources/k6/next/_index.md
+++ b/docs/sources/k6/next/_index.md
@@ -36,8 +36,8 @@ cards:
       description: Have a particular testing need? Find k6 extensions that extend the native k6 functionality.
       height: 24
     - title: k6 script examples
-      href: ./extensions/
-      description: Learn how to script your tests with this list of common k6 examples.
+      href: ./examples/
+      description: Learn how to write test scripts with this list of common k6 examples.
       height: 24
 ---
 

--- a/docs/sources/k6/next/_index.md
+++ b/docs/sources/k6/next/_index.md
@@ -39,6 +39,14 @@ cards:
       href: ./examples/
       description: Learn how to write test scripts with this list of common k6 examples.
       height: 24
+    - title: Grafana Cloud k6
+      href: https://grafana.com/docs/grafana-cloud/testing/k6/
+      description: Leverage the k6 OSS capabilities in Grafana Cloud, with built-in dashboards, insights into your application performance, and the ability to bring together teams in one place to resolve issues faster.
+      height: 24
+    - title: k6 Studio
+      href: https://grafana.com/docs/k6-studio/
+      description: Use the k6 Studio desktop application to quickly generate test scripts using a visual interface.
+      height: 24
 ---
 
 {{< docs/hero-simple key="hero" >}}

--- a/docs/sources/k6/next/k6-studio/_index.md
+++ b/docs/sources/k6/next/k6-studio/_index.md
@@ -17,4 +17,4 @@ k6 Studio is a desktop application that can help you:
 - Generate and customize a k6 test script from a HAR file, including the ability to use rules to quickly iterate on the script creation process.
 - Test and debug k6 scripts using a visual interface. Inspect the request and response details for any request in your script.
 
-Visit the [k6 Studio GitHub repository](https://github.com/grafana/k6-studio/) for more information and to download the application.
+Visit the [k6 Studio documentation](https://grafana.com/docs/k6-studio/) for more information.

--- a/docs/sources/k6/v0.52.x/_index.md
+++ b/docs/sources/k6/v0.52.x/_index.md
@@ -36,8 +36,8 @@ cards:
       description: Have a particular testing need? Find k6 extensions that extend the native k6 functionality.
       height: 24
     - title: k6 script examples
-      href: ./extensions/
-      description: Learn how to script your tests with this list of common k6 examples.
+      href: ./examples/
+      description: Learn how to write test scripts with this list of common k6 examples.
       height: 24
 ---
 

--- a/docs/sources/k6/v0.53.x/_index.md
+++ b/docs/sources/k6/v0.53.x/_index.md
@@ -36,8 +36,8 @@ cards:
       description: Have a particular testing need? Find k6 extensions that extend the native k6 functionality.
       height: 24
     - title: k6 script examples
-      href: ./extensions/
-      description: Learn how to script your tests with this list of common k6 examples.
+      href: ./examples/
+      description: Learn how to write test scripts with this list of common k6 examples.
       height: 24
 ---
 

--- a/docs/sources/k6/v0.53.x/k6-studio/_index.md
+++ b/docs/sources/k6/v0.53.x/k6-studio/_index.md
@@ -17,4 +17,4 @@ k6 Studio is a desktop application that can help you:
 - Generate and customize a k6 test script from a HAR file, including the ability to use rules to quickly iterate on the script creation process.
 - Test and debug k6 scripts using a visual interface. Inspect the request and response details for any request in your script.
 
-Visit the [k6 Studio GitHub repository](https://github.com/grafana/k6-studio/) for more information and to download the application.
+Visit the [k6 Studio documentation](https://grafana.com/docs/k6-studio/) for more information.

--- a/docs/sources/k6/v0.54.x/_index.md
+++ b/docs/sources/k6/v0.54.x/_index.md
@@ -36,8 +36,8 @@ cards:
       description: Have a particular testing need? Find k6 extensions that extend the native k6 functionality.
       height: 24
     - title: k6 script examples
-      href: ./extensions/
-      description: Learn how to script your tests with this list of common k6 examples.
+      href: ./examples/
+      description: Learn how to write test scripts with this list of common k6 examples.
       height: 24
 ---
 

--- a/docs/sources/k6/v0.54.x/k6-studio/_index.md
+++ b/docs/sources/k6/v0.54.x/k6-studio/_index.md
@@ -17,4 +17,4 @@ k6 Studio is a desktop application that can help you:
 - Generate and customize a k6 test script from a HAR file, including the ability to use rules to quickly iterate on the script creation process.
 - Test and debug k6 scripts using a visual interface. Inspect the request and response details for any request in your script.
 
-Visit the [k6 Studio GitHub repository](https://github.com/grafana/k6-studio/) for more information and to download the application.
+Visit the [k6 Studio documentation](https://grafana.com/docs/k6-studio/) for more information.

--- a/docs/sources/k6/v0.55.x/_index.md
+++ b/docs/sources/k6/v0.55.x/_index.md
@@ -36,8 +36,8 @@ cards:
       description: Have a particular testing need? Find k6 extensions that extend the native k6 functionality.
       height: 24
     - title: k6 script examples
-      href: ./extensions/
-      description: Learn how to script your tests with this list of common k6 examples.
+      href: ./examples/
+      description: Learn how to write test scripts with this list of common k6 examples.
       height: 24
 ---
 

--- a/docs/sources/k6/v0.55.x/_index.md
+++ b/docs/sources/k6/v0.55.x/_index.md
@@ -39,6 +39,14 @@ cards:
       href: ./examples/
       description: Learn how to write test scripts with this list of common k6 examples.
       height: 24
+    - title: Grafana Cloud k6
+      href: https://grafana.com/docs/grafana-cloud/testing/k6/
+      description: Leverage the k6 OSS capabilities in Grafana Cloud, with built-in dashboards, insights into your application performance, and the ability to bring together teams in one place to resolve issues faster.
+      height: 24
+    - title: k6 Studio
+      href: https://grafana.com/docs/k6-studio/
+      description: Use the k6 Studio desktop application to quickly generate test scripts using a visual interface.
+      height: 24
 ---
 
 {{< docs/hero-simple key="hero" >}}

--- a/docs/sources/k6/v0.55.x/k6-studio/_index.md
+++ b/docs/sources/k6/v0.55.x/k6-studio/_index.md
@@ -17,4 +17,4 @@ k6 Studio is a desktop application that can help you:
 - Generate and customize a k6 test script from a HAR file, including the ability to use rules to quickly iterate on the script creation process.
 - Test and debug k6 scripts using a visual interface. Inspect the request and response details for any request in your script.
 
-Visit the [k6 Studio GitHub repository](https://github.com/grafana/k6-studio/) for more information and to download the application.
+Visit the [k6 Studio documentation](https://grafana.com/docs/k6-studio/) for more information.


### PR DESCRIPTION
## What?

Feedback from @L-M-K-B, the k6 Studio page we had in the k6 OSS docs didn't have a link to the k6 Studio documentation.

I've updated the k6 Studio page to link to the k6 Studio documentation, and also added links to both k6 Studio docs and Grafana Cloud k6 docs to the homepage.

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [x] I have made my changes in the `docs/sources/next` folder of the documentation.
- [x] I have reflected my changes in the `docs/sources/v{most_recent_release}` folder of the documentation.
- [x] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->