### PR TITLE
fix the link to the report usage source code

### DIFF
--- a/docs/sources/k6/next/set-up/usage-collection.md
+++ b/docs/sources/k6/next/set-up/usage-collection.md
@@ -32,4 +32,4 @@ The usage report does not contain any information about what you are testing. Th
 
 This report is sent to an HTTPS server that collects statistics on k6 usage.
 
-k6 is an open-source project and for those interested, the actual code that generates and sends the usage report can be directly reviewed [here](https://github.com/grafana/k6/blob/master/cmd/report.go).
+k6 is an open-source project and for those interested, the actual code that generates and sends the usage report can be directly reviewed [here](https://github.com/grafana/k6/blob/master/internal/cmd/report.go).

--- a/docs/sources/k6/v0.54.x/set-up/usage-collection.md
+++ b/docs/sources/k6/v0.54.x/set-up/usage-collection.md
@@ -32,4 +32,4 @@ The usage report does not contain any information about what you are testing. Th
 
 This report is sent to an HTTPS server that collects statistics on k6 usage.
 
-k6 is an open-source project and for those interested, the actual code that generates and sends the usage report can be directly reviewed [here](https://github.com/grafana/k6/blob/master/cmd/report.go).
+k6 is an open-source project and for those interested, the actual code that generates and sends the usage report can be directly reviewed [here](https://github.com/grafana/k6/blob/master/internal/cmd/report.go).

--- a/docs/sources/k6/v0.55.x/set-up/usage-collection.md
+++ b/docs/sources/k6/v0.55.x/set-up/usage-collection.md
@@ -32,4 +32,4 @@ The usage report does not contain any information about what you are testing. Th
 
 This report is sent to an HTTPS server that collects statistics on k6 usage.
 
-k6 is an open-source project and for those interested, the actual code that generates and sends the usage report can be directly reviewed [here](https://github.com/grafana/k6/blob/master/cmd/report.go).
+k6 is an open-source project and for those interested, the actual code that generates and sends the usage report can be directly reviewed [here](https://github.com/grafana/k6/blob/master/internal/cmd/report.go).

--- a/docs/sources/k6/v0.56.x/set-up/usage-collection.md
+++ b/docs/sources/k6/v0.56.x/set-up/usage-collection.md
@@ -32,4 +32,4 @@ The usage report does not contain any information about what you are testing. Th
 
 This report is sent to an HTTPS server that collects statistics on k6 usage.
 
-k6 is an open-source project and for those interested, the actual code that generates and sends the usage report can be directly reviewed [here](https://github.com/grafana/k6/blob/master/cmd/report.go).
+k6 is an open-source project and for those interested, the actual code that generates and sends the usage report can be directly reviewed [here](https://github.com/grafana/k6/blob/master/internal/cmd/report.go).


### PR DESCRIPTION
<!-- 
Please make sure you have read the contribution guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md as well as the
the code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md before opening a PR.
-->

## What?

After moving packages to the `internal` the link that we have from the https://grafana.com/docs/k6/latest/set-up/usage-collection/ doc page has been broken.

This PR adjust it to the actual one.

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [ ] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [ ] I have made my changes in the `docs/sources/k6/next` folder of the documentation.
- [ ] I have reflected my changes in the `docs/sources/k6/v{most_recent_release}` folder of the documentation.
- [ ] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->

<!-- 2. If updating the documentation for the next release of k6: -->
- [ ] I have made my changes in the `docs/sources/k6/next` folder of the documentation.

## Related PR(s)/Issue(s)

https://github.com/grafana/k6/pull/4133

<!-- Does it close an issue? -->
<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->