### PR TITLE
Update k6 Studio page in k6 OSS docs

### DIFF
--- a/docs/sources/k6/next/k6-studio/_index.md
+++ b/docs/sources/k6/next/k6-studio/_index.md
@@ -13,4 +13,8 @@ Grafana k6 Studio is a desktop application that can help you:
 - Generate and customize a k6 test script from a HAR file, including the ability to use rules to quickly iterate on the script creation process.
 - Test and debug k6 scripts using a visual interface. Inspect the request and response details for any request in your script.
 
-Visit the [k6 Studio documentation](https://grafana.com/docs/k6-studio/) for more information.
+For more details:
+
+- [Download Grafana k6 Studio](https://github.com/grafana/k6-studio/releases)
+- [Learn how to get started with Grafana k6 Studio](https://grafana.com/docs/k6-studio/record-your-first-script/)
+- [Visit the Grafana k6 Studio documentation](https://grafana.com/docs/k6-studio/)

--- a/docs/sources/k6/next/k6-studio/_index.md
+++ b/docs/sources/k6/next/k6-studio/_index.md
@@ -1,13 +1,13 @@
 ---
 weight: 950
-title: k6 Studio
+title: Grafana k6 Studio
 ---
 
-# k6 Studio
+# Grafana k6 Studio
 
-{{< figure src="/media/docs/k6-studio/screenshot-k6-studio-homepage-3.png" alt="k6 Studio homepage" >}}
+{{< figure src="/media/docs/k6-studio/screenshot-k6-studio-homepage-3.png" alt="Grafana k6 Studio homepage" >}}
 
-k6 Studio is a desktop application that can help you:
+Grafana k6 Studio is a desktop application that can help you:
 
 - Record a user flow from browser interactions and generate a HAR file.
 - Generate and customize a k6 test script from a HAR file, including the ability to use rules to quickly iterate on the script creation process.


### PR DESCRIPTION
## What?

A couple of updates to the k6 Studio page in the k6 OSS docs:

- Update "k6 Studio" to "Grafana k6 Studio".
- Add links to download and get started tutorial in Grafana k6 Studio docs.

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.