### PR TITLE
Remove symbols from CLI command code snippets

### DIFF
--- a/docs/sources/k6/next/examples/generating-uuids.md
+++ b/docs/sources/k6/next/examples/generating-uuids.md
@@ -9,8 +9,6 @@ weight: 11
 If you want to make a version 4 UUID,
 you can use the [`uuidv4` function](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/utils/uuidv4) from the [k6 JS lib repository](https://jslib.k6.io/).
 
-{{< code >}}
-
 ```javascript
 import { uuidv4 } from 'https://jslib.k6.io/k6-utils/1.4.0/index.js';
 
@@ -19,8 +17,6 @@ export default function () {
   console.log(randomUUID); // 35acae14-f7cb-468a-9866-1fc45713149a
 }
 ```
-
-{{< /code >}}
 
 If you really need other UUID versions, you must rely on an external library.
 
@@ -57,17 +53,15 @@ For this to work, we first need to go through a few required steps:
 4. Move the `uuid.js` file to the same folder as your script file. Now you can import
    it into your test script:
 
-   {{< code >}}
+   <!-- md-k6:skip -->
 
    ```javascript
    import uuid from './uuid.js';
    ```
 
-   {{< /code >}}
-
 This example generates a v1 UUID:
 
-{{< code >}}
+<!-- md-k6:skip -->
 
 ```javascript
 import uuid from './uuid.js';
@@ -78,5 +72,3 @@ export default function () {
   console.log(uuid1);
 }
 ```
-
-{{< /code >}}

--- a/docs/sources/k6/next/examples/generating-uuids.md
+++ b/docs/sources/k6/next/examples/generating-uuids.md
@@ -40,7 +40,7 @@ For this to work, we first need to go through a few required steps:
    {{< code >}}
 
    ```bash
-   $ npm install uuid@3.4.0
+   npm install uuid@3.4.0
    ```
 
    {{< /code >}}
@@ -49,7 +49,7 @@ For this to work, we first need to go through a few required steps:
    {{< code >}}
 
    ```bash
-   $ browserify node_modules/uuid/index.js -s uuid > uuid.js
+   browserify node_modules/uuid/index.js -s uuid > uuid.js
    ```
 
    {{< /code >}}

--- a/docs/sources/k6/next/extensions/build-k6-binary-using-go.md
+++ b/docs/sources/k6/next/extensions/build-k6-binary-using-go.md
@@ -25,7 +25,7 @@ Not interested in setting up a Go environment? You can [use Docker instead](http
 Given the prerequisite Go setup, installing [xk6](https://github.com/grafana/xk6) itself requires only the following command:
 
 ```bash
-$ go install go.k6.io/xk6/cmd/xk6@latest
+go install go.k6.io/xk6/cmd/xk6@latest
 ```
 
 To confirm your installation, run `which xk6` on Linux and Mac, or `where xk6` on Windows.
@@ -41,7 +41,7 @@ Once installed, building a k6 binary with one or more extensions can be done wit
 command as follows:
 
 ```bash
-$ xk6 build latest \
+xk6 build latest \
   --with github.com/grafana/xk6-sql@v0.0.1 \
   --with github.com/grafana/xk6-output-prometheus-remote
 ```
@@ -112,7 +112,7 @@ Now that we have our newly built k6 binary, we can run scripts using the functio
 of the bundled extensions.
 
 ```bash
-$ ./k6 run my-script.js
+./k6 run my-script.js
 ```
 
 > Be sure to specify the binary just built in the current directory as `./k6`, or else

--- a/docs/sources/k6/next/extensions/create/javascript-extensions.md
+++ b/docs/sources/k6/next/extensions/create/javascript-extensions.md
@@ -25,7 +25,7 @@ To run this tutorial, you'll need the following applications installed:
 You also need to install xk6:
 
 ```bash
-$ go install go.k6.io/xk6/cmd/xk6@latest
+go install go.k6.io/xk6/cmd/xk6@latest
 ```
 
 ## Write a simple extension
@@ -33,7 +33,7 @@ $ go install go.k6.io/xk6/cmd/xk6@latest
 1. First, set up a directory to work in:
 
 ```bash
-$ mkdir xk6-compare; cd xk6-compare; go mod init xk6-compare
+mkdir xk6-compare; cd xk6-compare; go mod init xk6-compare
 ```
 
 1. In the directory, make a Go file for your JavaScript extension.
@@ -123,7 +123,7 @@ func (c *Compare) IsGreater(a, b int) bool {
 To build a k6 binary with this extension, run this command:
 
 ```bash
-$ xk6 build --with xk6-compare=.
+xk6 build --with xk6-compare=.
 ```
 
 {{< admonition type="note" >}}

--- a/docs/sources/k6/next/extensions/create/javascript-extensions.md
+++ b/docs/sources/k6/next/extensions/create/javascript-extensions.md
@@ -139,7 +139,7 @@ Now, use the extension in a test script!
 
 1. Make a file with a name like `test.js` then add this code:
 
-{{< code >}}
+<!-- md-k6:skip -->
 
 ```javascript
 import compare from 'k6/x/compare';
@@ -149,8 +149,6 @@ export default function () {
   console.log(`${compare.isGreater(1, 3)}, ${compare.comparison_result}`);
 }
 ```
-
-{{< /code >}}
 
 1. Run the test with `./k6 run test.js`.
 
@@ -302,7 +300,7 @@ func (c *Compare) GetInternalState() *InternalState {
 
 Create a test script to utilize the new `getInternalState()` function as in the following:
 
-{{< code >}}
+<!-- md-k6:skip -->
 
 ```javascript
 import compare from 'k6/x/compare';
@@ -314,8 +312,6 @@ export default function () {
   );
 }
 ```
-
-{{< /code >}}
 
 Executing the script as `./k6 run test-state.js --vus 2 --iterations 5` will produce output similar to the following:
 

--- a/docs/sources/k6/next/extensions/create/output-extensions.md
+++ b/docs/sources/k6/next/extensions/create/output-extensions.md
@@ -30,7 +30,7 @@ To run this tutorial, you'll need the following applications installed:
 You also need to install xk6:
 
 ```bash
-$ go install go.k6.io/xk6/cmd/xk6@latest
+go install go.k6.io/xk6/cmd/xk6@latest
 ```
 
 ## Write a simple extension
@@ -38,7 +38,7 @@ $ go install go.k6.io/xk6/cmd/xk6@latest
 1. Set up a directory to work in.
 
 ```bash
-$ mkdir xk6-output-logger; cd xk6-output-logger; go mod init xk6-output-logger
+mkdir xk6-output-logger; cd xk6-output-logger; go mod init xk6-output-logger
 ```
 
 1. The core of an Output extension is a struct that implements the [`output.Output`](https://pkg.go.dev/go.k6.io/k6/output#Output)
@@ -178,7 +178,7 @@ Notice a couple of things:
 To build a k6 binary with this extension, run:
 
 ```bash
-$ xk6 build --with xk6-output-logger=.
+xk6 build --with xk6-output-logger=.
 ```
 
 {{< admonition type="note" >}}
@@ -212,7 +212,7 @@ export default function () {
 1. Now, run the test.
 
 ```bash
-$ ./k6 run test.js --out logger --quiet --no-summary --iterations 2
+./k6 run test.js --out logger --quiet --no-summary --iterations 2
 ```
 
 {{< admonition type="note" >}}

--- a/docs/sources/k6/next/get-started/running-k6.md
+++ b/docs/sources/k6/next/get-started/running-k6.md
@@ -29,15 +29,15 @@ To run a simple local script:
    {{< code >}}
 
    ```linux
-   $ k6 new
+   k6 new
    ```
 
    ```docker
-   $ docker run --rm -u $(id -u) -v $PWD:/app -w /app grafana/k6 new
+   docker run --rm -u $(id -u) -v $PWD:/app -w /app grafana/k6 new
    ```
 
    ```windows
-   PS C:\> docker run --rm -i -v ${PWD}:/app -w /app grafana/k6 init
+   docker run --rm -i -v ${PWD}:/app -w /app grafana/k6 init
    ```
 
    {{< /code >}}
@@ -50,7 +50,7 @@ To run a simple local script:
    {{< code >}}
 
    ```linux
-   $ k6 run script.js
+   k6 run script.js
    ```
 
    ```docker
@@ -60,11 +60,11 @@ To run a simple local script:
    # pipe the actual file into the container with `<` or equivalent. This will
    # cause the file to be redirected into the container and be read by k6.
 
-   $ docker run --rm -i grafana/k6 run - <script.js
+   docker run --rm -i grafana/k6 run - <script.js
    ```
 
    ```windows
-   PS C:\> cat script.js | docker run --rm -i grafana/k6 run -
+   cat script.js | docker run --rm -i grafana/k6 run -
    ```
 
    {{< /code >}}
@@ -76,15 +76,15 @@ Now run a load test with more than one virtual user and a longer duration:
 {{< code >}}
 
 ```linux
-$ k6 run --vus 10 --duration 30s script.js
+k6 run --vus 10 --duration 30s script.js
 ```
 
 ```docker
-$ docker run --rm -i grafana/k6 run --vus 10 --duration 30s - <script.js
+docker run --rm -i grafana/k6 run --vus 10 --duration 30s - <script.js
 ```
 
 ```windows
-PS C:\> cat script.js | docker run --rm -i grafana/k6 run --vus 10 --duration 30s -
+cat script.js | docker run --rm -i grafana/k6 run --vus 10 --duration 30s -
 ```
 
 {{< /code >}}
@@ -147,15 +147,15 @@ If you run the script without flags, k6 uses the options defined in the script:
 {{< code >}}
 
 ```linux
-$ k6 run script.js
+k6 run script.js
 ```
 
 ```docker
-$ docker run --rm -i grafana/k6 run - <script.js
+docker run --rm -i grafana/k6 run - <script.js
 ```
 
 ```windows
-PS C:\> cat script.js | docker run --rm -i grafana/k6 run -
+cat script.js | docker run --rm -i grafana/k6 run -
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/next/javascript-api/k6-browser/_index.md
+++ b/docs/sources/k6/next/javascript-api/k6-browser/_index.md
@@ -79,7 +79,7 @@ Then, you can run the test with this command. Also, see the [browser module opti
 {{< code >}}
 
 ```bash
-$ k6 run script.js
+k6 run script.js
 ```
 
 ```docker
@@ -97,11 +97,11 @@ docker run --rm -i grafana/k6:master-with-browser run - <script.js
 ```
 
 ```windows
-C:\k6> k6 run script.js
+k6 run script.js
 ```
 
 ```windows-powershell
-PS C:\k6> k6 run script.js
+k6 run script.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/next/javascript-api/k6-experimental/websockets/params.md
+++ b/docs/sources/k6/next/javascript-api/k6-experimental/websockets/params.md
@@ -47,7 +47,7 @@ The preceding example uses a WebSocket echo server, which you can run with the f
 {{< code >}}
 
 ```bash
-$ docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
+docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/next/javascript-api/k6-experimental/websockets/websocket/_index.md
+++ b/docs/sources/k6/next/javascript-api/k6-experimental/websockets/websocket/_index.md
@@ -52,7 +52,7 @@ The preceding example uses a WebSocket echo server, which you can run with the f
 {{< code >}}
 
 ```bash
-$ docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
+docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/next/javascript-api/k6-experimental/websockets/websocket/websocket-addeventlistener.md
+++ b/docs/sources/k6/next/javascript-api/k6-experimental/websockets/websocket/websocket-addeventlistener.md
@@ -33,7 +33,7 @@ import { WebSocket } from 'k6/experimental/websockets';
 
 export default function () {
   const ws = new WebSocket('ws://localhost:10000');
-  ws.binaryType = "arraybuffer";
+  ws.binaryType = 'arraybuffer';
 
   ws.onopen = () => {
     console.log('connected');
@@ -60,7 +60,7 @@ The preceding example uses a WebSocket echo server, which you can run with the f
 {{< code >}}
 
 ```bash
-$ docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
+docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/next/javascript-api/k6-experimental/websockets/websocket/websocket-close.md
+++ b/docs/sources/k6/next/javascript-api/k6-experimental/websockets/websocket/websocket-close.md
@@ -38,7 +38,7 @@ The preceding example uses a WebSocket echo server, which you can run with the f
 {{< code >}}
 
 ```bash
-$ docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
+docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/next/javascript-api/k6-experimental/websockets/websocket/websocket-onclose.md
+++ b/docs/sources/k6/next/javascript-api/k6-experimental/websockets/websocket/websocket-onclose.md
@@ -40,7 +40,7 @@ The preceding example uses a WebSocket echo server, which you can run with the f
 {{< code >}}
 
 ```bash
-$ docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
+docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/next/javascript-api/k6-experimental/websockets/websocket/websocket-onerror.md
+++ b/docs/sources/k6/next/javascript-api/k6-experimental/websockets/websocket/websocket-onerror.md
@@ -35,7 +35,7 @@ The preceding example uses a WebSocket echo server, which you can run with the f
 {{< code >}}
 
 ```bash
-$ docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
+docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/next/javascript-api/k6-experimental/websockets/websocket/websocket-onmessage.md
+++ b/docs/sources/k6/next/javascript-api/k6-experimental/websockets/websocket/websocket-onmessage.md
@@ -37,7 +37,7 @@ The preceding example uses a WebSocket echo server, which you can run with the f
 {{< code >}}
 
 ```bash
-$ docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
+docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/next/javascript-api/k6-experimental/websockets/websocket/websocket-onopen.md
+++ b/docs/sources/k6/next/javascript-api/k6-experimental/websockets/websocket/websocket-onopen.md
@@ -35,7 +35,7 @@ The preceding example uses a WebSocket echo server, which you can run with the f
 {{< code >}}
 
 ```bash
-$ docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
+docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/next/javascript-api/k6-experimental/websockets/websocket/websocket-onpong.md
+++ b/docs/sources/k6/next/javascript-api/k6-experimental/websockets/websocket/websocket-onpong.md
@@ -28,7 +28,7 @@ export default function () {
 
   ws.onopen = () => {
     ws.ping();
-  }
+  };
 }
 ```
 
@@ -39,7 +39,7 @@ The preceding example uses a WebSocket echo server, which you can run with the f
 {{< code >}}
 
 ```bash
-$ docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
+docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/next/javascript-api/k6-experimental/websockets/websocket/websocket-ping.md
+++ b/docs/sources/k6/next/javascript-api/k6-experimental/websockets/websocket/websocket-ping.md
@@ -40,7 +40,7 @@ The preceding example uses a WebSocket echo server, which you can run with the f
 {{< code >}}
 
 ```bash
-$ docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
+docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/next/javascript-api/k6-experimental/websockets/websocket/websocket-send.md
+++ b/docs/sources/k6/next/javascript-api/k6-experimental/websockets/websocket/websocket-send.md
@@ -39,7 +39,7 @@ The preceding example uses a WebSocket echo server, which you can run with the f
 {{< code >}}
 
 ```bash
-$ docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
+docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/next/javascript-api/k6-net-grpc/stream/_index.md
+++ b/docs/sources/k6/next/javascript-api/k6-net-grpc/stream/_index.md
@@ -202,7 +202,7 @@ The preceding examples use a demo server, which you can run with the following c
 {{< code >}}
 
 ```bash
-$ go run -mod=mod examples/grpc_server/*.go
+go run -mod=mod examples/grpc_server/*.go
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/next/javascript-api/k6-net-grpc/stream/_index.md
+++ b/docs/sources/k6/next/javascript-api/k6-net-grpc/stream/_index.md
@@ -23,7 +23,7 @@ Using a gRPC client creates a stream. The client should be connected to the serv
 
 _A k6 script that sends several randomly chosen points from the pre-generated feature database with a variable delay in between. Prints the statistics when they are sent from the server._
 
-{{< code >}}
+<!-- md-k6:skip -->
 
 ```javascript
 import { Client, Stream } from 'k6/net/grpc';
@@ -133,11 +133,9 @@ const pointSender = (stream, point) => {
 };
 ```
 
-{{< /code >}}
-
 _A k6 script that sends a rectangle message and results (features) are streamed back to the client._
 
-{{< code >}}
+<!-- md-k6:skip -->
 
 ```javascript
 import { Client, Stream } from 'k6/net/grpc';
@@ -195,14 +193,8 @@ export default () => {
 };
 ```
 
-{{< /code >}}
-
 The preceding examples use a demo server, which you can run with the following command (Golang should be installed) in [k6 repository's root](https://github.com/grafana/k6):
-
-{{< code >}}
 
 ```bash
 go run -mod=mod examples/grpc_server/*.go
 ```
-
-{{< /code >}}

--- a/docs/sources/k6/next/misc/archive.md
+++ b/docs/sources/k6/next/misc/archive.md
@@ -22,7 +22,7 @@ Let's say that you normally execute a test using:
 {{< code >}}
 
 ```bash
-$ k6 run script.js
+k6 run script.js
 ```
 
 {{< /code >}}
@@ -35,7 +35,7 @@ into a tar file:
 {{< code >}}
 
 ```bash
-$ k6 archive script.js
+k6 archive script.js
 ```
 
 {{< /code >}}
@@ -52,7 +52,7 @@ files you can execute:
 {{< code >}}
 
 ```bash
-$ k6 run archive.tar
+k6 run archive.tar
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/next/results-output/real-time/amazon-cloudwatch.md
+++ b/docs/sources/k6/next/results-output/real-time/amazon-cloudwatch.md
@@ -29,13 +29,13 @@ We presume that you already have a machine that supports both running k6 and Clo
 2. Download the CloudWatch Agent package suitable for your operating system. For example, on Debian 10 (Buster), we've used the following link. For other operating systems, please refer to this [guide](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/download-cloudwatch-agent-commandline.html):
 
    ```bash
-   $ wget https://s3.amazonaws.com/amazoncloudwatch-agent/debian/amd64/latest/amazon-cloudwatch-agent.deb
+   wget https://s3.amazonaws.com/amazoncloudwatch-agent/debian/amd64/latest/amazon-cloudwatch-agent.deb
    ```
 
 3. Install the package:
 
    ```bash
-   $ sudo dpkg -i amazon-cloudwatch-agent.deb
+   sudo dpkg -i amazon-cloudwatch-agent.deb
    ```
 
 4. Configure the agent to receive data from k6. For this, create a file called "_/opt/aws/amazon-cloudwatch-agent/etc/statsd.json_" and paste the following JSON config object into it. This configuration means that the agent would listen on port number 8125, which is the default port number for k6 and StatsD. The interval for collecting metrics is 5 seconds and we don't aggregate them, since we need the raw data later in CloudWatch.
@@ -58,13 +58,13 @@ We presume that you already have a machine that supports both running k6 and Clo
 5. Run the following command to start the agent:
 
    ```bash
-   $ sudo amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/etc/statsd.json
+   sudo amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/etc/statsd.json
    ```
 
 6. You can check the status of the agent using the following command:
 
    ```bash
-   $ amazon-cloudwatch-agent-ctl -a status
+   amazon-cloudwatch-agent-ctl -a status
    ```
 
 ## Run the k6 test
@@ -74,7 +74,7 @@ Once the agent is running, you can run your test with:
 {{< code >}}
 
 ```bash
-$ K6_STATSD_ENABLE_TAGS=true k6 run --out output-statsd script.js
+K6_STATSD_ENABLE_TAGS=true k6 run --out output-statsd script.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/next/results-output/real-time/apache-kafka.md
+++ b/docs/sources/k6/next/results-output/real-time/apache-kafka.md
@@ -41,7 +41,7 @@ You can configure the broker (or multiple ones), topic and message format direct
 {{< code >}}
 
 ```bash
-$ k6 run --out xk6-kafka=brokers=broker_host:8000,topic=k6
+k6 run --out xk6-kafka=brokers=broker_host:8000,topic=k6
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/next/results-output/real-time/cloud.md
+++ b/docs/sources/k6/next/results-output/real-time/cloud.md
@@ -41,7 +41,7 @@ so `k6 cloud run --local-execution` will consume VUH or test runs from your subs
    {{< code >}}
 
    ```bash
-   $ k6 cloud login --token <YOUR_API_TOKEN>
+   k6 cloud login --token <YOUR_API_TOKEN>
    ```
 
    {{< /code >}}
@@ -53,7 +53,7 @@ so `k6 cloud run --local-execution` will consume VUH or test runs from your subs
    {{< code >}}
 
    ```bash
-   $ k6 cloud run --local-execution script.js
+   k6 cloud run --local-execution script.js
    ```
 
    {{< /code >}}
@@ -63,7 +63,7 @@ so `k6 cloud run --local-execution` will consume VUH or test runs from your subs
    {{< code >}}
 
    ```bash
-   $ K6_CLOUD_TOKEN=<YOUR_API_TOKEN> k6 cloud run --local-execution script.js
+   K6_CLOUD_TOKEN=<YOUR_API_TOKEN> k6 cloud run --local-execution script.js
    ```
 
    {{< /code >}}

--- a/docs/sources/k6/next/results-output/real-time/csv.md
+++ b/docs/sources/k6/next/results-output/real-time/csv.md
@@ -13,7 +13,7 @@ Pass the path for your CSV file as the flag argument:
 {{< code >}}
 
 ```bash
-$ k6 run --out csv=test_results.csv script.js
+k6 run --out csv=test_results.csv script.js
 ```
 
 {{< /code >}}
@@ -23,7 +23,7 @@ You can also get the results gzipped, like this:
 {{< code >}}
 
 ```bash
-$ k6 run --out csv=test_results.gz script.js
+k6 run --out csv=test_results.gz script.js
 ```
 
 {{< /code >}}
@@ -31,7 +31,7 @@ $ k6 run --out csv=test_results.gz script.js
 To inspect the output in real time, you can use a command like `tail -f` on the file you save:
 
 ```bash
-$ tail -f test_results.csv
+tail -f test_results.csv
 ```
 
 ## CSV format

--- a/docs/sources/k6/next/results-output/real-time/datadog.md
+++ b/docs/sources/k6/next/results-output/real-time/datadog.md
@@ -67,7 +67,7 @@ Once the Datadog Agent service is running, run the k6 test and send the metrics 
 {{< code >}}
 
 ```bash
-$ K6_STATSD_ENABLE_TAGS=true k6 run --out output-statsd script.js
+K6_STATSD_ENABLE_TAGS=true k6 run --out output-statsd script.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/next/results-output/real-time/json.md
+++ b/docs/sources/k6/next/results-output/real-time/json.md
@@ -13,11 +13,11 @@ Pass the path for your JSON file as the flag argument:
 {{< code >}}
 
 ```bash
-$ k6 run --out json=test_results.json script.js
+k6 run --out json=test_results.json script.js
 ```
 
 ```docker
-$ docker run -it --rm \
+docker run -it --rm \
     -v <scriptdir>:/scripts \
     -v <outputdir>:/jsonoutput \
     grafana/k6 run --out json=/jsonoutput/my_test_result.json /scripts/script.js
@@ -32,11 +32,11 @@ Or if you want to get the result gzipped, like this:
 {{< code >}}
 
 ```bash
-$ k6 run --out json=test_results.gz script.js
+k6 run --out json=test_results.gz script.js
 ```
 
 ```docker
-$ docker run -it --rm \
+docker run -it --rm \
     -v <scriptdir>:/scripts \
     -v <outputdir>:/jsonoutput \
     grafana/k6 run --out json=/jsonoutput/my_test_result.gz /scripts/script.js
@@ -49,7 +49,7 @@ $ docker run -it --rm \
 To inspect the output in real time, you can use a command like `tail -f` on the file you save:
 
 ```bash
-$ tail -f test_results.json
+tail -f test_results.json
 ```
 
 ## JSON format
@@ -101,7 +101,7 @@ You can quickly create [filters][jq_filters_url] to return a particular metric o
 {{< code >}}
 
 ```bash
-$ jq '. | select(.type=="Point" and .metric == "http_req_duration" and .data.tags.status >= "200")' myscript-output.json
+jq '. | select(.type=="Point" and .metric == "http_req_duration" and .data.tags.status >= "200")' myscript-output.json
 ```
 
 {{< /code >}}
@@ -111,7 +111,7 @@ And calculate an aggregated value of any metric:
 {{< code >}}
 
 ```bash
-$ jq '. | select(.type=="Point" and .metric == "http_req_duration" and .data.tags.status >= "200") | .data.value' myscript-output.json | jq -s 'add/length'
+jq '. | select(.type=="Point" and .metric == "http_req_duration" and .data.tags.status >= "200") | .data.value' myscript-output.json | jq -s 'add/length'
 ```
 
 {{< /code >}}
@@ -119,7 +119,7 @@ $ jq '. | select(.type=="Point" and .metric == "http_req_duration" and .data.tag
 {{< code >}}
 
 ```bash
-$ jq '. | select(.type=="Point" and .metric == "http_req_duration" and .data.tags.status >= "200") | .data.value' myscript-output.json | jq -s min
+jq '. | select(.type=="Point" and .metric == "http_req_duration" and .data.tags.status >= "200") | .data.value' myscript-output.json | jq -s min
 ```
 
 {{< /code >}}
@@ -127,7 +127,7 @@ $ jq '. | select(.type=="Point" and .metric == "http_req_duration" and .data.tag
 {{< code >}}
 
 ```bash
-$ jq '. | select(.type=="Point" and .metric == "http_req_duration" and .data.tags.status >= "200") | .data.value' myscript-output.json | jq -s max
+jq '. | select(.type=="Point" and .metric == "http_req_duration" and .data.tags.status >= "200") | .data.value' myscript-output.json | jq -s max
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/next/results-output/real-time/newrelic.md
+++ b/docs/sources/k6/next/results-output/real-time/newrelic.md
@@ -74,7 +74,7 @@ Once the integration is running, run the k6 test and send the metrics to the int
 {{< code >}}
 
 ```bash
-$ K6_STATSD_ENABLE_TAGS=true k6 run --out output-statsd script.js
+K6_STATSD_ENABLE_TAGS=true k6 run --out output-statsd script.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/next/results-output/real-time/opentelemetry.md
+++ b/docs/sources/k6/next/results-output/real-time/opentelemetry.md
@@ -28,7 +28,7 @@ You can use the `--out experimental-opentelemetry` option when running your test
 {{< code >}}
 
 ```bash
-$  K6_OTEL_GRPC_EXPORTER_INSECURE=true K6_OTEL_METRIC_PREFIX=k6_ k6 run --tag test-id=123 -o experimental-opentelemetry examples/script.js
+K6_OTEL_GRPC_EXPORTER_INSECURE=true K6_OTEL_METRIC_PREFIX=k6_ k6 run --tag test-id=123 -o experimental-opentelemetry examples/script.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/next/results-output/real-time/statsd.md
+++ b/docs/sources/k6/next/results-output/real-time/statsd.md
@@ -43,7 +43,7 @@ Using the k6 binary you built in the previous step, you can use the `--out outpu
 {{< code >}}
 
 ```bash
-$ ./k6 run --out output-statsd script.js
+./k6 run --out output-statsd script.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/next/shared/browser/env-var-options.md
+++ b/docs/sources/k6/next/shared/browser/env-var-options.md
@@ -17,7 +17,7 @@ The following command passes the browser options as environment variables to lau
 {{< code >}}
 
 ```bash
-$ K6_BROWSER_HEADLESS=false K6_BROWSER_ARGS='show-property-changed-rects' k6 run script.js
+K6_BROWSER_HEADLESS=false K6_BROWSER_ARGS='show-property-changed-rects' k6 run script.js
 ```
 
 ```docker
@@ -35,11 +35,11 @@ docker run --rm -i -e K6_BROWSER_HEADLESS=false -e K6_BROWSER_ARGS='show-propert
 ```
 
 ```windows
-C:\k6> set "K6_BROWSER_HEADLESS=false" && set "K6_BROWSER_ARGS='show-property-changed-rects' " && k6 run script.js
+set "K6_BROWSER_HEADLESS=false" && set "K6_BROWSER_ARGS='show-property-changed-rects' " && k6 run script.js
 ```
 
 ```windows-powershell
-PS C:\k6> $env:K6_BROWSER_HEADLESS="false" ; $env:K6_BROWSER_ARGS='show-property-changed-rects' ; k6 run script.js
+$env:K6_BROWSER_HEADLESS="false" ; $env:K6_BROWSER_ARGS='show-property-changed-rects' ; k6 run script.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/next/testing-guides/injecting-faults-with-xk6-disruptor/xk6-disruptor/poddisruptor/_index.md
+++ b/docs/sources/k6/next/testing-guides/injecting-faults-with-xk6-disruptor/xk6-disruptor/poddisruptor/_index.md
@@ -28,6 +28,8 @@ This example:
 - Creates a selector that matches all pods in the `default` namespace with the `run=nginx` label
 - Injects a delay of 100ms and makes 10 percent of requests return an http response code `500`.
 
+<!-- md-k6:skip -->
+
 ```javascript
 import { PodDisruptor } from 'k6/x/disruptor';
 

--- a/docs/sources/k6/next/testing-guides/injecting-faults-with-xk6-disruptor/xk6-disruptor/poddisruptor/_index.md
+++ b/docs/sources/k6/next/testing-guides/injecting-faults-with-xk6-disruptor/xk6-disruptor/poddisruptor/_index.md
@@ -14,11 +14,11 @@ To construct a `PodDisruptor`, use the [PodDisruptor() constructor](https://graf
 
 ## Methods
 
-| Method                                                                                                                                 | Description                                                                                                                                         |
-| -------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Method                                                                                                                                                                     | Description                                                                                                                                                                             |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [PodDisruptor.injectGrpcFaults()](https://grafana.com/docs/k6/<K6_VERSION>/testing-guides/injecting-faults-with-xk6-disruptor/xk6-disruptor/poddisruptor/injectgrpcfaults) | Inject [gRPC faults](https://grafana.com/docs/k6/<K6_VERSION>/testing-guides/injecting-faults-with-xk6-disruptor/xk6-disruptor/faults/grpc) in the target Pods                          |
 | [PodDisruptor.injectHTTPFaults()](https://grafana.com/docs/k6/<K6_VERSION>/testing-guides/injecting-faults-with-xk6-disruptor/xk6-disruptor/poddisruptor/injecthttpfaults) | Inject [HTTP faults](https://grafana.com/docs/k6/<K6_VERSION>/testing-guides/injecting-faults-with-xk6-disruptor/xk6-disruptor/faults/http) in the target Pods                          |
-| PodDisruptor.targets()                                                                                                                 | Returns the list of target Pods of the PodDisruptor                                                                                                 |
+| PodDisruptor.targets()                                                                                                                                                     | Returns the list of target Pods of the PodDisruptor                                                                                                                                     |
 | [PodDisruptor.terminatePods()](https://grafana.com/docs/k6/<K6_VERSION>/testing-guides/injecting-faults-with-xk6-disruptor/xk6-disruptor/poddisruptor/terminate-pods)      | executes a [Pod Termination fault](https://grafana.com/docs/k6/<K6_VERSION>/testing-guides/injecting-faults-with-xk6-disruptor/xk6-disruptor/faults/pod-termination) in the target Pods |
 
 ## Example
@@ -57,7 +57,7 @@ export default function () {
 You can test this script by first creating a pod running nginx with the command below, assuming you have [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) installed in your environment:
 
 ```bash
-$ kubectl run nginx --image=nginx
+kubectl run nginx --image=nginx
 ```
 
 You can also use the [xk6-kubernetes](https://github.com/grafana/xk6-kubernetes) extension for creating these resources from your test script.

--- a/docs/sources/k6/next/using-k6-browser/running-browser-tests.md
+++ b/docs/sources/k6/next/using-k6-browser/running-browser-tests.md
@@ -73,7 +73,7 @@ To run a simple local script:
    {{< code >}}
 
    ```bash
-   $ k6 run script.js
+   k6 run script.js
    ```
 
    ```docker
@@ -91,11 +91,11 @@ To run a simple local script:
    ```
 
    ```windows
-   C:\k6> k6 run script.js
+   k6 run script.js
    ```
 
    ```powershell
-   PS C:\k6> k6 run script.js
+   k6 run script.js
    ```
 
    {{< /code >}}
@@ -105,7 +105,7 @@ To run a simple local script:
    {{< code >}}
 
    ```bash
-   $ K6_BROWSER_HEADLESS=false k6 run script.js
+   K6_BROWSER_HEADLESS=false k6 run script.js
    ```
 
    ```docker
@@ -123,11 +123,11 @@ To run a simple local script:
    ```
 
    ```windows
-   C:\k6> set "K6_BROWSER_HEADLESS=false" && k6 run script.js
+   set "K6_BROWSER_HEADLESS=false" && k6 run script.js
    ```
 
    ```powershell
-   PS C:\k6> $env:K6_BROWSER_HEADLESS=false ; k6 run script.js
+   $env:K6_BROWSER_HEADLESS=false ; k6 run script.js
    ```
 
    {{< /code >}}
@@ -145,8 +145,8 @@ To run a simple local script:
    2. Update [Rosetta](<https://en.wikipedia.org/wiki/Rosetta_(software)>) and export an environment variable with the following:
 
       ```bash
-       $ softwareupdate --install-rosetta
-       $ export DOCKER_DEFAULT_PLATFORM=linux/amd64
+      softwareupdate --install-rosetta &&
+        export DOCKER_DEFAULT_PLATFORM=linux/amd64
       ```
 
    3. Select VirtuoFS in **Settings** > **General** > **VirtuoFS**.
@@ -158,7 +158,7 @@ To run a simple local script:
    6. Run the browser image with the following command (adds the `--platform` flag):
 
       ```bash
-      $ docker run --rm -i --platform linux/amd64 -v $(pwd):/home/k6/screenshots -e K6_BROWSER_HEADLESS=false grafana/k6:master-with-browser run - <script.js
+      docker run --rm -i --platform linux/amd64 -v $(pwd):/home/k6/screenshots -e K6_BROWSER_HEADLESS=false grafana/k6:master-with-browser run - <script.js
       ```
 
 ## Interact with elements on your webpage
@@ -258,13 +258,10 @@ export default async function () {
 
     const submitButton = page.locator('input[type="submit"]');
 
-    await Promise.all([
-      page.waitForNavigation(),
-      submitButton.click(),
-    ]);
+    await Promise.all([page.waitForNavigation(), submitButton.click()]);
 
     await check(page.locator('h2'), {
-      'header': async lo => await lo.textContent() == 'Welcome, admin!'
+      header: async (lo) => (await lo.textContent()) == 'Welcome, admin!',
     });
   } finally {
     await page.close();
@@ -332,8 +329,8 @@ export async function browserTest() {
     await page.locator('#checkbox1').check();
 
     await check(page.locator('#checkbox-info-display'), {
-      'checkbox is checked': async lo =>
-        await lo.textContent() === 'Thanks for checking the box'
+      'checkbox is checked': async (lo) =>
+        (await lo.textContent()) === 'Thanks for checking the box',
     });
   } finally {
     await page.close();

--- a/docs/sources/k6/next/using-k6/environment-variables.md
+++ b/docs/sources/k6/next/using-k6/environment-variables.md
@@ -19,6 +19,8 @@ You can use environment variables for two main purposes:
 In k6, the environment variables are exposed through a global `__ENV` variable, a JS object.
 For reference, see the script example below:
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 import { sleep } from 'k6';

--- a/docs/sources/k6/next/using-k6/environment-variables.md
+++ b/docs/sources/k6/next/using-k6/environment-variables.md
@@ -35,7 +35,7 @@ The recommended option to pass environment variables to your testing script is t
 {{< code >}}
 
 ```bash
-$ k6 run -e MY_HOSTNAME=test.k6.io script.js
+k6 run -e MY_HOSTNAME=test.k6.io script.js
 ```
 
 {{< /code >}}
@@ -52,15 +52,15 @@ $ k6 run -e MY_HOSTNAME=test.k6.io script.js
 A second option to pass environment variables is to source them from the local system.
 
 ```bash
-$ MY_HOSTNAME=test.k6.io k6 run script.js
+MY_HOSTNAME=test.k6.io k6 run script.js
 ```
 
 ```windows
-C:\k6> set "MY_HOSTNAME=test.k6.io" && k6 run script.js
+set "MY_HOSTNAME=test.k6.io" && k6 run script.js
 ```
 
 ```powershell
-PS C:\k6> $env:MY_HOSTNAME="test.k6.io"; k6 run script.js
+$env:MY_HOSTNAME="test.k6.io"; k6 run script.js
 ```
 
 #### ⚠️ Warning
@@ -93,15 +93,15 @@ For example, this snippet configures the script to run 10 virtual users for a du
 {{< code >}}
 
 ```bash
-$ K6_VUS=10 K6_DURATION=10s k6 run script.js
+K6_VUS=10 K6_DURATION=10s k6 run script.js
 ```
 
 ```windows
-C:\k6> set "K6_VUS=10 K6_DURATION=10s" && k6 run script.js
+set "K6_VUS=10 K6_DURATION=10s" && k6 run script.js
 ```
 
 ```powershell
-PS C:\k6> $env:K6_VUS=10 ; $env:K6_DURATION="10s" ; k6 run script.js
+$env:K6_VUS=10 ; $env:K6_DURATION="10s" ; k6 run script.js
 ```
 
 {{< /code >}}
@@ -116,7 +116,7 @@ To ensure you're always working with the highest precedence, use command-line fl
 {{< code >}}
 
 ```bash
-$ k6 run -e MY_HOSTNAME=test.k6.io --duration 10s --vus 10 script.js
+k6 run -e MY_HOSTNAME=test.k6.io --duration 10s --vus 10 script.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/next/using-k6/javascript-typescript-compatibility-mode.md
+++ b/docs/sources/k6/next/using-k6/javascript-typescript-compatibility-mode.md
@@ -37,7 +37,7 @@ By default, k6 uses the `--compatibility-mode=extended` mode:
 {{< code >}}
 
 ```bash
-$ k6 run script.js
+k6 run script.js
 ```
 
 {{< /code >}}
@@ -47,11 +47,11 @@ $ k6 run script.js
 {{< code >}}
 
 ```cli
-$ k6 run --compatibility-mode=base script.js
+k6 run --compatibility-mode=base script.js
 ```
 
 ```env
-$ K6_COMPATIBILITY_MODE=base k6 run script.js
+K6_COMPATIBILITY_MODE=base k6 run script.js
 ```
 
 {{< /code >}}
@@ -61,11 +61,11 @@ $ K6_COMPATIBILITY_MODE=base k6 run script.js
 {{< code >}}
 
 ```cli
-$ k6 run script.ts
+k6 run script.ts
 ```
 
 ```env
-$ k6 run script.ts
+k6 run script.ts
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/next/using-k6/javascript-typescript-compatibility-mode.md
+++ b/docs/sources/k6/next/using-k6/javascript-typescript-compatibility-mode.md
@@ -34,13 +34,9 @@ When running tests, you can change the mode by using the `--compatibility-mode` 
 
 By default, k6 uses the `--compatibility-mode=extended` mode:
 
-{{< code >}}
-
 ```bash
 k6 run script.js
 ```
-
-{{< /code >}}
 
 ## Base mode
 
@@ -76,8 +72,6 @@ TypeScript support is partial as it strips the type information but doesn't prov
 
 ### CommonJS Example
 
-{{< code >}}
-
 ```javascript
 const http = require('k6/http');
 const k6 = require('k6');
@@ -92,8 +86,6 @@ module.exports.default = function () {
   k6.sleep(1);
 };
 ```
-
-{{< /code >}}
 
 > ### ⚠️ About require()
 >

--- a/docs/sources/k6/next/using-k6/k6-options/how-to.md
+++ b/docs/sources/k6/next/using-k6/k6-options/how-to.md
@@ -93,21 +93,21 @@ You can also set the options from the previous example through environment varia
 {{< code >}}
 
 ```bash
-$ K6_NO_CONNECTION_REUSE=true K6_USER_AGENT="MyK6UserAgentString/1.0" k6 run script.js
+K6_NO_CONNECTION_REUSE=true K6_USER_AGENT="MyK6UserAgentString/1.0" k6 run script.js
 
-$ k6 run --no-connection-reuse --user-agent "MyK6UserAgentString/1.0" script.js
+k6 run --no-connection-reuse --user-agent "MyK6UserAgentString/1.0" script.js
 ```
 
 ```windows
-C:\k6> set "K6_NO_CONNECTION_REUSE=true" && set "K6_USER_AGENT=MyK6UserAgentString/1.0" && k6 run script.js
+set "K6_NO_CONNECTION_REUSE=true" && set "K6_USER_AGENT=MyK6UserAgentString/1.0" && k6 run script.js
 
-C:\k6> k6 run --no-connection-reuse --user-agent "MyK6UserAgentString/1.0" script.js
+k6 run --no-connection-reuse --user-agent "MyK6UserAgentString/1.0" script.js
 ```
 
 ```powershell
-PS C:\k6> $env:K6_NO_CONNECTION_REUSE=true; $env:K6_USER_AGENT="MyK6UserAgentString/1.0"; k6 run script.js
+$env:K6_NO_CONNECTION_REUSE=true; $env:K6_USER_AGENT="MyK6UserAgentString/1.0"; k6 run script.js
 
-PS C:\k6> k6 run --no-connection-reuse --user-agent "MyK6UserAgentString/1.0" script.js
+k6 run --no-connection-reuse --user-agent "MyK6UserAgentString/1.0" script.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/next/using-k6/k6-options/how-to.md
+++ b/docs/sources/k6/next/using-k6/k6-options/how-to.md
@@ -62,8 +62,6 @@ The following JS snippets show some examples of how you can set options.
 
 ### Set options in the script
 
-{{< code >}}
-
 ```javascript
 import http from 'k6/http';
 
@@ -83,8 +81,6 @@ export default function () {
   http.get('http://test.k6.io/');
 }
 ```
-
-{{< /code >}}
 
 ### Set options with environment variables
 
@@ -126,7 +122,7 @@ k6 run script.js --env MY_USER_AGENT="hello"
 Then, your script could then set the `userAgent` option based on the variable's value.
 This allows for quick configuration.
 
-{{< code >}}
+<!-- md-k6:skip -->
 
 ```javascript
 import http from 'k6/http';
@@ -139,8 +135,6 @@ export default function () {
   http.get('http://test.k6.io/');
 }
 ```
-
-{{< /code >}}
 
 > **Note**: Though this method uses the `--env` flag, this is not the same as using an environment variable.
 > For an explanation, refer to the [environment variables document](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/environment-variables).
@@ -158,8 +152,6 @@ k6 run --config options.json script.js
 ```
 
 This command would set test options according to the values in the `options.json` file.
-
-{{< code >}}
 
 ```json
 {
@@ -188,9 +180,9 @@ This command would set test options according to the values in the `options.json
 }
 ```
 
-{{< /code >}}
-
 For an alternative way to separate configuration from logic, you can use the `JSON.parse()` method in your script file:
+
+<!-- md-k6:skip -->
 
 ```javascript
 // load test config, used to populate exported options object:
@@ -207,8 +199,6 @@ With `test.options`, you can access the consolidated and derived options of your
 A common use of this feature is to log the value of a tag, but there are many possibilities.
 For example, this script accesses the value of the test's current stage:
 
-{{< code >}}
-
 ```javascript
 import exec from 'k6/execution';
 
@@ -223,7 +213,3 @@ export default function () {
   console.log(exec.test.options.scenarios.default.stages[0].target); // 100
 }
 ```
-
-{{< /code >}}
-
-<br/>

--- a/docs/sources/k6/next/using-k6/k6-options/how-to.md
+++ b/docs/sources/k6/next/using-k6/k6-options/how-to.md
@@ -201,6 +201,8 @@ With `test.options`, you can access the consolidated and derived options of your
 A common use of this feature is to log the value of a tag, but there are many possibilities.
 For example, this script accesses the value of the test's current stage:
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/next/using-k6/k6-options/how-to.md
+++ b/docs/sources/k6/next/using-k6/k6-options/how-to.md
@@ -62,6 +62,8 @@ The following JS snippets show some examples of how you can set options.
 
 ### Set options in the script
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 

--- a/docs/sources/k6/next/using-k6/k6-options/reference.md
+++ b/docs/sources/k6/next/using-k6/k6-options/reference.md
@@ -95,7 +95,7 @@ By default, the server listens on `localhost:6565`. Read more on [k6 REST API](h
 {{< code >}}
 
 ```bash
-$ k6 run --address "localhost:3000" script.js
+k6 run --address "localhost:3000" script.js
 ```
 
 {{< /code >}}
@@ -186,7 +186,7 @@ export const options = {
 {{< code >}}
 
 ```bash
-$ k6 run --block-hostnames="test.k6.io,*.example.com" script.js
+k6 run --block-hostnames="test.k6.io,*.example.com" script.js
 ```
 
 {{< /code >}}
@@ -204,7 +204,7 @@ Read about the different modes on the [JavaScript Compatibility Mode documentati
 {{< code >}}
 
 ```bash
-$ k6 run --compatibility-mode=base script.js
+k6 run --compatibility-mode=base script.js
 ```
 
 {{< /code >}}
@@ -245,7 +245,7 @@ Redirects logs logged by `console` methods to the provided output file. Availabl
 {{< code >}}
 
 ```bash
-$ k6 run --console-output "loadtest.log" script.js
+k6 run --console-output "loadtest.log" script.js
 ```
 
 {{< /code >}}
@@ -416,7 +416,7 @@ With this option, you can exit early and let the script run in the background. A
 {{< code >}}
 
 ```bash
-$ k6 cloud run --exit-on-running script.js
+k6 cloud run --exit-on-running script.js
 ```
 
 {{< /code >}}
@@ -490,7 +490,7 @@ Pass the real system [environment variables](https://grafana.com/docs/k6/<K6_VER
 {{< code >}}
 
 ```bash
-$ k6 run --include-system-env-vars ~/script.js
+k6 run --include-system-env-vars ~/script.js
 ```
 
 {{< /code >}}
@@ -592,7 +592,7 @@ Available in the `k6 run` command.
 {{< code >}}
 
 ```bash
-$ k6 run --local-ips=192.168.20.12-192.168.20.15,192.168.10.0/27 script.js
+k6 run --local-ips=192.168.20.12-192.168.20.15,192.168.10.0/27 script.js
 ```
 
 {{< /code >}}
@@ -608,7 +608,7 @@ This option specifies where to send logs to and another configuration connected 
 {{< code >}}
 
 ```bash
-$ k6 run --log-output=stdout script.js
+k6 run --log-output=stdout script.js
 ```
 
 {{< /code >}}
@@ -629,7 +629,7 @@ For additional instructions and a step-by-step guide, check out the [Loki tutori
 {{< code >}}
 
 ```bash
-$ k6 run --log-output=loki=http://127.0.0.1:3100/loki/api/v1/push,label.something=else,label.foo=bar,limit=32,level=info,pushPeriod=5m32s,msgMaxSize=1231 script.js
+k6 run --log-output=loki=http://127.0.0.1:3100/loki/api/v1/push,label.something=else,label.foo=bar,limit=32,level=info,pushPeriod=5m32s,msgMaxSize=1231 script.js
 ```
 
 {{< /code >}}
@@ -656,7 +656,7 @@ The file can be configured as below, where an explicit file path is required:
 {{< code >}}
 
 ```bash
-$ k6 run --log-output=file=./k6.log script.js
+k6 run --log-output=file=./k6.log script.js
 ```
 
 {{< /code >}}
@@ -682,7 +682,7 @@ A value specifying the log format. By default, k6 includes extra debug informati
 {{< code >}}
 
 ```bash
-$ k6 run --log-format raw test.js
+k6 run --log-format raw test.js
 ```
 
 {{< /code >}}
@@ -737,7 +737,7 @@ A boolean specifying whether colored output is disabled. Available in `k6 run` a
 {{< code >}}
 
 ```bash
-$ k6 run --no-color script.js
+k6 run --no-color script.js
 ```
 
 {{< /code >}}
@@ -794,7 +794,7 @@ Available in the `k6 run` command.
 {{< code >}}
 
 ```bash
-$ k6 run --no-summary ~/script.js
+k6 run --no-summary ~/script.js
 ```
 
 {{< /code >}}
@@ -810,7 +810,7 @@ A boolean specifying whether `setup()` function should be run. Available in `k6 
 {{< code >}}
 
 ```bash
-$ k6 run --no-setup script.js
+k6 run --no-setup script.js
 ```
 
 {{< /code >}}
@@ -826,7 +826,7 @@ A boolean specifying whether `teardown()` function should be run. Available in `
 {{< code >}}
 
 ```bash
-$ k6 run --no-teardown script.js
+k6 run --no-teardown script.js
 ```
 
 {{< /code >}}
@@ -842,7 +842,7 @@ Disables threshold execution. Available in the `k6 run` command.
 {{< code >}}
 
 ```bash
-$ k6 run --no-thresholds ~/script.js
+k6 run --no-thresholds ~/script.js
 ```
 
 {{< /code >}}
@@ -861,7 +861,7 @@ learn more, have a look at the [Usage reports](https://grafana.com/docs/k6/<K6_V
 {{< code >}}
 
 ```bash
-$ k6 run --no-usage-report ~/script.js
+k6 run --no-usage-report ~/script.js
 ```
 
 {{< /code >}}
@@ -917,7 +917,7 @@ Enables [pprof](https://pkg.go.dev/net/http/pprof) profiling endpoints under the
 {{< code >}}
 
 ```bash
-$ k6 run --profiling-enabled script.js
+k6 run --profiling-enabled script.js
 ```
 
 {{< /code >}}
@@ -933,7 +933,7 @@ A boolean, true or false, that disables the progress update bar on the console o
 {{< code >}}
 
 ```bash
-$ k6 run script.js -d 20s --quiet
+k6 run script.js -d 20s --quiet
 ```
 
 {{< /code >}}
@@ -951,7 +951,7 @@ refer to [Results output](https://grafana.com/docs/k6/<K6_VERSION>/results-outpu
 {{< code >}}
 
 ```bash
-$ k6 run --out influxdb=http://localhost:8086/k6 script.js
+k6 run --out influxdb=http://localhost:8086/k6 script.js
 ```
 
 {{< /code >}}
@@ -1060,7 +1060,7 @@ A boolean specifying whether the cloud logs are printed out to the terminal. Ava
 {{< code >}}
 
 ```bash
-$ k6 cloud run --show-logs=false script.js
+k6 cloud run --show-logs=false script.js
 ```
 
 {{< /code >}}
@@ -1095,28 +1095,28 @@ export const options = {
 ```
 
 ```bash
-$ k6 run --stage 5s:10,5m:20,10s:5 script.js
+k6 run --stage 5s:10,5m:20,10s:5 script.js
 
 # or...
 
-$ K6_STAGES="5s:10,5m:20,10s:5" k6 run script.js
+K6_STAGES="5s:10,5m:20,10s:5" k6 run script.js
 ```
 
 ```windows
-C:\k6> k6 run --stage 5s:10,5m:20,10s:5 script.js
+k6 run --stage 5s:10,5m:20,10s:5 script.js
 
 # or...
 
-C:\k6> set "K6_STAGES=5s:10,5m:20,10s:5" && k6 run script.js
+set "K6_STAGES=5s:10,5m:20,10s:5" && k6 run script.js
 
 ```
 
 ```powershell
-C:\k6> k6 run --stage 5s:10,5m:20,10s:5 script.js
+k6 run --stage 5s:10,5m:20,10s:5 script.js
 
 # or...
 
-C:\k6> $env:K6_STAGES="5s:10,5m:20,10s:5"; k6 run script.js
+$env:K6_STAGES="5s:10,5m:20,10s:5"; k6 run script.js
 
 ```
 
@@ -1139,29 +1139,27 @@ Available in the `k6 run` command.
 {{< code >}}
 
 ```bash
-$ k6 run --summary-export export.json script.js
+k6 run --summary-export export.json script.js
 
 # or...
 
-$ K6_SUMMARY_EXPORT="export.json" k6 run script.js
+K6_SUMMARY_EXPORT="export.json" k6 run script.js
 ```
 
 ```windows
-C:\k6> k6 run --summary-export export.json script.js
+k6 run --summary-export export.json script.js
 
 # or...
 
-C:\k6> set "K6_SUMMARY_EXPORT=export.json" && k6 run script.js
-
+set "K6_SUMMARY_EXPORT=export.json" && k6 run script.js
 ```
 
 ```powershell
-C:\k6> k6 run --summary-export export.json script.js
+k6 run --summary-export export.json script.js
 
 # or...
 
-C:\k6> $env:K6_SUMMARY_EXPORT="export.json"; k6 run script.js
-
+$env:K6_SUMMARY_EXPORT="export.json"; k6 run script.js
 ```
 
 {{< /code >}}
@@ -1192,7 +1190,7 @@ Compare this behavior with `K6_ITERATIONS=120 k6 run script.js`, which _does_ se
 {{< code >}}
 
 ```bash
-$ k6 run -e FOO=bar ~/script.js
+k6 run -e FOO=bar ~/script.js
 ```
 
 {{< /code >}}
@@ -1259,7 +1257,7 @@ export const options = {
 {{< code >}}
 
 ```bash
-$ k6 run --summary-trend-stats="avg,min,med,max,p(90),p(99.9),p(99.99),count" ./script.js
+k6 run --summary-trend-stats="avg,min,med,max,p(90),p(99.9),p(99.99),count" ./script.js
 ```
 
 {{< /code >}}
@@ -1445,7 +1443,7 @@ This option specifies where to send traces to. Available in the `k6 run` command
 {{< code >}}
 
 ```bash
-$ k6 run --traces-output=otel script.js
+k6 run --traces-output=otel script.js
 ```
 
 {{< /code >}}
@@ -1462,7 +1460,7 @@ Use the `traces-output` option to configure [Open Telemetry](https://opentelemet
 {{< code >}}
 
 ```bash
-$ k6 run --traces-output=otel=http://127.0.0.1:4318,proto=http,header.AdditionalHeader=example script.js
+k6 run --traces-output=otel=http://127.0.0.1:4318,proto=http,header.AdditionalHeader=example script.js
 ```
 
 {{< /code >}}
@@ -1495,7 +1493,7 @@ This would be useful if you would like to update a given test and run it later. 
 {{< code >}}
 
 ```bash
-$ k6 cloud run --upload-only script.js
+k6 cloud run --upload-only script.js
 ```
 
 {{< /code >}}
@@ -1532,7 +1530,7 @@ A boolean specifying whether verbose logging is enabled. Available in `k6 run` a
 {{< code >}}
 
 ```bash
-$ k6 run --verbose script.js
+k6 run --verbose script.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/next/using-k6/k6-options/reference.md
+++ b/docs/sources/k6/next/using-k6/k6-options/reference.md
@@ -7,6 +7,8 @@ weight: 02
 
 # Options reference
 
+<!-- md-k6:skipall -->
+
 Options define test-run behavior.
 Most options can be passed in multiple places.
 If an option is defined in multiple places, k6 chooses the value from the highest [order of precedence](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/how-to#order-of-precedence).

--- a/docs/sources/k6/next/using-k6/modules.md
+++ b/docs/sources/k6/next/using-k6/modules.md
@@ -210,7 +210,7 @@ is usually accomplished within minutes. Start by creating a project folder and i
 `npm`:
 
 ```bash
-$ mkdir ./example-project && \
+mkdir ./example-project && \
     cd "$_" && \
     npm init -y
 ```
@@ -220,7 +220,7 @@ $ mkdir ./example-project && \
 Then, install the packages needed:
 
 ```bash
-$ npm install --save-dev \
+npm install --save-dev \
     webpack \
     webpack-cli \
     @types/k6 \
@@ -421,7 +421,7 @@ To run index.js and make the modules available for import we execute the followi
 {{< code >}}
 
 ```bash
-$ docker run --rm -v /home/k6/example/src:/src -i grafana/k6 run /src/index.js
+docker run --rm -v /home/k6/example/src:/src -i grafana/k6 run /src/index.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/next/using-k6/scenarios/advanced-examples.md
+++ b/docs/sources/k6/next/using-k6/scenarios/advanced-examples.md
@@ -256,15 +256,15 @@ Then from the command line, you could run the test script and only execute the `
 {{< code >}}
 
 ```bash
-$ SCENARIO=my_web_test k6 run script.js
+SCENARIO=my_web_test k6 run script.js
 ```
 
 ```windows
-C:\k6> set "SCENARIO=my_web_test" && k6 run script.js
+set "SCENARIO=my_web_test" && k6 run script.js
 ```
 
 ```powershell
-PS C:\k6> $env:SCENARIO="my_web_test"; k6 run script.js
+$env:SCENARIO="my_web_test"; k6 run script.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/next/using-k6/test-authoring/create-tests-from-recordings/using-the-har-converter.md
+++ b/docs/sources/k6/next/using-k6/test-authoring/create-tests-from-recordings/using-the-har-converter.md
@@ -95,6 +95,8 @@ k6 lets you configure this in several ways:
 
 - As options in the script file.
 
+  <!-- md-k6:skip -->
+
   ```javascript
   export const options = {
     vus: 10,

--- a/docs/sources/k6/next/using-k6/test-authoring/create-tests-from-recordings/using-the-har-converter.md
+++ b/docs/sources/k6/next/using-k6/test-authoring/create-tests-from-recordings/using-the-har-converter.md
@@ -54,7 +54,7 @@ The [har-to-k6 converter](https://github.com/k6io/har-to-k6) is a NodeJS tool th
 1. Install the converter. You can use `npm`:
 
    ```bash
-   $ npm install -g har-to-k6
+   npm install -g har-to-k6
    ```
 
    For other installation options, check out the [har-to-k6 installation instructions](https://github.com/k6io/har-to-k6#installation).
@@ -62,7 +62,7 @@ The [har-to-k6 converter](https://github.com/k6io/har-to-k6) is a NodeJS tool th
 1. Generate a k6 script from a HAR file with the convert command:
 
    ```bash
-   $ har-to-k6 myfile.har -o loadtest.js
+   har-to-k6 myfile.har -o loadtest.js
    ```
 
    This command auto-generates a k6 script for you.
@@ -157,7 +157,7 @@ Now, you can run your load test with k6. If you have not installed k6 yet, pleas
 Execute the `k6 run` command to run your k6 script:
 
 ```bash
-$ k6 run loadtest.js
+k6 run loadtest.js
 ```
 
 To learn about running k6, check out the [Running k6 tutorial](https://grafana.com/docs/k6/<K6_VERSION>/get-started/running-k6).

--- a/docs/sources/k6/next/using-k6/test-lifecycle.md
+++ b/docs/sources/k6/next/using-k6/test-lifecycle.md
@@ -23,7 +23,7 @@ a function called in a specific sequence in the k6 runtime.
 
 {{< /admonition >}}
 
-{{< code >}}
+<!-- md-k6:skip -->
 
 ```javascript
 // 1. init code
@@ -40,8 +40,6 @@ export function teardown(data) {
   // 4. teardown code
 }
 ```
-
-{{< /code >}}
 
 ## Overview of the lifecycle stages
 
@@ -74,8 +72,6 @@ Some operations that might happen in `init` include the following:
 **All code that is outside of a lifecycle function is code in the `init` context**.
 Code in the `init` context _always executes first_.
 
-{{< code >}}
-
 <!-- md-k6:skip -->
 
 ```javascript
@@ -98,8 +94,6 @@ function myCustomFunction() {
 }
 ```
 
-{{< /code >}}
-
 Separating the `init` stage from the VU stage removes irrelevant computation from VU code, which improves k6 performance and makes test results more reliable.
 One limitation of `init` code is that it **cannot** make HTTP requests.
 This limitation ensures that the `init` stage is reproducible across tests (the response from protocol requests is dynamic and unpredictable)
@@ -110,15 +104,13 @@ Scripts must contain, at least, a _scenario function_ that defines the logic of 
 The code inside this function is _VU code_.
 Typically, VU code is inside the `default` function, but it can also be inside the function defined by a scenario (see subsequent section for an example).
 
-{{< code >}}
+<!-- md-k6:skip -->
 
 ```javascript
 export default function () {
   // do things here...
 }
 ```
-
-{{< /code >}}
 
 **VU code runs over and over through the test duration.**
 VU code can make HTTP requests, emit metrics, and generally do everything you'd expect a load test to do.
@@ -148,8 +140,6 @@ But unlike the `default` function, k6 calls `setup` and `teardown` only once per
 You can call the full k6 API in the setup and teardown stages, unlike the init stage.
 For example, you can make HTTP requests:
 
-{{< code >}}
-
 ```javascript
 import http from 'k6/http';
 
@@ -167,26 +157,20 @@ export default function (data) {
 }
 ```
 
-{{< /code >}}
-
 ### Skip setup and teardown execution
 
 You can skip the execution of setup and teardown stages using the options `--no-setup` and
 `--no-teardown`.
 
-{{< code >}}
-
 ```bash
 k6 run --no-setup --no-teardown ...
 ```
-
-{{< /code >}}
 
 ### Use data from setup in default and teardown
 
 Again, let's have a look at the basic structure of a k6 test:
 
-{{< code >}}
+<!-- md-k6:skip -->
 
 ```javascript
 // 1. init code
@@ -204,13 +188,11 @@ export function teardown(data) {
 }
 ```
 
-{{< /code >}}
-
 You might have noticed the function signatures of the `default()` and `teardown()` functions take an argument, referred to here as `data`.
 
 Here's an example of passing some data from the setup code to the VU and teardown stages:
 
-{{< code >}}
+<!-- md-k6:skip -->
 
 ```javascript
 export function setup() {
@@ -227,8 +209,6 @@ export function teardown(data) {
   }
 }
 ```
-
-{{< /code >}}
 
 For example, with the data returned by the `setup()` function, you can:
 
@@ -259,7 +239,6 @@ k6 has a few additional ways to use lifecycle functions:
 
 - **Scenario functions**. Instead of the `default` function, you can also run VU code in scenario functions.
 
-  {{< code >}}
   <!-- md-k6:skip -->
 
   ```javascript
@@ -283,5 +262,3 @@ k6 has a few additional ways to use lifecycle functions:
     sleep(Math.random() * 2);
   }
   ```
-
-  {{< /code >}}

--- a/docs/sources/k6/next/using-k6/test-lifecycle.md
+++ b/docs/sources/k6/next/using-k6/test-lifecycle.md
@@ -177,7 +177,7 @@ You can skip the execution of setup and teardown stages using the options `--no-
 {{< code >}}
 
 ```bash
-$ k6 run --no-setup --no-teardown ...
+k6 run --no-setup --no-teardown ...
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v0.57.x/examples/generating-uuids.md
+++ b/docs/sources/k6/v0.57.x/examples/generating-uuids.md
@@ -9,8 +9,6 @@ weight: 11
 If you want to make a version 4 UUID,
 you can use the [`uuidv4` function](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/utils/uuidv4) from the [k6 JS lib repository](https://jslib.k6.io/).
 
-{{< code >}}
-
 ```javascript
 import { uuidv4 } from 'https://jslib.k6.io/k6-utils/1.4.0/index.js';
 
@@ -19,8 +17,6 @@ export default function () {
   console.log(randomUUID); // 35acae14-f7cb-468a-9866-1fc45713149a
 }
 ```
-
-{{< /code >}}
 
 If you really need other UUID versions, you must rely on an external library.
 
@@ -40,7 +36,7 @@ For this to work, we first need to go through a few required steps:
    {{< code >}}
 
    ```bash
-   $ npm install uuid@3.4.0
+   npm install uuid@3.4.0
    ```
 
    {{< /code >}}
@@ -49,7 +45,7 @@ For this to work, we first need to go through a few required steps:
    {{< code >}}
 
    ```bash
-   $ browserify node_modules/uuid/index.js -s uuid > uuid.js
+   browserify node_modules/uuid/index.js -s uuid > uuid.js
    ```
 
    {{< /code >}}
@@ -57,17 +53,15 @@ For this to work, we first need to go through a few required steps:
 4. Move the `uuid.js` file to the same folder as your script file. Now you can import
    it into your test script:
 
-   {{< code >}}
+   <!-- md-k6:skip -->
 
    ```javascript
    import uuid from './uuid.js';
    ```
 
-   {{< /code >}}
-
 This example generates a v1 UUID:
 
-{{< code >}}
+<!-- md-k6:skip -->
 
 ```javascript
 import uuid from './uuid.js';
@@ -78,5 +72,3 @@ export default function () {
   console.log(uuid1);
 }
 ```
-
-{{< /code >}}

--- a/docs/sources/k6/v0.57.x/extensions/build-k6-binary-using-go.md
+++ b/docs/sources/k6/v0.57.x/extensions/build-k6-binary-using-go.md
@@ -25,7 +25,7 @@ Not interested in setting up a Go environment? You can [use Docker instead](http
 Given the prerequisite Go setup, installing [xk6](https://github.com/grafana/xk6) itself requires only the following command:
 
 ```bash
-$ go install go.k6.io/xk6/cmd/xk6@latest
+go install go.k6.io/xk6/cmd/xk6@latest
 ```
 
 To confirm your installation, run `which xk6` on Linux and Mac, or `where xk6` on Windows.
@@ -41,7 +41,7 @@ Once installed, building a k6 binary with one or more extensions can be done wit
 command as follows:
 
 ```bash
-$ xk6 build latest \
+xk6 build latest \
   --with github.com/grafana/xk6-sql@v0.0.1 \
   --with github.com/grafana/xk6-output-prometheus-remote
 ```
@@ -112,7 +112,7 @@ Now that we have our newly built k6 binary, we can run scripts using the functio
 of the bundled extensions.
 
 ```bash
-$ ./k6 run my-script.js
+./k6 run my-script.js
 ```
 
 > Be sure to specify the binary just built in the current directory as `./k6`, or else

--- a/docs/sources/k6/v0.57.x/extensions/create/javascript-extensions.md
+++ b/docs/sources/k6/v0.57.x/extensions/create/javascript-extensions.md
@@ -25,7 +25,7 @@ To run this tutorial, you'll need the following applications installed:
 You also need to install xk6:
 
 ```bash
-$ go install go.k6.io/xk6/cmd/xk6@latest
+go install go.k6.io/xk6/cmd/xk6@latest
 ```
 
 ## Write a simple extension
@@ -33,7 +33,7 @@ $ go install go.k6.io/xk6/cmd/xk6@latest
 1. First, set up a directory to work in:
 
 ```bash
-$ mkdir xk6-compare; cd xk6-compare; go mod init xk6-compare
+mkdir xk6-compare; cd xk6-compare; go mod init xk6-compare
 ```
 
 1. In the directory, make a Go file for your JavaScript extension.
@@ -123,7 +123,7 @@ func (c *Compare) IsGreater(a, b int) bool {
 To build a k6 binary with this extension, run this command:
 
 ```bash
-$ xk6 build --with xk6-compare=.
+xk6 build --with xk6-compare=.
 ```
 
 {{< admonition type="note" >}}
@@ -139,7 +139,7 @@ Now, use the extension in a test script!
 
 1. Make a file with a name like `test.js` then add this code:
 
-{{< code >}}
+<!-- md-k6:skip -->
 
 ```javascript
 import compare from 'k6/x/compare';
@@ -149,8 +149,6 @@ export default function () {
   console.log(`${compare.isGreater(1, 3)}, ${compare.comparison_result}`);
 }
 ```
-
-{{< /code >}}
 
 1. Run the test with `./k6 run test.js`.
 
@@ -302,7 +300,7 @@ func (c *Compare) GetInternalState() *InternalState {
 
 Create a test script to utilize the new `getInternalState()` function as in the following:
 
-{{< code >}}
+<!-- md-k6:skip -->
 
 ```javascript
 import compare from 'k6/x/compare';
@@ -314,8 +312,6 @@ export default function () {
   );
 }
 ```
-
-{{< /code >}}
 
 Executing the script as `./k6 run test-state.js --vus 2 --iterations 5` will produce output similar to the following:
 

--- a/docs/sources/k6/v0.57.x/extensions/create/output-extensions.md
+++ b/docs/sources/k6/v0.57.x/extensions/create/output-extensions.md
@@ -30,7 +30,7 @@ To run this tutorial, you'll need the following applications installed:
 You also need to install xk6:
 
 ```bash
-$ go install go.k6.io/xk6/cmd/xk6@latest
+go install go.k6.io/xk6/cmd/xk6@latest
 ```
 
 ## Write a simple extension
@@ -38,7 +38,7 @@ $ go install go.k6.io/xk6/cmd/xk6@latest
 1. Set up a directory to work in.
 
 ```bash
-$ mkdir xk6-output-logger; cd xk6-output-logger; go mod init xk6-output-logger
+mkdir xk6-output-logger; cd xk6-output-logger; go mod init xk6-output-logger
 ```
 
 1. The core of an Output extension is a struct that implements the [`output.Output`](https://pkg.go.dev/go.k6.io/k6/output#Output)
@@ -178,7 +178,7 @@ Notice a couple of things:
 To build a k6 binary with this extension, run:
 
 ```bash
-$ xk6 build --with xk6-output-logger=.
+xk6 build --with xk6-output-logger=.
 ```
 
 {{< admonition type="note" >}}
@@ -212,7 +212,7 @@ export default function () {
 1. Now, run the test.
 
 ```bash
-$ ./k6 run test.js --out logger --quiet --no-summary --iterations 2
+./k6 run test.js --out logger --quiet --no-summary --iterations 2
 ```
 
 {{< admonition type="note" >}}

--- a/docs/sources/k6/v0.57.x/get-started/running-k6.md
+++ b/docs/sources/k6/v0.57.x/get-started/running-k6.md
@@ -29,15 +29,15 @@ To run a simple local script:
    {{< code >}}
 
    ```linux
-   $ k6 new
+   k6 new
    ```
 
    ```docker
-   $ docker run --rm -u $(id -u) -v $PWD:/app -w /app grafana/k6 new
+   docker run --rm -u $(id -u) -v $PWD:/app -w /app grafana/k6 new
    ```
 
    ```windows
-   PS C:\> docker run --rm -i -v ${PWD}:/app -w /app grafana/k6 init
+   docker run --rm -i -v ${PWD}:/app -w /app grafana/k6 init
    ```
 
    {{< /code >}}
@@ -50,7 +50,7 @@ To run a simple local script:
    {{< code >}}
 
    ```linux
-   $ k6 run script.js
+   k6 run script.js
    ```
 
    ```docker
@@ -60,11 +60,11 @@ To run a simple local script:
    # pipe the actual file into the container with `<` or equivalent. This will
    # cause the file to be redirected into the container and be read by k6.
 
-   $ docker run --rm -i grafana/k6 run - <script.js
+   docker run --rm -i grafana/k6 run - <script.js
    ```
 
    ```windows
-   PS C:\> cat script.js | docker run --rm -i grafana/k6 run -
+   cat script.js | docker run --rm -i grafana/k6 run -
    ```
 
    {{< /code >}}
@@ -76,15 +76,15 @@ Now run a load test with more than one virtual user and a longer duration:
 {{< code >}}
 
 ```linux
-$ k6 run --vus 10 --duration 30s script.js
+k6 run --vus 10 --duration 30s script.js
 ```
 
 ```docker
-$ docker run --rm -i grafana/k6 run --vus 10 --duration 30s - <script.js
+docker run --rm -i grafana/k6 run --vus 10 --duration 30s - <script.js
 ```
 
 ```windows
-PS C:\> cat script.js | docker run --rm -i grafana/k6 run --vus 10 --duration 30s -
+cat script.js | docker run --rm -i grafana/k6 run --vus 10 --duration 30s -
 ```
 
 {{< /code >}}
@@ -147,15 +147,15 @@ If you run the script without flags, k6 uses the options defined in the script:
 {{< code >}}
 
 ```linux
-$ k6 run script.js
+k6 run script.js
 ```
 
 ```docker
-$ docker run --rm -i grafana/k6 run - <script.js
+docker run --rm -i grafana/k6 run - <script.js
 ```
 
 ```windows
-PS C:\> cat script.js | docker run --rm -i grafana/k6 run -
+cat script.js | docker run --rm -i grafana/k6 run -
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v0.57.x/javascript-api/k6-browser/_index.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/k6-browser/_index.md
@@ -79,7 +79,7 @@ Then, you can run the test with this command. Also, see the [browser module opti
 {{< code >}}
 
 ```bash
-$ k6 run script.js
+k6 run script.js
 ```
 
 ```docker
@@ -97,11 +97,11 @@ docker run --rm -i grafana/k6:master-with-browser run - <script.js
 ```
 
 ```windows
-C:\k6> k6 run script.js
+k6 run script.js
 ```
 
 ```windows-powershell
-PS C:\k6> k6 run script.js
+k6 run script.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v0.57.x/javascript-api/k6-experimental/websockets/params.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/k6-experimental/websockets/params.md
@@ -47,7 +47,7 @@ The preceding example uses a WebSocket echo server, which you can run with the f
 {{< code >}}
 
 ```bash
-$ docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
+docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v0.57.x/javascript-api/k6-experimental/websockets/websocket/_index.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/k6-experimental/websockets/websocket/_index.md
@@ -52,7 +52,7 @@ The preceding example uses a WebSocket echo server, which you can run with the f
 {{< code >}}
 
 ```bash
-$ docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
+docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v0.57.x/javascript-api/k6-experimental/websockets/websocket/websocket-addeventlistener.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/k6-experimental/websockets/websocket/websocket-addeventlistener.md
@@ -33,7 +33,7 @@ import { WebSocket } from 'k6/experimental/websockets';
 
 export default function () {
   const ws = new WebSocket('ws://localhost:10000');
-  ws.binaryType = "arraybuffer";
+  ws.binaryType = 'arraybuffer';
 
   ws.onopen = () => {
     console.log('connected');
@@ -60,7 +60,7 @@ The preceding example uses a WebSocket echo server, which you can run with the f
 {{< code >}}
 
 ```bash
-$ docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
+docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v0.57.x/javascript-api/k6-experimental/websockets/websocket/websocket-close.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/k6-experimental/websockets/websocket/websocket-close.md
@@ -38,7 +38,7 @@ The preceding example uses a WebSocket echo server, which you can run with the f
 {{< code >}}
 
 ```bash
-$ docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
+docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v0.57.x/javascript-api/k6-experimental/websockets/websocket/websocket-onclose.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/k6-experimental/websockets/websocket/websocket-onclose.md
@@ -40,7 +40,7 @@ The preceding example uses a WebSocket echo server, which you can run with the f
 {{< code >}}
 
 ```bash
-$ docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
+docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v0.57.x/javascript-api/k6-experimental/websockets/websocket/websocket-onerror.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/k6-experimental/websockets/websocket/websocket-onerror.md
@@ -35,7 +35,7 @@ The preceding example uses a WebSocket echo server, which you can run with the f
 {{< code >}}
 
 ```bash
-$ docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
+docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v0.57.x/javascript-api/k6-experimental/websockets/websocket/websocket-onmessage.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/k6-experimental/websockets/websocket/websocket-onmessage.md
@@ -37,7 +37,7 @@ The preceding example uses a WebSocket echo server, which you can run with the f
 {{< code >}}
 
 ```bash
-$ docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
+docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v0.57.x/javascript-api/k6-experimental/websockets/websocket/websocket-onopen.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/k6-experimental/websockets/websocket/websocket-onopen.md
@@ -35,7 +35,7 @@ The preceding example uses a WebSocket echo server, which you can run with the f
 {{< code >}}
 
 ```bash
-$ docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
+docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v0.57.x/javascript-api/k6-experimental/websockets/websocket/websocket-onpong.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/k6-experimental/websockets/websocket/websocket-onpong.md
@@ -28,7 +28,7 @@ export default function () {
 
   ws.onopen = () => {
     ws.ping();
-  }
+  };
 }
 ```
 
@@ -39,7 +39,7 @@ The preceding example uses a WebSocket echo server, which you can run with the f
 {{< code >}}
 
 ```bash
-$ docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
+docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v0.57.x/javascript-api/k6-experimental/websockets/websocket/websocket-ping.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/k6-experimental/websockets/websocket/websocket-ping.md
@@ -40,7 +40,7 @@ The preceding example uses a WebSocket echo server, which you can run with the f
 {{< code >}}
 
 ```bash
-$ docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
+docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v0.57.x/javascript-api/k6-experimental/websockets/websocket/websocket-send.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/k6-experimental/websockets/websocket/websocket-send.md
@@ -39,7 +39,7 @@ The preceding example uses a WebSocket echo server, which you can run with the f
 {{< code >}}
 
 ```bash
-$ docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
+docker run --detach --rm --name ws-echo-server -p 10000:8080 jmalloc/echo-server
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v0.57.x/javascript-api/k6-net-grpc/stream/_index.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/k6-net-grpc/stream/_index.md
@@ -23,7 +23,7 @@ Using a gRPC client creates a stream. The client should be connected to the serv
 
 _A k6 script that sends several randomly chosen points from the pre-generated feature database with a variable delay in between. Prints the statistics when they are sent from the server._
 
-{{< code >}}
+<!-- md-k6:skip -->
 
 ```javascript
 import { Client, Stream } from 'k6/net/grpc';
@@ -133,11 +133,9 @@ const pointSender = (stream, point) => {
 };
 ```
 
-{{< /code >}}
-
 _A k6 script that sends a rectangle message and results (features) are streamed back to the client._
 
-{{< code >}}
+<!-- md-k6:skip -->
 
 ```javascript
 import { Client, Stream } from 'k6/net/grpc';
@@ -195,14 +193,8 @@ export default () => {
 };
 ```
 
-{{< /code >}}
-
 The preceding examples use a demo server, which you can run with the following command (Golang should be installed) in [k6 repository's root](https://github.com/grafana/k6):
 
-{{< code >}}
-
 ```bash
-$ go run -mod=mod examples/grpc_server/*.go
+go run -mod=mod examples/grpc_server/*.go
 ```
-
-{{< /code >}}

--- a/docs/sources/k6/v0.57.x/misc/archive.md
+++ b/docs/sources/k6/v0.57.x/misc/archive.md
@@ -22,7 +22,7 @@ Let's say that you normally execute a test using:
 {{< code >}}
 
 ```bash
-$ k6 run script.js
+k6 run script.js
 ```
 
 {{< /code >}}
@@ -35,7 +35,7 @@ into a tar file:
 {{< code >}}
 
 ```bash
-$ k6 archive script.js
+k6 archive script.js
 ```
 
 {{< /code >}}
@@ -52,7 +52,7 @@ files you can execute:
 {{< code >}}
 
 ```bash
-$ k6 run archive.tar
+k6 run archive.tar
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v0.57.x/results-output/real-time/amazon-cloudwatch.md
+++ b/docs/sources/k6/v0.57.x/results-output/real-time/amazon-cloudwatch.md
@@ -29,13 +29,13 @@ We presume that you already have a machine that supports both running k6 and Clo
 2. Download the CloudWatch Agent package suitable for your operating system. For example, on Debian 10 (Buster), we've used the following link. For other operating systems, please refer to this [guide](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/download-cloudwatch-agent-commandline.html):
 
    ```bash
-   $ wget https://s3.amazonaws.com/amazoncloudwatch-agent/debian/amd64/latest/amazon-cloudwatch-agent.deb
+   wget https://s3.amazonaws.com/amazoncloudwatch-agent/debian/amd64/latest/amazon-cloudwatch-agent.deb
    ```
 
 3. Install the package:
 
    ```bash
-   $ sudo dpkg -i amazon-cloudwatch-agent.deb
+   sudo dpkg -i amazon-cloudwatch-agent.deb
    ```
 
 4. Configure the agent to receive data from k6. For this, create a file called "_/opt/aws/amazon-cloudwatch-agent/etc/statsd.json_" and paste the following JSON config object into it. This configuration means that the agent would listen on port number 8125, which is the default port number for k6 and StatsD. The interval for collecting metrics is 5 seconds and we don't aggregate them, since we need the raw data later in CloudWatch.
@@ -58,13 +58,13 @@ We presume that you already have a machine that supports both running k6 and Clo
 5. Run the following command to start the agent:
 
    ```bash
-   $ sudo amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/etc/statsd.json
+   sudo amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/etc/statsd.json
    ```
 
 6. You can check the status of the agent using the following command:
 
    ```bash
-   $ amazon-cloudwatch-agent-ctl -a status
+   amazon-cloudwatch-agent-ctl -a status
    ```
 
 ## Run the k6 test
@@ -74,7 +74,7 @@ Once the agent is running, you can run your test with:
 {{< code >}}
 
 ```bash
-$ K6_STATSD_ENABLE_TAGS=true k6 run --out output-statsd script.js
+K6_STATSD_ENABLE_TAGS=true k6 run --out output-statsd script.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v0.57.x/results-output/real-time/apache-kafka.md
+++ b/docs/sources/k6/v0.57.x/results-output/real-time/apache-kafka.md
@@ -41,7 +41,7 @@ You can configure the broker (or multiple ones), topic and message format direct
 {{< code >}}
 
 ```bash
-$ k6 run --out xk6-kafka=brokers=broker_host:8000,topic=k6
+k6 run --out xk6-kafka=brokers=broker_host:8000,topic=k6
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v0.57.x/results-output/real-time/cloud.md
+++ b/docs/sources/k6/v0.57.x/results-output/real-time/cloud.md
@@ -41,7 +41,7 @@ so `k6 cloud run --local-execution` will consume VUH or test runs from your subs
    {{< code >}}
 
    ```bash
-   $ k6 cloud login --token <YOUR_API_TOKEN>
+   k6 cloud login --token <YOUR_API_TOKEN>
    ```
 
    {{< /code >}}
@@ -53,7 +53,7 @@ so `k6 cloud run --local-execution` will consume VUH or test runs from your subs
    {{< code >}}
 
    ```bash
-   $ k6 cloud run --local-execution script.js
+   k6 cloud run --local-execution script.js
    ```
 
    {{< /code >}}
@@ -63,7 +63,7 @@ so `k6 cloud run --local-execution` will consume VUH or test runs from your subs
    {{< code >}}
 
    ```bash
-   $ K6_CLOUD_TOKEN=<YOUR_API_TOKEN> k6 cloud run --local-execution script.js
+   K6_CLOUD_TOKEN=<YOUR_API_TOKEN> k6 cloud run --local-execution script.js
    ```
 
    {{< /code >}}

--- a/docs/sources/k6/v0.57.x/results-output/real-time/csv.md
+++ b/docs/sources/k6/v0.57.x/results-output/real-time/csv.md
@@ -13,7 +13,7 @@ Pass the path for your CSV file as the flag argument:
 {{< code >}}
 
 ```bash
-$ k6 run --out csv=test_results.csv script.js
+k6 run --out csv=test_results.csv script.js
 ```
 
 {{< /code >}}
@@ -23,7 +23,7 @@ You can also get the results gzipped, like this:
 {{< code >}}
 
 ```bash
-$ k6 run --out csv=test_results.gz script.js
+k6 run --out csv=test_results.gz script.js
 ```
 
 {{< /code >}}
@@ -31,7 +31,7 @@ $ k6 run --out csv=test_results.gz script.js
 To inspect the output in real time, you can use a command like `tail -f` on the file you save:
 
 ```bash
-$ tail -f test_results.csv
+tail -f test_results.csv
 ```
 
 ## CSV format

--- a/docs/sources/k6/v0.57.x/results-output/real-time/datadog.md
+++ b/docs/sources/k6/v0.57.x/results-output/real-time/datadog.md
@@ -67,7 +67,7 @@ Once the Datadog Agent service is running, run the k6 test and send the metrics 
 {{< code >}}
 
 ```bash
-$ K6_STATSD_ENABLE_TAGS=true k6 run --out output-statsd script.js
+K6_STATSD_ENABLE_TAGS=true k6 run --out output-statsd script.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v0.57.x/results-output/real-time/json.md
+++ b/docs/sources/k6/v0.57.x/results-output/real-time/json.md
@@ -13,11 +13,11 @@ Pass the path for your JSON file as the flag argument:
 {{< code >}}
 
 ```bash
-$ k6 run --out json=test_results.json script.js
+k6 run --out json=test_results.json script.js
 ```
 
 ```docker
-$ docker run -it --rm \
+docker run -it --rm \
     -v <scriptdir>:/scripts \
     -v <outputdir>:/jsonoutput \
     grafana/k6 run --out json=/jsonoutput/my_test_result.json /scripts/script.js
@@ -32,11 +32,11 @@ Or if you want to get the result gzipped, like this:
 {{< code >}}
 
 ```bash
-$ k6 run --out json=test_results.gz script.js
+k6 run --out json=test_results.gz script.js
 ```
 
 ```docker
-$ docker run -it --rm \
+docker run -it --rm \
     -v <scriptdir>:/scripts \
     -v <outputdir>:/jsonoutput \
     grafana/k6 run --out json=/jsonoutput/my_test_result.gz /scripts/script.js
@@ -49,7 +49,7 @@ $ docker run -it --rm \
 To inspect the output in real time, you can use a command like `tail -f` on the file you save:
 
 ```bash
-$ tail -f test_results.json
+tail -f test_results.json
 ```
 
 ## JSON format
@@ -101,7 +101,7 @@ You can quickly create [filters][jq_filters_url] to return a particular metric o
 {{< code >}}
 
 ```bash
-$ jq '. | select(.type=="Point" and .metric == "http_req_duration" and .data.tags.status >= "200")' myscript-output.json
+jq '. | select(.type=="Point" and .metric == "http_req_duration" and .data.tags.status >= "200")' myscript-output.json
 ```
 
 {{< /code >}}
@@ -111,7 +111,7 @@ And calculate an aggregated value of any metric:
 {{< code >}}
 
 ```bash
-$ jq '. | select(.type=="Point" and .metric == "http_req_duration" and .data.tags.status >= "200") | .data.value' myscript-output.json | jq -s 'add/length'
+jq '. | select(.type=="Point" and .metric == "http_req_duration" and .data.tags.status >= "200") | .data.value' myscript-output.json | jq -s 'add/length'
 ```
 
 {{< /code >}}
@@ -119,7 +119,7 @@ $ jq '. | select(.type=="Point" and .metric == "http_req_duration" and .data.tag
 {{< code >}}
 
 ```bash
-$ jq '. | select(.type=="Point" and .metric == "http_req_duration" and .data.tags.status >= "200") | .data.value' myscript-output.json | jq -s min
+jq '. | select(.type=="Point" and .metric == "http_req_duration" and .data.tags.status >= "200") | .data.value' myscript-output.json | jq -s min
 ```
 
 {{< /code >}}
@@ -127,7 +127,7 @@ $ jq '. | select(.type=="Point" and .metric == "http_req_duration" and .data.tag
 {{< code >}}
 
 ```bash
-$ jq '. | select(.type=="Point" and .metric == "http_req_duration" and .data.tags.status >= "200") | .data.value' myscript-output.json | jq -s max
+jq '. | select(.type=="Point" and .metric == "http_req_duration" and .data.tags.status >= "200") | .data.value' myscript-output.json | jq -s max
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v0.57.x/results-output/real-time/newrelic.md
+++ b/docs/sources/k6/v0.57.x/results-output/real-time/newrelic.md
@@ -74,7 +74,7 @@ Once the integration is running, run the k6 test and send the metrics to the int
 {{< code >}}
 
 ```bash
-$ K6_STATSD_ENABLE_TAGS=true k6 run --out output-statsd script.js
+K6_STATSD_ENABLE_TAGS=true k6 run --out output-statsd script.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v0.57.x/results-output/real-time/opentelemetry.md
+++ b/docs/sources/k6/v0.57.x/results-output/real-time/opentelemetry.md
@@ -30,7 +30,7 @@ You can use the `--out experimental-opentelemetry` option when running your test
 {{< code >}}
 
 ```bash
-$  K6_OTEL_GRPC_EXPORTER_INSECURE=true K6_OTEL_METRIC_PREFIX=k6_ k6 run --tag test-id=123 -o experimental-opentelemetry examples/script.js
+K6_OTEL_GRPC_EXPORTER_INSECURE=true K6_OTEL_METRIC_PREFIX=k6_ k6 run --tag test-id=123 -o experimental-opentelemetry examples/script.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v0.57.x/results-output/real-time/statsd.md
+++ b/docs/sources/k6/v0.57.x/results-output/real-time/statsd.md
@@ -43,7 +43,7 @@ Using the k6 binary you built in the previous step, you can use the `--out outpu
 {{< code >}}
 
 ```bash
-$ ./k6 run --out output-statsd script.js
+./k6 run --out output-statsd script.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v0.57.x/shared/browser/env-var-options.md
+++ b/docs/sources/k6/v0.57.x/shared/browser/env-var-options.md
@@ -17,7 +17,7 @@ The following command passes the browser options as environment variables to lau
 {{< code >}}
 
 ```bash
-$ K6_BROWSER_HEADLESS=false K6_BROWSER_ARGS='show-property-changed-rects' k6 run script.js
+K6_BROWSER_HEADLESS=false K6_BROWSER_ARGS='show-property-changed-rects' k6 run script.js
 ```
 
 ```docker
@@ -35,11 +35,11 @@ docker run --rm -i -e K6_BROWSER_HEADLESS=false -e K6_BROWSER_ARGS='show-propert
 ```
 
 ```windows
-C:\k6> set "K6_BROWSER_HEADLESS=false" && set "K6_BROWSER_ARGS='show-property-changed-rects' " && k6 run script.js
+set "K6_BROWSER_HEADLESS=false" && set "K6_BROWSER_ARGS='show-property-changed-rects' " && k6 run script.js
 ```
 
 ```windows-powershell
-PS C:\k6> $env:K6_BROWSER_HEADLESS="false" ; $env:K6_BROWSER_ARGS='show-property-changed-rects' ; k6 run script.js
+$env:K6_BROWSER_HEADLESS="false" ; $env:K6_BROWSER_ARGS='show-property-changed-rects' ; k6 run script.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v0.57.x/testing-guides/injecting-faults-with-xk6-disruptor/xk6-disruptor/poddisruptor/_index.md
+++ b/docs/sources/k6/v0.57.x/testing-guides/injecting-faults-with-xk6-disruptor/xk6-disruptor/poddisruptor/_index.md
@@ -14,11 +14,11 @@ To construct a `PodDisruptor`, use the [PodDisruptor() constructor](https://graf
 
 ## Methods
 
-| Method                                                                                                                                 | Description                                                                                                                                         |
-| -------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Method                                                                                                                                                                     | Description                                                                                                                                                                             |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [PodDisruptor.injectGrpcFaults()](https://grafana.com/docs/k6/<K6_VERSION>/testing-guides/injecting-faults-with-xk6-disruptor/xk6-disruptor/poddisruptor/injectgrpcfaults) | Inject [gRPC faults](https://grafana.com/docs/k6/<K6_VERSION>/testing-guides/injecting-faults-with-xk6-disruptor/xk6-disruptor/faults/grpc) in the target Pods                          |
 | [PodDisruptor.injectHTTPFaults()](https://grafana.com/docs/k6/<K6_VERSION>/testing-guides/injecting-faults-with-xk6-disruptor/xk6-disruptor/poddisruptor/injecthttpfaults) | Inject [HTTP faults](https://grafana.com/docs/k6/<K6_VERSION>/testing-guides/injecting-faults-with-xk6-disruptor/xk6-disruptor/faults/http) in the target Pods                          |
-| PodDisruptor.targets()                                                                                                                 | Returns the list of target Pods of the PodDisruptor                                                                                                 |
+| PodDisruptor.targets()                                                                                                                                                     | Returns the list of target Pods of the PodDisruptor                                                                                                                                     |
 | [PodDisruptor.terminatePods()](https://grafana.com/docs/k6/<K6_VERSION>/testing-guides/injecting-faults-with-xk6-disruptor/xk6-disruptor/poddisruptor/terminate-pods)      | executes a [Pod Termination fault](https://grafana.com/docs/k6/<K6_VERSION>/testing-guides/injecting-faults-with-xk6-disruptor/xk6-disruptor/faults/pod-termination) in the target Pods |
 
 ## Example
@@ -27,6 +27,8 @@ This example:
 
 - Creates a selector that matches all pods in the `default` namespace with the `run=nginx` label
 - Injects a delay of 100ms and makes 10 percent of requests return an http response code `500`.
+
+<!-- md-k6:skip -->
 
 ```javascript
 import { PodDisruptor } from 'k6/x/disruptor';
@@ -57,7 +59,7 @@ export default function () {
 You can test this script by first creating a pod running nginx with the command below, assuming you have [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) installed in your environment:
 
 ```bash
-$ kubectl run nginx --image=nginx
+kubectl run nginx --image=nginx
 ```
 
 You can also use the [xk6-kubernetes](https://github.com/grafana/xk6-kubernetes) extension for creating these resources from your test script.

--- a/docs/sources/k6/v0.57.x/using-k6-browser/running-browser-tests.md
+++ b/docs/sources/k6/v0.57.x/using-k6-browser/running-browser-tests.md
@@ -73,7 +73,7 @@ To run a simple local script:
    {{< code >}}
 
    ```bash
-   $ k6 run script.js
+   k6 run script.js
    ```
 
    ```docker
@@ -91,11 +91,11 @@ To run a simple local script:
    ```
 
    ```windows
-   C:\k6> k6 run script.js
+   k6 run script.js
    ```
 
    ```powershell
-   PS C:\k6> k6 run script.js
+   k6 run script.js
    ```
 
    {{< /code >}}
@@ -105,7 +105,7 @@ To run a simple local script:
    {{< code >}}
 
    ```bash
-   $ K6_BROWSER_HEADLESS=false k6 run script.js
+   K6_BROWSER_HEADLESS=false k6 run script.js
    ```
 
    ```docker
@@ -123,11 +123,11 @@ To run a simple local script:
    ```
 
    ```windows
-   C:\k6> set "K6_BROWSER_HEADLESS=false" && k6 run script.js
+   set "K6_BROWSER_HEADLESS=false" && k6 run script.js
    ```
 
    ```powershell
-   PS C:\k6> $env:K6_BROWSER_HEADLESS=false ; k6 run script.js
+   $env:K6_BROWSER_HEADLESS=false ; k6 run script.js
    ```
 
    {{< /code >}}
@@ -145,8 +145,8 @@ To run a simple local script:
    2. Update [Rosetta](<https://en.wikipedia.org/wiki/Rosetta_(software)>) and export an environment variable with the following:
 
       ```bash
-       $ softwareupdate --install-rosetta
-       $ export DOCKER_DEFAULT_PLATFORM=linux/amd64
+      softwareupdate --install-rosetta &&
+        export DOCKER_DEFAULT_PLATFORM=linux/amd64
       ```
 
    3. Select VirtuoFS in **Settings** > **General** > **VirtuoFS**.
@@ -158,7 +158,7 @@ To run a simple local script:
    6. Run the browser image with the following command (adds the `--platform` flag):
 
       ```bash
-      $ docker run --rm -i --platform linux/amd64 -v $(pwd):/home/k6/screenshots -e K6_BROWSER_HEADLESS=false grafana/k6:master-with-browser run - <script.js
+      docker run --rm -i --platform linux/amd64 -v $(pwd):/home/k6/screenshots -e K6_BROWSER_HEADLESS=false grafana/k6:master-with-browser run - <script.js
       ```
 
 ## Interact with elements on your webpage
@@ -258,13 +258,10 @@ export default async function () {
 
     const submitButton = page.locator('input[type="submit"]');
 
-    await Promise.all([
-      page.waitForNavigation(),
-      submitButton.click(),
-    ]);
+    await Promise.all([page.waitForNavigation(), submitButton.click()]);
 
     await check(page.locator('h2'), {
-      'header': async lo => await lo.textContent() == 'Welcome, admin!'
+      header: async (lo) => (await lo.textContent()) == 'Welcome, admin!',
     });
   } finally {
     await page.close();
@@ -332,8 +329,8 @@ export async function browserTest() {
     await page.locator('#checkbox1').check();
 
     await check(page.locator('#checkbox-info-display'), {
-      'checkbox is checked': async lo =>
-        await lo.textContent() === 'Thanks for checking the box'
+      'checkbox is checked': async (lo) =>
+        (await lo.textContent()) === 'Thanks for checking the box',
     });
   } finally {
     await page.close();

--- a/docs/sources/k6/v0.57.x/using-k6/environment-variables.md
+++ b/docs/sources/k6/v0.57.x/using-k6/environment-variables.md
@@ -19,6 +19,8 @@ You can use environment variables for two main purposes:
 In k6, the environment variables are exposed through a global `__ENV` variable, a JS object.
 For reference, see the script example below:
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 import { sleep } from 'k6';
@@ -35,7 +37,7 @@ The recommended option to pass environment variables to your testing script is t
 {{< code >}}
 
 ```bash
-$ k6 run -e MY_HOSTNAME=test.k6.io script.js
+k6 run -e MY_HOSTNAME=test.k6.io script.js
 ```
 
 {{< /code >}}
@@ -52,15 +54,15 @@ $ k6 run -e MY_HOSTNAME=test.k6.io script.js
 A second option to pass environment variables is to source them from the local system.
 
 ```bash
-$ MY_HOSTNAME=test.k6.io k6 run script.js
+MY_HOSTNAME=test.k6.io k6 run script.js
 ```
 
 ```windows
-C:\k6> set "MY_HOSTNAME=test.k6.io" && k6 run script.js
+set "MY_HOSTNAME=test.k6.io" && k6 run script.js
 ```
 
 ```powershell
-PS C:\k6> $env:MY_HOSTNAME="test.k6.io"; k6 run script.js
+$env:MY_HOSTNAME="test.k6.io"; k6 run script.js
 ```
 
 #### ⚠️ Warning
@@ -93,15 +95,15 @@ For example, this snippet configures the script to run 10 virtual users for a du
 {{< code >}}
 
 ```bash
-$ K6_VUS=10 K6_DURATION=10s k6 run script.js
+K6_VUS=10 K6_DURATION=10s k6 run script.js
 ```
 
 ```windows
-C:\k6> set "K6_VUS=10 K6_DURATION=10s" && k6 run script.js
+set "K6_VUS=10 K6_DURATION=10s" && k6 run script.js
 ```
 
 ```powershell
-PS C:\k6> $env:K6_VUS=10 ; $env:K6_DURATION="10s" ; k6 run script.js
+$env:K6_VUS=10 ; $env:K6_DURATION="10s" ; k6 run script.js
 ```
 
 {{< /code >}}
@@ -116,7 +118,7 @@ To ensure you're always working with the highest precedence, use command-line fl
 {{< code >}}
 
 ```bash
-$ k6 run -e MY_HOSTNAME=test.k6.io --duration 10s --vus 10 script.js
+k6 run -e MY_HOSTNAME=test.k6.io --duration 10s --vus 10 script.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v0.57.x/using-k6/javascript-typescript-compatibility-mode.md
+++ b/docs/sources/k6/v0.57.x/using-k6/javascript-typescript-compatibility-mode.md
@@ -34,24 +34,20 @@ When running tests, you can change the mode by using the `--compatibility-mode` 
 
 By default, k6 uses the `--compatibility-mode=extended` mode:
 
-{{< code >}}
-
 ```bash
-$ k6 run script.js
+k6 run script.js
 ```
-
-{{< /code >}}
 
 ## Base mode
 
 {{< code >}}
 
 ```cli
-$ k6 run --compatibility-mode=base script.js
+k6 run --compatibility-mode=base script.js
 ```
 
 ```env
-$ K6_COMPATIBILITY_MODE=base k6 run script.js
+K6_COMPATIBILITY_MODE=base k6 run script.js
 ```
 
 {{< /code >}}
@@ -61,11 +57,11 @@ $ K6_COMPATIBILITY_MODE=base k6 run script.js
 {{< code >}}
 
 ```cli
-$ k6 run script.ts
+k6 run script.ts
 ```
 
 ```env
-$ k6 run script.ts
+k6 run script.ts
 ```
 
 {{< /code >}}
@@ -75,8 +71,6 @@ k6 uses [esbuild](https://esbuild.github.io/) to transpile TypeScript (TS) code 
 TypeScript support is partial as it strips the type information but doesn't provide type safety.
 
 ### CommonJS Example
-
-{{< code >}}
 
 ```javascript
 const http = require('k6/http');
@@ -92,8 +86,6 @@ module.exports.default = function () {
   k6.sleep(1);
 };
 ```
-
-{{< /code >}}
 
 > ### ⚠️ About require()
 >

--- a/docs/sources/k6/v0.57.x/using-k6/k6-options/how-to.md
+++ b/docs/sources/k6/v0.57.x/using-k6/k6-options/how-to.md
@@ -62,7 +62,7 @@ The following JS snippets show some examples of how you can set options.
 
 ### Set options in the script
 
-{{< code >}}
+<!-- md-k6:skip -->
 
 ```javascript
 import http from 'k6/http';
@@ -84,8 +84,6 @@ export default function () {
 }
 ```
 
-{{< /code >}}
-
 ### Set options with environment variables
 
 You can also set the options from the previous example through environment variables and command-line flags:
@@ -93,21 +91,21 @@ You can also set the options from the previous example through environment varia
 {{< code >}}
 
 ```bash
-$ K6_NO_CONNECTION_REUSE=true K6_USER_AGENT="MyK6UserAgentString/1.0" k6 run script.js
+K6_NO_CONNECTION_REUSE=true K6_USER_AGENT="MyK6UserAgentString/1.0" k6 run script.js
 
-$ k6 run --no-connection-reuse --user-agent "MyK6UserAgentString/1.0" script.js
+k6 run --no-connection-reuse --user-agent "MyK6UserAgentString/1.0" script.js
 ```
 
 ```windows
-C:\k6> set "K6_NO_CONNECTION_REUSE=true" && set "K6_USER_AGENT=MyK6UserAgentString/1.0" && k6 run script.js
+set "K6_NO_CONNECTION_REUSE=true" && set "K6_USER_AGENT=MyK6UserAgentString/1.0" && k6 run script.js
 
-C:\k6> k6 run --no-connection-reuse --user-agent "MyK6UserAgentString/1.0" script.js
+k6 run --no-connection-reuse --user-agent "MyK6UserAgentString/1.0" script.js
 ```
 
 ```powershell
-PS C:\k6> $env:K6_NO_CONNECTION_REUSE=true; $env:K6_USER_AGENT="MyK6UserAgentString/1.0"; k6 run script.js
+$env:K6_NO_CONNECTION_REUSE=true; $env:K6_USER_AGENT="MyK6UserAgentString/1.0"; k6 run script.js
 
-PS C:\k6> k6 run --no-connection-reuse --user-agent "MyK6UserAgentString/1.0" script.js
+k6 run --no-connection-reuse --user-agent "MyK6UserAgentString/1.0" script.js
 ```
 
 {{< /code >}}
@@ -126,7 +124,7 @@ k6 run script.js --env MY_USER_AGENT="hello"
 Then, your script could then set the `userAgent` option based on the variable's value.
 This allows for quick configuration.
 
-{{< code >}}
+<!-- md-k6:skip -->
 
 ```javascript
 import http from 'k6/http';
@@ -139,8 +137,6 @@ export default function () {
   http.get('http://test.k6.io/');
 }
 ```
-
-{{< /code >}}
 
 > **Note**: Though this method uses the `--env` flag, this is not the same as using an environment variable.
 > For an explanation, refer to the [environment variables document](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/environment-variables).
@@ -158,8 +154,6 @@ k6 run --config options.json script.js
 ```
 
 This command would set test options according to the values in the `options.json` file.
-
-{{< code >}}
 
 ```json
 {
@@ -188,9 +182,9 @@ This command would set test options according to the values in the `options.json
 }
 ```
 
-{{< /code >}}
-
 For an alternative way to separate configuration from logic, you can use the `JSON.parse()` method in your script file:
+
+<!-- md-k6:skip -->
 
 ```javascript
 // load test config, used to populate exported options object:
@@ -207,7 +201,7 @@ With `test.options`, you can access the consolidated and derived options of your
 A common use of this feature is to log the value of a tag, but there are many possibilities.
 For example, this script accesses the value of the test's current stage:
 
-{{< code >}}
+<!-- md-k6:skip -->
 
 ```javascript
 import exec from 'k6/execution';
@@ -223,7 +217,3 @@ export default function () {
   console.log(exec.test.options.scenarios.default.stages[0].target); // 100
 }
 ```
-
-{{< /code >}}
-
-<br/>

--- a/docs/sources/k6/v0.57.x/using-k6/k6-options/reference.md
+++ b/docs/sources/k6/v0.57.x/using-k6/k6-options/reference.md
@@ -7,6 +7,8 @@ weight: 02
 
 # Options reference
 
+<!-- md-k6:skipall -->
+
 Options define test-run behavior.
 Most options can be passed in multiple places.
 If an option is defined in multiple places, k6 chooses the value from the highest [order of precedence](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/how-to#order-of-precedence).
@@ -95,7 +97,7 @@ By default, the server listens on `localhost:6565`. Read more on [k6 REST API](h
 {{< code >}}
 
 ```bash
-$ k6 run --address "localhost:3000" script.js
+k6 run --address "localhost:3000" script.js
 ```
 
 {{< /code >}}
@@ -186,7 +188,7 @@ export const options = {
 {{< code >}}
 
 ```bash
-$ k6 run --block-hostnames="test.k6.io,*.example.com" script.js
+k6 run --block-hostnames="test.k6.io,*.example.com" script.js
 ```
 
 {{< /code >}}
@@ -204,7 +206,7 @@ Read about the different modes on the [JavaScript Compatibility Mode documentati
 {{< code >}}
 
 ```bash
-$ k6 run --compatibility-mode=base script.js
+k6 run --compatibility-mode=base script.js
 ```
 
 {{< /code >}}
@@ -245,7 +247,7 @@ Redirects logs logged by `console` methods to the provided output file. Availabl
 {{< code >}}
 
 ```bash
-$ k6 run --console-output "loadtest.log" script.js
+k6 run --console-output "loadtest.log" script.js
 ```
 
 {{< /code >}}
@@ -416,7 +418,7 @@ With this option, you can exit early and let the script run in the background. A
 {{< code >}}
 
 ```bash
-$ k6 cloud run --exit-on-running script.js
+k6 cloud run --exit-on-running script.js
 ```
 
 {{< /code >}}
@@ -490,7 +492,7 @@ Pass the real system [environment variables](https://grafana.com/docs/k6/<K6_VER
 {{< code >}}
 
 ```bash
-$ k6 run --include-system-env-vars ~/script.js
+k6 run --include-system-env-vars ~/script.js
 ```
 
 {{< /code >}}
@@ -592,7 +594,7 @@ Available in the `k6 run` command.
 {{< code >}}
 
 ```bash
-$ k6 run --local-ips=192.168.20.12-192.168.20.15,192.168.10.0/27 script.js
+k6 run --local-ips=192.168.20.12-192.168.20.15,192.168.10.0/27 script.js
 ```
 
 {{< /code >}}
@@ -608,7 +610,7 @@ This option specifies where to send logs to and another configuration connected 
 {{< code >}}
 
 ```bash
-$ k6 run --log-output=stdout script.js
+k6 run --log-output=stdout script.js
 ```
 
 {{< /code >}}
@@ -629,7 +631,7 @@ For additional instructions and a step-by-step guide, check out the [Loki tutori
 {{< code >}}
 
 ```bash
-$ k6 run --log-output=loki=http://127.0.0.1:3100/loki/api/v1/push,label.something=else,label.foo=bar,limit=32,level=info,pushPeriod=5m32s,msgMaxSize=1231 script.js
+k6 run --log-output=loki=http://127.0.0.1:3100/loki/api/v1/push,label.something=else,label.foo=bar,limit=32,level=info,pushPeriod=5m32s,msgMaxSize=1231 script.js
 ```
 
 {{< /code >}}
@@ -656,7 +658,7 @@ The file can be configured as below, where an explicit file path is required:
 {{< code >}}
 
 ```bash
-$ k6 run --log-output=file=./k6.log script.js
+k6 run --log-output=file=./k6.log script.js
 ```
 
 {{< /code >}}
@@ -682,7 +684,7 @@ A value specifying the log format. By default, k6 includes extra debug informati
 {{< code >}}
 
 ```bash
-$ k6 run --log-format raw test.js
+k6 run --log-format raw test.js
 ```
 
 {{< /code >}}
@@ -737,7 +739,7 @@ A boolean specifying whether colored output is disabled. Available in `k6 run` a
 {{< code >}}
 
 ```bash
-$ k6 run --no-color script.js
+k6 run --no-color script.js
 ```
 
 {{< /code >}}
@@ -794,7 +796,7 @@ Available in the `k6 run` command.
 {{< code >}}
 
 ```bash
-$ k6 run --no-summary ~/script.js
+k6 run --no-summary ~/script.js
 ```
 
 {{< /code >}}
@@ -810,7 +812,7 @@ A boolean specifying whether `setup()` function should be run. Available in `k6 
 {{< code >}}
 
 ```bash
-$ k6 run --no-setup script.js
+k6 run --no-setup script.js
 ```
 
 {{< /code >}}
@@ -826,7 +828,7 @@ A boolean specifying whether `teardown()` function should be run. Available in `
 {{< code >}}
 
 ```bash
-$ k6 run --no-teardown script.js
+k6 run --no-teardown script.js
 ```
 
 {{< /code >}}
@@ -842,7 +844,7 @@ Disables threshold execution. Available in the `k6 run` command.
 {{< code >}}
 
 ```bash
-$ k6 run --no-thresholds ~/script.js
+k6 run --no-thresholds ~/script.js
 ```
 
 {{< /code >}}
@@ -861,7 +863,7 @@ learn more, have a look at the [Usage reports](https://grafana.com/docs/k6/<K6_V
 {{< code >}}
 
 ```bash
-$ k6 run --no-usage-report ~/script.js
+k6 run --no-usage-report ~/script.js
 ```
 
 {{< /code >}}
@@ -917,7 +919,7 @@ Enables [pprof](https://pkg.go.dev/net/http/pprof) profiling endpoints under the
 {{< code >}}
 
 ```bash
-$ k6 run --profiling-enabled script.js
+k6 run --profiling-enabled script.js
 ```
 
 {{< /code >}}
@@ -933,7 +935,7 @@ A boolean, true or false, that disables the progress update bar on the console o
 {{< code >}}
 
 ```bash
-$ k6 run script.js -d 20s --quiet
+k6 run script.js -d 20s --quiet
 ```
 
 {{< /code >}}
@@ -951,7 +953,7 @@ refer to [Results output](https://grafana.com/docs/k6/<K6_VERSION>/results-outpu
 {{< code >}}
 
 ```bash
-$ k6 run --out influxdb=http://localhost:8086/k6 script.js
+k6 run --out influxdb=http://localhost:8086/k6 script.js
 ```
 
 {{< /code >}}
@@ -1060,7 +1062,7 @@ A boolean specifying whether the cloud logs are printed out to the terminal. Ava
 {{< code >}}
 
 ```bash
-$ k6 cloud run --show-logs=false script.js
+k6 cloud run --show-logs=false script.js
 ```
 
 {{< /code >}}
@@ -1095,28 +1097,28 @@ export const options = {
 ```
 
 ```bash
-$ k6 run --stage 5s:10,5m:20,10s:5 script.js
+k6 run --stage 5s:10,5m:20,10s:5 script.js
 
 # or...
 
-$ K6_STAGES="5s:10,5m:20,10s:5" k6 run script.js
+K6_STAGES="5s:10,5m:20,10s:5" k6 run script.js
 ```
 
 ```windows
-C:\k6> k6 run --stage 5s:10,5m:20,10s:5 script.js
+k6 run --stage 5s:10,5m:20,10s:5 script.js
 
 # or...
 
-C:\k6> set "K6_STAGES=5s:10,5m:20,10s:5" && k6 run script.js
+set "K6_STAGES=5s:10,5m:20,10s:5" && k6 run script.js
 
 ```
 
 ```powershell
-C:\k6> k6 run --stage 5s:10,5m:20,10s:5 script.js
+k6 run --stage 5s:10,5m:20,10s:5 script.js
 
 # or...
 
-C:\k6> $env:K6_STAGES="5s:10,5m:20,10s:5"; k6 run script.js
+$env:K6_STAGES="5s:10,5m:20,10s:5"; k6 run script.js
 
 ```
 
@@ -1139,29 +1141,27 @@ Available in the `k6 run` command.
 {{< code >}}
 
 ```bash
-$ k6 run --summary-export export.json script.js
+k6 run --summary-export export.json script.js
 
 # or...
 
-$ K6_SUMMARY_EXPORT="export.json" k6 run script.js
+K6_SUMMARY_EXPORT="export.json" k6 run script.js
 ```
 
 ```windows
-C:\k6> k6 run --summary-export export.json script.js
+k6 run --summary-export export.json script.js
 
 # or...
 
-C:\k6> set "K6_SUMMARY_EXPORT=export.json" && k6 run script.js
-
+set "K6_SUMMARY_EXPORT=export.json" && k6 run script.js
 ```
 
 ```powershell
-C:\k6> k6 run --summary-export export.json script.js
+k6 run --summary-export export.json script.js
 
 # or...
 
-C:\k6> $env:K6_SUMMARY_EXPORT="export.json"; k6 run script.js
-
+$env:K6_SUMMARY_EXPORT="export.json"; k6 run script.js
 ```
 
 {{< /code >}}
@@ -1192,7 +1192,7 @@ Compare this behavior with `K6_ITERATIONS=120 k6 run script.js`, which _does_ se
 {{< code >}}
 
 ```bash
-$ k6 run -e FOO=bar ~/script.js
+k6 run -e FOO=bar ~/script.js
 ```
 
 {{< /code >}}
@@ -1259,7 +1259,7 @@ export const options = {
 {{< code >}}
 
 ```bash
-$ k6 run --summary-trend-stats="avg,min,med,max,p(90),p(99.9),p(99.99),count" ./script.js
+k6 run --summary-trend-stats="avg,min,med,max,p(90),p(99.9),p(99.99),count" ./script.js
 ```
 
 {{< /code >}}
@@ -1445,7 +1445,7 @@ This option specifies where to send traces to. Available in the `k6 run` command
 {{< code >}}
 
 ```bash
-$ k6 run --traces-output=otel script.js
+k6 run --traces-output=otel script.js
 ```
 
 {{< /code >}}
@@ -1462,7 +1462,7 @@ Use the `traces-output` option to configure [Open Telemetry](https://opentelemet
 {{< code >}}
 
 ```bash
-$ k6 run --traces-output=otel=http://127.0.0.1:4318,proto=http,header.AdditionalHeader=example script.js
+k6 run --traces-output=otel=http://127.0.0.1:4318,proto=http,header.AdditionalHeader=example script.js
 ```
 
 {{< /code >}}
@@ -1495,7 +1495,7 @@ This would be useful if you would like to update a given test and run it later. 
 {{< code >}}
 
 ```bash
-$ k6 cloud run --upload-only script.js
+k6 cloud run --upload-only script.js
 ```
 
 {{< /code >}}
@@ -1532,7 +1532,7 @@ A boolean specifying whether verbose logging is enabled. Available in `k6 run` a
 {{< code >}}
 
 ```bash
-$ k6 run --verbose script.js
+k6 run --verbose script.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v0.57.x/using-k6/modules.md
+++ b/docs/sources/k6/v0.57.x/using-k6/modules.md
@@ -210,7 +210,7 @@ is usually accomplished within minutes. Start by creating a project folder and i
 `npm`:
 
 ```bash
-$ mkdir ./example-project && \
+mkdir ./example-project && \
     cd "$_" && \
     npm init -y
 ```
@@ -220,7 +220,7 @@ $ mkdir ./example-project && \
 Then, install the packages needed:
 
 ```bash
-$ npm install --save-dev \
+npm install --save-dev \
     webpack \
     webpack-cli \
     @types/k6 \
@@ -421,7 +421,7 @@ To run index.js and make the modules available for import we execute the followi
 {{< code >}}
 
 ```bash
-$ docker run --rm -v /home/k6/example/src:/src -i grafana/k6 run /src/index.js
+docker run --rm -v /home/k6/example/src:/src -i grafana/k6 run /src/index.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v0.57.x/using-k6/scenarios/advanced-examples.md
+++ b/docs/sources/k6/v0.57.x/using-k6/scenarios/advanced-examples.md
@@ -256,15 +256,15 @@ Then from the command line, you could run the test script and only execute the `
 {{< code >}}
 
 ```bash
-$ SCENARIO=my_web_test k6 run script.js
+SCENARIO=my_web_test k6 run script.js
 ```
 
 ```windows
-C:\k6> set "SCENARIO=my_web_test" && k6 run script.js
+set "SCENARIO=my_web_test" && k6 run script.js
 ```
 
 ```powershell
-PS C:\k6> $env:SCENARIO="my_web_test"; k6 run script.js
+$env:SCENARIO="my_web_test"; k6 run script.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v0.57.x/using-k6/test-authoring/create-tests-from-recordings/using-the-har-converter.md
+++ b/docs/sources/k6/v0.57.x/using-k6/test-authoring/create-tests-from-recordings/using-the-har-converter.md
@@ -54,7 +54,7 @@ The [har-to-k6 converter](https://github.com/k6io/har-to-k6) is a NodeJS tool th
 1. Install the converter. You can use `npm`:
 
    ```bash
-   $ npm install -g har-to-k6
+   npm install -g har-to-k6
    ```
 
    For other installation options, check out the [har-to-k6 installation instructions](https://github.com/k6io/har-to-k6#installation).
@@ -62,7 +62,7 @@ The [har-to-k6 converter](https://github.com/k6io/har-to-k6) is a NodeJS tool th
 1. Generate a k6 script from a HAR file with the convert command:
 
    ```bash
-   $ har-to-k6 myfile.har -o loadtest.js
+   har-to-k6 myfile.har -o loadtest.js
    ```
 
    This command auto-generates a k6 script for you.
@@ -94,6 +94,8 @@ k6 lets you configure this in several ways:
   ```
 
 - As options in the script file.
+
+  <!-- md-k6:skip -->
 
   ```javascript
   export const options = {
@@ -157,7 +159,7 @@ Now, you can run your load test with k6. If you have not installed k6 yet, pleas
 Execute the `k6 run` command to run your k6 script:
 
 ```bash
-$ k6 run loadtest.js
+k6 run loadtest.js
 ```
 
 To learn about running k6, check out the [Running k6 tutorial](https://grafana.com/docs/k6/<K6_VERSION>/get-started/running-k6).

--- a/docs/sources/k6/v0.57.x/using-k6/test-lifecycle.md
+++ b/docs/sources/k6/v0.57.x/using-k6/test-lifecycle.md
@@ -23,7 +23,7 @@ a function called in a specific sequence in the k6 runtime.
 
 {{< /admonition >}}
 
-{{< code >}}
+<!-- md-k6:skip -->
 
 ```javascript
 // 1. init code
@@ -40,8 +40,6 @@ export function teardown(data) {
   // 4. teardown code
 }
 ```
-
-{{< /code >}}
 
 ## Overview of the lifecycle stages
 
@@ -74,8 +72,6 @@ Some operations that might happen in `init` include the following:
 **All code that is outside of a lifecycle function is code in the `init` context**.
 Code in the `init` context _always executes first_.
 
-{{< code >}}
-
 <!-- md-k6:skip -->
 
 ```javascript
@@ -98,8 +94,6 @@ function myCustomFunction() {
 }
 ```
 
-{{< /code >}}
-
 Separating the `init` stage from the VU stage removes irrelevant computation from VU code, which improves k6 performance and makes test results more reliable.
 One limitation of `init` code is that it **cannot** make HTTP requests.
 This limitation ensures that the `init` stage is reproducible across tests (the response from protocol requests is dynamic and unpredictable)
@@ -110,15 +104,13 @@ Scripts must contain, at least, a _scenario function_ that defines the logic of 
 The code inside this function is _VU code_.
 Typically, VU code is inside the `default` function, but it can also be inside the function defined by a scenario (see subsequent section for an example).
 
-{{< code >}}
+<!-- md-k6:skip -->
 
 ```javascript
 export default function () {
   // do things here...
 }
 ```
-
-{{< /code >}}
 
 **VU code runs over and over through the test duration.**
 VU code can make HTTP requests, emit metrics, and generally do everything you'd expect a load test to do.
@@ -148,8 +140,6 @@ But unlike the `default` function, k6 calls `setup` and `teardown` only once per
 You can call the full k6 API in the setup and teardown stages, unlike the init stage.
 For example, you can make HTTP requests:
 
-{{< code >}}
-
 ```javascript
 import http from 'k6/http';
 
@@ -167,26 +157,20 @@ export default function (data) {
 }
 ```
 
-{{< /code >}}
-
 ### Skip setup and teardown execution
 
 You can skip the execution of setup and teardown stages using the options `--no-setup` and
 `--no-teardown`.
 
-{{< code >}}
-
 ```bash
-$ k6 run --no-setup --no-teardown ...
+k6 run --no-setup --no-teardown ...
 ```
-
-{{< /code >}}
 
 ### Use data from setup in default and teardown
 
 Again, let's have a look at the basic structure of a k6 test:
 
-{{< code >}}
+<!-- md-k6:skip -->
 
 ```javascript
 // 1. init code
@@ -204,13 +188,11 @@ export function teardown(data) {
 }
 ```
 
-{{< /code >}}
-
 You might have noticed the function signatures of the `default()` and `teardown()` functions take an argument, referred to here as `data`.
 
 Here's an example of passing some data from the setup code to the VU and teardown stages:
 
-{{< code >}}
+<!-- md-k6:skip -->
 
 ```javascript
 export function setup() {
@@ -227,8 +209,6 @@ export function teardown(data) {
   }
 }
 ```
-
-{{< /code >}}
 
 For example, with the data returned by the `setup()` function, you can:
 
@@ -259,7 +239,6 @@ k6 has a few additional ways to use lifecycle functions:
 
 - **Scenario functions**. Instead of the `default` function, you can also run VU code in scenario functions.
 
-  {{< code >}}
   <!-- md-k6:skip -->
 
   ```javascript
@@ -283,5 +262,3 @@ k6 has a few additional ways to use lifecycle functions:
     sleep(Math.random() * 2);
   }
   ```
-
-  {{< /code >}}


### PR DESCRIPTION
## What?

Remove symbols (`$`, `C:\k6>`, and `PS C:\k6>`) from command-line code snippets, so users can copy+paste them and run them in their terminals more easily.

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [ ] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [x] I have made my changes in the `docs/sources/k6/next` folder of the documentation.
- [ ] I have reflected my changes in the `docs/sources/k6/v{most_recent_release}` folder of the documentation.
- [ ] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->
<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->