### PR TITLE
Fixed docker command in get started doc

### DIFF
--- a/docs/sources/k6/next/get-started/running-k6.md
+++ b/docs/sources/k6/next/get-started/running-k6.md
@@ -33,7 +33,7 @@ To run a simple local script:
    ```
 
    ```docker
-   $ docker run --rm -i -v $PWD:/app -w /app grafana/k6 new
+   $ docker run --rm -i --user $UID -v $PWD:/app -w /app grafana/k6 new
    ```
 
    ```windows

--- a/docs/sources/k6/next/get-started/running-k6.md
+++ b/docs/sources/k6/next/get-started/running-k6.md
@@ -33,7 +33,7 @@ To run a simple local script:
    ```
 
    ```docker
-   $ docker run --rm -i --user $UID -v $PWD:/app -w /app grafana/k6 new
+   $ docker run --rm -u $(id -u) -v $PWD:/app -w /app grafana/k6 new
    ```
 
    ```windows

--- a/docs/sources/k6/v0.48.x/get-started/running-k6.md
+++ b/docs/sources/k6/v0.48.x/get-started/running-k6.md
@@ -29,7 +29,7 @@ To run a simple local script:
    ```
 
    ```docker
-   $ docker run --rm -i -v $PWD:/app -w /app grafana/k6 new
+   $ docker run --rm -i --user $UID -v $PWD:/app -w /app grafana/k6 new
    ```
 
    ```windows

--- a/docs/sources/k6/v0.48.x/get-started/running-k6.md
+++ b/docs/sources/k6/v0.48.x/get-started/running-k6.md
@@ -29,7 +29,7 @@ To run a simple local script:
    ```
 
    ```docker
-   $ docker run --rm -i --user $UID -v $PWD:/app -w /app grafana/k6 new
+   $ docker run --rm -u $(id -u) -v $PWD:/app -w /app grafana/k6 new
    ```
 
    ```windows

--- a/docs/sources/k6/v0.49.x/get-started/running-k6.md
+++ b/docs/sources/k6/v0.49.x/get-started/running-k6.md
@@ -29,7 +29,7 @@ To run a simple local script:
    ```
 
    ```docker
-   $ docker run --rm -i -v $PWD:/app -w /app grafana/k6 new
+   $ docker run --rm -i --user $UID -v $PWD:/app -w /app grafana/k6 new
    ```
 
    ```windows

--- a/docs/sources/k6/v0.49.x/get-started/running-k6.md
+++ b/docs/sources/k6/v0.49.x/get-started/running-k6.md
@@ -29,7 +29,7 @@ To run a simple local script:
    ```
 
    ```docker
-   $ docker run --rm -i --user $UID -v $PWD:/app -w /app grafana/k6 new
+   $ docker run --rm -u $(id -u) -v $PWD:/app -w /app grafana/k6 new
    ```
 
    ```windows

--- a/docs/sources/k6/v0.50.x/get-started/running-k6.md
+++ b/docs/sources/k6/v0.50.x/get-started/running-k6.md
@@ -33,7 +33,7 @@ To run a simple local script:
    ```
 
    ```docker
-   $ docker run --rm -i -v $PWD:/app -w /app grafana/k6 new
+   $ docker run --rm -i --user $UID -v $PWD:/app -w /app grafana/k6 new
    ```
 
    ```windows

--- a/docs/sources/k6/v0.50.x/get-started/running-k6.md
+++ b/docs/sources/k6/v0.50.x/get-started/running-k6.md
@@ -33,7 +33,7 @@ To run a simple local script:
    ```
 
    ```docker
-   $ docker run --rm -i --user $UID -v $PWD:/app -w /app grafana/k6 new
+   $ docker run --rm -u $(id -u) -v $PWD:/app -w /app grafana/k6 new
    ```
 
    ```windows

--- a/docs/sources/k6/v0.51.x/get-started/running-k6.md
+++ b/docs/sources/k6/v0.51.x/get-started/running-k6.md
@@ -33,7 +33,7 @@ To run a simple local script:
    ```
 
    ```docker
-   $ docker run --rm -i -v $PWD:/app -w /app grafana/k6 new
+   $ docker run --rm -i --user $UID -v $PWD:/app -w /app grafana/k6 new
    ```
 
    ```windows

--- a/docs/sources/k6/v0.51.x/get-started/running-k6.md
+++ b/docs/sources/k6/v0.51.x/get-started/running-k6.md
@@ -33,7 +33,7 @@ To run a simple local script:
    ```
 
    ```docker
-   $ docker run --rm -i --user $UID -v $PWD:/app -w /app grafana/k6 new
+   $ docker run --rm -u $(id -u) -v $PWD:/app -w /app grafana/k6 new
    ```
 
    ```windows

--- a/docs/sources/k6/v0.52.x/get-started/running-k6.md
+++ b/docs/sources/k6/v0.52.x/get-started/running-k6.md
@@ -33,7 +33,7 @@ To run a simple local script:
    ```
 
    ```docker
-   $ docker run --rm -i -v $PWD:/app -w /app grafana/k6 new
+   $ docker run --rm -i --user $UID -v $PWD:/app -w /app grafana/k6 new
    ```
 
    ```windows

--- a/docs/sources/k6/v0.52.x/get-started/running-k6.md
+++ b/docs/sources/k6/v0.52.x/get-started/running-k6.md
@@ -33,7 +33,7 @@ To run a simple local script:
    ```
 
    ```docker
-   $ docker run --rm -i --user $UID -v $PWD:/app -w /app grafana/k6 new
+   $ docker run --rm -u $(id -u) -v $PWD:/app -w /app grafana/k6 new
    ```
 
    ```windows

--- a/docs/sources/k6/v0.53.x/get-started/running-k6.md
+++ b/docs/sources/k6/v0.53.x/get-started/running-k6.md
@@ -33,7 +33,7 @@ To run a simple local script:
    ```
 
    ```docker
-   $ docker run --rm -i -v $PWD:/app -w /app grafana/k6 new
+   $ docker run --rm -i --user $UID -v $PWD:/app -w /app grafana/k6 new
    ```
 
    ```windows

--- a/docs/sources/k6/v0.53.x/get-started/running-k6.md
+++ b/docs/sources/k6/v0.53.x/get-started/running-k6.md
@@ -33,7 +33,7 @@ To run a simple local script:
    ```
 
    ```docker
-   $ docker run --rm -i --user $UID -v $PWD:/app -w /app grafana/k6 new
+   $ docker run --rm -u $(id -u) -v $PWD:/app -w /app grafana/k6 new
    ```
 
    ```windows

--- a/docs/sources/k6/v0.54.x/get-started/running-k6.md
+++ b/docs/sources/k6/v0.54.x/get-started/running-k6.md
@@ -33,7 +33,7 @@ To run a simple local script:
    ```
 
    ```docker
-   $ docker run --rm -i -v $PWD:/app -w /app grafana/k6 new
+   $ docker run --rm -i --user $UID -v $PWD:/app -w /app grafana/k6 new
    ```
 
    ```windows

--- a/docs/sources/k6/v0.54.x/get-started/running-k6.md
+++ b/docs/sources/k6/v0.54.x/get-started/running-k6.md
@@ -33,7 +33,7 @@ To run a simple local script:
    ```
 
    ```docker
-   $ docker run --rm -i --user $UID -v $PWD:/app -w /app grafana/k6 new
+   $ docker run --rm -u $(id -u) -v $PWD:/app -w /app grafana/k6 new
    ```
 
    ```windows

--- a/docs/sources/k6/v0.55.x/get-started/running-k6.md
+++ b/docs/sources/k6/v0.55.x/get-started/running-k6.md
@@ -33,7 +33,7 @@ To run a simple local script:
    ```
 
    ```docker
-   $ docker run --rm -i -v $PWD:/app -w /app grafana/k6 new
+   $ docker run --rm -i --user $UID -v $PWD:/app -w /app grafana/k6 new
    ```
 
    ```windows

--- a/docs/sources/k6/v0.55.x/get-started/running-k6.md
+++ b/docs/sources/k6/v0.55.x/get-started/running-k6.md
@@ -33,7 +33,7 @@ To run a simple local script:
    ```
 
    ```docker
-   $ docker run --rm -i --user $UID -v $PWD:/app -w /app grafana/k6 new
+   $ docker run --rm -u $(id -u) -v $PWD:/app -w /app grafana/k6 new
    ```
 
    ```windows

--- a/docs/sources/k6/v0.56.x/get-started/running-k6.md
+++ b/docs/sources/k6/v0.56.x/get-started/running-k6.md
@@ -33,7 +33,7 @@ To run a simple local script:
    ```
 
    ```docker
-   $ docker run --rm -i -v $PWD:/app -w /app grafana/k6 new
+   $ docker run --rm -i --user $UID -v $PWD:/app -w /app grafana/k6 new
    ```
 
    ```windows

--- a/docs/sources/k6/v0.56.x/get-started/running-k6.md
+++ b/docs/sources/k6/v0.56.x/get-started/running-k6.md
@@ -33,7 +33,7 @@ To run a simple local script:
    ```
 
    ```docker
-   $ docker run --rm -i --user $UID -v $PWD:/app -w /app grafana/k6 new
+   $ docker run --rm -u $(id -u) -v $PWD:/app -w /app grafana/k6 new
    ```
 
    ```windows

--- a/src/data/markdown/translated-guides/en/01 Get started/03 Running k6.md
+++ b/src/data/markdown/translated-guides/en/01 Get started/03 Running k6.md
@@ -26,7 +26,7 @@ To run a simple local script:
     ```
 
     ```bash
-    $ docker run --rm -i --user $UID -v $PWD:/app -w /app grafana/k6 new
+    $ docker run --rm -u $(id -u) -v $PWD:/app -w /app grafana/k6 new
     ```
 
     ```bash

--- a/src/data/markdown/translated-guides/en/01 Get started/03 Running k6.md
+++ b/src/data/markdown/translated-guides/en/01 Get started/03 Running k6.md
@@ -26,7 +26,7 @@ To run a simple local script:
     ```
 
     ```bash
-    $ docker run --rm -i -v $PWD:/app -w /app grafana/k6 new
+    $ docker run --rm -i --user $UID -v $PWD:/app -w /app grafana/k6 new
     ```
 
     ```bash


### PR DESCRIPTION
## What?

It fixes the docker command listed in the `Get started documentation` following https://github.com/grafana/k6-docs/issues/1536

## Checklist

<!-- Please fill in this template: -->
- [X] I have used a meaningful title for the PR.
- [X] I have described the changes I've made in the "What?" section above.
- [X] I have performed a self-review of my changes.
- [X] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->


- [X] I have made my changes in the `docs/sources/k6/next` folder of the documentation.
- [X] I have reflected my changes in the `docs/sources/k6/v{most_recent_release}` folder of the documentation.
- [X] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).

## Related PR(s)/Issue(s)

- Closes https://github.com/grafana/k6-docs/issues/1536