### PR TITLE
Add deprecation warning to k6 DevTools recorder page

### DIFF
--- a/docs/sources/k6/next/examples/crawl-webpage.md
+++ b/docs/sources/k6/next/examples/crawl-webpage.md
@@ -9,4 +9,4 @@ weight: 17
 
 Refer to this [Stack Overflow answer](https://stackoverflow.com/questions/60927653/downloading-whole-websites-with-k6/) for details on how you can use k6 to crawl a web page.
 
-You can also use the [Grafana k6 Browser Recorder](https://chromewebstore.google.com/detail/grafana-k6-browser-record/fbanjfonbcedhifbgikmjelkkckhhidl), or the [k6 DevTools Recorder](https://chromewebstore.google.com/detail/k6-devtools-recorder/fkajbajcclbdgaoanencnhpfnigfipgc) to record a browser session and export it as a k6 test script.
+You can also use the [Grafana k6 Browser Recorder](https://chromewebstore.google.com/detail/grafana-k6-browser-record/fbanjfonbcedhifbgikmjelkkckhhidl) to record a browser session and export it as a k6 test script.

--- a/docs/sources/k6/next/using-k6/test-authoring/create-tests-from-recordings/_index.md
+++ b/docs/sources/k6/next/using-k6/test-authoring/create-tests-from-recordings/_index.md
@@ -15,7 +15,6 @@ For example, testing advanced scenarios on websites or mobile applications, such
 k6 provides three tools that can directly convert a recording into k6 script:
 
 - [Browser recorder](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-authoring/create-tests-from-recordings/using-the-browser-recorder) generates a k6 script from a browser session.
-- [DevTools recorder](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-authoring/create-tests-from-recordings/using-the-devtools-recorder) generates a k6 Browser script from user flows recorded in Chrome DevTools.
 - [HAR converter](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-authoring/create-tests-from-recordings/using-the-har-converter) generates a k6 script from the requests included in a HAR file.
 
 ## Steps

--- a/docs/sources/k6/next/using-k6/test-authoring/create-tests-from-recordings/using-the-devtools-recorder.md
+++ b/docs/sources/k6/next/using-k6/test-authoring/create-tests-from-recordings/using-the-devtools-recorder.md
@@ -6,6 +6,12 @@ weight: 01
 
 # Using the k6 DevTools recorder
 
+{{< admonition type="caution" >}}
+
+The k6 DevTools recorder extension is deprecated and will be removed in a future release.
+
+{{< /admonition >}}
+
 The k6 DevTools recorder lets you record user journeys using Chrome DevTools and then export them as a k6 script.
 
 ## Before you begin

--- a/docs/sources/k6/v0.53.x/examples/crawl-webpage.md
+++ b/docs/sources/k6/v0.53.x/examples/crawl-webpage.md
@@ -9,4 +9,4 @@ weight: 17
 
 Refer to this [Stack Overflow answer](https://stackoverflow.com/questions/60927653/downloading-whole-websites-with-k6/) for details on how you can use k6 to crawl a web page.
 
-You can also use the [Grafana k6 Browser Recorder](https://chromewebstore.google.com/detail/grafana-k6-browser-record/fbanjfonbcedhifbgikmjelkkckhhidl), or the [k6 DevTools Recorder](https://chromewebstore.google.com/detail/k6-devtools-recorder/fkajbajcclbdgaoanencnhpfnigfipgc) to record a browser session and export it as a k6 test script.
+You can also use the [Grafana k6 Browser Recorder](https://chromewebstore.google.com/detail/grafana-k6-browser-record/fbanjfonbcedhifbgikmjelkkckhhidl) to record a browser session and export it as a k6 test script.

--- a/docs/sources/k6/v0.53.x/using-k6/test-authoring/create-tests-from-recordings/_index.md
+++ b/docs/sources/k6/v0.53.x/using-k6/test-authoring/create-tests-from-recordings/_index.md
@@ -15,7 +15,6 @@ For example, testing advanced scenarios on websites or mobile applications, such
 k6 provides three tools that can directly convert a recording into k6 script:
 
 - [Browser recorder](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-authoring/create-tests-from-recordings/using-the-browser-recorder) generates a k6 script from a browser session.
-- [DevTools recorder](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-authoring/create-tests-from-recordings/using-the-devtools-recorder) generates a k6 Browser script from user flows recorded in Chrome DevTools.
 - [HAR converter](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-authoring/create-tests-from-recordings/using-the-har-converter) generates a k6 script from the requests included in a HAR file.
 
 ## Steps

--- a/docs/sources/k6/v0.53.x/using-k6/test-authoring/create-tests-from-recordings/using-the-devtools-recorder.md
+++ b/docs/sources/k6/v0.53.x/using-k6/test-authoring/create-tests-from-recordings/using-the-devtools-recorder.md
@@ -6,6 +6,12 @@ weight: 01
 
 # Using the k6 DevTools recorder
 
+{{< admonition type="caution" >}}
+
+The k6 DevTools recorder extension is deprecated and will be removed in a future release.
+
+{{< /admonition >}}
+
 The k6 DevTools recorder lets you record user journeys using Chrome DevTools and then export them as a k6 script.
 
 ## Before you begin

--- a/docs/sources/k6/v0.54.x/examples/crawl-webpage.md
+++ b/docs/sources/k6/v0.54.x/examples/crawl-webpage.md
@@ -9,4 +9,4 @@ weight: 17
 
 Refer to this [Stack Overflow answer](https://stackoverflow.com/questions/60927653/downloading-whole-websites-with-k6/) for details on how you can use k6 to crawl a web page.
 
-You can also use the [Grafana k6 Browser Recorder](https://chromewebstore.google.com/detail/grafana-k6-browser-record/fbanjfonbcedhifbgikmjelkkckhhidl), or the [k6 DevTools Recorder](https://chromewebstore.google.com/detail/k6-devtools-recorder/fkajbajcclbdgaoanencnhpfnigfipgc) to record a browser session and export it as a k6 test script.
+You can also use the [Grafana k6 Browser Recorder](https://chromewebstore.google.com/detail/grafana-k6-browser-record/fbanjfonbcedhifbgikmjelkkckhhidl) to record a browser session and export it as a k6 test script.

--- a/docs/sources/k6/v0.54.x/using-k6/test-authoring/create-tests-from-recordings/_index.md
+++ b/docs/sources/k6/v0.54.x/using-k6/test-authoring/create-tests-from-recordings/_index.md
@@ -15,7 +15,6 @@ For example, testing advanced scenarios on websites or mobile applications, such
 k6 provides three tools that can directly convert a recording into k6 script:
 
 - [Browser recorder](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-authoring/create-tests-from-recordings/using-the-browser-recorder) generates a k6 script from a browser session.
-- [DevTools recorder](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-authoring/create-tests-from-recordings/using-the-devtools-recorder) generates a k6 Browser script from user flows recorded in Chrome DevTools.
 - [HAR converter](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-authoring/create-tests-from-recordings/using-the-har-converter) generates a k6 script from the requests included in a HAR file.
 
 ## Steps

--- a/docs/sources/k6/v0.54.x/using-k6/test-authoring/create-tests-from-recordings/using-the-devtools-recorder.md
+++ b/docs/sources/k6/v0.54.x/using-k6/test-authoring/create-tests-from-recordings/using-the-devtools-recorder.md
@@ -6,6 +6,12 @@ weight: 01
 
 # Using the k6 DevTools recorder
 
+{{< admonition type="caution" >}}
+
+The k6 DevTools recorder extension is deprecated and will be removed in a future release.
+
+{{< /admonition >}}
+
 The k6 DevTools recorder lets you record user journeys using Chrome DevTools and then export them as a k6 script.
 
 ## Before you begin

--- a/docs/sources/k6/v0.55.x/examples/crawl-webpage.md
+++ b/docs/sources/k6/v0.55.x/examples/crawl-webpage.md
@@ -9,4 +9,4 @@ weight: 17
 
 Refer to this [Stack Overflow answer](https://stackoverflow.com/questions/60927653/downloading-whole-websites-with-k6/) for details on how you can use k6 to crawl a web page.
 
-You can also use the [Grafana k6 Browser Recorder](https://chromewebstore.google.com/detail/grafana-k6-browser-record/fbanjfonbcedhifbgikmjelkkckhhidl), or the [k6 DevTools Recorder](https://chromewebstore.google.com/detail/k6-devtools-recorder/fkajbajcclbdgaoanencnhpfnigfipgc) to record a browser session and export it as a k6 test script.
+You can also use the [Grafana k6 Browser Recorder](https://chromewebstore.google.com/detail/grafana-k6-browser-record/fbanjfonbcedhifbgikmjelkkckhhidl) to record a browser session and export it as a k6 test script.

--- a/docs/sources/k6/v0.55.x/using-k6/test-authoring/create-tests-from-recordings/_index.md
+++ b/docs/sources/k6/v0.55.x/using-k6/test-authoring/create-tests-from-recordings/_index.md
@@ -15,7 +15,6 @@ For example, testing advanced scenarios on websites or mobile applications, such
 k6 provides three tools that can directly convert a recording into k6 script:
 
 - [Browser recorder](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-authoring/create-tests-from-recordings/using-the-browser-recorder) generates a k6 script from a browser session.
-- [DevTools recorder](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-authoring/create-tests-from-recordings/using-the-devtools-recorder) generates a k6 Browser script from user flows recorded in Chrome DevTools.
 - [HAR converter](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-authoring/create-tests-from-recordings/using-the-har-converter) generates a k6 script from the requests included in a HAR file.
 
 ## Steps

--- a/docs/sources/k6/v0.55.x/using-k6/test-authoring/create-tests-from-recordings/using-the-devtools-recorder.md
+++ b/docs/sources/k6/v0.55.x/using-k6/test-authoring/create-tests-from-recordings/using-the-devtools-recorder.md
@@ -6,6 +6,12 @@ weight: 01
 
 # Using the k6 DevTools recorder
 
+{{< admonition type="caution" >}}
+
+The k6 DevTools recorder extension is deprecated and will be removed in a future release.
+
+{{< /admonition >}}
+
 The k6 DevTools recorder lets you record user journeys using Chrome DevTools and then export them as a k6 script.
 
 ## Before you begin


### PR DESCRIPTION
## What?

Add a deprecation warning to the k6 DevTools recorder page, and remove mentions of it.

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [x] I have made my changes in the `docs/sources/k6/next` folder of the documentation.
- [x] I have reflected my changes in the `docs/sources/k6/v{most_recent_release}` folder of the documentation.
- [ ] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->

## Related PR(s)/Issue(s)

https://github.com/grafana/k6-docs/issues/1829