### PR TITLE
Update end-of-test results page according to new format

### DIFF
--- a/docs/sources/k6/next/examples/get-started-with-k6/analyze-results.md
+++ b/docs/sources/k6/next/examples/get-started-with-k6/analyze-results.md
@@ -22,24 +22,43 @@ By default, the [end-of-test summary](https://grafana.com/docs/k6/<K6_VERSION>/r
 {{< code >}}
 
 ```bash
-checks.........................: 50.00% ✓ 45       ✗ 45
-data_received..................: 1.3 MB 31 kB/s
-data_sent......................: 81 kB  2.0 kB/s
-group_duration.................: avg=6.45s    min=4.01s    med=6.78s    max=10.15s   p(90)=9.29s    p(95)=9.32s
-http_req_blocked...............: avg=57.62ms  min=7µs      med=12.25µs  max=1.35s    p(90)=209.41ms p(95)=763.61ms
-http_req_connecting............: avg=20.51ms  min=0s       med=0s       max=1.1s     p(90)=100.76ms p(95)=173.41ms
-http_req_duration..............: avg=144.56ms min=104.11ms med=110.47ms max=1.14s    p(90)=203.54ms p(95)=215.95ms
-  { expected_response:true }...: avg=144.56ms min=104.11ms med=110.47ms max=1.14s    p(90)=203.54ms p(95)=215.95ms
-http_req_failed................: 0.00%  ✓ 0        ✗ 180
-http_req_receiving.............: avg=663.96µs min=128.46µs med=759.82µs max=1.66ms   p(90)=1.3ms    p(95)=1.46ms
-http_req_sending...............: avg=88.01µs  min=43.07µs  med=78.03µs  max=318.81µs p(90)=133.15µs p(95)=158.3µs
-http_req_tls_handshaking.......: avg=29.25ms  min=0s       med=0s       max=458.71ms p(90)=108.31ms p(95)=222.46ms
-http_req_waiting...............: avg=143.8ms  min=103.5ms  med=109.5ms  max=1.14s    p(90)=203.19ms p(95)=215.56ms
-http_reqs......................: 180    4.36938/s
-iteration_duration.............: avg=12.91s   min=12.53s   med=12.77s   max=14.35s   p(90)=13.36s   p(95)=13.37s
-iterations.....................: 45     1.092345/s
-vus............................: 1      min=1      max=19
-vus_max........................: 20     min=20     max=20
+  █ THRESHOLDS
+
+    http_req_duration
+    ✓ 'p(95)<1500' p(95)=148.21ms
+    ✓ 'p(90)<2000' p(90)=146.88ms
+
+    http_req_failed
+    ✓ 'rate<0.01' rate=0.00%
+
+
+  █ TOTAL RESULTS
+
+    checks_total.......................: 90      13.122179/s
+    checks_succeeded...................: 100.00% 90 out of 90
+    checks_failed......................: 0.00%   0 out of 90
+
+    ✓ test-api.k6.io is up
+    ✓ status is 200
+
+    CUSTOM
+    custom_waiting_time................: avg=152.355556 min=120      med=141      max=684      p(90)=147.2    p(95)=148.8
+
+    HTTP
+    http_req_duration..................: avg=140.36ms   min=119.08ms med=140.96ms max=154.63ms p(90)=146.88ms p(95)=148.21ms
+      { expected_response:true }.......: avg=140.36ms   min=119.08ms med=140.96ms max=154.63ms p(90)=146.88ms p(95)=148.21ms
+    http_req_failed....................: 0.00%  0 out of 45
+    http_reqs..........................: 45     6.56109/s
+
+    EXECUTION
+    iteration_duration.................: avg=152.38ms   min=119.37ms med=141.27ms max=684.62ms p(90)=147.11ms p(95)=148.39ms
+    iterations.........................: 45     6.56109/s
+    vus................................: 1      min=1       max=1
+    vus_max............................: 1      min=1       max=1
+
+    NETWORK
+    data_received......................: 519 kB 76 kB/s
+    data_sent..........................: 4.9 kB 718 B/s
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/next/examples/get-started-with-k6/test-for-performance.md
+++ b/docs/sources/k6/next/examples/get-started-with-k6/test-for-performance.md
@@ -96,9 +96,13 @@ k6 run api-test.js
 Inspect the console output to determine whether performance crossed a threshold.
 
 ```
-✓ http_req_duration..............: avg=66.14ms    min=0s         med=0s         max=198.42ms   p(90)=158.73ms   p(95)=178.58ms
-       { expected_response:true }...: avg=198.42ms   min=198.42ms   med=198.42ms   max=198.42ms   p(90)=198.42ms   p(95)=198.42ms
-✗ http_req_failed................: 0.00% ✓ 0        ✗ 1
+  █ THRESHOLDS
+
+    http_req_duration
+    ✓ 'p(99)<1000' p(99)=148.21ms
+
+    http_req_failed
+    ✗ 'rate<0.01' rate=20.%
 ```
 
 The ✓ and ✗ symbols indicate whether the performance thresholds passed or failed.

--- a/docs/sources/k6/next/results-output/end-of-test/_index.md
+++ b/docs/sources/k6/next/results-output/end-of-test/_index.md
@@ -186,7 +186,11 @@ The summary displays metrics based on their source:
 - **Execution metrics**: Test execution details like iterations and virtual users (VUs)
 - **Network metrics**: Data transfer statistics
 
-Note: Categories appear only when relevant. For example, browser metrics appear only when using the `k6/browser` module.
+{{< admonition type="note" >}}
+
+Categories appear only when relevant. For example, browser metrics appear only when using the `k6/browser` module.
+
+{{< /admonition >}}
 
 ### Checks and thresholds
 

--- a/docs/sources/k6/next/results-output/end-of-test/_index.md
+++ b/docs/sources/k6/next/results-output/end-of-test/_index.md
@@ -226,7 +226,6 @@ Customize the summary output with these options:
 k6 offers additional ways to process and analyze test results:
 
 - [**Custom summaries**](https://grafana.com/docs/k6/<K6_VERSION>/results-output/end-of-test/custom-summary): Create your own summary format with complete control over the output
-- [**Real-time outputs**](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/): Stream metrics during the test run:
-  - [CSV output](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/csv): For spreadsheet analysis
-  - [JSON output](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/json): For programmatic processing
-  - Head to the [real-time outputs section](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/) for more.
+- [**Real-time output**](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/): Stream metrics during the test run and:
+  - Save them to a [CSV](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/csv) or [JSON](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/json) file.
+  - Send them to an [external service](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/#service).

--- a/docs/sources/k6/next/results-output/end-of-test/_index.md
+++ b/docs/sources/k6/next/results-output/end-of-test/_index.md
@@ -206,7 +206,7 @@ Note: Categories appear only when relevant. For example, browser metrics appear 
 When using full mode, you'll see additional sections:
 
 - [**Groups**](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/tags-and-groups/): Results for logical groupings of related requests
-- [**Scenarios**](https://grafana.com/docs/k6/latest/using-k6/scenarios/): Results for each test scenario configuration
+- [**Scenarios**](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/scenarios/): Results for each test scenario configuration
 
 ## Summary options
 

--- a/docs/sources/k6/next/results-output/end-of-test/_index.md
+++ b/docs/sources/k6/next/results-output/end-of-test/_index.md
@@ -12,9 +12,9 @@ When a test finishes, k6 prints a summary of the aggregated results to `stdout`.
 
 k6 provides three different ways to display test results through the [`--summary-mode` option](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-mode):
 
-- **compact** (default): Displays the most relevant test results in a concise format
-- **full**: Includes everything from the compact format, plus additional k6 metrics and detailed results for each group and scenario
-- **legacy**: Uses the pre-v1.0.0 summary format for backward compatibility
+- **compact** (default): Displays the most relevant test results in a concise format.
+- **full**: Includes everything from the compact format, plus additional k6 metrics and detailed results for each group and scenario.
+- **legacy**: Uses the pre-v1.0.0 summary format for backward compatibility.
 
 ### Compact mode (default)
 

--- a/docs/sources/k6/next/results-output/end-of-test/_index.md
+++ b/docs/sources/k6/next/results-output/end-of-test/_index.md
@@ -2,118 +2,227 @@
 title: End of test
 description: When a test finishes, k6 prints a summary of results, with aggregated metrics and meta-data about the test. You can customize this, or configure the test to write granular metrics to a file.
 weight: 100
-weight: 100
 ---
 
 # End of test
 
-When a test finishes, k6 prints a top-level overview of the aggregated results to `stdout`.
+When a test finishes, k6 prints a summary of the aggregated results to `stdout`. By default, k6 uses a "compact" summary mode that focuses on the most important metrics, but you can also use a "full" mode that shows all available information.
+
+## Summary modes
+
+k6 provides three different ways to display test results through the [`--summary-mode` option](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-mode):
+
+- **compact** (default): Displays the most relevant test results in a concise format
+- **full**: Includes everything from the compact format, plus additional k6 metrics and detailed results for each group and scenario
+- **legacy**: Uses the pre-v1.0.0 summary format for backward compatibility
+
+### Compact mode (default)
+
+The compact mode provides a concise overview focusing on three key aspects:
+
+- Thresholds results
+- Checks results
+- Aggregated metrics results by category
 
 ```bash
-checks.........................: 50.00% ✓ 45       ✗ 45
-data_received..................: 1.3 MB 31 kB/s
-data_sent......................: 81 kB  2.0 kB/s
-group_duration.................: avg=6.45s    min=4.01s    med=6.78s    max=10.15s   p(90)=9.29s    p(95)=9.32s
-http_req_blocked...............: avg=57.62ms  min=7µs      med=12.25µs  max=1.35s    p(90)=209.41ms p(95)=763.61ms
-http_req_connecting............: avg=20.51ms  min=0s       med=0s       max=1.1s     p(90)=100.76ms p(95)=173.41ms
-http_req_duration..............: avg=144.56ms min=104.11ms med=110.47ms max=1.14s    p(90)=203.54ms p(95)=215.95ms
-  { expected_response:true }...: avg=144.56ms min=104.11ms med=110.47ms max=1.14s    p(90)=203.54ms p(95)=215.95ms
-http_req_failed................: 0.00%  ✓ 0        ✗ 180
-http_req_receiving.............: avg=663.96µs min=128.46µs med=759.82µs max=1.66ms   p(90)=1.3ms    p(95)=1.46ms
-http_req_sending...............: avg=88.01µs  min=43.07µs  med=78.03µs  max=318.81µs p(90)=133.15µs p(95)=158.3µs
-http_req_tls_handshaking.......: avg=29.25ms  min=0s       med=0s       max=458.71ms p(90)=108.31ms p(95)=222.46ms
-http_req_waiting...............: avg=143.8ms  min=103.5ms  med=109.5ms  max=1.14s    p(90)=203.19ms p(95)=215.56ms
-http_reqs......................: 180    4.36938/s
-iteration_duration.............: avg=12.91s   min=12.53s   med=12.77s   max=14.35s   p(90)=13.36s   p(95)=13.37s
-iterations.....................: 45     1.092345/s
-vus............................: 1      min=1      max=19
-vus_max........................: 20     min=20     max=20
+  █ THRESHOLDS
+
+    http_req_duration
+    ✓ 'p(95)<1500' p(95)=148.21ms
+    ✓ 'p(90)<2000' p(90)=146.88ms
+
+    http_req_failed
+    ✓ 'rate<0.01' rate=0.00%
+
+
+  █ TOTAL RESULTS
+
+    checks_total.......................: 90      13.122179/s
+    checks_succeeded...................: 100.00% 90 out of 90
+    checks_failed......................: 0.00%   0 out of 90
+
+    ✓ test-api.k6.io is up
+    ✓ status is 200
+
+    CUSTOM
+    custom_waiting_time................: avg=152.355556 min=120      med=141      max=684      p(90)=147.2    p(95)=148.8
+
+    HTTP
+    http_req_duration..................: avg=140.36ms   min=119.08ms med=140.96ms max=154.63ms p(90)=146.88ms p(95)=148.21ms
+      { expected_response:true }.......: avg=140.36ms   min=119.08ms med=140.96ms max=154.63ms p(90)=146.88ms p(95)=148.21ms
+    http_req_failed....................: 0.00%  0 out of 45
+    http_reqs..........................: 45     6.56109/s
+
+    EXECUTION
+    iteration_duration.................: avg=152.38ms   min=119.37ms med=141.27ms max=684.62ms p(90)=147.11ms p(95)=148.39ms
+    iterations.........................: 45     6.56109/s
+    vus................................: 1      min=1       max=1
+    vus_max............................: 1      min=1       max=1
+
+    NETWORK
+    data_received......................: 519 kB 76 kB/s
+    data_sent..........................: 4.9 kB 718 B/s
 ```
 
-<br/>
+### Full mode
 
-Besides this default summary, k6 can output the results in other formats at the end of the test:
+The full mode provides comprehensive test results, including:
 
-| On this page                                                                                         | Result format            | Read about...                                                 |
-| ---------------------------------------------------------------------------------------------------- | ------------------------ | ------------------------------------------------------------- |
-| [Custom summary](https://grafana.com/docs/k6/<K6_VERSION>/results-output/end-of-test/custom-summary) | Aggregated               | Using the `handleSummary()` to make completely custom reports |
-| [CSV](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/csv)                         | Time-stamped data points | Writing results as a CSV file, and the structure of the data  |
-| [JSON](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/json)                       | Time-stamped data points | Writing results as a JSON file, and the structure of the data |
+- All information from compact mode
+- Group-specific results
+- Scenario-specific results
 
-## The default summary
-
-The end-of-test summary reports details and aggregated statistics for the primary aspects of the test:
-
-- Summary statistics about each built-in and custom [metric](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/metrics#built-in-metrics) (e.g. mean, median, p95, etc).
-- A list of the test's [groups](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/tags-and-groups#groups) and [scenarios](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/scenarios)
-- The pass/fail results of the test's [thresholds](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/thresholds) and [checks](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/checks).
-
-{{< code >}}
+For example:
 
 ```bash
-Ramp_Up ✓ [======================================] 00/20 VUs  30s
-     █ GET home - https://example.com/
+  █ THRESHOLDS
 
-       ✓ status equals 200
+    http_req_duration
+    ✓ 'p(95)<1500' p(95)=145.17ms
+    ✓ 'p(90)<2000' p(90)=132.76ms
 
-     █ Create resource - https://example.com/create
+    http_req_failed
+    ✓ 'rate<0.01' rate=0.00%
 
-       ✗ status equals 201
-        ↳  0% — ✓ 0 / ✗ 45
 
-     checks.........................: 50.00% ✓ 45       ✗ 45
-     data_received..................: 1.3 MB 31 kB/s
-     data_sent......................: 81 kB  2.0 kB/s
-     group_duration.................: avg=6.45s    min=4.01s    med=6.78s    max=10.15s   p(90)=9.29s    p(95)=9.32s
-     http_req_blocked...............: avg=57.62ms  min=7µs      med=12.25µs  max=1.35s    p(90)=209.41ms p(95)=763.61ms
-     http_req_connecting............: avg=20.51ms  min=0s       med=0s       max=1.1s     p(90)=100.76ms p(95)=173.41ms
-   ✗ http_req_duration..............: avg=144.56ms min=104.11ms med=110.47ms max=1.14s    p(90)=203.54ms p(95)=215.95ms
-       { expected_response:true }...: avg=144.56ms min=104.11ms med=110.47ms max=1.14s    p(90)=203.54ms p(95)=215.95ms
-     http_req_failed................: 0.00%  ✓ 0        ✗ 180
-     http_req_receiving.............: avg=663.96µs min=128.46µs med=759.82µs max=1.66ms   p(90)=1.3ms    p(95)=1.46ms
-     http_req_sending...............: avg=88.01µs  min=43.07µs  med=78.03µs  max=318.81µs p(90)=133.15µs p(95)=158.3µs
-     http_req_tls_handshaking.......: avg=29.25ms  min=0s       med=0s       max=458.71ms p(90)=108.31ms p(95)=222.46ms
-     http_req_waiting...............: avg=143.8ms  min=103.5ms  med=109.5ms  max=1.14s    p(90)=203.19ms p(95)=215.56ms
-     http_reqs......................: 180    4.36938/s
-     iteration_duration.............: avg=12.91s   min=12.53s   med=12.77s   max=14.35s   p(90)=13.36s   p(95)=13.37s
-     iterations.....................: 45     1.092345/s
-     vus............................: 1      min=1      max=19
-     vus_max........................: 20     min=20     max=20
+  █ TOTAL RESULTS
 
-ERRO[0044] some thresholds have failed
+    checks_total.......................: 110     19.569305/s
+    checks_succeeded...................: 100.00% 110 out of 110
+    checks_failed......................: 0.00%   0 out of 110
+
+    ✓ grafana.com is up
+    ✓ status is 200
+    ✓ test-api.k6.io is up
+    ✓ crocodile exists
+
+    CUSTOM
+    custom_waiting_time................: avg=92.444444 min=56      med=63       max=365      p(90)=120      p(95)=121
+
+    HTTP
+    http_req_blocked...................: avg=4.36ms    min=0s      med=5µs      max=245.04ms p(90)=13µs     p(95)=14.59µs
+    http_req_connecting................: avg=1.99ms    min=0s      med=0s       max=115.51ms p(90)=0s       p(95)=0s
+    http_req_duration..................: avg=105.72ms  min=56.31ms med=117.44ms max=328.62ms p(90)=132.76ms p(95)=145.17ms
+      { expected_response:true }.......: avg=105.72ms  min=56.31ms med=117.44ms max=328.62ms p(90)=132.76ms p(95)=145.17ms
+    http_req_failed....................: 0.00%  0 out of 65
+    http_req_receiving.................: avg=11.83ms   min=39µs    med=168µs    max=54.2ms   p(90)=30.73ms  p(95)=31.49ms
+    http_req_sending...................: avg=43.32µs   min=11µs    med=27µs     max=485µs    p(90)=74.2µs   p(95)=81.59µs
+    http_req_tls_handshaking...........: avg=2.3ms     min=0s      med=0s       max=127.41ms p(90)=0s       p(95)=0s
+    http_req_waiting...................: avg=93.85ms   min=26.54ms med=117.12ms max=328.38ms p(90)=132.61ms p(95)=145.11ms
+    http_reqs..........................: 65     11.56368/s
+
+    EXECUTION
+    iteration_duration.................: avg=159.31ms  min=56.45ms med=62.65ms  max=570.47ms p(90)=258.2ms  p(95)=350.51ms
+    iterations.........................: 45     8.005625/s
+    vus................................: 1      min=1       max=2
+    vus_max............................: 2      min=2       max=2
+
+    NETWORK
+    data_received......................: 7.1 MB 1.3 MB/s
+    data_sent..........................: 32 kB  5.6 kB/s
+
+
+  █ SCENARIO: left
+
+    checks_total.......................: 60      10.674166/s
+    checks_succeeded...................: 100.00% 60 out of 60
+    checks_failed......................: 0.00%   0 out of 60
+
+    ✓ test-api.k6.io is up
+    ✓ status is 200
+    ✓ crocodile exists
+
+    CUSTOM
+    custom_waiting_time................: avg=130.6    min=116      med=118      max=365      p(90)=121      p(95)=133.2
+
+    HTTP
+    http_req_blocked...................: avg=6.13ms   min=2µs      med=6µs      max=245.04ms p(90)=13µs     p(95)=15.99µs
+    http_req_connecting................: avg=2.88ms   min=0s       med=0s       max=115.51ms p(90)=0s       p(95)=0s
+    http_req_duration..................: avg=134.17ms min=116.42ms med=122.02ms max=328.62ms p(90)=140.36ms p(95)=207.85ms
+    http_req_failed....................: 0.00%  0 out of 40
+    http_req_receiving.................: avg=128.64µs min=39µs     med=88µs     max=630µs    p(90)=207µs    p(95)=234.04µs
+    http_req_sending...................: avg=21.82µs  min=11µs     med=20µs     max=44µs     p(90)=29.3µs   p(95)=34.05µs
+    http_req_tls_handshaking...........: avg=3.18ms   min=0s       med=0s       max=127.41ms p(90)=0s       p(95)=0s
+    http_req_waiting...................: avg=134.02ms min=116.32ms med=121.93ms max=328.38ms p(90)=140.29ms p(95)=207.73ms
+    http_reqs..........................: 40     7.116111/s
+
+    EXECUTION
+    iteration_duration.................: avg=281.02ms min=239.75ms med=249.02ms max=570.47ms p(90)=379.3ms  p(95)=455.72ms
+    iterations.........................: 20     3.558055/s
+
+    NETWORK
+    data_received......................: 239 kB 43 kB/s
+    data_sent..........................: 4.8 kB 857 B/s
+
+    ↳ GROUP: crocodiles results
+
+      checks_total.....................: 20      3.558055/s
+      checks_succeeded.................: 100.00% 20 out of 20
+      checks_failed....................: 0.00%   0 out of 20
+
+      ✓ crocodile exists
+
+      HTTP
+      http_req_blocked.................: avg=7.75µs   min=4µs      med=6µs      max=35µs     p(90)=9.4µs    p(95)=14.09µs
+      http_req_connecting..............: avg=0s       min=0s       med=0s       max=0s       p(90)=0s       p(95)=0s
+      http_req_duration................: avg=150.15ms min=122.84ms med=130.79ms max=328.62ms p(90)=210.14ms p(95)=255.24ms
+      http_req_failed..................: 0.00% 0 out of 20
+      http_req_receiving...............: avg=130.99µs min=43µs     med=95.5µs   max=558µs    p(90)=207µs    p(95)=233.09µs
+      http_req_sending.................: avg=19.95µs  min=13µs     med=19µs     max=35µs     p(90)=23.2µs   p(95)=25.49µs
+      http_req_tls_handshaking.........: avg=0s       min=0s       med=0s       max=0s       p(90)=0s       p(95)=0s
+      http_req_waiting.................: avg=150ms    min=122.78ms med=130.46ms max=328.38ms p(90)=210.01ms p(95)=255.02ms
+      http_reqs........................: 20    3.558055/s
 ```
 
-{{< /code >}}
+## Understanding the summary components
 
-Above's an example of a report that k6 generated after a test run.
+The summary report organizes information into several key sections:
 
-- It has a scenario, `Ramp_Up`
-- The requests are split into two groups:
-  - `GET home`, which has a check that responses are `200` (all passed)
-  - `Create resource`, which has a check that responses are `201` (all failed)
-- The test has one threshold, requiring that 95% of requests have a duration under 200ms (failed)
+### Metrics by category
+
+The summary displays metrics based on their source:
+
+- **Protocol-specific metrics**: Results from modules like `k6/http`, `k6/net/grpc`, or `k6/browser`
+- **Execution metrics**: Test execution details like iterations and virtual users (VUs)
+- **Network metrics**: Data transfer statistics
+
+Note: Categories appear only when relevant. For example, browser metrics appear only when using the `k6/browser` module.
+
+### Checks and thresholds
+
+- [**Thresholds**](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/thresholds/): Pass/fail results of performance requirements defined in your test options
+
+  - Example: Response time limits or error rate limits
+  - Always displayed at the top of the results
+  - Clear indication of success (✓) or failure (✗)
+
+- [**Checks**](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/checks/): Results of test assertions that verify specific behaviors
+  - Example: Response status codes or response body content
+  - Shows pass/fail ratio for each check
+  - In full mode, checks appear under their respective groups or scenarios
+
+### Groups and scenarios (full mode only)
+
+When using full mode, you'll see additional sections:
+
+- [**Groups**](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/tags-and-groups/): Results for logical groupings of related requests
+- [**Scenarios**](https://grafana.com/docs/k6/latest/using-k6/scenarios/): Results for each test scenario configuration
 
 ## Summary options
 
-k6 provides some options to filter or silence summary output:
+Customize the summary output with these options:
 
-- The [`--summary-trend-stats` option](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-trend-stats) defines which [Trend metric](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-metrics/trend) statistics to calculate and show.
-- The [`--summary-time-unit` option](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-time-unit) forces k6 to use a fixed-time unit for all time values in the summary.
-- The [`--no-summary` option](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#no-summary) completely disables report generation, including `--summary-export` and `handleSummary()`.
+- [`--summary-mode`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-mode): Choose between compact, full, or legacy display
+- [`--no-summary`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#no-summary): Disable the end-of-test report
+- [`--summary-trend-stats`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-trend-stats): Select which statistics to show for Trend metrics
+- [`--summary-time-unit`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-time-unit): Set a consistent time unit for all values
 
-{{< collapse title="Summary export to a JSON file (Discouraged)" >}}
+## Going further
 
-### Summary export to a JSON file
+k6 offers additional ways to process and analyze test results:
 
-k6 also has the [`--summary-export=path/to/file.json` option](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-export), which exports some summary report data to a JSON file.
-
-The format of `--summary-export` is similar to the `data` parameter of the `handleSummary()` function.
-Unfortunately, the `--summary-export` format is limited and has a few confusing peculiarities.
-For example, groups and checks are unordered,
-and threshold values are unintuitive: `true` indicates the threshold failed, and `false` that it succeeded.
-
-We couldn't change the `--summary-export` data format, because it would have broken backward compatibility in a feature that people depended on in CI pipelines.
-But, the recommended approach to export to a JSON file is to use the `handleSummary()` function].
-The `--summary-export` option will likely be deprecated in the future.
-
-{{< /collapse >}}
+- [**Custom summaries**](https://grafana.com/docs/k6/<K6_VERSION>/results-output/end-of-test/custom-summary): Create your own summary format with complete control over the output
+- [**Real-time outputs**](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/): Stream metrics during the test run:
+  - [CSV output](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/csv): For spreadsheet analysis
+  - [JSON output](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/json): For programmatic processing
+  - Head to the [real-time outputs section](https://grafana.com/docs/k6/<K6_VERSION>/results-output/real-time/) for more.

--- a/docs/sources/k6/next/results-output/end-of-test/custom-summary.md
+++ b/docs/sources/k6/next/results-output/end-of-test/custom-summary.md
@@ -161,15 +161,13 @@ export function handleSummary(data) {
 
 {{< /code >}}
 
-In the collapsible, you can use the tabs to compare default and modified reports.
+In the collapsible section, you can compare the default and modified reports.
 
 {{< collapse title="Compare the default and modified reports" >}}
 
-To see the output of the preceding script,
-select **Modified**.
 For compactness, these outputs were limited with the `summaryTrendStats` option.
 
-{{< code >}}
+The default report would be:
 
 ```
     HTTP
@@ -195,6 +193,8 @@ For compactness, these outputs were limited with the `summaryTrendStats` option.
     data_sent......................: 830 B 557 B/s
 ```
 
+The modified report would be:
+
 ```
     HTTP
 →   http_req_blocked...........: med=10.98µs  count=5 p(99)=485.16ms p(99.99)=505.18ms
@@ -215,8 +215,6 @@ For compactness, these outputs were limited with the `summaryTrendStats` option.
 →   data_received..............: 63 kB 39 kB/s
 →   data_sent..................: 830 B 507 B/s
 ```
-
-{{< /code >}}
 
 {{< /collapse >}}
 

--- a/docs/sources/k6/next/results-output/end-of-test/custom-summary.md
+++ b/docs/sources/k6/next/results-output/end-of-test/custom-summary.md
@@ -172,38 +172,48 @@ For compactness, these outputs were limited with the `summaryTrendStats` option.
 {{< code >}}
 
 ```
-     data_received..................: 63 kB 42 kB/s
-     data_sent......................: 830 B 557 B/s
-     http_req_blocked...............: med=10.39µs  count=5 p(99)=451.07ms p(99.99)=469.67ms
-     http_req_connecting............: med=0s       count=5 p(99)=223.97ms p(99.99)=233.21ms
-     http_req_duration..............: med=202.26ms count=5 p(99)=225.81ms p(99.99)=226.71ms
-       { expected_response:true }...: med=202.26ms count=5 p(99)=225.81ms p(99.99)=226.71ms
-     http_req_failed................: 0.00% ✓ 0        ✗ 5
-     http_req_receiving.............: med=278.27µs count=5 p(99)=377.64µs p(99.99)=381.29µs
-     http_req_sending...............: med=47.57µs  count=5 p(99)=108.42µs p(99.99)=108.72µs
-     http_req_tls_handshaking.......: med=0s       count=5 p(99)=204.42ms p(99.99)=212.86ms
-     http_req_waiting...............: med=201.77ms count=5 p(99)=225.6ms  p(99.99)=226.5ms
-     http_reqs......................: 5     3.352646/s
-     iteration_duration.............: med=204.41ms count=5 p(99)=654.78ms p(99.99)=672.43ms
-     iterations.....................: 5     3.352646/s
-     vus............................: 1     min=1      max=1
-     vus_max........................: 1     min=1      max=1
+    HTTP
+    http_req_blocked...............: med=10.39µs  count=5 p(99)=451.07ms p(99.99)=469.67ms
+    http_req_connecting............: med=0s       count=5 p(99)=223.97ms p(99.99)=233.21ms
+    http_req_duration..............: med=202.26ms count=5 p(99)=225.81ms p(99.99)=226.71ms
+      { expected_response:true }...: med=202.26ms count=5 p(99)=225.81ms p(99.99)=226.71ms
+    http_req_failed................: 0.00% ✓ 0        ✗ 5
+    http_req_receiving.............: med=278.27µs count=5 p(99)=377.64µs p(99.99)=381.29µs
+    http_req_sending...............: med=47.57µs  count=5 p(99)=108.42µs p(99.99)=108.72µs
+    http_req_tls_handshaking.......: med=0s       count=5 p(99)=204.42ms p(99.99)=212.86ms
+    http_req_waiting...............: med=201.77ms count=5 p(99)=225.6ms  p(99.99)=226.5ms
+    http_reqs......................: 5     3.352646/s
+
+    EXECUTION
+    iteration_duration.............: med=204.41ms count=5 p(99)=654.78ms p(99.99)=672.43ms
+    iterations.....................: 5     3.352646/s
+    vus............................: 1     min=1      max=1
+    vus_max........................: 1     min=1      max=1
+
+    NETWORK
+    data_received..................: 63 kB 42 kB/s
+    data_sent......................: 830 B 557 B/s
 ```
 
 ```
-→    data_received..............: 63 kB 39 kB/s
-→    data_sent..................: 830 B 507 B/s
-→    http_req_blocked...........: med=10.98µs  count=5 p(99)=485.16ms p(99.99)=505.18ms
-→    http_req_connecting........: med=0s       count=5 p(99)=245.05ms p(99.99)=255.15ms
-→    http_req_duration..........: med=208.68ms count=5 p(99)=302.87ms p(99.99)=306.61ms
-→    http_req_failed............: 0.00% ✓ 0        ✗ 5
-→    http_req_receiving.........: med=206.12µs count=5 p(99)=341.05µs p(99.99)=344.13µs
-→    http_req_sending...........: med=47.8µs   count=5 p(99)=166.94µs p(99.99)=170.92µs
-→    http_req_tls_handshaking...: med=0s       count=5 p(99)=207.2ms  p(99.99)=215.74ms
-→    http_req_waiting...........: med=208.47ms count=5 p(99)=302.49ms p(99.99)=306.23ms
-→    http_reqs..................: 5     3.054928/s
-→    vus........................: 1     min=1      max=1
-→    vus_max....................: 1     min=1      max=1
+    HTTP
+→   http_req_blocked...........: med=10.98µs  count=5 p(99)=485.16ms p(99.99)=505.18ms
+→   http_req_connecting........: med=0s       count=5 p(99)=245.05ms p(99.99)=255.15ms
+→   http_req_duration..........: med=208.68ms count=5 p(99)=302.87ms p(99.99)=306.61ms
+→   http_req_failed............: 0.00% ✓ 0        ✗ 5
+→   http_req_receiving.........: med=206.12µs count=5 p(99)=341.05µs p(99.99)=344.13µs
+→   http_req_sending...........: med=47.8µs   count=5 p(99)=166.94µs p(99.99)=170.92µs
+→   http_req_tls_handshaking...: med=0s       count=5 p(99)=207.2ms  p(99.99)=215.74ms
+→   http_req_waiting...........: med=208.47ms count=5 p(99)=302.49ms p(99.99)=306.23ms
+→   http_reqs..................: 5     3.054928/s
+
+    EXECUTION
+→   vus........................: 1     min=1      max=1
+→   vus_max....................: 1     min=1      max=1
+
+    NETWORK
+→   data_received..............: 63 kB 39 kB/s
+→   data_sent..................: 830 B 507 B/s
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/next/testing-guides/api-load-testing.md
+++ b/docs/sources/k6/next/testing-guides/api-load-testing.md
@@ -329,44 +329,47 @@ export const options = {
 };
 ```
 
-When k6 runs a test, the test output indicates whether the metrics were within the thresholds, ✅, or whether they crossed them, ❌.
-In this output, the test met both thresholds.
-
-```bash
-✓ http_req_duration..............: avg=104.7ms  min=101.87ms med=103.92ms max=120.68ms p(90)=107.2ms  p(95)=111.38ms
-    { expected_response:true }...: avg=104.7ms  min=101.87ms med=103.92ms max=120.68ms p(90)=107.2ms  p(95)=111.38ms
-✓ http_req_failed................: 0.00%   ✓ 0         ✗ 1501
-```
-
 When the test fails, the k6 CLI returns a non-zero exit code—a necessary condition for test automation.
 As an example of a failed test, here's the output for a test with a threshold that 95 percent of requests finish in under 50ms, `http_req_duration:["p(95)<50"]`:
 
 ```bash
+  █ THRESHOLDS
+
+    http_req_duration
+    ✗ 'p(95)<200' p(95)=348.21ms
+
+    http_req_failed
+    ✓ 'rate<0.01' rate=0.05%
+
+
+  █ TOTAL RESULTS
+
+    checks_total.......................: 90      13.122179/s
+    checks_succeeded...................: 100.00% 90 out of 90
+    checks_failed......................: 0.00%   0 out of 90
+
+    ✓ Post status is 200
+    ✓ Post Content-Type header
+    ✓ Post response name
+
+    HTTP
+    http_req_duration..................: avg=140.36ms   min=119.08ms med=140.96ms max=154.63ms p(90)=146.88ms p(95)=148.21ms
+      { expected_response:true }.......: avg=140.36ms   min=119.08ms med=140.96ms max=154.63ms p(90)=146.88ms p(95)=148.21ms
+    http_req_failed....................: 0.00%  0 out of 45
+    http_reqs..........................: 45     6.56109/s
+
+    EXECUTION
+    iteration_duration.................: avg=152.38ms   min=119.37ms med=141.27ms max=684.62ms p(90)=147.11ms p(95)=148.39ms
+    iterations.........................: 45     6.56109/s
+    vus................................: 1      min=1       max=1
+    vus_max............................: 1      min=1       max=1
+
+    NETWORK
+    data_received......................: 519 kB 76 kB/s
+    data_sent..........................: 4.9 kB 718 B/s
+
 running (0m30.1s), 00/50 VUs, 1501 complete and 0 interrupted iterations
 my_scenario1 ✓ [======================================] 00/50 VUs  30s  50.00 iters/s
-
-     ✓ Post status is 200
-     ✓ Post Content-Type header
-     ✓ Post response name
-
-     checks.........................: 100.00% ✓ 4503      ✗ 0
-     data_received..................: 1.3 MB  45 kB/s
-     data_sent......................: 313 kB  10 kB/s
-     http_req_blocked...............: avg=9.26ms   min=2µs      med=14µs     max=557.32ms p(90)=25µs     p(95)=46µs
-     http_req_connecting............: avg=3.5ms    min=0s       med=0s       max=113.46ms p(90)=0s       p(95)=0s
-   ✗ http_req_duration..............: avg=105.14ms min=102.01ms med=103.86ms max=171.56ms p(90)=112.4ms  p(95)=113.18ms
-       { expected_response:true }...: avg=105.14ms min=102.01ms med=103.86ms max=171.56ms p(90)=112.4ms  p(95)=113.18ms
-   ✓ http_req_failed................: 0.00%   ✓ 0         ✗ 1501
-     http_req_receiving.............: avg=202.86µs min=17µs     med=170µs    max=4.69ms   p(90)=264µs    p(95)=341µs
-     http_req_sending...............: avg=97.56µs  min=11µs     med=63µs     max=5.56ms   p(90)=98µs     p(95)=133µs
-     http_req_tls_handshaking.......: avg=4.14ms   min=0s       med=0s       max=169.35ms p(90)=0s       p(95)=0s
-     http_req_waiting...............: avg=104.84ms min=101.88ms med=103.6ms  max=171.52ms p(90)=112.18ms p(95)=112.85ms
-     http_reqs......................: 1501    49.834813/s
-     iteration_duration.............: avg=115.18ms min=102.51ms med=104.66ms max=704.99ms p(90)=113.68ms p(95)=115.54ms
-     iterations.....................: 1501    49.834813/s
-     vus............................: 50      min=50      max=50
-     vus_max........................: 50      min=50      max=50
-
 ERRO[0030] some thresholds have failed
 ```
 

--- a/docs/sources/k6/next/testing-guides/injecting-faults-with-xk6-disruptor/examples/inject-http-faults-into-pod.md
+++ b/docs/sources/k6/next/testing-guides/injecting-faults-with-xk6-disruptor/examples/inject-http-faults-into-pod.md
@@ -140,11 +140,11 @@ We will first execute the test without introducing faults to have an baseline us
 {{< code >}}
 
 ```bash
-xk6-disruptor run --env SKIP_FAULTS=1 --env SVC_IP=$SVC_IP disrupt-pod.js
+xk6-disruptor run --env SKIP_FAULTS=1 --env SVC_IP=$SVC_IP --summary-mode=legacy disrupt-pod.js
 ```
 
 ```windows-powershell
-xk6-disruptor run --env SKIP_FAULTS=1 --env "SVC_IP=$Env:SVC_IP" disrupt-pod.js
+xk6-disruptor run --env SKIP_FAULTS=1 --env "SVC_IP=$Env:SVC_IP" --summary-mode=legacy disrupt-pod.js
 ```
 
 {{< /code >}}
@@ -203,11 +203,11 @@ We repeat the execution injecting the faults. Notice we have removed the `--env 
 {{< code >}}
 
 ```bash
-xk6-disruptor run --env SVC_IP=$SVC_IP disrupt-pod.js
+xk6-disruptor run --env SVC_IP=$SVC_IP --summary-mode=legacy disrupt-pod.js
 ```
 
 ```windows-powershell
-xk6-disruptor run --env "SVC_IP=$Env:SVC_IP" disrupt-pod.js
+xk6-disruptor run --env "SVC_IP=$Env:SVC_IP" --summary-mode=legacy disrupt-pod.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/next/using-k6/k6-options/reference.md
+++ b/docs/sources/k6/next/using-k6/k6-options/reference.md
@@ -65,6 +65,7 @@ Each option has its own detailed reference in a separate section.
 | [Supply environment variable](#supply-environment-variables) | Add/override environment variable with `VAR=value`                                                                                                                                                                                                                                                                                                 |
 | [System tags](#system-tags)                                  | Specify which System Tags will be in the collected metrics                                                                                                                                                                                                                                                                                         |
 | [Summary export](#summary-export)                            | Output the [end-of-test summary](https://grafana.com/docs/k6/<K6_VERSION>/results-output/end-of-test) report to a JSON file (discouraged, use [handleSummary()](https://grafana.com/docs/k6/<K6_VERSION>/results-output/end-of-test/custom-summary) instead)                                                                                       |
+| [Summary mode](#summary-mode)                                | Define how detailed the end-of-test summary should be                                                                                                                                                                                                                                                                                              |
 | [Summary trend stats](#summary-trend-stats)                  | Define stats for trend metrics in the [end-of-test summary](https://grafana.com/docs/k6/<K6_VERSION>/results-output/end-of-test)                                                                                                                                                                                                                   |
 | [Summary time unit](#summary-time-unit)                      | Time unit to be used for _all_ time values in the [end-of-test summary](https://grafana.com/docs/k6/<K6_VERSION>/results-output/end-of-test)                                                                                                                                                                                                       |
 | [Tags](#tags)                                                | Specify tags that should be set test-wide across all metrics                                                                                                                                                                                                                                                                                       |
@@ -1168,6 +1169,81 @@ $env:K6_SUMMARY_EXPORT="export.json"; k6 run script.js
 
 See an example file on the [Results Output](https://grafana.com/docs/k6/<K6_VERSION>/get-started/results-output#summary-export) page.
 
+## Summary mode
+
+Define how detailed the [end-of-test summary](https://grafana.com/docs/k6/<K6_VERSION>/results-output/end-of-test/) should be. Available in the `k6 run` command.
+
+| Env               | CLI              | Code / Config file | Default     |
+| ----------------- | ---------------- | ------------------ | ----------- |
+| `K6_SUMMARY_MODE` | `--summary-mode` | N/A                | `"compact"` |
+
+The following modes are available:
+
+- **compact** (default): Shows the most relevant test results in a concise format, focusing on:
+  - Thresholds results
+  - Checks results
+  - Aggregated metrics by category
+- **full**: Shows all available information, including:
+  - Everything from compact mode
+  - Detailed metrics for each protocol-specific category
+  - Group-specific results
+  - Scenario-specific results
+- **legacy**: Uses the pre-v1.0.0 summary format for backward compatibility
+
+{{< code >}}
+
+```bash
+k6 run --summary-mode=full script.js
+```
+
+{{< /code >}}
+
+## Summary trend stats
+
+Define which stats for [`Trend` metrics](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-metrics/trend) (e.g. response times, group/iteration durations, etc.) will be shown in the [end-of-test summary](https://grafana.com/docs/k6/<K6_VERSION>/results-output/end-of-test). Possible values include `avg` (average), `med` (median), `min`, `max`, `count`, as well as arbitrary percentile values (e.g. `p(95)`, `p(99)`, `p(99.99)`, etc.).
+
+For further summary customization and exporting the summary in various formats (e.g. JSON, JUnit/XUnit/etc. XML, HTML, .txt, etc.), use the [`handleSummary()` function](https://grafana.com/docs/k6/<K6_VERSION>/results-output/end-of-test/custom-summary).
+
+| Env                      | CLI                     | Code / Config file  | Default                       |
+| ------------------------ | ----------------------- | ------------------- | ----------------------------- |
+| `K6_SUMMARY_TREND_STATS` | `--summary-trend-stats` | `summaryTrendStats` | `avg,min,med,max,p(90),p(95)` |
+
+{{< code >}}
+
+```javascript
+export const options = {
+  summaryTrendStats: ['avg', 'min', 'med', 'max', 'p(90)', 'p(95)', 'p(99.99)', 'count'],
+};
+```
+
+{{< /code >}}
+
+{{< code >}}
+
+```bash
+k6 run --summary-trend-stats="avg,min,med,max,p(90),p(99.9),p(99.99),count" ./script.js
+```
+
+{{< /code >}}
+
+## Summary time unit
+
+Define which time unit will be used for _all_ time values in the [end-of-test summary](https://grafana.com/docs/k6/<K6_VERSION>/results-output/end-of-test). Possible values are `s` (seconds), `ms` (milliseconds) and `us` (microseconds). If no value is specified, k6 will use mixed time units, choosing the most appropriate unit for each value.
+
+| Env                    | CLI                   | Code / Config file | Default |
+| ---------------------- | --------------------- | ------------------ | ------- |
+| `K6_SUMMARY_TIME_UNIT` | `--summary-time-unit` | `summaryTimeUnit`  | `null`  |
+
+{{< code >}}
+
+```javascript
+export const options = {
+  summaryTimeUnit: 'ms',
+};
+```
+
+{{< /code >}}
+
 ## Supply environment variables
 
 Add/override an [environment variable](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/environment-variables) with `VAR=value`in a k6 script. Available in `k6 run` and `k6 cloud` commands.
@@ -1214,52 +1290,6 @@ CLI. Available in `k6 run` and `k6 cloud` commands
 export const options = {
   systemTags: ['status', 'method', 'url'],
 };
-```
-
-{{< /code >}}
-
-## Summary time unit
-
-Define which time unit will be used for _all_ time values in the [end-of-test summary](https://grafana.com/docs/k6/<K6_VERSION>/results-output/end-of-test). Possible values are `s` (seconds), `ms` (milliseconds) and `us` (microseconds). If no value is specified, k6 will use mixed time units, choosing the most appropriate unit for each value.
-
-| Env                    | CLI                   | Code / Config file | Default |
-| ---------------------- | --------------------- | ------------------ | ------- |
-| `K6_SUMMARY_TIME_UNIT` | `--summary-time-unit` | `summaryTimeUnit`  | `null`  |
-
-{{< code >}}
-
-```javascript
-export const options = {
-  summaryTimeUnit: 'ms',
-};
-```
-
-{{< /code >}}
-
-## Summary trend stats
-
-Define which stats for [`Trend` metrics](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-metrics/trend) (e.g. response times, group/iteration durations, etc.) will be shown in the [end-of-test summary](https://grafana.com/docs/k6/<K6_VERSION>/results-output/end-of-test). Possible values include `avg` (average), `med` (median), `min`, `max`, `count`, as well as arbitrary percentile values (e.g. `p(95)`, `p(99)`, `p(99.99)`, etc.).
-
-For further summary customization and exporting the summary in various formats (e.g. JSON, JUnit/XUnit/etc. XML, HTML, .txt, etc.), use the [`handleSummary()` function](https://grafana.com/docs/k6/<K6_VERSION>/results-output/end-of-test/custom-summary).
-
-| Env                      | CLI                     | Code / Config file  | Default                       |
-| ------------------------ | ----------------------- | ------------------- | ----------------------------- |
-| `K6_SUMMARY_TREND_STATS` | `--summary-trend-stats` | `summaryTrendStats` | `avg,min,med,max,p(90),p(95)` |
-
-{{< code >}}
-
-```javascript
-export const options = {
-  summaryTrendStats: ['avg', 'min', 'med', 'max', 'p(95)', 'p(99)', 'p(99.99)', 'count'],
-};
-```
-
-{{< /code >}}
-
-{{< code >}}
-
-```bash
-k6 run --summary-trend-stats="avg,min,med,max,p(90),p(99.9),p(99.99),count" ./script.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/next/using-k6/metrics/_index.md
+++ b/docs/sources/k6/next/using-k6/metrics/_index.md
@@ -82,25 +82,25 @@ $ k6 run script.js
            * default: 1 iterations for each of 1 VUs (maxDuration: 10m0s, gracefulStop: 30s)
 
 
+
+  █ TOTAL RESULTS
+
+    HTTP
+    http_req_duration.......................................................: avg=117.55ms min=117.55ms med=117.55ms max=117.55ms p(90)=117.55ms p(95)=117.55ms
+      { expected_response:true }............................................: avg=117.55ms min=117.55ms med=117.55ms max=117.55ms p(90)=117.55ms p(95)=117.55ms
+    http_req_failed.........................................................: 0.00%  0 out of 1
+    http_reqs...............................................................: 1      2.768749/s
+
+    EXECUTION
+    iteration_duration......................................................: avg=361.09ms min=361.09ms med=361.09ms max=361.09ms p(90)=361.09ms p(95)=361.09ms
+    iterations..............................................................: 1      2.768749/s
+
+    NETWORK
+    data_received...........................................................: 6.8 kB 19 kB/s
+    data_sent...............................................................: 541 B  1.5 kB/s
+
 running (00m03.8s), 0/1 VUs, 1 complete and 0 interrupted iterations
 default ✓ [======================================] 1 VUs  00m03.8s/10m0s  1/1 iters, 1 per VU
-
-     data_received..................: 22 kB 5.7 kB/s
-     data_sent......................: 742 B 198 B/s
-     http_req_blocked...............: avg=1.05s    min=1.05s    med=1.05s    max=1.05s    p(90)=1.05s    p(95)=1.05s
-     http_req_connecting............: avg=334.26ms min=334.26ms med=334.26ms max=334.26ms p(90)=334.26ms p(95)=334.26ms
-     http_req_duration..............: avg=2.7s     min=2.7s     med=2.7s     max=2.7s     p(90)=2.7s     p(95)=2.7s
-       { expected_response:true }...: avg=2.7s     min=2.7s     med=2.7s     max=2.7s     p(90)=2.7s     p(95)=2.7s
-     http_req_failed................: 0.00% ✓ 0        ✗ 1
-     http_req_receiving.............: avg=112.41µs min=112.41µs med=112.41µs max=112.41µs p(90)=112.41µs p(95)=112.41µs
-     http_req_sending...............: avg=294.48µs min=294.48µs med=294.48µs max=294.48µs p(90)=294.48µs p(95)=294.48µs
-     http_req_tls_handshaking.......: avg=700.6ms  min=700.6ms  med=700.6ms  max=700.6ms  p(90)=700.6ms  p(95)=700.6ms
-     http_req_waiting...............: avg=2.7s     min=2.7s     med=2.7s     max=2.7s     p(90)=2.7s     p(95)=2.7s
-     http_reqs......................: 1     0.266167/s
-     iteration_duration.............: avg=3.75s    min=3.75s    med=3.75s    max=3.75s    p(90)=3.75s    p(95)=3.75s
-     iterations.....................: 1     0.266167/s
-     vus............................: 1     min=1      max=1
-     vus_max........................: 1     min=1      max=1
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/next/using-k6/scenarios/_index.md
+++ b/docs/sources/k6/next/using-k6/scenarios/_index.md
@@ -175,36 +175,77 @@ on: 10m0s, gracefulStop: 30s)
            * per_vu_scenario: 10 iterations for each of 10 VUs (maxDuration: 10m
 0s, startTime: 10s, gracefulStop: 30s)
 
+  █ TOTAL RESULTS
+
+    HTTP
+    http_req_blocked........................................................: avg=24.59ms  min=1µs      med=4µs      max=263.64ms p(90)=22.48ms  p(95)=245.04ms
+    http_req_connecting.....................................................: avg=11.36ms  min=0s       med=0s       max=120.45ms p(90)=10.76ms  p(95)=115.19ms
+    http_req_duration.......................................................: avg=115.25ms min=108.25ms med=115.66ms max=170.62ms p(90)=119.59ms p(95)=121.13ms
+      { expected_response:true }............................................: avg=115.25ms min=108.25ms med=115.66ms max=170.62ms p(90)=119.59ms p(95)=121.13ms
+    http_req_failed.........................................................: 0.00%  0 out of 200
+    http_req_receiving......................................................: avg=214.61µs min=15µs     med=73.5µs   max=4.57ms   p(90)=253.4µs  p(95)=1.08ms
+    http_req_sending........................................................: avg=17.79µs  min=3µs      med=12µs     max=669µs    p(90)=22µs     p(95)=25µs
+    http_req_tls_handshaking................................................: avg=12.01ms  min=0s       med=0s       max=126.23ms p(90)=11.49ms  p(95)=120.04ms
+    http_req_waiting........................................................: avg=115.02ms min=107.7ms  med=115.33ms max=170.59ms p(90)=119.54ms p(95)=121.04ms
+    http_reqs...............................................................: 200    17.489795/s
+
+    EXECUTION
+    iteration_duration......................................................: avg=140.07ms min=108.3ms  med=116.14ms max=383.32ms p(90)=187.14ms p(95)=363.64ms
+    iterations..............................................................: 200    17.489795/s
+    vus.....................................................................: 10     min=0        max=10
+    vus_max.................................................................: 20     min=20       max=20
+
+    NETWORK
+    data_received...........................................................: 2.4 MB 209 kB/s
+    data_sent...............................................................: 26 kB  2.3 kB/s
+
+
+  █ SCENARIO: per_vu_scenario
+
+    HTTP
+    http_req_blocked...................................: avg=23.52ms  min=1µs      med=4µs      max=244.87ms p(90)=22.39ms  p(95)=234.84ms
+    http_req_connecting................................: avg=11.45ms  min=0s       med=0s       max=120.45ms p(90)=10.84ms  p(95)=115.81ms
+    http_req_duration..................................: avg=114.86ms min=108.25ms med=115.74ms max=123.17ms p(90)=120.08ms p(95)=121.13ms
+    http_req_failed....................................: 0.00%  0 out of 100
+    http_req_receiving.................................: avg=195.59µs min=15µs     med=73.5µs   max=4.57ms   p(90)=247.5µs  p(95)=875.99µs
+    http_req_sending...................................: avg=20.8µs   min=3µs      med=12µs     max=669µs    p(90)=22.1µs   p(95)=27.09µs
+    http_req_tls_handshaking...........................: avg=12.06ms  min=0s       med=0s       max=126.23ms p(90)=11.49ms  p(95)=120.61ms
+    http_req_waiting...................................: avg=114.64ms min=107.78ms med=115.38ms max=123.07ms p(90)=120.04ms p(95)=121.04ms
+    http_reqs..........................................: 100    8.744897/s
+
+    EXECUTION
+    iteration_duration.................................: avg=138.53ms min=108.3ms  med=116.22ms max=363.71ms p(90)=144.44ms p(95)=353.48ms
+    iterations.........................................: 100    8.744897/s
+
+    NETWORK
+    data_received......................................: 1.2 MB 104 kB/s
+    data_sent..........................................: 13 kB  1.1 kB/s
+
+
+  █ SCENARIO: shared_iter_scenario
+
+    HTTP
+    http_req_blocked...................................: avg=25.66ms  min=1µs      med=4µs      max=263.64ms p(90)=24.98ms  p(95)=256.16ms
+    http_req_connecting................................: avg=11.27ms  min=0s       med=0s       max=115.37ms p(90)=10.76ms  p(95)=115.15ms
+    http_req_duration..................................: avg=115.65ms min=108.38ms med=115.61ms max=170.62ms p(90)=119.11ms p(95)=120.91ms
+    http_req_failed....................................: 0.00%  0 out of 100
+    http_req_receiving.................................: avg=233.63µs min=22µs     med=73.5µs   max=4.22ms   p(90)=324.6µs  p(95)=1.11ms
+    http_req_sending...................................: avg=14.77µs  min=3µs      med=12µs     max=128µs    p(90)=20µs     p(95)=22µs
+    http_req_tls_handshaking...........................: avg=11.96ms  min=0s       med=0s       max=124.34ms p(90)=11.64ms  p(95)=118.98ms
+    http_req_waiting...................................: avg=115.4ms  min=107.7ms  med=115.33ms max=170.59ms p(90)=118.94ms p(95)=120.85ms
+    http_reqs..........................................: 100    8.744897/s
+
+    EXECUTION
+    iteration_duration.................................: avg=141.6ms  min=108.46ms med=116.09ms max=383.32ms p(90)=189.98ms p(95)=375.24ms
+    iterations.........................................: 100    8.744897/s
+
+    NETWORK
+    data_received......................................: 1.2 MB 104 kB/s
+    data_sent..........................................: 13 kB  1.1 kB/s
 
 running (00m12.8s), 00/20 VUs, 200 complete and 0 interrupted iterations
 shared_iter_scenario ✓ [ 100% ] 10 VUs  00m02.7s/10m0s  100/100 shared iters
 per_vu_scenario      ✓ [ 100% ] 10 VUs  00m02.8s/10m0s  100/100 iters, 10 per V
-
-     data_received..................: 2.4 MB 188 kB/s
-     data_sent......................: 26 kB  2.1 kB/s
-     http_req_blocked...............: avg=64.26ms  min=1.56µs   med=8.28µs   max
-=710.86ms p(90)=57.63ms  p(95)=582.36ms
-     http_req_connecting............: avg=28.6ms   min=0s       med=0s       max
-=365.92ms p(90)=20.38ms  p(95)=224.44ms
-     http_req_duration..............: avg=204.25ms min=169.55ms med=204.36ms max
-=407.95ms p(90)=205.96ms p(95)=239.32ms
-       { expected_response:true }...: avg=204.25ms min=169.55ms med=204.36ms max
-=407.95ms p(90)=205.96ms p(95)=239.32ms
-     http_req_failed................: 0.00%  ✓ 0         ✗ 200
-     http_req_receiving.............: avg=195.54µs min=53.87µs  med=162.55µs max
-=1.52ms   p(90)=260.6µs  p(95)=317.89µs
-     http_req_sending...............: avg=38.16µs  min=7.61µs   med=37.99µs  max
-=167.54µs p(90)=50.16µs  p(95)=60.18µs
-     http_req_tls_handshaking.......: avg=24.03ms  min=0s       med=0s       max
-=274.05ms p(90)=20.81ms  p(95)=212.74ms
-     http_req_waiting...............: avg=204.01ms min=169.32ms med=204.11ms max
-=407.82ms p(90)=205.74ms p(95)=239.01ms
-     http_reqs......................: 200    15.593759/s
-     iteration_duration.............: avg=268.83ms min=169.78ms med=204.67ms max
-=952.85ms p(90)=444.97ms p(95)=786.52ms
-     iterations.....................: 200    15.593759/s
-     vus............................: 10     min=0       max=10
-     vus_max........................: 20     min=20      max=20
 ```
 
 {{< /collapse >}}

--- a/docs/sources/k6/next/using-k6/thresholds.md
+++ b/docs/sources/k6/next/using-k6/thresholds.md
@@ -62,9 +62,20 @@ After executing that script, k6 outputs something similar to this:
 {{< code >}}
 
 ```bash
-   ✓ http_req_duration..............: avg=151.06ms min=151.06ms med=151.06ms max=151.06ms p(90)=151.06ms p(95)=151.06ms
-       { expected_response:true }...: avg=151.06ms min=151.06ms med=151.06ms max=151.06ms p(90)=151.06ms p(95)=151.06ms
-   ✓ http_req_failed................: 0.00%  ✓ 0 ✗ 1
+  █ THRESHOLDS
+
+    http_req_duration
+    ✓ 'p(95)<200' p(95)=148.21ms
+
+    http_req_failed
+    ✓ 'rate<0.01' rate=0.05%
+
+  █ TOTAL RESULTS
+
+    HTTP
+    http_req_duration..............: avg=151.06ms min=151.06ms med=151.06ms max=151.06ms p(90)=151.06ms p(95)=151.06ms
+       { expected_response:true }..: avg=151.06ms min=151.06ms med=151.06ms max=151.06ms p(90)=151.06ms p(95)=151.06ms
+    http_req_failed................: 0.00%  ✓ 0 ✗ 1
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/next/using-k6/workaround-iteration-duration.md
+++ b/docs/sources/k6/next/using-k6/workaround-iteration-duration.md
@@ -56,14 +56,20 @@ Dedicated sub-metrics have been generated collecting samples only for the scope 
 {{< code >}}
 
 ```bash
-http_req_duration..............: avg=1.48s    min=101.95ms med=148.4ms  max=5.22s    p(90)=4.21s    p(95)=4.71s
-  { expected_response:true }...: avg=1.48s    min=101.95ms med=148.4ms  max=5.22s    p(90)=4.21s    p(95)=4.71s
-✓ { scenario:default }.........: avg=148.4ms  min=103.1ms  med=148.4ms  max=193.7ms  p(90)=184.64ms p(95)=189.17ms
+  █ THRESHOLDS
 
-iteration_duration.............: avg=5.51s    min=1.61s    med=6.13s    max=8.81s    p(90)=8.27s    p(95)=8.54s
-✓ { group:::setup }............: avg=6.13s    min=6.13s    med=6.13s    max=6.13s    p(90)=6.13s    p(95)=6.13s
-✓ { group:::teardown }.........: avg=8.81s    min=8.81s    med=8.81s    max=8.81s    p(90)=8.81s    p(95)=8.81s
-✓ { scenario:default }.........: avg=1.61s    min=1.61s    med=1.61s    max=1.61s    p(90)=1.61s    p(95)=1.61s
+    http_req_duration{scenario:default}
+    ✓ 'max>=0' max=117.34ms
+
+    iteration_duration{group:::setup}
+    ✓ 'max>=0' max=0s
+
+    iteration_duration{group:::teardown}
+    ✓ 'max>=0' max=0s
+
+    iteration_duration{scenario:default}
+    ✓ 'max>=0' max=1.13s
+
 ```
 
 {{< /code >}}


### PR DESCRIPTION
## What?

This Pull Request updates the page specific to the end of test summary to document the new format we're introducing with v1.0.0-rc. It also updates existing examples and pages leveraging the end of test summary format, and updates them to use the new format too.

## Checklist

- [X] I have used a meaningful title for the PR.
- [X] I have described the changes I've made in the "What?" section above.
- [X] I have performed a self-review of my changes.
- [X] I have run the `npm start` command locally and verified that the changes look good.
- [X] I have made my changes in the `docs/sources/k6/next` folder of the documentation.
