### PR TITLE
Add link from k6 Operator troubleshoot page to PLZ troubleshoot page

### DIFF
--- a/docs/sources/k6/next/set-up/set-up-distributed-k6/troubleshooting.md
+++ b/docs/sources/k6/next/set-up/set-up-distributed-k6/troubleshooting.md
@@ -1,9 +1,11 @@
 ---
+aliases:
+  - ./troubleshooting # docs/k6/<K6_VERSION>/set-up/set-up-distributed-k6/troubleshooting
 weight: 400
-title: Troubleshooting
+title: Troubleshoot
 ---
 
-# Troubleshooting
+# Troubleshoot
 
 This topic includes instructions to help you troubleshoot common issues with the k6 Operator.
 

--- a/docs/sources/k6/next/set-up/set-up-distributed-k6/troubleshooting.md
+++ b/docs/sources/k6/next/set-up/set-up-distributed-k6/troubleshooting.md
@@ -9,6 +9,8 @@ title: Troubleshoot
 
 This topic includes instructions to help you troubleshoot common issues with the k6 Operator.
 
+If you’re using Private Load Zones in Grafana Cloud k6, refer to [Troubleshoot Private Load Zones](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/private-load-zone/troubleshoot/).
+
 ## How to troubleshoot
 
 {{< docs/shared source="k6" lookup="k6-operator/troubleshooting-how-to.md" version="<K6_VERSION>" >}}


### PR DESCRIPTION
## What?

Add a link from the k6 Operator troubleshoot page to the PLZ troubleshoot page to help users find the correct information based on their k6 usage.

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [x] I have made my changes in the `docs/sources/k6/next` folder of the documentation.
- [ ] I have reflected my changes in the `docs/sources/k6/v{most_recent_release}` folder of the documentation.
- [ ] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->

## Related PR(s)/Issue(s)

Closes https://github.com/grafana/k6-operator/issues/538.