### PR TITLE
`xk6-disruptor`: Document timeout option

### DIFF
--- a/docs/sources/k6/v1.0.x/testing-guides/injecting-faults-with-xk6-disruptor/xk6-disruptor/faults/pod-termination.md
+++ b/docs/sources/k6/v1.0.x/testing-guides/injecting-faults-with-xk6-disruptor/xk6-disruptor/faults/pod-termination.md
@@ -12,9 +12,10 @@ A Pod Termination Fault allows terminating either a fixed number or a percentage
 
 A Pod Termination fault is defined by the following attributes:
 
-| Attribute | Type                  | Description                                                                                                                                                                   |
-| --------- | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| count     | integer or percentage | the number of pods to be terminated. It can be specified as a integer number or as a percentage, for example `30%`, that defines the fraction of target pods to be terminated |
+| Attribute | Type                  | Default  | Description                                                                                                                                                                   |
+| --------- | --------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| count     | integer or percentage | Required | the number of pods to be terminated. It can be specified as a integer number or as a percentage, for example `30%`, that defines the fraction of target pods to be terminated |
+| timeout   | duration              | 10s      | how long to wait for pods to be terminated before terminating the process with an error
 
 {{< admonition type="note" >}}
 


### PR DESCRIPTION
See here for the code where it's support: https://github.com/grafana/xk6-disruptor/blob/main/pkg/disruptors/terminate.go#L34