### PR TITLE
Add workflow to prevent changes to Extensions list

### DIFF
--- a/.github/workflows/prevent-manual-extension-registry-changes.yml
+++ b/.github/workflows/prevent-manual-extension-registry-changes.yml
@@ -1,0 +1,31 @@
+# This workflow prevents users from manually changing the
+# docs/sources/next/extensions/explore.md file.
+
+# Changes to the registry should only be made automatically
+# by the extension-registry-changed workflow.
+
+name: Prevent file change
+on:
+  pull_request_target:
+    paths:
+      - 'docs/k6/*/extensions/explore.md'
+
+permissions:
+  pull-requests: read
+
+jobs:
+  prevent-file-change:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        with:
+          persist-credentials: false
+        uses: actions/checkout@v4
+
+      - name: Prevent manual changes to the extension registry file
+        uses: xalvarez/prevent-file-change-action@v2
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          pattern: .*\extensions/explore\.md
+          trustedAuthors: heitortsergent, szkiba, pablochacin, andrewslotin, mstoykov, inancgumus, oleiade, ankur22, codebien, joanlopez, AgnesToulet
+          allowNewFiles: true # To prevent issues when we release a new version of k6


### PR DESCRIPTION
## What?

Add a workflow to prevent users from changing the `explore.md` file. The file should only be updated by maintainers, or the Extension Registry workflow in this repo.

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [ ] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [ ] I have made my changes in the `docs/sources/k6/next` folder of the documentation.
- [ ] I have reflected my changes in the `docs/sources/k6/v{most_recent_release}` folder of the documentation.
- [ ] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->

<!-- 2. If updating the documentation for the next release of k6: -->
- [ ] I have made my changes in the `docs/sources/k6/next` folder of the documentation.

## Related PR(s)/Issue(s)

https://github.com/grafana/k6-docs/pull/1961