### PR TITLE
Update options reference to showcase multiple tags being set

### DIFF
--- a/docs/sources/k6/next/using-k6/k6-options/reference.md
+++ b/docs/sources/k6/next/using-k6/k6-options/reference.md
@@ -1310,7 +1310,7 @@ export const options = {
 
 {{< /code >}}
 
-Multiple cli flags can be provided to set more than one tag at a time:
+Multiple CLI flags can be provided to set more than one tag at a time:
 
 {{< code >}}
 

--- a/docs/sources/k6/next/using-k6/k6-options/reference.md
+++ b/docs/sources/k6/next/using-k6/k6-options/reference.md
@@ -218,8 +218,8 @@ Specify the config file in JSON format.
 If the config file is not specified, k6 looks for `config.json` in the `k6/` directory inside the regular directory for configuration files on the operating system.
 Default config locations on different operating systems are as follows:
 
-| OS         | Default Config Path                                             |
-| ---------- | --------------------------------------------------------------- |
+| OS         | Default Config Path                                  |
+| ---------- | ---------------------------------------------------- |
 | Unix-based | `${HOME}/.config/k6/config.json`                     |
 | macOS      | `${HOME}/Library/Application Support/k6/config.json` |
 | Windows    | `%AppData%/k6/config.json`                           |
@@ -1303,8 +1303,19 @@ tag. Available in `k6 run` and `k6 cloud` commands.
 export const options = {
   tags: {
     name: 'value',
+    another: 'different value',
   },
 };
+```
+
+{{< /code >}}
+
+Multiple cli flags can be provided to set more than one tag at a time:
+
+{{< code >}}
+
+```shell
+k6 run --tag name=value --tag another="different value" script.js
 ```
 
 {{< /code >}}


### PR DESCRIPTION

## What?
Update the options reference to showcase multiple tags being set.

## Checklist

<!-- Please fill in this template: -->
- [X] I have used a meaningful title for the PR.
- [X] I have described the changes I've made in the "What?" section above.
- [X] I have performed a self-review of my changes.
- [X] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [ ] I have made my changes in the `docs/sources/k6/next` folder of the documentation.
- [ ] I have reflected my changes in the `docs/sources/k6/v{most_recent_release}` folder of the documentation.
- [ ] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->

<!-- 2. If updating the documentation for the next release of k6: -->
- [ ] I have made my changes in the `docs/sources/k6/next` folder of the documentation.

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->
<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->