### PR TITLE
Add redirect from removed crawl webpage example

### DIFF
--- a/docs/sources/k6/next/using-k6-browser/_index.md
+++ b/docs/sources/k6/next/using-k6-browser/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - ./examples/crawl-webpage # docs/k6/<K6_VERSION>/examples/crawl-webpage
 title: Using k6 browser
 description: 'The browser module brings browser automation and end-to-end testing to k6 while supporting core k6 features. Interact with real browsers and collect frontend metrics as part of your k6 tests.'
 weight: 300

--- a/docs/sources/k6/v0.55.x/using-k6-browser/_index.md
+++ b/docs/sources/k6/v0.55.x/using-k6-browser/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - ./examples/crawl-webpage # docs/k6/<K6_VERSION>/examples/crawl-webpage
 title: Using k6 browser
 description: 'The browser module brings browser automation and end-to-end testing to k6 while supporting core k6 features. Interact with real browsers and collect frontend metrics as part of your k6 tests.'
 weight: 300
@@ -58,18 +60,15 @@ export default async function () {
   const page = await context.newPage();
 
   try {
-    await page.goto("https://test.k6.io/my_messages.php");
+    await page.goto('https://test.k6.io/my_messages.php');
 
-    await page.locator('input[name="login"]').type("admin");
-    await page.locator('input[name="password"]').type("123");
+    await page.locator('input[name="login"]').type('admin');
+    await page.locator('input[name="password"]').type('123');
 
-    await Promise.all([
-      page.waitForNavigation(),
-      page.locator('input[type="submit"]').click(),
-    ]);
+    await Promise.all([page.waitForNavigation(), page.locator('input[type="submit"]').click()]);
 
-    await check(page.locator("h2"), {
-      'header': async h2 => await h2.textContent() == "Welcome, admin!"
+    await check(page.locator('h2'), {
+      header: async (h2) => (await h2.textContent()) == 'Welcome, admin!',
     });
   } finally {
     await page.close();

--- a/docs/sources/k6/v0.56.x/using-k6-browser/_index.md
+++ b/docs/sources/k6/v0.56.x/using-k6-browser/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - ./examples/crawl-webpage # docs/k6/<K6_VERSION>/examples/crawl-webpage
 title: Using k6 browser
 description: 'The browser module brings browser automation and end-to-end testing to k6 while supporting core k6 features. Interact with real browsers and collect frontend metrics as part of your k6 tests.'
 weight: 300

--- a/docs/sources/k6/v0.57.x/using-k6-browser/_index.md
+++ b/docs/sources/k6/v0.57.x/using-k6-browser/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - ./examples/crawl-webpage # docs/k6/<K6_VERSION>/examples/crawl-webpage
 title: Using k6 browser
 description: 'The browser module brings browser automation and end-to-end testing to k6 while supporting core k6 features. Interact with real browsers and collect frontend metrics as part of your k6 tests.'
 weight: 300


### PR DESCRIPTION
## What?

Add redirects from removed web crawl example page to Using k6 browser section.

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [x] I have made my changes in the `docs/sources/k6/next` folder of the documentation.
- [x] I have reflected my changes in the `docs/sources/k6/v{most_recent_release}` folder of the documentation.
- [x] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->

## Related PR(s)/Issue(s)

Related to https://github.com/grafana/k6-docs/pull/1879/.