### PR TITLE
Document the csv parser's `asObjects` option

### DIFF
--- a/docs/sources/k6/next/javascript-api/k6-experimental/csv/Options.md
+++ b/docs/sources/k6/next/javascript-api/k6-experimental/csv/Options.md
@@ -13,7 +13,7 @@ The `Options` object describes the configuration available for the operation of 
 | Property      | Type              | Description                                                                                               |
 | :------------ | :---------------- | :-------------------------------------------------------------------------------------------------------- |
 | delimiter     | string            | The character used to separate fields in the CSV file. Default is `','`.                                  |
-| asObjects     | boolean           | Whether to parse the CSV file's lines as JavaScript objects. If it is false then they are parsed as arrays. Default is `false`.                                 |
+| asObjects     | boolean           | Whether to parse the CSV file's lines as JavaScript objects. If it is `false` then they are parsed as arrays. Default is `false`.                                 |
 | skipFirstLine | boolean           | Whether to skip the first line of the CSV file. Default is `false`.                                       |
 | fromLine      | (optional) number | The line number from which to start reading the CSV file. Default is `0`.                                 |
 | toLine        | (optional) number | The line number at which to stop reading the CSV file. If the option is not set, then read until the end. |

--- a/docs/sources/k6/next/javascript-api/k6-experimental/csv/Options.md
+++ b/docs/sources/k6/next/javascript-api/k6-experimental/csv/Options.md
@@ -43,6 +43,8 @@ Will be parsed into the following array of objects:
 
 {{< code >}}
 
+<!--md-k6:skip-->
+
 ```javascript
 import { open } from 'k6/experimental/fs';
 import csv from 'k6/experimental/csv';

--- a/docs/sources/k6/next/javascript-api/k6-experimental/csv/Options.md
+++ b/docs/sources/k6/next/javascript-api/k6-experimental/csv/Options.md
@@ -13,7 +13,7 @@ The `Options` object describes the configuration available for the operation of 
 | Property      | Type              | Description                                                                                               |
 | :------------ | :---------------- | :-------------------------------------------------------------------------------------------------------- |
 | delimiter     | string            | The character used to separate fields in the CSV file. Default is `','`.                                  |
-| asObjects     | boolean           | Whether to parse the CSV file's lines as JavaScript objects. If it is `false` then they are parsed as arrays. Default is `false`.                                 |
+| asObjects     | boolean           | Whether to parse the CSV file's lines as JavaScript objects. If it is `false`, then they are parsed as arrays. Default is `false`.                                 |
 | skipFirstLine | boolean           | Whether to skip the first line of the CSV file. Default is `false`.                                       |
 | fromLine      | (optional) number | The line number from which to start reading the CSV file. Default is `0`.                                 |
 | toLine        | (optional) number | The line number at which to stop reading the CSV file. If the option is not set, then read until the end. |

--- a/docs/sources/k6/next/javascript-api/k6-experimental/csv/Options.md
+++ b/docs/sources/k6/next/javascript-api/k6-experimental/csv/Options.md
@@ -13,7 +13,7 @@ The `Options` object describes the configuration available for the operation of 
 | Property      | Type              | Description                                                                                               |
 | :------------ | :---------------- | :-------------------------------------------------------------------------------------------------------- |
 | delimiter     | string            | The character used to separate fields in the CSV file. Default is `','`.                                  |
-| asObjects     | boolean           | Whether to parse the CSV file as an array of objects. Default is `false`.                                 |
+| asObjects     | boolean           | Whether to parse the CSV file's lines as JavaScript objects. If it is false then they are parsed as arrays. Default is `false`.                                 |
 | skipFirstLine | boolean           | Whether to skip the first line of the CSV file. Default is `false`.                                       |
 | fromLine      | (optional) number | The line number from which to start reading the CSV file. Default is `0`.                                 |
 | toLine        | (optional) number | The line number at which to stop reading the CSV file. If the option is not set, then read until the end. |

--- a/docs/sources/k6/next/javascript-api/k6-experimental/csv/Options.md
+++ b/docs/sources/k6/next/javascript-api/k6-experimental/csv/Options.md
@@ -13,9 +13,31 @@ The `Options` object describes the configuration available for the operation of 
 | Property      | Type              | Description                                                                                               |
 | :------------ | :---------------- | :-------------------------------------------------------------------------------------------------------- |
 | delimiter     | string            | The character used to separate fields in the CSV file. Default is `','`.                                  |
+| asObjects     | boolean           | Whether to parse the CSV file as an array of objects. Default is `false`.                                 |
 | skipFirstLine | boolean           | Whether to skip the first line of the CSV file. Default is `false`.                                       |
 | fromLine      | (optional) number | The line number from which to start reading the CSV file. Default is `0`.                                 |
 | toLine        | (optional) number | The line number at which to stop reading the CSV file. If the option is not set, then read until the end. |
+
+### asObjects
+
+When `asObjects` is set to `true`, parsing operations over the CSV file will return an array of objects. The object keys are the column names from the CSV file, as inferred from the first line of the file, and the values are the field values from the CSV record. Note that the first line of the CSV file is skipped, as it is assumed to contain the column names (header row).
+
+As a result, the following CSV file:
+
+```csv
+name,age
+John,30
+Jane,25
+```
+
+Will be parsed into the following array of objects:
+
+```json
+[
+  { "name": "John", "age": "30" },
+  { "name": "Jane", "age": "25" }
+]
+```
 
 ## Example
 

--- a/docs/sources/k6/next/javascript-api/k6-experimental/csv/Parser.md
+++ b/docs/sources/k6/next/javascript-api/k6-experimental/csv/Parser.md
@@ -71,7 +71,7 @@ export default async function () {
 
 ### Using `asObjects`
 
-The `asObjects` option parses the CSV file into an array of objects. The object keys are the column names from the CSV file. and the values are the field values from the CSV record.
+The `asObjects` option parses the CSV file into an array of objects. The object keys are the column names from the CSV file, and the values are the field values from the CSV record.
 Note that the first line of the CSV file is skipped, as it is assumed to contain the column names (header row).
 
 {{< code >}}

--- a/docs/sources/k6/next/javascript-api/k6-experimental/csv/Parser.md
+++ b/docs/sources/k6/next/javascript-api/k6-experimental/csv/Parser.md
@@ -37,6 +37,8 @@ A promise resolving to an object with the following properties:
 
 {{< code >}}
 
+<!--md-k6:skip-->
+
 ```javascript
 import { open } from 'k6/experimental/fs';
 import csv from 'k6/experimental/csv';
@@ -73,6 +75,8 @@ The `asObjects` option parses the CSV file into an array of objects. The object 
 Note that the first line of the CSV file is skipped, as it is assumed to contain the column names (header row).
 
 {{< code >}}
+
+<!--md-k6:skip-->
 
 ```javascript
 import { open } from 'k6/experimental/fs';

--- a/docs/sources/k6/next/javascript-api/k6-experimental/csv/Parser.md
+++ b/docs/sources/k6/next/javascript-api/k6-experimental/csv/Parser.md
@@ -9,27 +9,6 @@ weight: 30
 The `csv.Parser` class provides a streaming parser that reads CSV files line-by-line, offering fine-grained control over the parsing process and minimizing memory consumption.
 It's well-suited for scenarios where memory efficiency is crucial or when you need to process large CSV files without loading the entire file into memory.
 
-## Asynchronous nature
-
-The `csv.Parser` class methods are asynchronous and return Promises.
-Due to k6's current limitation with the [init context](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-lifecycle/#the-init-stage) (which doesn't support asynchronous functions directly), you need to use an asynchronous wrapper such as:
-
-{{< code >}}
-
-```javascript
-import { open } from 'k6/experimental/fs';
-import csv from 'k6/experimental/csv';
-
-let file;
-let parser;
-(async function () {
-  file = await open('data.csv');
-  parser = new csv.Parser(file);
-})();
-```
-
-{{< /code >}}
-
 ## Constructor
 
 | Parameter | Type                                                                                          | Description                                                                                               |
@@ -53,6 +32,8 @@ A promise resolving to an object with the following properties:
 | value    | string[] | Contains the fields of the CSV record as an array of strings. If done is true, value is undefined.    |
 
 ## Example
+
+### Basic Usage
 
 {{< code >}}
 
@@ -81,6 +62,51 @@ export default async function () {
   // We expect the `value` property to be an array of strings, where each string is a field
   // from the CSV record.
   console.log(done, value);
+}
+```
+
+{{< /code >}}
+
+### Using `asObjects`
+
+The `asObjects` option parses the CSV file into an array of objects. The object keys are the column names from the CSV file. and the values are the field values from the CSV record.
+Note that the first line of the CSV file is skipped, as it is assumed to contain the column names (header row).
+
+{{< code >}}
+
+```javascript
+import { open } from 'k6/experimental/fs';
+import csv from 'k6/experimental/csv';
+import { scenario } from 'k6/execution';
+
+export const options = {
+  iterations: 3,
+};
+
+const file = await open('data.csv');
+const parser = new csv.Parser(file, { asObjects: true });
+
+export default async function () {
+  // Will print the record for the current iteration as an object.
+  //
+  // For example, given the following CSV file:
+  //
+  // firstname,lastname
+  // francois,mitterand
+  // helmut,kohl
+  // pierre,mendes-france
+  //
+  // The test will print:
+  //
+  // { firstname: 'francois', lastname: 'mitterand' }
+  // { firstname: 'helmut', lastname: 'kohl' }
+  // { firstname: 'pierre', lastname: 'mendes-france' }
+  const { done, value } = await parser.next();
+  if (done) {
+    throw new Error('No more rows to read');
+  }
+
+  console.log(value);
 }
 ```
 

--- a/docs/sources/k6/next/javascript-api/k6-experimental/csv/_index.md
+++ b/docs/sources/k6/next/javascript-api/k6-experimental/csv/_index.md
@@ -32,10 +32,11 @@ performance and memory optimization.
 
 ## API
 
-| Function/Object                                                                                  | Description                                                                                       |
-| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------- |
-| [csv.parse()](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/csv/parse) | Parses an entire CSV file into a SharedArray for high-performance scenarios.                      |
-| [csv.Parser](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/csv/parser) | A class for streaming CSV parsing, allowing line-by-line reading with minimal memory consumption. |
+| Function/Object                                                                                | Description                                                                                                                                                                                                                                                                                                                     |
+| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [parse](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/csv/parse)     | Parses an entire CSV file into a SharedArray for high-performance scenarios.                                                                                                                                                                                                                                                    |
+| [Parser](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/csv/parser)   | A class for streaming CSV parsing, allowing line-by-line reading with minimal memory consumption.                                                                                                                                                                                                                               |
+| [Options](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/csv/options) | An object that describes the configuration available for the operation of parsing CSV files using the [`parse()`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/csv/parse) function and the [`csv.Parser`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/csv/parser) class. |
 
 ## Example
 

--- a/docs/sources/k6/next/javascript-api/k6-experimental/csv/_index.md
+++ b/docs/sources/k6/next/javascript-api/k6-experimental/csv/_index.md
@@ -44,6 +44,8 @@ performance and memory optimization.
 
 {{< code >}}
 
+<!--md-k6:skip-->
+
 ```javascript
 import { open } from 'k6/experimental/fs';
 import csv from 'k6/experimental/csv';
@@ -73,6 +75,8 @@ export default async function () {
 ### Streaming a CSV file line-by-line
 
 {{< code >}}
+
+<!--md-k6:skip-->
 
 ```javascript
 import { open } from 'k6/experimental/fs';

--- a/docs/sources/k6/next/javascript-api/k6-experimental/csv/parse.md
+++ b/docs/sources/k6/next/javascript-api/k6-experimental/csv/parse.md
@@ -27,6 +27,8 @@ A promise resolving to a [SharedArray](https://grafana.com/docs/k6/<K6_VERSION>/
 
 {{< code >}}
 
+<!--md-k6:skip-->
+
 ```javascript
 import { open } from 'k6/experimental/fs';
 import csv from 'k6/experimental/csv';
@@ -59,6 +61,8 @@ The `asObjects` option parses the CSV file into an array of objects. The object 
 Note that the first line of the CSV file is skipped, as it is assumed to contain the column names (header row).
 
 {{< code >}}
+
+<!--md-k6:skip-->
 
 ```javascript
 import { open } from 'k6/experimental/fs';

--- a/docs/sources/k6/next/javascript-api/k6-experimental/csv/parse.md
+++ b/docs/sources/k6/next/javascript-api/k6-experimental/csv/parse.md
@@ -57,7 +57,7 @@ export default async function () {
 
 ### Using `asObjects`
 
-The `asObjects` option parses the CSV file into an array of objects. The object keys are the column names from the CSV file. and the values are the field values from the CSV record.
+The `asObjects` option parses the CSV file into an array of objects. The object keys are the column names from the CSV file, and the values are the field values from the CSV record.
 Note that the first line of the CSV file is skipped, as it is assumed to contain the column names (header row).
 
 {{< code >}}

--- a/docs/sources/k6/next/javascript-api/k6-experimental/csv/parse.md
+++ b/docs/sources/k6/next/javascript-api/k6-experimental/csv/parse.md
@@ -10,39 +10,20 @@ The `csv.parse` function parses an entire CSV file at once and returns a promise
 This function uses Go-based processing, which results in faster parsing and lower memory usage compared to JavaScript alternatives.
 It's ideal for scenarios where performance is a priority, and the entire CSV file can be loaded into memory.
 
-## Asynchronous Nature
-
-`csv.parse` is an asynchronous function that returns a Promise. Due to k6's current limitation with the [init context](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-lifecycle/) (which
-doesn't support asynchronous functions directly), you need to use an asynchronous wrapper like this:
-
-{{< code >}}
-
-```javascript
-import { open } from 'k6/experimental/fs';
-import csv from 'k6/experimental/csv';
-
-let file;
-let csvRecords;
-(async function () {
-  file = await open('data.csv');
-  csvRecords = await csv.parse(file, { delimiter: ',' });
-})();
-```
-
-{{< /code >}}
-
 ## Parameters
 
-| Parameter | Type                                                                                          | Description                                                     |
-| :-------- | :-------------------------------------------------------------------------------------------- | :-------------------------------------------------------------- |
-| file      | [fs.File](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/fs/file)    | A file instance opened using the `fs.open` function.            |
-| options   | [Options](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/fs/options) | An optional parameter object to customize the parsing behavior. |
+| Parameter | Type                                                                                           | Description                                                     |
+| :-------- | :--------------------------------------------------------------------------------------------- | :-------------------------------------------------------------- |
+| file      | [fs.File](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/fs/file)     | A file instance opened using the `fs.open` function.            |
+| options   | [Options](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/csv/options) | An optional parameter object to customize the parsing behavior. |
 
 ## Returns
 
 A promise resolving to a [SharedArray](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-data/sharedarray) instance, where each element is an array representing a CSV record, and each sub-element is a field from that record.
 
-## Example
+## Examples
+
+### Basic Usage
 
 {{< code >}}
 
@@ -59,13 +40,53 @@ const file = await open('data.csv');
 
 // The `csv.parse` function consumes the entire file at once and returns
 // the parsed records as a `SharedArray` object.
-const csvRecords = await csv.parse(file, { skipFirstLine: true });
+const csvRecords = await csv.parse(file);
 
 export default async function () {
   // `csvRecords` is a `SharedArray`. Each element is a record from the CSV file, represented as an array
   // where each element is a field from the CSV record.
   //
   // `csvRecords[scenario.iterationInTest]` gives the record for the current iteration.
+  console.log(csvRecords[scenario.iterationInTest]);
+}
+```
+
+{{< /code >}}
+
+### Using `asObjects`
+
+The `asObjects` option parses the CSV file into an array of objects. The object keys are the column names from the CSV file. and the values are the field values from the CSV record.
+Note that the first line of the CSV file is skipped, as it is assumed to contain the column names (header row).
+
+{{< code >}}
+
+```javascript
+import { open } from 'k6/experimental/fs';
+import csv from 'k6/experimental/csv';
+import { scenario } from 'k6/execution';
+
+export const options = {
+  iterations: 3,
+};
+
+const file = await open('data.csv');
+const csvRecords = await csv.parse(file, { asObjects: true });
+
+export default function () {
+  // Will print the record for the current iteration as an object.
+  //
+  // For example, given the following CSV file:
+  //
+  // firstname,lastname
+  // francois,mitterand
+  // helmut,kohl
+  // pierre,mendes-france
+  //
+  // The test will print:
+  //
+  // { firstname: 'francois', lastname: 'mitterand' }
+  // { firstname: 'helmut', lastname: 'kohl' }
+  // { firstname: 'pierre', lastname: 'mendes-france' }
   console.log(csvRecords[scenario.iterationInTest]);
 }
 ```

--- a/docs/sources/k6/next/shared/javascript-api/k6-experimental.md
+++ b/docs/sources/k6/next/shared/javascript-api/k6-experimental.md
@@ -4,7 +4,7 @@ title: javascript-api/k6-experimental
 
 | Modules                                                                                          | Description                                                                                                                |
 | ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
-| [csv](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/csv)               | Provides support for efficient and convinient of parsing CSV files.                                                        |
+| [csv](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/csv)               | Provides support for efficient and convenient parsing of CSV files.                                                     |
 | [fs](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/fs)                 | Provides a memory-efficient way to handle file interactions within your test scripts.                                      |
 | [redis](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/redis)           | Functionality to interact with [Redis](https://redis.io/).                                                                 |
 | [streams](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/streams)       | Provides an implementation of the Streams API specification, offering support for defining and consuming readable streams. |

--- a/docs/sources/k6/next/shared/javascript-api/k6-experimental.md
+++ b/docs/sources/k6/next/shared/javascript-api/k6-experimental.md
@@ -4,7 +4,7 @@ title: javascript-api/k6-experimental
 
 | Modules                                                                                          | Description                                                                                                                |
 | ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
-| [csv](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/fs)                | Provides support for efficient and convinient of parsing CSV files.                                                        |
+| [csv](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/csv)               | Provides support for efficient and convinient of parsing CSV files.                                                        |
 | [fs](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/fs)                 | Provides a memory-efficient way to handle file interactions within your test scripts.                                      |
 | [redis](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/redis)           | Functionality to interact with [Redis](https://redis.io/).                                                                 |
 | [streams](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/streams)       | Provides an implementation of the Streams API specification, offering support for defining and consuming readable streams. |


### PR DESCRIPTION
## What?

Documents the newly introduced `asObjects` option of the `k6/experimental/csv` module.

## Checklist

- [X] I have used a meaningful title for the PR.
- [X] I have described the changes I've made in the "What?" section above.
- [X] I have performed a self-review of my changes.
- [X] I have run the `npm start` command locally and verified that the changes look good.
- [X] I have made my changes in the `docs/sources/k6/next` folder of the documentation.

## Related PR(s)/Issue(s)

https://github.com/grafana/k6/pull/4295