### PR TITLE
Fix url to point to the correct section of the docs

### DIFF
--- a/docs/sources/k6/next/misc/archive.md
+++ b/docs/sources/k6/next/misc/archive.md
@@ -101,7 +101,7 @@ k6 cloud upload archive.tar
 
 ### Distributed Execution
 
-[k6-operator](https://github.com/grafana/k6-operator#multi-file-tests) can distribute a k6 test across a Kubernetes cluster.
+[k6-operator](https://grafana.com/docs/k6/<K6_VERSION>/set-up/set-up-distributed-k6/usage/executing-k6-scripts-with-testrun-crd/#multi-file-tests) can distribute a k6 test across a Kubernetes cluster.
 
 When a k6 test has multiple files, you can use the archive functionality to bundle the k6 test in a single _archived_ file and pass this file to run the test.
 

--- a/docs/sources/k6/v0.56.x/misc/archive.md
+++ b/docs/sources/k6/v0.56.x/misc/archive.md
@@ -101,7 +101,7 @@ k6 cloud upload archive.tar
 
 ### Distributed Execution
 
-[k6-operator](https://github.com/grafana/k6-operator#multi-file-tests) can distribute a k6 test across a Kubernetes cluster.
+[k6-operator](https://grafana.com/docs/k6/<K6_VERSION>/set-up/set-up-distributed-k6/usage/executing-k6-scripts-with-testrun-crd/#multi-file-tests) can distribute a k6 test across a Kubernetes cluster.
 
 When a k6 test has multiple files, you can use the archive functionality to bundle the k6 test in a single _archived_ file and pass this file to run the test.
 


### PR DESCRIPTION
## What?

The documentation is no longer in Github: https://github.com/grafana/k6-operator/commit/4b0b7626d7268dca0dce407c049510f71be5a4e2#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L312, it has been moved to k6-docs (here).

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.
