### PR TITLE
Fix extension list generation on registry changes

### DIFF
--- a/.github/workflows/extension-registry-changed.yml
+++ b/.github/workflows/extension-registry-changed.yml
@@ -51,4 +51,4 @@ jobs:
             The [k6 Extension Registry](https://registry.k6.io) has changed.
             This pull request contains the files generated from the k6 Extension Registry.
           add-paths: |
-            docs/sources/next/extensions/explore.md
+            docs/sources/k6/next/extensions/explore.md


### PR DESCRIPTION
## What?

The list of k6 extensions was not automatically generated when the k6 extension registry was changed.

The reason for this is the extension list path in the workflow file:

```
docs/sources/next/extensions/explore.md
```

This has been fixed to:

```
docs/sources/k6/next/extensions/explore.md
```

<!-- A description of the changes this PR brings to the documentation. -->

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [ ] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [ ] I have made my changes in the `docs/sources/k6/next` folder of the documentation.
- [ ] I have reflected my changes in the `docs/sources/k6/v{most_recent_release}` folder of the documentation.
- [ ] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->

<!-- 2. If updating the documentation for the next release of k6: -->
- [ ] I have made my changes in the `docs/sources/k6/next` folder of the documentation.

## Related PR(s)/Issue(s)

#1950
#1951 

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->
<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->