### PR TITLE
Set javascript syntax highlight on `http-debugging.md`

### DIFF
--- a/docs/sources/k6/next/using-k6/http-debugging.md
+++ b/docs/sources/k6/next/using-k6/http-debugging.md
@@ -19,7 +19,7 @@ Given the following script:
 
 {{< code >}}
 
-```bash
+```javascript
 import http from "k6/http";
 
 export default function() {

--- a/docs/sources/k6/v0.47.x/using-k6/http-debugging.md
+++ b/docs/sources/k6/v0.47.x/using-k6/http-debugging.md
@@ -19,7 +19,7 @@ Given the following script:
 
 {{< code >}}
 
-```bash
+```javascript
 import http from "k6/http";
 
 export default function() {

--- a/docs/sources/k6/v0.48.x/using-k6/http-debugging.md
+++ b/docs/sources/k6/v0.48.x/using-k6/http-debugging.md
@@ -19,7 +19,7 @@ Given the following script:
 
 {{< code >}}
 
-```bash
+```javascript
 import http from "k6/http";
 
 export default function() {

--- a/docs/sources/k6/v0.49.x/using-k6/http-debugging.md
+++ b/docs/sources/k6/v0.49.x/using-k6/http-debugging.md
@@ -19,7 +19,7 @@ Given the following script:
 
 {{< code >}}
 
-```bash
+```javascript
 import http from "k6/http";
 
 export default function() {

--- a/docs/sources/k6/v0.50.x/using-k6/http-debugging.md
+++ b/docs/sources/k6/v0.50.x/using-k6/http-debugging.md
@@ -19,7 +19,7 @@ Given the following script:
 
 {{< code >}}
 
-```bash
+```javascript
 import http from "k6/http";
 
 export default function() {

--- a/docs/sources/k6/v0.51.x/using-k6/http-debugging.md
+++ b/docs/sources/k6/v0.51.x/using-k6/http-debugging.md
@@ -19,7 +19,7 @@ Given the following script:
 
 {{< code >}}
 
-```bash
+```javascript
 import http from "k6/http";
 
 export default function() {

--- a/docs/sources/k6/v0.52.x/using-k6/http-debugging.md
+++ b/docs/sources/k6/v0.52.x/using-k6/http-debugging.md
@@ -19,7 +19,7 @@ Given the following script:
 
 {{< code >}}
 
-```bash
+```javascript
 import http from "k6/http";
 
 export default function() {

--- a/docs/sources/k6/v0.53.x/using-k6/http-debugging.md
+++ b/docs/sources/k6/v0.53.x/using-k6/http-debugging.md
@@ -19,7 +19,7 @@ Given the following script:
 
 {{< code >}}
 
-```bash
+```javascript
 import http from "k6/http";
 
 export default function() {

--- a/docs/sources/k6/v0.54.x/using-k6/http-debugging.md
+++ b/docs/sources/k6/v0.54.x/using-k6/http-debugging.md
@@ -19,7 +19,7 @@ Given the following script:
 
 {{< code >}}
 
-```bash
+```javascript
 import http from "k6/http";
 
 export default function() {

--- a/docs/sources/k6/v0.55.x/using-k6/http-debugging.md
+++ b/docs/sources/k6/v0.55.x/using-k6/http-debugging.md
@@ -19,7 +19,7 @@ Given the following script:
 
 {{< code >}}
 
-```bash
+```javascript
 import http from "k6/http";
 
 export default function() {

--- a/docs/sources/k6/v0.56.x/using-k6/http-debugging.md
+++ b/docs/sources/k6/v0.56.x/using-k6/http-debugging.md
@@ -19,7 +19,7 @@ Given the following script:
 
 {{< code >}}
 
-```bash
+```javascript
 import http from "k6/http";
 
 export default function() {

--- a/docs/sources/k6/v0.57.x/using-k6/http-debugging.md
+++ b/docs/sources/k6/v0.57.x/using-k6/http-debugging.md
@@ -19,7 +19,7 @@ Given the following script:
 
 {{< code >}}
 
-```bash
+```javascript
 import http from "k6/http";
 
 export default function() {

--- a/docs/sources/k6/v1.0.x/using-k6/http-debugging.md
+++ b/docs/sources/k6/v1.0.x/using-k6/http-debugging.md
@@ -19,7 +19,7 @@ Given the following script:
 
 {{< code >}}
 
-```bash
+```javascript
 import http from "k6/http";
 
 export default function() {


### PR DESCRIPTION
<!-- 
Please make sure you have read the contribution guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md as well as the
the code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md before opening a PR.
-->

## What?

<!-- A description of the changes this PR brings to the documentation. -->
Some code block in HTTP debugging page is highlighted as bash, but it's actually javascript code.

So changed syntax highlight with javascript.

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- I have updated all versions

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->
<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->

## Additional Question
I noticed that this HTTP debugging page is unlisted.
Is it intended?