### PR TITLE
Update Kind `K6` to `TestRun`

### DIFF
--- a/docs/sources/k6/next/get-started/running-k6.md
+++ b/docs/sources/k6/next/get-started/running-k6.md
@@ -210,12 +210,12 @@ k6 supports three execution modes to run a k6 test: local, distributed, and clou
 
 - **Distributed**: the test execution is [distributed across a Kubernetes cluster](https://k6.io/blog/running-distributed-tests-on-k8s/).
 
-  Save the following YAML as `k6-resource.yaml`:
+  Save the following YAML as `k6-testrun-resource.yaml`:
 
   ```yaml
   ---
   apiVersion: k6.io/v1alpha1
-  kind: K6
+  kind: TestRun
   metadata:
     name: k6-sample
   spec:
@@ -229,7 +229,7 @@ k6 supports three execution modes to run a k6 test: local, distributed, and clou
   Apply the resource with the following command:
 
   ```bash
-  kubectl apply -f /path/to/k6-resource.yaml
+  kubectl apply -f /path/to/k6-testrun-resource.yaml
   ```
 
 - **Cloud**: the test runs on [Grafana Cloud k6](https://grafana.com/docs/grafana-cloud/testing/k6/get-started/run-cloud-tests-from-the-cli/).

--- a/docs/sources/k6/next/set-up/set-up-distributed-k6/install-k6-operator.md
+++ b/docs/sources/k6/next/set-up/set-up-distributed-k6/install-k6-operator.md
@@ -71,12 +71,6 @@ The k6 Operator includes custom resources called `TestRun`, `PrivateLoadZone`, a
 make install
 ```
 
-{{< admonition type="warning" >}}
-
-The `K6` CRD has been replaced by the `TestRun` CRD and will be deprecated in the future. We recommend using the `TestRun` CRD.
-
-{{< /admonition >}}
-
 ## Watch namespace
 
 By default, the k6 Operator watches the `TestRun` and `PrivateLoadZone` custom resources in all namespaces. You can also configure the k6 Operator to watch a specific namespace by setting the `WATCH_NAMESPACE` environment variable for the operator's deployment:

--- a/docs/sources/k6/v0.56.x/get-started/running-k6.md
+++ b/docs/sources/k6/v0.56.x/get-started/running-k6.md
@@ -210,12 +210,12 @@ k6 supports three execution modes to run a k6 test: local, distributed, and clou
 
 - **Distributed**: the test execution is [distributed across a Kubernetes cluster](https://k6.io/blog/running-distributed-tests-on-k8s/).
 
-  Save the following YAML as `k6-resource.yaml`:
+  Save the following YAML as `k6-testrun-resource.yaml`:
 
   ```yaml
   ---
   apiVersion: k6.io/v1alpha1
-  kind: K6
+  kind: TestRun
   metadata:
     name: k6-sample
   spec:
@@ -229,7 +229,7 @@ k6 supports three execution modes to run a k6 test: local, distributed, and clou
   Apply the resource with the following command:
 
   ```bash
-  kubectl apply -f /path/to/k6-resource.yaml
+  kubectl apply -f /path/to/k6-testrun-resource.yaml
   ```
 
 - **Cloud**: the test runs on [Grafana Cloud k6](https://grafana.com/docs/grafana-cloud/testing/k6/get-started/run-cloud-tests-from-the-cli/).

--- a/docs/sources/k6/v0.56.x/set-up/set-up-distributed-k6/install-k6-operator.md
+++ b/docs/sources/k6/v0.56.x/set-up/set-up-distributed-k6/install-k6-operator.md
@@ -71,12 +71,6 @@ The k6 Operator includes custom resources called `TestRun`, `PrivateLoadZone`, a
 make install
 ```
 
-{{< admonition type="warning" >}}
-
-The `K6` CRD has been replaced by the `TestRun` CRD and will be deprecated in the future. We recommend using the `TestRun` CRD.
-
-{{< /admonition >}}
-
 ## Watch namespace
 
 By default, the k6 Operator watches the `TestRun` and `PrivateLoadZone` custom resources in all namespaces. You can also configure the k6 Operator to watch a specific namespace by setting the `WATCH_NAMESPACE` environment variable for the operator's deployment:


### PR DESCRIPTION
## What?
Update resource Kind to TestRun since the K6 CRD has been deprecated.

Commit removing the K6 CRD: https://github.com/grafana/k6-operator/commit/b9627bb8941a304a6f23586e4302c596b0638abe#diff-a58710028eee01ef4372e98c17d32838cbcb10b4c1332fc46e2aaf141699c701

Should this warning message be updated as well?
https://grafana.com/docs/k6/latest/set-up/set-up-distributed-k6/install-k6-operator/#install-the-crd

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.
