### PR TITLE
Correct typo in api-load-testing.md

### DIFF
--- a/docs/sources/k6/next/testing-guides/api-load-testing.md
+++ b/docs/sources/k6/next/testing-guides/api-load-testing.md
@@ -520,7 +520,7 @@ Other times, you might just choose the location based on convenience or practica
 Either way, when you set the location of the load generator, keep the following in mind:
 
 - **Required locations.** To compare performance or ensure accurate results, some load tests need to measure the latency from specific locations. These tests launch the load generators from locations that match their user's region.
-- **Optional locations.** Other tests try to measure against a performance baseline—how the system performance changes from a particular performance status or time. To avoid skewed latency results, ensure that the location of the load generator is constant across test tuns, and avoid running the tests from locations that are too close to the SUT.
+- **Optional locations.** Other tests try to measure against a performance baseline—how the system performance changes from a particular performance status or time. To avoid skewed latency results, ensure that the location of the load generator is constant across test runs, and avoid running the tests from locations that are too close to the SUT.
 
 ### Internal APIs
 

--- a/docs/sources/k6/v1.0.x/testing-guides/api-load-testing.md
+++ b/docs/sources/k6/v1.0.x/testing-guides/api-load-testing.md
@@ -520,7 +520,7 @@ Other times, you might just choose the location based on convenience or practica
 Either way, when you set the location of the load generator, keep the following in mind:
 
 - **Required locations.** To compare performance or ensure accurate results, some load tests need to measure the latency from specific locations. These tests launch the load generators from locations that match their user's region.
-- **Optional locations.** Other tests try to measure against a performance baseline—how the system performance changes from a particular performance status or time. To avoid skewed latency results, ensure that the location of the load generator is constant across test tuns, and avoid running the tests from locations that are too close to the SUT.
+- **Optional locations.** Other tests try to measure against a performance baseline—how the system performance changes from a particular performance status or time. To avoid skewed latency results, ensure that the location of the load generator is constant across test runs, and avoid running the tests from locations that are too close to the SUT.
 
 ### Internal APIs
 


### PR DESCRIPTION
In the context of your quoted sentence-"To avoid skewed latency results, ensure that the location of the load generator is constant across test tuns, and avoid running the tests from locations that are too close to the SUT"- most probably the word "tuns" is a typographical error and should actually be "runs" (as in "test runs")

## What?
Correct typo: "tuns" -> "runs"


## Checklist
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have reflected my changes in the `docs/sources/k6/v{most_recent_release}` folder of the documentation.
- [x] I have reflected my changes in the `docs/sources/k6/next` folder of the documentation.
