### PR TITLE
relref replace - k6

### DIFF
--- a/docs/sources/k6/next/extensions/_index.md
+++ b/docs/sources/k6/next/extensions/_index.md
@@ -11,15 +11,15 @@ Expand the potential use cases for k6.
 ## Quickstart
 
 <div class="nav-cards">
-    <a href={{< relref "./explore" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=explore/ class="nav-cards__item nav-cards__item--guide">
         <h4>🔎 Explore</h4>
         <p>A list of more than 50 available extensions.</p>
     </a>
-    <a href={{< relref "./build-k6-binary-using-go" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=build-k6-binary-using-go/ class="nav-cards__item nav-cards__item--guide">
         <h4>🧩 Bundle</h4>
         <p>Combine multiple extensions into a custom k6 binary.</p>
     </a>
-    <a href={{< relref "./create/" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=create/ class="nav-cards__item nav-cards__item--guide">
         <h4>🏗️ Create</h4>
         <p>Learn how to make your own k6 extension.</p>
     </a>

--- a/docs/sources/k6/next/shared/blocking-aws-blockquote.md
+++ b/docs/sources/k6/next/shared/blocking-aws-blockquote.md
@@ -7,6 +7,6 @@ title: jslib/aws module blocking admonition
 In some cases, using this library&apos;s operations might impact performance and skew your test results.
 <br>
 <br>
-To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions](../../using-k6/test-lifecycle/). These functions run before and after the test run and have no impact on the test results.
+To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions](/docs/k6/<K6_VERSION>/using-k6/test-lifecycle). These functions run before and after the test run and have no impact on the test results.
 
 {{< /admonition >}}

--- a/docs/sources/k6/next/shared/blocking-aws-blockquote.md
+++ b/docs/sources/k6/next/shared/blocking-aws-blockquote.md
@@ -7,6 +7,6 @@ title: jslib/aws module blocking admonition
 In some cases, using this library&apos;s operations might impact performance and skew your test results.
 <br>
 <br>
-To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions]({{< relref "../using-k6/test-lifecycle" >}}). These functions run before and after the test run and have no impact on the test results.
+To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions](../../using-k6/test-lifecycle/). These functions run before and after the test run and have no impact on the test results.
 
 {{< /admonition >}}

--- a/docs/sources/k6/next/shared/crypto-module.md
+++ b/docs/sources/k6/next/shared/crypto-module.md
@@ -7,6 +7,6 @@ title: k6/crypto module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/webcrypto API]({{< relref "../javascript-api/k6-experimental/webcrypto" >}}) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto]({{< relref "../javascript-api/k6-crypto" >}}).
+The new [k6/experimental/webcrypto API](../../javascript-api/k6-experimental/webcrypto/) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto](../../javascript-api/k6-crypto/).
 
 {{< /admonition >}}

--- a/docs/sources/k6/next/shared/crypto-module.md
+++ b/docs/sources/k6/next/shared/crypto-module.md
@@ -7,6 +7,6 @@ title: k6/crypto module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/webcrypto API](../../javascript-api/k6-experimental/webcrypto/) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto](../../javascript-api/k6-crypto/).
+The new [k6/experimental/webcrypto API](/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/webcrypto/) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto](/docs/k6/<K6_VERSION>/javascript-api/k6-crypto/).
 
 {{< /admonition >}}

--- a/docs/sources/k6/next/shared/experimental-module.md
+++ b/docs/sources/k6/next/shared/experimental-module.md
@@ -7,7 +7,7 @@ title: Experimental module admonition
 This is an experimental module.
 <br>
 <br>
-While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process]({{< relref "../extensions/explanations/extension-graduation" >}}).
+While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process](../../extensions/explanations/extension-graduation/).
 <br>
 <br>
 Experimental modules maintain a high level of stability and follow regular maintenance and security measures. Feel free to [open an issue](https://github.com/grafana/k6/issues) if you have any feedback or suggestions.

--- a/docs/sources/k6/next/shared/experimental-module.md
+++ b/docs/sources/k6/next/shared/experimental-module.md
@@ -7,7 +7,7 @@ title: Experimental module admonition
 This is an experimental module.
 <br>
 <br>
-While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process](../../extensions/explanations/extension-graduation/).
+While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process](/docs/k6/<K6_VERSION>/extensions/explanations/extension-graduation/).
 <br>
 <br>
 Experimental modules maintain a high level of stability and follow regular maintenance and security measures. Feel free to [open an issue](https://github.com/grafana/k6/issues) if you have any feedback or suggestions.

--- a/docs/sources/k6/next/shared/ws-module.md
+++ b/docs/sources/k6/next/shared/ws-module.md
@@ -7,7 +7,7 @@ title: k6/ws module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/websockets API]({{< relref "../javascript-api/k6-experimental/websockets" >}}) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
+The new [k6/experimental/websockets API](../../javascript-api/k6-experimental/websockets/) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
 <br>
 <br>
 When possible, we recommend using the new API. It uses a global event loop for consistency with other k6 APIs and better performance.

--- a/docs/sources/k6/next/shared/ws-module.md
+++ b/docs/sources/k6/next/shared/ws-module.md
@@ -7,7 +7,7 @@ title: k6/ws module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/websockets API](../../javascript-api/k6-experimental/websockets/) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
+The new [k6/experimental/websockets API](/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/websockets/) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
 <br>
 <br>
 When possible, we recommend using the new API. It uses a global event loop for consistency with other k6 APIs and better performance.

--- a/docs/sources/k6/v0.47.x/_index.md
+++ b/docs/sources/k6/v0.47.x/_index.md
@@ -14,15 +14,15 @@ This documentation will help you go from a total beginner to a seasoned k6 exper
 ## Get started
 
 <div class="nav-cards">
-    <a href={{< relref "./get-started/installation" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=get-started/installation/ class="nav-cards__item nav-cards__item--guide">
         <h4>🚀 Installation</h4>
         <p>Get up and running in no-time, using either a package manager, standalone installer or the official Docker image.</p>
     </a>
-    <a href={{< relref "./get-started/running-k6" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=get-started/running-k6/ class="nav-cards__item nav-cards__item--guide">
         <h4>🏎️💨 Running k6</h4>
         <p>Write and execute your first load test locally using JavaScript and the k6 API, adding multiple virtual users, checks and ramping stages.</p>
     </a>
-    <a href={{< relref "./get-started/results-output" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=get-started/results-output/ class="nav-cards__item nav-cards__item--guide">
         <h4>⏱ Results output</h4>
         <p>Learn how to leverage the results output to gain actionable insight about your application's performance.</p>
     </a>

--- a/docs/sources/k6/v0.47.x/extensions/_index.md
+++ b/docs/sources/k6/v0.47.x/extensions/_index.md
@@ -11,15 +11,15 @@ Expand the potential use cases for k6.
 ## Quickstart
 
 <div class="nav-cards">
-    <a href={{< relref "./explore" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=explore/ class="nav-cards__item nav-cards__item--guide">
         <h4>🔎 Explore</h4>
         <p>A list of more than 50 available extensions.</p>
     </a>
-    <a href={{< relref "./build-k6-binary-using-go" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=build-k6-binary-using-go/ class="nav-cards__item nav-cards__item--guide">
         <h4>🧩 Bundle</h4>
         <p>Combine multiple extensions into a custom k6 binary.</p>
     </a>
-    <a href={{< relref "./create/" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=create/ class="nav-cards__item nav-cards__item--guide">
         <h4>🏗️ Create</h4>
         <p>Learn how to make your own k6 extension.</p>
     </a>

--- a/docs/sources/k6/v0.47.x/shared/blocking-aws-blockquote.md
+++ b/docs/sources/k6/v0.47.x/shared/blocking-aws-blockquote.md
@@ -7,6 +7,6 @@ title: jslib/aws module blocking admonition
 In some cases, using this library&apos;s operations might impact performance and skew your test results.
 <br>
 <br>
-To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions](../../using-k6/test-lifecycle/). These functions run before and after the test run and have no impact on the test results.
+To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions](/docs/k6/<K6_VERSION>/using-k6/test-lifecycle/). These functions run before and after the test run and have no impact on the test results.
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.47.x/shared/blocking-aws-blockquote.md
+++ b/docs/sources/k6/v0.47.x/shared/blocking-aws-blockquote.md
@@ -7,6 +7,6 @@ title: jslib/aws module blocking admonition
 In some cases, using this library&apos;s operations might impact performance and skew your test results.
 <br>
 <br>
-To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions]({{< relref "../using-k6/test-lifecycle" >}}). These functions run before and after the test run and have no impact on the test results.
+To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions](../../using-k6/test-lifecycle/). These functions run before and after the test run and have no impact on the test results.
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.47.x/shared/crypto-module.md
+++ b/docs/sources/k6/v0.47.x/shared/crypto-module.md
@@ -7,6 +7,6 @@ title: k6/crypto module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/webcrypto API]({{< relref "../javascript-api/k6-experimental/webcrypto" >}}) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto]({{< relref "../javascript-api/k6-crypto" >}}).
+The new [k6/experimental/webcrypto API](../../javascript-api/k6-experimental/webcrypto/) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto](../../javascript-api/k6-crypto/).
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.47.x/shared/crypto-module.md
+++ b/docs/sources/k6/v0.47.x/shared/crypto-module.md
@@ -7,6 +7,6 @@ title: k6/crypto module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/webcrypto API](../../javascript-api/k6-experimental/webcrypto/) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto](../../javascript-api/k6-crypto/).
+The new [k6/experimental/webcrypto API](/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/webcrypto/) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto](/docs/k6/<K6_VERSION>/javascript-api/k6-crypto/).
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.47.x/shared/experimental-module.md
+++ b/docs/sources/k6/v0.47.x/shared/experimental-module.md
@@ -7,7 +7,7 @@ title: Experimental module admonition
 This is an experimental module.
 <br>
 <br>
-While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process]({{< relref "../extensions/explanations/extension-graduation" >}}).
+While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process](../../extensions/explanations/extension-graduation/).
 <br>
 <br>
 Experimental modules maintain a high level of stability and follow regular maintenance and security measures. Feel free to [open an issue](https://github.com/grafana/k6/issues) if you have any feedback or suggestions.

--- a/docs/sources/k6/v0.47.x/shared/experimental-module.md
+++ b/docs/sources/k6/v0.47.x/shared/experimental-module.md
@@ -7,7 +7,7 @@ title: Experimental module admonition
 This is an experimental module.
 <br>
 <br>
-While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process](../../extensions/explanations/extension-graduation/).
+While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process](/docs/k6/<K6_VERSION>/extensions/explanations/extension-graduation/).
 <br>
 <br>
 Experimental modules maintain a high level of stability and follow regular maintenance and security measures. Feel free to [open an issue](https://github.com/grafana/k6/issues) if you have any feedback or suggestions.

--- a/docs/sources/k6/v0.47.x/shared/grpc-module.md
+++ b/docs/sources/k6/v0.47.x/shared/grpc-module.md
@@ -7,6 +7,6 @@ title: k6/grpc module admonition
 A module with streaming support exists.
 <br>
 <br>
-The new [k6/experimental/grpc]({{< relref "../javascript-api/k6-experimental/grpc" >}}) module extends [k6/net/grpc]({{< relref "../javascript-api/k6-net-grpc" >}}) to support [gRPC streaming]({{< relref "../javascript-api/k6-experimental/grpc/stream" >}}). We recommend using the new module.
+The new [k6/experimental/grpc](../../javascript-api/k6-experimental/grpc/) module extends [k6/net/grpc](../../javascript-api/k6-net-grpc/) to support [gRPC streaming](../../javascript-api/k6-experimental/grpc/stream/). We recommend using the new module.
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.47.x/shared/grpc-module.md
+++ b/docs/sources/k6/v0.47.x/shared/grpc-module.md
@@ -7,6 +7,6 @@ title: k6/grpc module admonition
 A module with streaming support exists.
 <br>
 <br>
-The new [k6/experimental/grpc](../../javascript-api/k6-experimental/grpc/) module extends [k6/net/grpc](../../javascript-api/k6-net-grpc/) to support [gRPC streaming](../../javascript-api/k6-experimental/grpc/stream/). We recommend using the new module.
+The new [k6/experimental/grpc](/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/grpc/) module extends [k6/net/grpc](/docs/k6/<K6_VERSION>/javascript-api/k6-net-grpc/) to support [gRPC streaming](/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/grpc/stream/). We recommend using the new module.
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.47.x/shared/ws-module.md
+++ b/docs/sources/k6/v0.47.x/shared/ws-module.md
@@ -7,7 +7,7 @@ title: k6/ws module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/websockets API]({{< relref "../javascript-api/k6-experimental/websockets" >}}) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
+The new [k6/experimental/websockets API](../../javascript-api/k6-experimental/websockets/) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
 <br>
 <br>
 When possible, we recommend using the new API. It uses a global event loop for consistency with other k6 APIs and better performance.

--- a/docs/sources/k6/v0.47.x/shared/ws-module.md
+++ b/docs/sources/k6/v0.47.x/shared/ws-module.md
@@ -7,7 +7,7 @@ title: k6/ws module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/websockets API](../../javascript-api/k6-experimental/websockets/) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
+The new [k6/experimental/websockets API](/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/websockets/) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
 <br>
 <br>
 When possible, we recommend using the new API. It uses a global event loop for consistency with other k6 APIs and better performance.

--- a/docs/sources/k6/v0.48.x/_index.md
+++ b/docs/sources/k6/v0.48.x/_index.md
@@ -14,15 +14,15 @@ This documentation will help you go from a total beginner to a seasoned k6 exper
 ## Get started
 
 <div class="nav-cards">
-    <a href={{< relref "./get-started/installation" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=get-started/installation/ class="nav-cards__item nav-cards__item--guide">
         <h4>🚀 Installation</h4>
         <p>Get up and running in no-time, using either a package manager, standalone installer or the official Docker image.</p>
     </a>
-    <a href={{< relref "./get-started/running-k6" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=get-started/running-k6/ class="nav-cards__item nav-cards__item--guide">
         <h4>🏎️💨 Running k6</h4>
         <p>Write and execute your first load test locally using JavaScript and the k6 API, adding multiple virtual users, checks and ramping stages.</p>
     </a>
-    <a href={{< relref "./get-started/results-output" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=get-started/results-output/ class="nav-cards__item nav-cards__item--guide">
         <h4>⏱ Results output</h4>
         <p>Learn how to leverage the results output to gain actionable insight about your application's performance.</p>
     </a>

--- a/docs/sources/k6/v0.48.x/extensions/_index.md
+++ b/docs/sources/k6/v0.48.x/extensions/_index.md
@@ -11,15 +11,15 @@ Expand the potential use cases for k6.
 ## Quickstart
 
 <div class="nav-cards">
-    <a href={{< relref "./explore" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=explore/ class="nav-cards__item nav-cards__item--guide">
         <h4>🔎 Explore</h4>
         <p>A list of more than 50 available extensions.</p>
     </a>
-    <a href={{< relref "./build-k6-binary-using-go" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=build-k6-binary-using-go/ class="nav-cards__item nav-cards__item--guide">
         <h4>🧩 Bundle</h4>
         <p>Combine multiple extensions into a custom k6 binary.</p>
     </a>
-    <a href={{< relref "./create/" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=create/ class="nav-cards__item nav-cards__item--guide">
         <h4>🏗️ Create</h4>
         <p>Learn how to make your own k6 extension.</p>
     </a>

--- a/docs/sources/k6/v0.48.x/shared/blocking-aws-blockquote.md
+++ b/docs/sources/k6/v0.48.x/shared/blocking-aws-blockquote.md
@@ -7,6 +7,6 @@ title: jslib/aws module blocking admonition
 In some cases, using this library&apos;s operations might impact performance and skew your test results.
 <br>
 <br>
-To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions](../../using-k6/test-lifecycle/). These functions run before and after the test run and have no impact on the test results.
+To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions](/docs/k6/<K6_VERSION>/using-k6/test-lifecycle/). These functions run before and after the test run and have no impact on the test results.
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.48.x/shared/blocking-aws-blockquote.md
+++ b/docs/sources/k6/v0.48.x/shared/blocking-aws-blockquote.md
@@ -7,6 +7,6 @@ title: jslib/aws module blocking admonition
 In some cases, using this library&apos;s operations might impact performance and skew your test results.
 <br>
 <br>
-To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions]({{< relref "../using-k6/test-lifecycle" >}}). These functions run before and after the test run and have no impact on the test results.
+To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions](../../using-k6/test-lifecycle/). These functions run before and after the test run and have no impact on the test results.
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.48.x/shared/crypto-module.md
+++ b/docs/sources/k6/v0.48.x/shared/crypto-module.md
@@ -7,6 +7,6 @@ title: k6/crypto module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/webcrypto API]({{< relref "../javascript-api/k6-experimental/webcrypto" >}}) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto]({{< relref "../javascript-api/k6-crypto" >}}).
+The new [k6/experimental/webcrypto API](../../javascript-api/k6-experimental/webcrypto/) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto](../../javascript-api/k6-crypto/).
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.48.x/shared/crypto-module.md
+++ b/docs/sources/k6/v0.48.x/shared/crypto-module.md
@@ -7,6 +7,6 @@ title: k6/crypto module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/webcrypto API](../../javascript-api/k6-experimental/webcrypto/) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto](../../javascript-api/k6-crypto/).
+The new [k6/experimental/webcrypto API](/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/webcrypto/) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto](/docs/k6/<K6_VERSION>/javascript-api/k6-crypto/).
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.48.x/shared/experimental-module.md
+++ b/docs/sources/k6/v0.48.x/shared/experimental-module.md
@@ -7,7 +7,7 @@ title: Experimental module admonition
 This is an experimental module.
 <br>
 <br>
-While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process]({{< relref "../extensions/explanations/extension-graduation" >}}).
+While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process](../../extensions/explanations/extension-graduation/).
 <br>
 <br>
 Experimental modules maintain a high level of stability and follow regular maintenance and security measures. Feel free to [open an issue](https://github.com/grafana/k6/issues) if you have any feedback or suggestions.

--- a/docs/sources/k6/v0.48.x/shared/experimental-module.md
+++ b/docs/sources/k6/v0.48.x/shared/experimental-module.md
@@ -7,7 +7,7 @@ title: Experimental module admonition
 This is an experimental module.
 <br>
 <br>
-While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process](../../extensions/explanations/extension-graduation/).
+While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process](/docs/k6/<K6_VERSION>/extensions/explanations/extension-graduation/).
 <br>
 <br>
 Experimental modules maintain a high level of stability and follow regular maintenance and security measures. Feel free to [open an issue](https://github.com/grafana/k6/issues) if you have any feedback or suggestions.

--- a/docs/sources/k6/v0.48.x/shared/grpc-module.md
+++ b/docs/sources/k6/v0.48.x/shared/grpc-module.md
@@ -7,6 +7,6 @@ title: k6/grpc module admonition
 A module with streaming support exists.
 <br>
 <br>
-The new [k6/experimental/grpc]({{< relref "../javascript-api/k6-experimental/grpc" >}}) module extends [k6/net/grpc]({{< relref "../javascript-api/k6-net-grpc" >}}) to support [gRPC streaming]({{< relref "../javascript-api/k6-experimental/grpc/stream" >}}). We recommend using the new module.
+The new [k6/experimental/grpc](../../javascript-api/k6-experimental/grpc/) module extends [k6/net/grpc](../../javascript-api/k6-net-grpc/) to support [gRPC streaming](../../javascript-api/k6-experimental/grpc/stream/). We recommend using the new module.
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.48.x/shared/grpc-module.md
+++ b/docs/sources/k6/v0.48.x/shared/grpc-module.md
@@ -7,6 +7,6 @@ title: k6/grpc module admonition
 A module with streaming support exists.
 <br>
 <br>
-The new [k6/experimental/grpc](../../javascript-api/k6-experimental/grpc/) module extends [k6/net/grpc](../../javascript-api/k6-net-grpc/) to support [gRPC streaming](../../javascript-api/k6-experimental/grpc/stream/). We recommend using the new module.
+The new [k6/experimental/grpc](/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/grpc/) module extends [k6/net/grpc](/docs/k6/<K6_VERSION>/javascript-api/k6-net-grpc/) to support [gRPC streaming](/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/grpc/stream/). We recommend using the new module.
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.48.x/shared/ws-module.md
+++ b/docs/sources/k6/v0.48.x/shared/ws-module.md
@@ -7,7 +7,7 @@ title: k6/ws module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/websockets API]({{< relref "../javascript-api/k6-experimental/websockets" >}}) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
+The new [k6/experimental/websockets API](../../javascript-api/k6-experimental/websockets/) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
 <br>
 <br>
 When possible, we recommend using the new API. It uses a global event loop for consistency with other k6 APIs and better performance.

--- a/docs/sources/k6/v0.48.x/shared/ws-module.md
+++ b/docs/sources/k6/v0.48.x/shared/ws-module.md
@@ -7,7 +7,7 @@ title: k6/ws module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/websockets API](../../javascript-api/k6-experimental/websockets/) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
+The new [k6/experimental/websockets API](/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/websockets/) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
 <br>
 <br>
 When possible, we recommend using the new API. It uses a global event loop for consistency with other k6 APIs and better performance.

--- a/docs/sources/k6/v0.49.x/_index.md
+++ b/docs/sources/k6/v0.49.x/_index.md
@@ -14,15 +14,15 @@ This documentation will help you go from a total beginner to a seasoned k6 exper
 ## Get started
 
 <div class="nav-cards">
-    <a href={{< relref "./get-started/installation" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=get-started/installation/ class="nav-cards__item nav-cards__item--guide">
         <h4>🚀 Installation</h4>
         <p>Get up and running in no-time, using either a package manager, standalone installer or the official Docker image.</p>
     </a>
-    <a href={{< relref "./get-started/running-k6" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=get-started/running-k6/ class="nav-cards__item nav-cards__item--guide">
         <h4>🏎️💨 Running k6</h4>
         <p>Write and execute your first load test locally using JavaScript and the k6 API, adding multiple virtual users, checks and ramping stages.</p>
     </a>
-    <a href={{< relref "./get-started/results-output" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=get-started/results-output/ class="nav-cards__item nav-cards__item--guide">
         <h4>⏱ Results output</h4>
         <p>Learn how to leverage the results output to gain actionable insight about your application's performance.</p>
     </a>

--- a/docs/sources/k6/v0.49.x/extensions/_index.md
+++ b/docs/sources/k6/v0.49.x/extensions/_index.md
@@ -11,15 +11,15 @@ Expand the potential use cases for k6.
 ## Quickstart
 
 <div class="nav-cards">
-    <a href={{< relref "./explore" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=explore/ class="nav-cards__item nav-cards__item--guide">
         <h4>🔎 Explore</h4>
         <p>A list of more than 50 available extensions.</p>
     </a>
-    <a href={{< relref "./build-k6-binary-using-go" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=build-k6-binary-using-go/ class="nav-cards__item nav-cards__item--guide">
         <h4>🧩 Bundle</h4>
         <p>Combine multiple extensions into a custom k6 binary.</p>
     </a>
-    <a href={{< relref "./create/" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=create/ class="nav-cards__item nav-cards__item--guide">
         <h4>🏗️ Create</h4>
         <p>Learn how to make your own k6 extension.</p>
     </a>

--- a/docs/sources/k6/v0.49.x/shared/blocking-aws-blockquote.md
+++ b/docs/sources/k6/v0.49.x/shared/blocking-aws-blockquote.md
@@ -7,6 +7,6 @@ title: jslib/aws module blocking admonition
 In some cases, using this library&apos;s operations might impact performance and skew your test results.
 <br>
 <br>
-To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions](../../using-k6/test-lifecycle/). These functions run before and after the test run and have no impact on the test results.
+To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions](/docs/k6/<K6_VERSION>/using-k6/test-lifecycle/). These functions run before and after the test run and have no impact on the test results.
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.49.x/shared/blocking-aws-blockquote.md
+++ b/docs/sources/k6/v0.49.x/shared/blocking-aws-blockquote.md
@@ -7,6 +7,6 @@ title: jslib/aws module blocking admonition
 In some cases, using this library&apos;s operations might impact performance and skew your test results.
 <br>
 <br>
-To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions]({{< relref "../using-k6/test-lifecycle" >}}). These functions run before and after the test run and have no impact on the test results.
+To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions](../../using-k6/test-lifecycle/). These functions run before and after the test run and have no impact on the test results.
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.49.x/shared/crypto-module.md
+++ b/docs/sources/k6/v0.49.x/shared/crypto-module.md
@@ -7,6 +7,6 @@ title: k6/crypto module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/webcrypto API]({{< relref "../javascript-api/k6-experimental/webcrypto" >}}) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto]({{< relref "../javascript-api/k6-crypto" >}}).
+The new [k6/experimental/webcrypto API](../../javascript-api/k6-experimental/webcrypto/) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto](../../javascript-api/k6-crypto/).
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.49.x/shared/crypto-module.md
+++ b/docs/sources/k6/v0.49.x/shared/crypto-module.md
@@ -7,6 +7,6 @@ title: k6/crypto module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/webcrypto API](../../javascript-api/k6-experimental/webcrypto/) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto](../../javascript-api/k6-crypto/).
+The new [k6/experimental/webcrypto API](/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/webcrypto/) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto](/docs/k6/<K6_VERSION>/javascript-api/k6-crypto/).
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.49.x/shared/experimental-module.md
+++ b/docs/sources/k6/v0.49.x/shared/experimental-module.md
@@ -7,7 +7,7 @@ title: Experimental module admonition
 This is an experimental module.
 <br>
 <br>
-While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process]({{< relref "../extensions/explanations/extension-graduation" >}}).
+While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process](../../extensions/explanations/extension-graduation/).
 <br>
 <br>
 Experimental modules maintain a high level of stability and follow regular maintenance and security measures. Feel free to [open an issue](https://github.com/grafana/k6/issues) if you have any feedback or suggestions.

--- a/docs/sources/k6/v0.49.x/shared/experimental-module.md
+++ b/docs/sources/k6/v0.49.x/shared/experimental-module.md
@@ -7,7 +7,7 @@ title: Experimental module admonition
 This is an experimental module.
 <br>
 <br>
-While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process](../../extensions/explanations/extension-graduation/).
+While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process](/docs/k6/<K6_VERSION>/extensions/explanations/extension-graduation/).
 <br>
 <br>
 Experimental modules maintain a high level of stability and follow regular maintenance and security measures. Feel free to [open an issue](https://github.com/grafana/k6/issues) if you have any feedback or suggestions.

--- a/docs/sources/k6/v0.49.x/shared/ws-module.md
+++ b/docs/sources/k6/v0.49.x/shared/ws-module.md
@@ -7,7 +7,7 @@ title: k6/ws module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/websockets API]({{< relref "../javascript-api/k6-experimental/websockets" >}}) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
+The new [k6/experimental/websockets API](../../javascript-api/k6-experimental/websockets/) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
 <br>
 <br>
 When possible, we recommend using the new API. It uses a global event loop for consistency with other k6 APIs and better performance.

--- a/docs/sources/k6/v0.49.x/shared/ws-module.md
+++ b/docs/sources/k6/v0.49.x/shared/ws-module.md
@@ -7,7 +7,7 @@ title: k6/ws module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/websockets API](../../javascript-api/k6-experimental/websockets/) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
+The new [k6/experimental/websockets API](/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/websockets/) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
 <br>
 <br>
 When possible, we recommend using the new API. It uses a global event loop for consistency with other k6 APIs and better performance.

--- a/docs/sources/k6/v0.50.x/_index.md
+++ b/docs/sources/k6/v0.50.x/_index.md
@@ -14,15 +14,15 @@ This documentation will help you go from a total beginner to a seasoned k6 exper
 ## Get started
 
 <div class="nav-cards">
-    <a href={{< relref "./set-up/install-k6" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=set-up/install-k6/ class="nav-cards__item nav-cards__item--guide">
         <h4>🚀 Installation</h4>
         <p>Get up and running in no-time, using either a package manager, standalone installer or the official Docker image.</p>
     </a>
-    <a href={{< relref "./get-started/running-k6" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=get-started/running-k6/ class="nav-cards__item nav-cards__item--guide">
         <h4>🏎️💨 Running k6</h4>
         <p>Write and execute your first load test locally using JavaScript and the k6 API, adding multiple virtual users, checks and ramping stages.</p>
     </a>
-    <a href={{< relref "./get-started/results-output" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=get-started/results-output/ class="nav-cards__item nav-cards__item--guide">
         <h4>⏱ Results output</h4>
         <p>Learn how to leverage the results output to gain actionable insight about your application's performance.</p>
     </a>

--- a/docs/sources/k6/v0.50.x/extensions/_index.md
+++ b/docs/sources/k6/v0.50.x/extensions/_index.md
@@ -11,15 +11,15 @@ Expand the potential use cases for k6.
 ## Quickstart
 
 <div class="nav-cards">
-    <a href={{< relref "./explore" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=explore/ class="nav-cards__item nav-cards__item--guide">
         <h4>🔎 Explore</h4>
         <p>A list of more than 50 available extensions.</p>
     </a>
-    <a href={{< relref "./build-k6-binary-using-go" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=build-k6-binary-using-go/ class="nav-cards__item nav-cards__item--guide">
         <h4>🧩 Bundle</h4>
         <p>Combine multiple extensions into a custom k6 binary.</p>
     </a>
-    <a href={{< relref "./create/" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=create/ class="nav-cards__item nav-cards__item--guide">
         <h4>🏗️ Create</h4>
         <p>Learn how to make your own k6 extension.</p>
     </a>

--- a/docs/sources/k6/v0.50.x/shared/blocking-aws-blockquote.md
+++ b/docs/sources/k6/v0.50.x/shared/blocking-aws-blockquote.md
@@ -7,6 +7,6 @@ title: jslib/aws module blocking admonition
 In some cases, using this library&apos;s operations might impact performance and skew your test results.
 <br>
 <br>
-To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions](../../using-k6/test-lifecycle/). These functions run before and after the test run and have no impact on the test results.
+To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions](/docs/k6/<K6_VERSION>/using-k6/test-lifecycle/). These functions run before and after the test run and have no impact on the test results.
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.50.x/shared/blocking-aws-blockquote.md
+++ b/docs/sources/k6/v0.50.x/shared/blocking-aws-blockquote.md
@@ -7,6 +7,6 @@ title: jslib/aws module blocking admonition
 In some cases, using this library&apos;s operations might impact performance and skew your test results.
 <br>
 <br>
-To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions]({{< relref "../using-k6/test-lifecycle" >}}). These functions run before and after the test run and have no impact on the test results.
+To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions](../../using-k6/test-lifecycle/). These functions run before and after the test run and have no impact on the test results.
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.50.x/shared/crypto-module.md
+++ b/docs/sources/k6/v0.50.x/shared/crypto-module.md
@@ -7,6 +7,6 @@ title: k6/crypto module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/webcrypto API]({{< relref "../javascript-api/k6-experimental/webcrypto" >}}) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto]({{< relref "../javascript-api/k6-crypto" >}}).
+The new [k6/experimental/webcrypto API](../../javascript-api/k6-experimental/webcrypto/) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto](../../javascript-api/k6-crypto/).
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.50.x/shared/crypto-module.md
+++ b/docs/sources/k6/v0.50.x/shared/crypto-module.md
@@ -7,6 +7,6 @@ title: k6/crypto module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/webcrypto API](../../javascript-api/k6-experimental/webcrypto/) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto](../../javascript-api/k6-crypto/).
+The new [k6/experimental/webcrypto API](/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/webcrypto/) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto](/docs/k6/<K6_VERSION>/javascript-api/k6-crypto/).
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.50.x/shared/experimental-module.md
+++ b/docs/sources/k6/v0.50.x/shared/experimental-module.md
@@ -7,7 +7,7 @@ title: Experimental module admonition
 This is an experimental module.
 <br>
 <br>
-While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process]({{< relref "../extensions/explanations/extension-graduation" >}}).
+While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process](../../extensions/explanations/extension-graduation/).
 <br>
 <br>
 Experimental modules maintain a high level of stability and follow regular maintenance and security measures. Feel free to [open an issue](https://github.com/grafana/k6/issues) if you have any feedback or suggestions.

--- a/docs/sources/k6/v0.50.x/shared/experimental-module.md
+++ b/docs/sources/k6/v0.50.x/shared/experimental-module.md
@@ -7,7 +7,7 @@ title: Experimental module admonition
 This is an experimental module.
 <br>
 <br>
-While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process](../../extensions/explanations/extension-graduation/).
+While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process](/docs/k6/<K6_VERSION>/extensions/explanations/extension-graduation/).
 <br>
 <br>
 Experimental modules maintain a high level of stability and follow regular maintenance and security measures. Feel free to [open an issue](https://github.com/grafana/k6/issues) if you have any feedback or suggestions.

--- a/docs/sources/k6/v0.50.x/shared/ws-module.md
+++ b/docs/sources/k6/v0.50.x/shared/ws-module.md
@@ -7,7 +7,7 @@ title: k6/ws module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/websockets API]({{< relref "../javascript-api/k6-experimental/websockets" >}}) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
+The new [k6/experimental/websockets API](../../javascript-api/k6-experimental/websockets/) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
 <br>
 <br>
 When possible, we recommend using the new API. It uses a global event loop for consistency with other k6 APIs and better performance.

--- a/docs/sources/k6/v0.50.x/shared/ws-module.md
+++ b/docs/sources/k6/v0.50.x/shared/ws-module.md
@@ -7,7 +7,7 @@ title: k6/ws module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/websockets API](../../javascript-api/k6-experimental/websockets/) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
+The new [k6/experimental/websockets API](/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/websockets/) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
 <br>
 <br>
 When possible, we recommend using the new API. It uses a global event loop for consistency with other k6 APIs and better performance.

--- a/docs/sources/k6/v0.51.x/_index.md
+++ b/docs/sources/k6/v0.51.x/_index.md
@@ -14,15 +14,15 @@ This documentation will help you go from a total beginner to a seasoned k6 exper
 ## Get started
 
 <div class="nav-cards">
-    <a href={{< relref "./set-up/install-k6" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=set-up/install-k6/ class="nav-cards__item nav-cards__item--guide">
         <h4>🚀 Installation</h4>
         <p>Get up and running in no-time, using either a package manager, standalone installer or the official Docker image.</p>
     </a>
-    <a href={{< relref "./get-started/running-k6" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=get-started/running-k6/ class="nav-cards__item nav-cards__item--guide">
         <h4>🏎️💨 Running k6</h4>
         <p>Write and execute your first load test locally using JavaScript and the k6 API, adding multiple virtual users, checks and ramping stages.</p>
     </a>
-    <a href={{< relref "./get-started/results-output" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=get-started/results-output/ class="nav-cards__item nav-cards__item--guide">
         <h4>⏱ Results output</h4>
         <p>Learn how to leverage the results output to gain actionable insight about your application's performance.</p>
     </a>

--- a/docs/sources/k6/v0.51.x/extensions/_index.md
+++ b/docs/sources/k6/v0.51.x/extensions/_index.md
@@ -11,15 +11,15 @@ Expand the potential use cases for k6.
 ## Quickstart
 
 <div class="nav-cards">
-    <a href={{< relref "./explore" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=explore/ class="nav-cards__item nav-cards__item--guide">
         <h4>🔎 Explore</h4>
         <p>A list of more than 50 available extensions.</p>
     </a>
-    <a href={{< relref "./build-k6-binary-using-go" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=build-k6-binary-using-go/ class="nav-cards__item nav-cards__item--guide">
         <h4>🧩 Bundle</h4>
         <p>Combine multiple extensions into a custom k6 binary.</p>
     </a>
-    <a href={{< relref "./create/" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=create/ class="nav-cards__item nav-cards__item--guide">
         <h4>🏗️ Create</h4>
         <p>Learn how to make your own k6 extension.</p>
     </a>

--- a/docs/sources/k6/v0.51.x/shared/blocking-aws-blockquote.md
+++ b/docs/sources/k6/v0.51.x/shared/blocking-aws-blockquote.md
@@ -7,6 +7,6 @@ title: jslib/aws module blocking admonition
 In some cases, using this library&apos;s operations might impact performance and skew your test results.
 <br>
 <br>
-To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions](../../using-k6/test-lifecycle/). These functions run before and after the test run and have no impact on the test results.
+To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions](/docs/k6/<K6_VERSION>/using-k6/test-lifecycle/). These functions run before and after the test run and have no impact on the test results.
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.51.x/shared/blocking-aws-blockquote.md
+++ b/docs/sources/k6/v0.51.x/shared/blocking-aws-blockquote.md
@@ -7,6 +7,6 @@ title: jslib/aws module blocking admonition
 In some cases, using this library&apos;s operations might impact performance and skew your test results.
 <br>
 <br>
-To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions]({{< relref "../using-k6/test-lifecycle" >}}). These functions run before and after the test run and have no impact on the test results.
+To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions](../../using-k6/test-lifecycle/). These functions run before and after the test run and have no impact on the test results.
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.51.x/shared/crypto-module.md
+++ b/docs/sources/k6/v0.51.x/shared/crypto-module.md
@@ -7,6 +7,6 @@ title: k6/crypto module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/webcrypto API]({{< relref "../javascript-api/k6-experimental/webcrypto" >}}) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto]({{< relref "../javascript-api/k6-crypto" >}}).
+The new [k6/experimental/webcrypto API](../../javascript-api/k6-experimental/webcrypto/) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto](../../javascript-api/k6-crypto/).
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.51.x/shared/crypto-module.md
+++ b/docs/sources/k6/v0.51.x/shared/crypto-module.md
@@ -7,6 +7,6 @@ title: k6/crypto module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/webcrypto API](../../javascript-api/k6-experimental/webcrypto/) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto](../../javascript-api/k6-crypto/).
+The new [k6/experimental/webcrypto API](/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/webcrypto/) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto](/docs/k6/<K6_VERSION>/javascript-api/k6-crypto/).
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.51.x/shared/experimental-module.md
+++ b/docs/sources/k6/v0.51.x/shared/experimental-module.md
@@ -7,7 +7,7 @@ title: Experimental module admonition
 This is an experimental module.
 <br>
 <br>
-While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process]({{< relref "../extensions/explanations/extension-graduation" >}}).
+While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process](../../extensions/explanations/extension-graduation/).
 <br>
 <br>
 Experimental modules maintain a high level of stability and follow regular maintenance and security measures. Feel free to [open an issue](https://github.com/grafana/k6/issues) if you have any feedback or suggestions.

--- a/docs/sources/k6/v0.51.x/shared/experimental-module.md
+++ b/docs/sources/k6/v0.51.x/shared/experimental-module.md
@@ -7,7 +7,7 @@ title: Experimental module admonition
 This is an experimental module.
 <br>
 <br>
-While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process](../../extensions/explanations/extension-graduation/).
+While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process](/docs/k6/<K6_VERSION>/extensions/explanations/extension-graduation/).
 <br>
 <br>
 Experimental modules maintain a high level of stability and follow regular maintenance and security measures. Feel free to [open an issue](https://github.com/grafana/k6/issues) if you have any feedback or suggestions.

--- a/docs/sources/k6/v0.51.x/shared/ws-module.md
+++ b/docs/sources/k6/v0.51.x/shared/ws-module.md
@@ -7,7 +7,7 @@ title: k6/ws module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/websockets API]({{< relref "../javascript-api/k6-experimental/websockets" >}}) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
+The new [k6/experimental/websockets API](../../javascript-api/k6-experimental/websockets/) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
 <br>
 <br>
 When possible, we recommend using the new API. It uses a global event loop for consistency with other k6 APIs and better performance.

--- a/docs/sources/k6/v0.51.x/shared/ws-module.md
+++ b/docs/sources/k6/v0.51.x/shared/ws-module.md
@@ -7,7 +7,7 @@ title: k6/ws module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/websockets API](../../javascript-api/k6-experimental/websockets/) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
+The new [k6/experimental/websockets API](/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/websockets/) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
 <br>
 <br>
 When possible, we recommend using the new API. It uses a global event loop for consistency with other k6 APIs and better performance.

--- a/docs/sources/k6/v0.52.x/extensions/_index.md
+++ b/docs/sources/k6/v0.52.x/extensions/_index.md
@@ -11,15 +11,15 @@ Expand the potential use cases for k6.
 ## Quickstart
 
 <div class="nav-cards">
-    <a href={{< relref "./explore" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=explore/ class="nav-cards__item nav-cards__item--guide">
         <h4>🔎 Explore</h4>
         <p>A list of more than 50 available extensions.</p>
     </a>
-    <a href={{< relref "./build-k6-binary-using-go" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=build-k6-binary-using-go/ class="nav-cards__item nav-cards__item--guide">
         <h4>🧩 Bundle</h4>
         <p>Combine multiple extensions into a custom k6 binary.</p>
     </a>
-    <a href={{< relref "./create/" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=create/ class="nav-cards__item nav-cards__item--guide">
         <h4>🏗️ Create</h4>
         <p>Learn how to make your own k6 extension.</p>
     </a>

--- a/docs/sources/k6/v0.52.x/shared/blocking-aws-blockquote.md
+++ b/docs/sources/k6/v0.52.x/shared/blocking-aws-blockquote.md
@@ -7,6 +7,6 @@ title: jslib/aws module blocking admonition
 In some cases, using this library&apos;s operations might impact performance and skew your test results.
 <br>
 <br>
-To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions](../../using-k6/test-lifecycle/). These functions run before and after the test run and have no impact on the test results.
+To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions](/docs/k6/<K6_VERSION>/using-k6/test-lifecycle/). These functions run before and after the test run and have no impact on the test results.
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.52.x/shared/blocking-aws-blockquote.md
+++ b/docs/sources/k6/v0.52.x/shared/blocking-aws-blockquote.md
@@ -7,6 +7,6 @@ title: jslib/aws module blocking admonition
 In some cases, using this library&apos;s operations might impact performance and skew your test results.
 <br>
 <br>
-To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions]({{< relref "../using-k6/test-lifecycle" >}}). These functions run before and after the test run and have no impact on the test results.
+To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions](../../using-k6/test-lifecycle/). These functions run before and after the test run and have no impact on the test results.
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.52.x/shared/crypto-module.md
+++ b/docs/sources/k6/v0.52.x/shared/crypto-module.md
@@ -7,6 +7,6 @@ title: k6/crypto module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/webcrypto API]({{< relref "../javascript-api/k6-experimental/webcrypto" >}}) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto]({{< relref "../javascript-api/k6-crypto" >}}).
+The new [k6/experimental/webcrypto API](../../javascript-api/k6-experimental/webcrypto/) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto](../../javascript-api/k6-crypto/).
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.52.x/shared/crypto-module.md
+++ b/docs/sources/k6/v0.52.x/shared/crypto-module.md
@@ -7,6 +7,6 @@ title: k6/crypto module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/webcrypto API](../../javascript-api/k6-experimental/webcrypto/) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto](../../javascript-api/k6-crypto/).
+The new [k6/experimental/webcrypto API](/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/webcrypto/) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto](/docs/k6/<K6_VERSION>/javascript-api/k6-crypto/).
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.52.x/shared/experimental-module.md
+++ b/docs/sources/k6/v0.52.x/shared/experimental-module.md
@@ -7,7 +7,7 @@ title: Experimental module admonition
 This is an experimental module.
 <br>
 <br>
-While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process]({{< relref "../extensions/explanations/extension-graduation" >}}).
+While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process](../../extensions/explanations/extension-graduation/).
 <br>
 <br>
 Experimental modules maintain a high level of stability and follow regular maintenance and security measures. Feel free to [open an issue](https://github.com/grafana/k6/issues) if you have any feedback or suggestions.

--- a/docs/sources/k6/v0.52.x/shared/experimental-module.md
+++ b/docs/sources/k6/v0.52.x/shared/experimental-module.md
@@ -7,7 +7,7 @@ title: Experimental module admonition
 This is an experimental module.
 <br>
 <br>
-While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process](../../extensions/explanations/extension-graduation/).
+While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process](/docs/k6/<K6_VERSION>/extensions/explanations/extension-graduation/).
 <br>
 <br>
 Experimental modules maintain a high level of stability and follow regular maintenance and security measures. Feel free to [open an issue](https://github.com/grafana/k6/issues) if you have any feedback or suggestions.

--- a/docs/sources/k6/v0.52.x/shared/ws-module.md
+++ b/docs/sources/k6/v0.52.x/shared/ws-module.md
@@ -7,7 +7,7 @@ title: k6/ws module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/websockets API]({{< relref "../javascript-api/k6-experimental/websockets" >}}) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
+The new [k6/experimental/websockets API](../../javascript-api/k6-experimental/websockets/) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
 <br>
 <br>
 When possible, we recommend using the new API. It uses a global event loop for consistency with other k6 APIs and better performance.

--- a/docs/sources/k6/v0.52.x/shared/ws-module.md
+++ b/docs/sources/k6/v0.52.x/shared/ws-module.md
@@ -7,7 +7,7 @@ title: k6/ws module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/websockets API](../../javascript-api/k6-experimental/websockets/) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
+The new [k6/experimental/websockets API](/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/websockets/) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
 <br>
 <br>
 When possible, we recommend using the new API. It uses a global event loop for consistency with other k6 APIs and better performance.

--- a/docs/sources/k6/v0.53.x/extensions/_index.md
+++ b/docs/sources/k6/v0.53.x/extensions/_index.md
@@ -11,15 +11,15 @@ Expand the potential use cases for k6.
 ## Quickstart
 
 <div class="nav-cards">
-    <a href={{< relref "./explore" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=explore/ class="nav-cards__item nav-cards__item--guide">
         <h4>🔎 Explore</h4>
         <p>A list of more than 50 available extensions.</p>
     </a>
-    <a href={{< relref "./build-k6-binary-using-go" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=build-k6-binary-using-go/ class="nav-cards__item nav-cards__item--guide">
         <h4>🧩 Bundle</h4>
         <p>Combine multiple extensions into a custom k6 binary.</p>
     </a>
-    <a href={{< relref "./create/" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=create/ class="nav-cards__item nav-cards__item--guide">
         <h4>🏗️ Create</h4>
         <p>Learn how to make your own k6 extension.</p>
     </a>

--- a/docs/sources/k6/v0.53.x/shared/blocking-aws-blockquote.md
+++ b/docs/sources/k6/v0.53.x/shared/blocking-aws-blockquote.md
@@ -7,6 +7,6 @@ title: jslib/aws module blocking admonition
 In some cases, using this library&apos;s operations might impact performance and skew your test results.
 <br>
 <br>
-To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions](../../using-k6/test-lifecycle/). These functions run before and after the test run and have no impact on the test results.
+To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions](/docs/k6/<K6_VERSION>/using-k6/test-lifecycle/). These functions run before and after the test run and have no impact on the test results.
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.53.x/shared/blocking-aws-blockquote.md
+++ b/docs/sources/k6/v0.53.x/shared/blocking-aws-blockquote.md
@@ -7,6 +7,6 @@ title: jslib/aws module blocking admonition
 In some cases, using this library&apos;s operations might impact performance and skew your test results.
 <br>
 <br>
-To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions]({{< relref "../using-k6/test-lifecycle" >}}). These functions run before and after the test run and have no impact on the test results.
+To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions](../../using-k6/test-lifecycle/). These functions run before and after the test run and have no impact on the test results.
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.53.x/shared/crypto-module.md
+++ b/docs/sources/k6/v0.53.x/shared/crypto-module.md
@@ -7,6 +7,6 @@ title: k6/crypto module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/webcrypto API]({{< relref "../javascript-api/k6-experimental/webcrypto" >}}) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto]({{< relref "../javascript-api/k6-crypto" >}}).
+The new [k6/experimental/webcrypto API](../../javascript-api/k6-experimental/webcrypto/) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto](../../javascript-api/k6-crypto/).
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.53.x/shared/crypto-module.md
+++ b/docs/sources/k6/v0.53.x/shared/crypto-module.md
@@ -7,6 +7,6 @@ title: k6/crypto module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/webcrypto API](../../javascript-api/k6-experimental/webcrypto/) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto](../../javascript-api/k6-crypto/).
+The new [k6/experimental/webcrypto API](/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/webcrypto/) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto](/docs/k6/<K6_VERSION>/javascript-api/k6-crypto/).
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.53.x/shared/experimental-module.md
+++ b/docs/sources/k6/v0.53.x/shared/experimental-module.md
@@ -7,7 +7,7 @@ title: Experimental module admonition
 This is an experimental module.
 <br>
 <br>
-While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process]({{< relref "../extensions/explanations/extension-graduation" >}}).
+While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process](../../extensions/explanations/extension-graduation/).
 <br>
 <br>
 Experimental modules maintain a high level of stability and follow regular maintenance and security measures. Feel free to [open an issue](https://github.com/grafana/k6/issues) if you have any feedback or suggestions.

--- a/docs/sources/k6/v0.53.x/shared/experimental-module.md
+++ b/docs/sources/k6/v0.53.x/shared/experimental-module.md
@@ -7,7 +7,7 @@ title: Experimental module admonition
 This is an experimental module.
 <br>
 <br>
-While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process](../../extensions/explanations/extension-graduation/).
+While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process](/docs/k6/<K6_VERSION>/extensions/explanations/extension-graduation/).
 <br>
 <br>
 Experimental modules maintain a high level of stability and follow regular maintenance and security measures. Feel free to [open an issue](https://github.com/grafana/k6/issues) if you have any feedback or suggestions.

--- a/docs/sources/k6/v0.53.x/shared/ws-module.md
+++ b/docs/sources/k6/v0.53.x/shared/ws-module.md
@@ -7,7 +7,7 @@ title: k6/ws module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/websockets API]({{< relref "../javascript-api/k6-experimental/websockets" >}}) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
+The new [k6/experimental/websockets API](../../javascript-api/k6-experimental/websockets/) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
 <br>
 <br>
 When possible, we recommend using the new API. It uses a global event loop for consistency with other k6 APIs and better performance.

--- a/docs/sources/k6/v0.53.x/shared/ws-module.md
+++ b/docs/sources/k6/v0.53.x/shared/ws-module.md
@@ -7,7 +7,7 @@ title: k6/ws module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/websockets API](../../javascript-api/k6-experimental/websockets/) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
+The new [k6/experimental/websockets API](/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/websockets/) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
 <br>
 <br>
 When possible, we recommend using the new API. It uses a global event loop for consistency with other k6 APIs and better performance.

--- a/docs/sources/k6/v0.54.x/extensions/_index.md
+++ b/docs/sources/k6/v0.54.x/extensions/_index.md
@@ -11,15 +11,15 @@ Expand the potential use cases for k6.
 ## Quickstart
 
 <div class="nav-cards">
-    <a href={{< relref "./explore" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=explore/ class="nav-cards__item nav-cards__item--guide">
         <h4>🔎 Explore</h4>
         <p>A list of more than 50 available extensions.</p>
     </a>
-    <a href={{< relref "./build-k6-binary-using-go" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=build-k6-binary-using-go/ class="nav-cards__item nav-cards__item--guide">
         <h4>🧩 Bundle</h4>
         <p>Combine multiple extensions into a custom k6 binary.</p>
     </a>
-    <a href={{< relref "./create/" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=create/ class="nav-cards__item nav-cards__item--guide">
         <h4>🏗️ Create</h4>
         <p>Learn how to make your own k6 extension.</p>
     </a>

--- a/docs/sources/k6/v0.54.x/shared/blocking-aws-blockquote.md
+++ b/docs/sources/k6/v0.54.x/shared/blocking-aws-blockquote.md
@@ -7,6 +7,6 @@ title: jslib/aws module blocking admonition
 In some cases, using this library&apos;s operations might impact performance and skew your test results.
 <br>
 <br>
-To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions](../../using-k6/test-lifecycle/). These functions run before and after the test run and have no impact on the test results.
+To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions](/docs/k6/<K6_VERSION>/using-k6/test-lifecycle/). These functions run before and after the test run and have no impact on the test results.
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.54.x/shared/blocking-aws-blockquote.md
+++ b/docs/sources/k6/v0.54.x/shared/blocking-aws-blockquote.md
@@ -7,6 +7,6 @@ title: jslib/aws module blocking admonition
 In some cases, using this library&apos;s operations might impact performance and skew your test results.
 <br>
 <br>
-To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions]({{< relref "../using-k6/test-lifecycle" >}}). These functions run before and after the test run and have no impact on the test results.
+To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions](../../using-k6/test-lifecycle/). These functions run before and after the test run and have no impact on the test results.
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.54.x/shared/crypto-module.md
+++ b/docs/sources/k6/v0.54.x/shared/crypto-module.md
@@ -7,6 +7,6 @@ title: k6/crypto module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/webcrypto API]({{< relref "../javascript-api/k6-experimental/webcrypto" >}}) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto]({{< relref "../javascript-api/k6-crypto" >}}).
+The new [k6/experimental/webcrypto API](../../javascript-api/k6-experimental/webcrypto/) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto](../../javascript-api/k6-crypto/).
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.54.x/shared/crypto-module.md
+++ b/docs/sources/k6/v0.54.x/shared/crypto-module.md
@@ -7,6 +7,6 @@ title: k6/crypto module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/webcrypto API](../../javascript-api/k6-experimental/webcrypto/) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto](../../javascript-api/k6-crypto/).
+The new [k6/experimental/webcrypto API](/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/webcrypto/) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto](/docs/k6/<K6_VERSION>/javascript-api/k6-crypto/).
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.54.x/shared/experimental-module.md
+++ b/docs/sources/k6/v0.54.x/shared/experimental-module.md
@@ -7,7 +7,7 @@ title: Experimental module admonition
 This is an experimental module.
 <br>
 <br>
-While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process]({{< relref "../extensions/explanations/extension-graduation" >}}).
+While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process](../../extensions/explanations/extension-graduation/).
 <br>
 <br>
 Experimental modules maintain a high level of stability and follow regular maintenance and security measures. Feel free to [open an issue](https://github.com/grafana/k6/issues) if you have any feedback or suggestions.

--- a/docs/sources/k6/v0.54.x/shared/experimental-module.md
+++ b/docs/sources/k6/v0.54.x/shared/experimental-module.md
@@ -7,7 +7,7 @@ title: Experimental module admonition
 This is an experimental module.
 <br>
 <br>
-While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process](../../extensions/explanations/extension-graduation/).
+While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process](/docs/k6/<K6_VERSION>/extensions/explanations/extension-graduation/).
 <br>
 <br>
 Experimental modules maintain a high level of stability and follow regular maintenance and security measures. Feel free to [open an issue](https://github.com/grafana/k6/issues) if you have any feedback or suggestions.

--- a/docs/sources/k6/v0.54.x/shared/ws-module.md
+++ b/docs/sources/k6/v0.54.x/shared/ws-module.md
@@ -7,7 +7,7 @@ title: k6/ws module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/websockets API]({{< relref "../javascript-api/k6-experimental/websockets" >}}) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
+The new [k6/experimental/websockets API](../../javascript-api/k6-experimental/websockets/) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
 <br>
 <br>
 When possible, we recommend using the new API. It uses a global event loop for consistency with other k6 APIs and better performance.

--- a/docs/sources/k6/v0.54.x/shared/ws-module.md
+++ b/docs/sources/k6/v0.54.x/shared/ws-module.md
@@ -7,7 +7,7 @@ title: k6/ws module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/websockets API](../../javascript-api/k6-experimental/websockets/) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
+The new [k6/experimental/websockets API](/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/websockets/) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
 <br>
 <br>
 When possible, we recommend using the new API. It uses a global event loop for consistency with other k6 APIs and better performance.

--- a/docs/sources/k6/v0.55.x/extensions/_index.md
+++ b/docs/sources/k6/v0.55.x/extensions/_index.md
@@ -11,15 +11,15 @@ Expand the potential use cases for k6.
 ## Quickstart
 
 <div class="nav-cards">
-    <a href={{< relref "./explore" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=explore/ class="nav-cards__item nav-cards__item--guide">
         <h4>🔎 Explore</h4>
         <p>A list of more than 50 available extensions.</p>
     </a>
-    <a href={{< relref "./build-k6-binary-using-go" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=build-k6-binary-using-go/ class="nav-cards__item nav-cards__item--guide">
         <h4>🧩 Bundle</h4>
         <p>Combine multiple extensions into a custom k6 binary.</p>
     </a>
-    <a href={{< relref "./create/" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=create/ class="nav-cards__item nav-cards__item--guide">
         <h4>🏗️ Create</h4>
         <p>Learn how to make your own k6 extension.</p>
     </a>

--- a/docs/sources/k6/v0.55.x/shared/blocking-aws-blockquote.md
+++ b/docs/sources/k6/v0.55.x/shared/blocking-aws-blockquote.md
@@ -7,6 +7,6 @@ title: jslib/aws module blocking admonition
 In some cases, using this library&apos;s operations might impact performance and skew your test results.
 <br>
 <br>
-To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions](../../using-k6/test-lifecycle/). These functions run before and after the test run and have no impact on the test results.
+To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions](/docs/k6/<K6_VERSION>/using-k6/test-lifecycle/). These functions run before and after the test run and have no impact on the test results.
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.55.x/shared/blocking-aws-blockquote.md
+++ b/docs/sources/k6/v0.55.x/shared/blocking-aws-blockquote.md
@@ -7,6 +7,6 @@ title: jslib/aws module blocking admonition
 In some cases, using this library&apos;s operations might impact performance and skew your test results.
 <br>
 <br>
-To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions]({{< relref "../using-k6/test-lifecycle" >}}). These functions run before and after the test run and have no impact on the test results.
+To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions](../../using-k6/test-lifecycle/). These functions run before and after the test run and have no impact on the test results.
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.55.x/shared/crypto-module.md
+++ b/docs/sources/k6/v0.55.x/shared/crypto-module.md
@@ -7,6 +7,6 @@ title: k6/crypto module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/webcrypto API]({{< relref "../javascript-api/k6-experimental/webcrypto" >}}) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto]({{< relref "../javascript-api/k6-crypto" >}}).
+The new [k6/experimental/webcrypto API](../../javascript-api/k6-experimental/webcrypto/) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto](../../javascript-api/k6-crypto/).
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.55.x/shared/crypto-module.md
+++ b/docs/sources/k6/v0.55.x/shared/crypto-module.md
@@ -7,6 +7,6 @@ title: k6/crypto module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/webcrypto API](../../javascript-api/k6-experimental/webcrypto/) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto](../../javascript-api/k6-crypto/).
+The new [k6/experimental/webcrypto API](/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/webcrypto/) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto](/docs/k6/<K6_VERSION>/javascript-api/k6-crypto/).
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.55.x/shared/experimental-module.md
+++ b/docs/sources/k6/v0.55.x/shared/experimental-module.md
@@ -7,7 +7,7 @@ title: Experimental module admonition
 This is an experimental module.
 <br>
 <br>
-While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process]({{< relref "../extensions/explanations/extension-graduation" >}}).
+While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process](../../extensions/explanations/extension-graduation/).
 <br>
 <br>
 Experimental modules maintain a high level of stability and follow regular maintenance and security measures. Feel free to [open an issue](https://github.com/grafana/k6/issues) if you have any feedback or suggestions.

--- a/docs/sources/k6/v0.55.x/shared/experimental-module.md
+++ b/docs/sources/k6/v0.55.x/shared/experimental-module.md
@@ -7,7 +7,7 @@ title: Experimental module admonition
 This is an experimental module.
 <br>
 <br>
-While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process](../../extensions/explanations/extension-graduation/).
+While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process](/docs/k6/<K6_VERSION>/extensions/explanations/extension-graduation/).
 <br>
 <br>
 Experimental modules maintain a high level of stability and follow regular maintenance and security measures. Feel free to [open an issue](https://github.com/grafana/k6/issues) if you have any feedback or suggestions.

--- a/docs/sources/k6/v0.55.x/shared/ws-module.md
+++ b/docs/sources/k6/v0.55.x/shared/ws-module.md
@@ -7,7 +7,7 @@ title: k6/ws module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/websockets API]({{< relref "../javascript-api/k6-experimental/websockets" >}}) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
+The new [k6/experimental/websockets API](../../javascript-api/k6-experimental/websockets/) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
 <br>
 <br>
 When possible, we recommend using the new API. It uses a global event loop for consistency with other k6 APIs and better performance.

--- a/docs/sources/k6/v0.55.x/shared/ws-module.md
+++ b/docs/sources/k6/v0.55.x/shared/ws-module.md
@@ -7,7 +7,7 @@ title: k6/ws module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/websockets API](../../javascript-api/k6-experimental/websockets/) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
+The new [k6/experimental/websockets API](/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/websockets/) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
 <br>
 <br>
 When possible, we recommend using the new API. It uses a global event loop for consistency with other k6 APIs and better performance.

--- a/docs/sources/k6/v0.56.x/extensions/_index.md
+++ b/docs/sources/k6/v0.56.x/extensions/_index.md
@@ -11,15 +11,15 @@ Expand the potential use cases for k6.
 ## Quickstart
 
 <div class="nav-cards">
-    <a href={{< relref "./explore" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=explore/ class="nav-cards__item nav-cards__item--guide">
         <h4>🔎 Explore</h4>
         <p>A list of more than 50 available extensions.</p>
     </a>
-    <a href={{< relref "./build-k6-binary-using-go" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=build-k6-binary-using-go/ class="nav-cards__item nav-cards__item--guide">
         <h4>🧩 Bundle</h4>
         <p>Combine multiple extensions into a custom k6 binary.</p>
     </a>
-    <a href={{< relref "./create/" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=create/ class="nav-cards__item nav-cards__item--guide">
         <h4>🏗️ Create</h4>
         <p>Learn how to make your own k6 extension.</p>
     </a>

--- a/docs/sources/k6/v0.56.x/shared/blocking-aws-blockquote.md
+++ b/docs/sources/k6/v0.56.x/shared/blocking-aws-blockquote.md
@@ -7,6 +7,6 @@ title: jslib/aws module blocking admonition
 In some cases, using this library&apos;s operations might impact performance and skew your test results.
 <br>
 <br>
-To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions](../../using-k6/test-lifecycle/). These functions run before and after the test run and have no impact on the test results.
+To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions](/docs/k6/<K6_VERSION>/using-k6/test-lifecycle/). These functions run before and after the test run and have no impact on the test results.
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.56.x/shared/blocking-aws-blockquote.md
+++ b/docs/sources/k6/v0.56.x/shared/blocking-aws-blockquote.md
@@ -7,6 +7,6 @@ title: jslib/aws module blocking admonition
 In some cases, using this library&apos;s operations might impact performance and skew your test results.
 <br>
 <br>
-To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions]({{< relref "../using-k6/test-lifecycle" >}}). These functions run before and after the test run and have no impact on the test results.
+To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions](../../using-k6/test-lifecycle/). These functions run before and after the test run and have no impact on the test results.
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.56.x/shared/crypto-module.md
+++ b/docs/sources/k6/v0.56.x/shared/crypto-module.md
@@ -7,6 +7,6 @@ title: k6/crypto module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/webcrypto API]({{< relref "../javascript-api/k6-experimental/webcrypto" >}}) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto]({{< relref "../javascript-api/k6-crypto" >}}).
+The new [k6/experimental/webcrypto API](../../javascript-api/k6-experimental/webcrypto/) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto](../../javascript-api/k6-crypto/).
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.56.x/shared/crypto-module.md
+++ b/docs/sources/k6/v0.56.x/shared/crypto-module.md
@@ -7,6 +7,6 @@ title: k6/crypto module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/webcrypto API](../../javascript-api/k6-experimental/webcrypto/) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto](../../javascript-api/k6-crypto/).
+The new [k6/experimental/webcrypto API](/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/webcrypto/) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto](/docs/k6/<K6_VERSION>/javascript-api/k6-crypto/).
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.56.x/shared/experimental-module.md
+++ b/docs/sources/k6/v0.56.x/shared/experimental-module.md
@@ -7,7 +7,7 @@ title: Experimental module admonition
 This is an experimental module.
 <br>
 <br>
-While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process]({{< relref "../extensions/explanations/extension-graduation" >}}).
+While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process](../../extensions/explanations/extension-graduation/).
 <br>
 <br>
 Experimental modules maintain a high level of stability and follow regular maintenance and security measures. Feel free to [open an issue](https://github.com/grafana/k6/issues) if you have any feedback or suggestions.

--- a/docs/sources/k6/v0.56.x/shared/experimental-module.md
+++ b/docs/sources/k6/v0.56.x/shared/experimental-module.md
@@ -7,7 +7,7 @@ title: Experimental module admonition
 This is an experimental module.
 <br>
 <br>
-While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process](../../extensions/explanations/extension-graduation/).
+While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process](/docs/k6/<K6_VERSION>/extensions/explanations/extension-graduation/).
 <br>
 <br>
 Experimental modules maintain a high level of stability and follow regular maintenance and security measures. Feel free to [open an issue](https://github.com/grafana/k6/issues) if you have any feedback or suggestions.

--- a/docs/sources/k6/v0.56.x/shared/ws-module.md
+++ b/docs/sources/k6/v0.56.x/shared/ws-module.md
@@ -7,7 +7,7 @@ title: k6/ws module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/websockets API]({{< relref "../javascript-api/k6-experimental/websockets" >}}) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
+The new [k6/experimental/websockets API](../../javascript-api/k6-experimental/websockets/) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
 <br>
 <br>
 When possible, we recommend using the new API. It uses a global event loop for consistency with other k6 APIs and better performance.

--- a/docs/sources/k6/v0.56.x/shared/ws-module.md
+++ b/docs/sources/k6/v0.56.x/shared/ws-module.md
@@ -7,7 +7,7 @@ title: k6/ws module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/websockets API](../../javascript-api/k6-experimental/websockets/) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
+The new [k6/experimental/websockets API](/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/websockets/) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
 <br>
 <br>
 When possible, we recommend using the new API. It uses a global event loop for consistency with other k6 APIs and better performance.

--- a/docs/sources/k6/v0.57.x/extensions/_index.md
+++ b/docs/sources/k6/v0.57.x/extensions/_index.md
@@ -11,15 +11,15 @@ Expand the potential use cases for k6.
 ## Quickstart
 
 <div class="nav-cards">
-    <a href={{< relref "./explore" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=explore/ class="nav-cards__item nav-cards__item--guide">
         <h4>🔎 Explore</h4>
         <p>A list of more than 50 available extensions.</p>
     </a>
-    <a href={{< relref "./build-k6-binary-using-go" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=build-k6-binary-using-go/ class="nav-cards__item nav-cards__item--guide">
         <h4>🧩 Bundle</h4>
         <p>Combine multiple extensions into a custom k6 binary.</p>
     </a>
-    <a href={{< relref "./create/" >}} class="nav-cards__item nav-cards__item--guide">
+    <a href=create/ class="nav-cards__item nav-cards__item--guide">
         <h4>🏗️ Create</h4>
         <p>Learn how to make your own k6 extension.</p>
     </a>

--- a/docs/sources/k6/v0.57.x/shared/blocking-aws-blockquote.md
+++ b/docs/sources/k6/v0.57.x/shared/blocking-aws-blockquote.md
@@ -7,6 +7,6 @@ title: jslib/aws module blocking admonition
 In some cases, using this library&apos;s operations might impact performance and skew your test results.
 <br>
 <br>
-To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions](../../using-k6/test-lifecycle/). These functions run before and after the test run and have no impact on the test results.
+To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions](/docs/k6/<K6_VERSION>/using-k6/test-lifecycle/). These functions run before and after the test run and have no impact on the test results.
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.57.x/shared/blocking-aws-blockquote.md
+++ b/docs/sources/k6/v0.57.x/shared/blocking-aws-blockquote.md
@@ -7,6 +7,6 @@ title: jslib/aws module blocking admonition
 In some cases, using this library&apos;s operations might impact performance and skew your test results.
 <br>
 <br>
-To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions]({{< relref "../using-k6/test-lifecycle" >}}). These functions run before and after the test run and have no impact on the test results.
+To ensure accurate results, consider executing these operations in the `setup` and `teardown` [lifecycle functions](../../using-k6/test-lifecycle/). These functions run before and after the test run and have no impact on the test results.
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.57.x/shared/crypto-module.md
+++ b/docs/sources/k6/v0.57.x/shared/crypto-module.md
@@ -7,6 +7,6 @@ title: k6/crypto module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/webcrypto API]({{< relref "../javascript-api/k6-experimental/webcrypto" >}}) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto]({{< relref "../javascript-api/k6-crypto" >}}).
+The new [k6/experimental/webcrypto API](../../javascript-api/k6-experimental/webcrypto/) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto](../../javascript-api/k6-crypto/).
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.57.x/shared/crypto-module.md
+++ b/docs/sources/k6/v0.57.x/shared/crypto-module.md
@@ -7,6 +7,6 @@ title: k6/crypto module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/webcrypto API](../../javascript-api/k6-experimental/webcrypto/) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto](../../javascript-api/k6-crypto/).
+The new [k6/experimental/webcrypto API](/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/webcrypto/) partially implements the [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/), supporting more features than [k6/crypto](/docs/k6/<K6_VERSION>/javascript-api/k6-crypto/).
 
 {{< /admonition >}}

--- a/docs/sources/k6/v0.57.x/shared/experimental-module.md
+++ b/docs/sources/k6/v0.57.x/shared/experimental-module.md
@@ -7,7 +7,7 @@ title: Experimental module admonition
 This is an experimental module.
 <br>
 <br>
-While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process]({{< relref "../extensions/explanations/extension-graduation" >}}).
+While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process](../../extensions/explanations/extension-graduation/).
 <br>
 <br>
 Experimental modules maintain a high level of stability and follow regular maintenance and security measures. Feel free to [open an issue](https://github.com/grafana/k6/issues) if you have any feedback or suggestions.

--- a/docs/sources/k6/v0.57.x/shared/experimental-module.md
+++ b/docs/sources/k6/v0.57.x/shared/experimental-module.md
@@ -7,7 +7,7 @@ title: Experimental module admonition
 This is an experimental module.
 <br>
 <br>
-While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process](../../extensions/explanations/extension-graduation/).
+While we intend to keep experimental modules as stable as possible, we may need to introduce breaking changes. This could happen at future k6 releases until the module becomes fully stable and graduates as a k6 core module. For more information, refer to the [extension graduation process](/docs/k6/<K6_VERSION>/extensions/explanations/extension-graduation/).
 <br>
 <br>
 Experimental modules maintain a high level of stability and follow regular maintenance and security measures. Feel free to [open an issue](https://github.com/grafana/k6/issues) if you have any feedback or suggestions.

--- a/docs/sources/k6/v0.57.x/shared/ws-module.md
+++ b/docs/sources/k6/v0.57.x/shared/ws-module.md
@@ -7,7 +7,7 @@ title: k6/ws module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/websockets API]({{< relref "../javascript-api/k6-experimental/websockets" >}}) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
+The new [k6/experimental/websockets API](../../javascript-api/k6-experimental/websockets/) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
 <br>
 <br>
 When possible, we recommend using the new API. It uses a global event loop for consistency with other k6 APIs and better performance.

--- a/docs/sources/k6/v0.57.x/shared/ws-module.md
+++ b/docs/sources/k6/v0.57.x/shared/ws-module.md
@@ -7,7 +7,7 @@ title: k6/ws module admonition
 A module with a better and standard API exists.
 <br>
 <br>
-The new [k6/experimental/websockets API](../../javascript-api/k6-experimental/websockets/) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
+The new [k6/experimental/websockets API](/docs/k6/<K6_VERSION>/javascript-api/k6-experimental/websockets/) partially implements the [WebSockets API living standard](https://websockets.spec.whatwg.org/).
 <br>
 <br>
 When possible, we recommend using the new API. It uses a global event loop for consistency with other k6 APIs and better performance.


### PR DESCRIPTION
For https://github.com/grafana/website/issues/24017

Removes all relref shortcodes.

Repository: grafana/k6-docs
Website-Pull-Request: https://github.com/grafana/website/pull/24498