### PR TITLE
TS support is on by default and reword compatibility-mode page

### DIFF
--- a/docs/sources/k6/next/get-started/write-your-first-test.md
+++ b/docs/sources/k6/next/get-started/write-your-first-test.md
@@ -45,25 +45,29 @@ Let’s walk through creating a simple test which performs 10 `GET` HTTP request
 
 2. **Import k6 modules**: As the end goal here is to perform HTTP requests, import the k6 `http` module at the top of the file. To help simulate a real-world scenario, import the `sleep` function from the `k6` module as well.
 
-   ```javascript
-   // Import the http module to make HTTP requests. From this point, you can use `http` methods to make HTTP requests.
-   import http from 'k6/http';
+<!--md-k6:skip-->
 
-   // Import the sleep function to introduce delays. From this point, you can use the `sleep` function to introduce delays in your test script.
-   import { sleep } from 'k6';
-   ```
+```javascript
+// Import the http module to make HTTP requests. From this point, you can use `http` methods to make HTTP requests.
+import http from 'k6/http';
+
+// Import the sleep function to introduce delays. From this point, you can use the `sleep` function to introduce delays in your test script.
+import { sleep } from 'k6';
+```
 
 3. **Define options**: To perform 10 HTTP requests, define an options block to configure the test execution. In this case, set the number of iterations to 10 to instruct k6 to execute the default function 10 times. Right beneath the imports, add the following code:
 
-   ```javascript
-   import http from 'k6/http';
-   import { sleep } from 'k6';
+<!--md-k6:skip-->
 
-   export const options = {
-     // Define the number of iterations for the test
-     iterations: 10,
-   };
-   ```
+```javascript
+import http from 'k6/http';
+import { sleep } from 'k6';
+
+export const options = {
+  // Define the number of iterations for the test
+  iterations: 10,
+};
+```
 
 4. **Define a default function**: The default exported function is the entry point for the test script. It will be executed repeatedly the number of times you define with the `iterations` option. In this function, make a `GET` request to a URL and introduce a 1-second delay between requests. Add the following code to your script:
 

--- a/docs/sources/k6/next/get-started/write-your-first-test.md
+++ b/docs/sources/k6/next/get-started/write-your-first-test.md
@@ -90,7 +90,7 @@ Let’s walk through creating a simple test which performs 10 `GET` HTTP request
 After you're comfortable with this basic script, you can extend its functionality in many ways. Here are a few ideas to get you started:
 
 1. **Multiple requests**: You can add more `http.get()` or `http.post()` requests to simulate complex user flows.
-2. **Using TypeScript**: If you prefer TypeScript, k6 also supports it. You can learn more in our [TypeScript guide](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/javascript-typescript-compatibility-mode/#experimental-enhanced-mode).
+2. **Using TypeScript**: If you prefer TypeScript, k6 also supports it. You can learn more in our [TypeScript guide](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/javascript-typescript-compatibility-mode/#typescript-support).
 3. **Thresholds, checks, and metrics**: You can add conditions to monitor performance. For example, you can set thresholds to ensure the response time doesn’t exceed a certain limit. Refer to [Thresholds](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/thresholds/) and [Checks](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/checks/) for more details.
 4. **Browser tests**: Use the browser module to simulate user interactions like clicking buttons or filling out forms. This is useful for testing web applications. Refer to [Using k6 browser](https://grafana.com/docs/k6/<K6_VERSION>/using-k6-browser/) for more details.
 

--- a/docs/sources/k6/next/using-k6/javascript-typescript-compatibility-mode.md
+++ b/docs/sources/k6/next/using-k6/javascript-typescript-compatibility-mode.md
@@ -3,26 +3,24 @@ aliases:
   - ./javascript-compatibility-mode/ # /docs/k6/<K6_VERSION>/using-k6/javascript-compatibility-mode/
 title: JavaScript and TypeScript compatibility mode
 menuTitle: JavaScript and TypeScript mode
-excerpt: 'k6 supports running test scripts with different ECMAScript and TypeScript compatibility modes using --compatibility-mode'
+excerpt: 'k6 supports running test scripts with different compatibility modes using --compatibility-mode'
 weight: 19
 ---
 
-# JavaScript and TypeScript compatibility mode
+# JavaScript compatibility mode
 
-You can write k6 tests in various ECMAScript versions:
+This is option most users should no longer be using.
 
-- ES6+ JavaScript with ES modules (ESM).
-- ES6+ JavaScript with CommonJS modules.
+In previous versions k6 used to not natively support as much of the ECMAScript standard as was desired. For this reason the default mode used to use babel internally to add support for what was missing. This though had performance impact on starting k6 and might still not have supported as much as was desired. As such a different mode without babel (and core.js) was added that was much faster in initialization, but likely required transpilation from the user.
 
-k6 supports both module types and most ES6+ features in all k6 execution modes: local, distributed, and cloud.
+Since v0.53.0 this hasn't been needed and in general this option has minimal usability and is likely to be removed completely in future versions. See [issue](https://github.com/grafana/k6/issues/3864) for the last remaining difference.
 
-Additionally, k6 also has experimental support for [esbuild](https://esbuild.github.io/), to transpile TypeScript (TS) code.
+Additionally, k6 also has support for [esbuild](https://esbuild.github.io/), to transpile TypeScript (TS) code. This used to use compatibility-mode but is now enabled by default and no configuration is required.
 
 Some users prefer to bundle their test code outside k6. For this reason, k6 offers three JavaScript compatibility modes:
 
-- [Extended mode](#extended-mode): The default option.
-- [Experimental enhanced mode](#experimental-enhanced-mode): The experimental option, supporting TS.
-- [Base mode](#base-mode): After v0.53.0 this is almost the same as extended, but doesn't alias `global` to `globalThis` - a nodejs compatibility.
+- [Extended mode](#extended-mode): The default option. That is `base` + aliasing `global` to `globalThis` - a nodejs compatibility.
+- [Base mode](#base-mode): Only using native support in k6 and the underlying JS engine. After v0.53.0 it has the same functionality as `extended` apart from the `global` aliasing.
 
 When running tests, you can change the mode by using the `--compatibility-mode` option:
 
@@ -44,23 +42,23 @@ $ k6 run script.js
 
 After v0.53.0 the only difference with base is that `global` (node's global variable) is aliased to the value of `globalThis`.
 
-## Experimental enhanced mode
+## Typescript support
 
 {{< code >}}
 
 ```cli
-$ k6 run --compatibility-mode=experimental_enhanced script.ts
+$ k6 run script.ts
 ```
 
 ```env
-$ K6_COMPATIBILITY_MODE=experimental_enhanced k6 run script.ts
+$ k6 run script.ts
 ```
 
 {{< /code >}}
 
-The experimental enhanced mode is similar to the extended mode, but it uses [esbuild](https://esbuild.github.io/) instead of Babel to transpile TypeScript (TS) code.
+It uses [esbuild](https://esbuild.github.io/) to transpile TypeScript (TS) code for all files that have the `.ts` extension.
 
-TypeScript support is partial as it removes the type information but doesn't provide type safety.
+TypeScript support is partial as it strips the type information but doesn't provide type safety.
 
 ## Base mode
 
@@ -75,8 +73,6 @@ $ K6_COMPATIBILITY_MODE=base k6 run script.js
 ```
 
 {{< /code >}}
-
-After v0.53.0 there isn't a big reason to use this. Before that it was dropping ESM support for usually improved startup speed.
 
 ### CommonJS Example
 

--- a/docs/sources/k6/next/using-k6/modules.md
+++ b/docs/sources/k6/next/using-k6/modules.md
@@ -355,7 +355,7 @@ $ k6 run dist/signup.bundle.js \
 
 ## Use TypeScript
 
-k6 supports partial TypeScript support with the `experimental_enhanced` compatibility mode. For more details, refer to [JavaScript and TypeScript compatibility mode](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/javascript-typescript-compatibility-mode/).
+k6 supports partial TypeScript support. For more details, refer to [JavaScript and TypeScript compatibility mode](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/javascript-typescript-compatibility-mode/).
 
 ## Use modules with Docker
 

--- a/docs/sources/k6/next/using-k6/modules.md
+++ b/docs/sources/k6/next/using-k6/modules.md
@@ -24,6 +24,8 @@ For example, the `http` client make requests against the
 system under test.
 For the full list of built-in modules, refer to the [API documentation](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api).
 
+<!--md-k6:skip-->
+
 ```javascript
 import http from 'k6/http';
 ```
@@ -34,6 +36,8 @@ These modules are stored on the local filesystem, and accessed either through re
 
 k6 adopts a **browser-like module resolution** and doesn't support [Node.js module resolution](https://nodejs.org/api/modules.html#modules_all_together). File names for `imports` must be fully specified, such as `./helpers.js`.
 
+<!--md-k6:skip-->
+
 ```javascript
 //my-test.js
 import { someHelper } from './helpers.js';
@@ -42,6 +46,8 @@ export default function () {
   someHelper();
 }
 ```
+
+<!--md-k6:skip-->
 
 ```javascript
 //helpers.js
@@ -63,7 +69,7 @@ For example, [jslib](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jsl
 import { randomItem } from 'https://jslib.k6.io/k6-utils/1.2.0/index.js';
 
 export default function () {
-  randomItem();
+  randomItem([1, 2, 3]);
 }
 ```
 
@@ -74,6 +80,8 @@ You can also build your custom Javascript libraries and distribute them via a pu
 Like the [k6 APIs](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api), you can build custom modules in Go code and expose them as JavaScript modules. These custom Go-to-JS modules are known as [k6 extensions](https://grafana.com/docs/k6/<K6_VERSION>/extensions).
 
 Below is an example that imports the `k6/x/kubernetes` module from the [xk6-kubernetes](https://github.com/grafana/xk6-kubernetes) extension.
+
+<!--md-k6:skip-->
 
 ```javascript
 import { Kubernetes } from 'k6/x/kubernetes';
@@ -120,6 +128,8 @@ The following options for distributing and sharing JavaScript libraries are avai
 
 You can host your modules in a public webserver like GitHub and any CDN and be imported remotely.
 
+<!--md-k6:skip-->
+
 ```javascript
 // As GitHub release assets
 import {
@@ -142,6 +152,8 @@ Be aware that k6 automatically executes remote modules, making it crucial to tru
 
 In this example, the previous remote modules have been downloaded to the `lib` folder of the testing project and imported as follows:
 
+<!--md-k6:skip-->
+
 ```javascript
 import { WorkloadConfig, sayHello } from './libs/test-commons.js';
 
@@ -161,6 +173,8 @@ k6 isn't Node.js or a browser. Packages that rely on APIs provided by Node.js, f
 {{< /admonition >}}
 
 In a JavaScript project running Node.js, modules are imported using either `import` or `require()`, using the Node.js module resolution algorithm. This means that a user can import modules by name, without providing the full filesystem path to the module. For instance:
+
+<!--md-k6:skip-->
 
 ```javascript
 import { ClassInAModule } from 'cool-module';
@@ -230,6 +244,8 @@ $ npm install --save-dev \
 
 Once these packages have been added, the next step will be to set up a `webpack.config.js` file:
 
+<!--md-k6:skip-->
+
 ```javascript
 const path = require('path');
 
@@ -263,6 +279,8 @@ The files Webpack will use as its entry points while performing the bundling. Fr
 Webpack will automatically traverse all imports recursively until every possible dependency path has
 been exhausted. For instance:
 
+<!--md-k6:skip-->
+
 ```javascript
 // login.test.js
 
@@ -272,6 +290,8 @@ const svc = new SomeService();
 ```
 
 and:
+
+<!--md-k6:skip-->
 
 ```javascript
 // some.service.js
@@ -372,6 +392,8 @@ For example, say you have the following structure on your host machine:
 
 {{< code >}}
 
+<!--md-k6:skip-->
+
 ```javascript
 import { hello_world } from './modules/module.js';
 
@@ -383,6 +405,8 @@ export default function () {
 {{< /code >}}
 
 {{< code >}}
+
+<!--md-k6:skip-->
 
 ```javascript
 export function hello_world() {


### PR DESCRIPTION
## What?
Document k6 supporting ts without additional options https://github.com/grafana/k6/pull/4292.

Also rewords compatibility-mode page as it really shouldn't be a thing most users are looking at.

Arguably Typescript support should have it own page or something like this instead of piggy backing on compatibility-mode at this point.
## Checklist

<!-- Please fill in this template: -->
- [ ] I have used a meaningful title for the PR.
- [ ] I have described the changes I've made in the "What?" section above.
- [ ] I have performed a self-review of my changes.
- [ ] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [ ] I have made my changes in the `docs/sources/k6/next` folder of the documentation.
- [ ] I have reflected my changes in the `docs/sources/k6/v{most_recent_release}` folder of the documentation.
- [ ] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->

<!-- 2. If updating the documentation for the next release of k6: -->
- [ ] I have made my changes in the `docs/sources/k6/next` folder of the documentation.

## Related PR(s)/Issue(s)
Documents https://github.com/grafana/k6/pull/4292 