### PR TITLE
Fix actions according to zizmor analytics

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -8,6 +8,9 @@ on:
       - ".github/workflows/build-website.yml"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-website:
     runs-on: ubuntu-latest

--- a/.github/workflows/extension-registry-changed.yml
+++ b/.github/workflows/extension-registry-changed.yml
@@ -22,19 +22,25 @@ on:
   repository_dispatch:
     types: [extension-registry-changed]
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
+        with:
+          persist-credentials: false
         uses: actions/checkout@v4
 
       - name: Generate Files
         run: ${{ github.workspace }}/scripts/extension-registry-changed
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         with:
           branch: extension-registry-changed
           commit-message: |

--- a/.github/workflows/publish-technical-documentation-k6-studio.yml
+++ b/.github/workflows/publish-technical-documentation-k6-studio.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: grafana/writers-toolkit/publish-technical-documentation@publish-technical-documentation/v1
         with:
           source_directory: docs/sources/k6-studio

--- a/.github/workflows/publish-technical-documentation-k6.yml
+++ b/.github/workflows/publish-technical-documentation-k6.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: grafana/writers-toolkit/publish-technical-documentation@publish-technical-documentation/v1
         with:
           source_directory: docs/sources/k6

--- a/.github/workflows/run-code-blocks.yml
+++ b/.github/workflows/run-code-blocks.yml
@@ -7,14 +7,20 @@ on:
     paths:
       - 'docs/sources/k6/next/**/*.md'
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   run-code-blocks:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Get Changed files
         id: changed-files
-        uses: step-security/changed-files@v45
+        uses: step-security/changed-files@3dbe17c78367e7d60f00d78ae6781a35be47b4a1 # v45.0.1
         with:
           files: |
             docs/sources/k6/next/**/*.md

--- a/.github/workflows/update-make-docs.yml
+++ b/.github/workflows/update-make-docs.yml
@@ -3,12 +3,18 @@ on:
   schedule:
     - cron: '0 7 * * 1-5'
   workflow_dispatch:
+
+permissions:
+  contents: read
+
 jobs:
   main:
     if: github.repository == 'grafana/k6-docs'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: grafana/writers-toolkit/update-make-docs@update-make-docs/v1
         with:
           pr_options: >


### PR DESCRIPTION
## What?

Fixing the github actions according to zizmor analytics run.

## Checklist

<!-- Please fill in this template: -->
- [ ] I have used a meaningful title for the PR.
- [ ] I have described the changes I've made in the "What?" section above.
- [ ] I have performed a self-review of my changes.
- [ ] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [ ] I have made my changes in the `docs/sources/k6/next` folder of the documentation.
- [ ] I have reflected my changes in the `docs/sources/k6/v{most_recent_release}` folder of the documentation.
- [ ] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->

<!-- 2. If updating the documentation for the next release of k6: -->
- [ ] I have made my changes in the `docs/sources/k6/next` folder of the documentation.

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->
<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->