### PR TITLE
Update jslib AWS version to v0.13.0

### DIFF
--- a/docs/sources/k6/_index.md
+++ b/docs/sources/k6/_index.md
@@ -19,7 +19,7 @@ cascade:
   github_branch: main
   github_dir: /docs/sources/k6
   replace_dir: docs/k6/
-  JSLIB_AWS_VERSION: 0.12.3
+  JSLIB_AWS_VERSION: 0.13.0
 versioned: true
 versioned_next: true
 ---


### PR DESCRIPTION
## What?

Update jslib/aws version to [0.13.0](https://github.com/grafana/k6-jslib-aws/releases/tag/v0.13.0).

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.