### PR TITLE
Add workflow that builds the website with both documentation sets

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -1,0 +1,29 @@
+name: build-website
+
+on:
+  push:
+    paths:
+      - "docs/sources/k6/**"
+      - "docs/sources/k6-studio/**"
+      - ".github/workflows/build-website.yml"
+  workflow_dispatch:
+
+jobs:
+  build-website:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Build website with k6 docs
+        uses: grafana/writers-toolkit/build-website@4b1248585248751e3b12fd020cf7ac91540ca09c # build-website/v1.0.1
+        with:
+          source_directory: docs/sources/k6
+          website_directory: content/docs/k6/next
+
+      - name: Build website with k6 Studio docs
+        uses: grafana/writers-toolkit/build-website@4b1248585248751e3b12fd020cf7ac91540ca09c # build-website/v1.0.1
+        with:
+          source_directory: docs/sources/k6-studio
+          website_directory: content/docs/k6-studio


### PR DESCRIPTION

## What?

Requested by @heitortsergent to ensure that the docs are always buildable.

The same `grafana/writers-toolkit/build-website` composite Action gates publishing documentation in those publishing workflows to make sure that no docs break the website build after syncing.

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [ ] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [ ] I have made my changes in the `docs/sources/k6/next` folder of the documentation.
- [ ] I have reflected my changes in the `docs/sources/k6/v{most_recent_release}` folder of the documentation.
- [ ] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->

<!-- 2. If updating the documentation for the next release of k6: -->
- [ ] I have made my changes in the `docs/sources/k6/next` folder of the documentation.

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->
<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->