### PR TITLE
add KinesisClient documentation for k6-jslib-aws

### DIFF
--- a/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/_index.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/_index.md
@@ -32,8 +32,8 @@ KinesisClient methods will throw errors in case of failure.
 
 | Error                 | Condition                                                  |
 | :-------------------- | :--------------------------------------------------------- |
-| InvalidSignatureError | when invalid credentials were provided.                    |
-| KinesisServiceError   | when AWS replied to the requested operation with an error. |
+| InvalidSignatureError | When invalid credentials are provided.                    |
+| KinesisServiceError   | When AWS replies to the requested operation with an error. |
 
 ### Examples
 

--- a/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/_index.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/_index.md
@@ -40,6 +40,8 @@ KinesisClient methods will throw errors in case of failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import { check } from 'k6';
 import exec from 'k6/execution';
@@ -106,6 +108,8 @@ export default async function () {
 #### Stream management
 
 {{< code >}}
+
+<!-- md-k6:skip -->
 
 ```javascript
 import {

--- a/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/_index.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'KinesisClient'
-head_title: 'KinesisClient'
 description: 'KinesisClient allows interacting with AWS Kinesis streams'
 weight: 00
 ---

--- a/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/_index.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/_index.md
@@ -37,7 +37,6 @@ KinesisClient methods will throw errors in case of failure.
 
 ### Examples
 
-{{< code >}}
 
 <!-- md-k6:skip -->
 
@@ -102,11 +101,9 @@ export default async function () {
 }
 ```
 
-{{< /code >}}
 
 #### Stream management
 
-{{< code >}}
 
 <!-- md-k6:skip -->
 
@@ -144,4 +141,3 @@ export default async function () {
 }
 ```
 
-{{< /code >}}

--- a/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/_index.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/_index.md
@@ -1,0 +1,144 @@
+---
+title: 'KinesisClient'
+head_title: 'KinesisClient'
+description: 'KinesisClient allows interacting with AWS Kinesis streams'
+weight: 00
+---
+
+# KinesisClient
+
+{{< docs/shared source="k6" lookup="blocking-aws-blockquote.md" version="<K6_VERSION>" >}}
+
+`KinesisClient` interacts with the AWS Kinesis service.
+
+With it, you can perform operations such as creating streams, putting records, listing streams, and reading records from streams. For a full list of supported operations, see [Methods](#methods).
+
+Both the dedicated `kinesis.js` jslib bundle and the all-encompassing `aws.js` bundle include the `KinesisClient`.
+
+### Methods
+
+| Function                                                                                                                                                                | Description                                            |
+| :---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------- |
+| [createStream(streamName, [options])](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/aws/kinesisclient/createstream)                                     | Create a new Kinesis stream                            |
+| [deleteStream(streamName)](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/aws/kinesisclient/deletestream)                                                | Delete a Kinesis stream                                |
+| [listStreams([options])](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/aws/kinesisclient/liststreams)                                                   | List available Kinesis streams                         |
+| [putRecords(streamName, records)](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/aws/kinesisclient/putrecords)                                           | Put multiple records into a Kinesis stream             |
+| [getRecords(shardIterator, [options])](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/aws/kinesisclient/getrecords)                                      | Get records from a Kinesis stream shard                |
+| [listShards(streamName, [options])](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/aws/kinesisclient/listshards)                                         | List shards in a Kinesis stream                        |
+| [getShardIterator(streamName, shardId, shardIteratorType, [options])](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/aws/kinesisclient/getsharditerator) | Get a shard iterator for reading records from a stream |
+
+### Throws
+
+KinesisClient methods will throw errors in case of failure.
+
+| Error                 | Condition                                                  |
+| :-------------------- | :--------------------------------------------------------- |
+| InvalidSignatureError | when invalid credentials were provided.                    |
+| KinesisServiceError   | when AWS replied to the requested operation with an error. |
+
+### Examples
+
+{{< code >}}
+
+```javascript
+import { check } from 'k6';
+import exec from 'k6/execution';
+
+import {
+  AWSConfig,
+  KinesisClient,
+} from 'https://jslib.k6.io/aws/{{< param "JSLIB_AWS_VERSION" >}}/kinesis.js';
+
+const awsConfig = new AWSConfig({
+  region: __ENV.AWS_REGION,
+  accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+  secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+});
+
+const kinesis = new KinesisClient(awsConfig);
+const testStreamName = 'test-stream';
+
+export default async function () {
+  // List available streams
+  const streams = await kinesis.listStreams();
+  console.log('Available streams:', streams.streamNames);
+
+  // Check if our test stream exists
+  if (!streams.streamNames.includes(testStreamName)) {
+    // Create the stream if it doesn't exist
+    await kinesis.createStream(testStreamName, { shardCount: 1 });
+    console.log(`Created stream: ${testStreamName}`);
+  }
+
+  // Put some records into the stream
+  const records = [
+    {
+      data: JSON.stringify({ message: 'Hello from k6!', timestamp: Date.now() }),
+      partitionKey: 'test-partition-1',
+    },
+    {
+      data: JSON.stringify({ message: 'Another message', timestamp: Date.now() }),
+      partitionKey: 'test-partition-2',
+    },
+  ];
+
+  const putResult = await kinesis.putRecords(testStreamName, records);
+  console.log('Put records result:', putResult);
+
+  // List shards in the stream
+  const shards = await kinesis.listShards(testStreamName);
+  console.log('Stream shards:', shards.shards);
+
+  // Get a shard iterator for reading records
+  if (shards.shards.length > 0) {
+    const shardId = shards.shards[0].shardId;
+    const shardIterator = await kinesis.getShardIterator(testStreamName, shardId, 'TRIM_HORIZON');
+
+    // Get records from the shard
+    const getResult = await kinesis.getRecords(shardIterator.shardIterator);
+    console.log('Retrieved records:', getResult.records);
+  }
+}
+```
+
+{{< /code >}}
+
+#### Stream management
+
+{{< code >}}
+
+```javascript
+import {
+  AWSConfig,
+  KinesisClient,
+} from 'https://jslib.k6.io/aws/{{< param "JSLIB_AWS_VERSION" >}}/kinesis.js';
+
+const awsConfig = new AWSConfig({
+  region: __ENV.AWS_REGION,
+  accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+  secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+});
+
+const kinesis = new KinesisClient(awsConfig);
+
+export default async function () {
+  const streamName = 'my-test-stream';
+
+  // Create a stream with on-demand billing
+  await kinesis.createStream(streamName, {
+    streamModeDetails: {
+      streamMode: 'ON_DEMAND',
+    },
+  });
+
+  // List all streams
+  const streams = await kinesis.listStreams();
+  console.log('All streams:', streams.streamNames);
+
+  // Clean up - delete the stream
+  await kinesis.deleteStream(streamName);
+  console.log(`Deleted stream: ${streamName}`);
+}
+```
+
+{{< /code >}}

--- a/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/createStream.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/createStream.md
@@ -1,0 +1,66 @@
+---
+title: 'createStream'
+head_title: 'KinesisClient.createStream(streamName, [options])'
+description: 'KinesisClient.createStream creates a new Kinesis stream'
+weight: 10
+---
+
+# createStream
+
+`KinesisClient.createStream(streamName, [options])` creates a new Kinesis stream.
+
+### Parameters
+
+| Parameter  | Type   | Description                                     |
+| :--------- | :----- | :---------------------------------------------- |
+| streamName | string | The name of the Kinesis stream to create.       |
+| options    | object | Optional configuration for the stream creation. |
+
+#### Options
+
+| Parameter                    | Type   | Description                                                           |
+| :--------------------------- | :----- | :-------------------------------------------------------------------- |
+| shardCount                   | number | The number of shards for the stream (for provisioned mode).           |
+| streamModeDetails            | object | Configuration for the stream mode.                                    |
+| streamModeDetails.streamMode | string | The billing mode for the stream. Either `PROVISIONED` or `ON_DEMAND`. |
+
+### Returns
+
+| Type            | Description                                                           |
+| :-------------- | :-------------------------------------------------------------------- |
+| `Promise<void>` | A Promise that fulfills when the stream creation request is complete. |
+
+### Example
+
+{{< code >}}
+
+```javascript
+import {
+  AWSConfig,
+  KinesisClient,
+} from 'https://jslib.k6.io/aws/{{< param "JSLIB_AWS_VERSION" >}}/kinesis.js';
+
+const awsConfig = new AWSConfig({
+  region: __ENV.AWS_REGION,
+  accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+  secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+});
+
+const kinesis = new KinesisClient(awsConfig);
+
+export default async function () {
+  // Create a stream with provisioned billing and 2 shards
+  await kinesis.createStream('my-provisioned-stream', {
+    shardCount: 2,
+  });
+
+  // Create a stream with on-demand billing
+  await kinesis.createStream('my-on-demand-stream', {
+    streamModeDetails: {
+      streamMode: 'ON_DEMAND',
+    },
+  });
+}
+```
+
+{{< /code >}}

--- a/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/createStream.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/createStream.md
@@ -1,6 +1,5 @@
 ---
 title: 'createStream'
-head_title: 'KinesisClient.createStream(streamName, [options])'
 description: 'KinesisClient.createStream creates a new Kinesis stream'
 weight: 10
 ---
@@ -32,7 +31,6 @@ weight: 10
 
 ### Example
 
-{{< code >}}
 
 <!-- md-k6:skip -->
 
@@ -65,4 +63,3 @@ export default async function () {
 }
 ```
 
-{{< /code >}}

--- a/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/createStream.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/createStream.md
@@ -34,6 +34,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/deleteStream.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/deleteStream.md
@@ -1,6 +1,5 @@
 ---
 title: 'deleteStream'
-head_title: 'KinesisClient.deleteStream(streamName)'
 description: 'KinesisClient.deleteStream deletes a Kinesis stream'
 weight: 10
 ---
@@ -23,7 +22,6 @@ weight: 10
 
 ### Example
 
-{{< code >}}
 
 <!-- md-k6:skip -->
 
@@ -50,4 +48,3 @@ export default async function () {
 }
 ```
 
-{{< /code >}}

--- a/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/deleteStream.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/deleteStream.md
@@ -1,0 +1,51 @@
+---
+title: 'deleteStream'
+head_title: 'KinesisClient.deleteStream(streamName)'
+description: 'KinesisClient.deleteStream deletes a Kinesis stream'
+weight: 10
+---
+
+# deleteStream
+
+`KinesisClient.deleteStream(streamName)` deletes a Kinesis stream.
+
+### Parameters
+
+| Parameter  | Type   | Description                               |
+| :--------- | :----- | :---------------------------------------- |
+| streamName | string | The name of the Kinesis stream to delete. |
+
+### Returns
+
+| Type            | Description                                                           |
+| :-------------- | :-------------------------------------------------------------------- |
+| `Promise<void>` | A Promise that fulfills when the stream deletion request is complete. |
+
+### Example
+
+{{< code >}}
+
+```javascript
+import {
+  AWSConfig,
+  KinesisClient,
+} from 'https://jslib.k6.io/aws/{{< param "JSLIB_AWS_VERSION" >}}/kinesis.js';
+
+const awsConfig = new AWSConfig({
+  region: __ENV.AWS_REGION,
+  accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+  secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+});
+
+const kinesis = new KinesisClient(awsConfig);
+
+export default async function () {
+  const streamName = 'my-test-stream';
+
+  // Delete the stream
+  await kinesis.deleteStream(streamName);
+  console.log(`Stream ${streamName} deleted`);
+}
+```
+
+{{< /code >}}

--- a/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/deleteStream.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/deleteStream.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/getRecords.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/getRecords.md
@@ -1,6 +1,5 @@
 ---
 title: 'getRecords'
-head_title: 'KinesisClient.getRecords(shardIterator, [options])'
 description: 'KinesisClient.getRecords gets records from a Kinesis stream shard'
 weight: 10
 ---
@@ -47,7 +46,6 @@ weight: 10
 
 ### Example
 
-{{< code >}}
 
 <!-- md-k6:skip -->
 
@@ -115,4 +113,3 @@ export default async function () {
 }
 ```
 
-{{< /code >}}

--- a/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/getRecords.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/getRecords.md
@@ -1,0 +1,116 @@
+---
+title: 'getRecords'
+head_title: 'KinesisClient.getRecords(shardIterator, [options])'
+description: 'KinesisClient.getRecords gets records from a Kinesis stream shard'
+weight: 10
+---
+
+# getRecords
+
+`KinesisClient.getRecords(shardIterator, [options])` gets records from a Kinesis stream shard using a shard iterator.
+
+### Parameters
+
+| Parameter     | Type   | Description                                           |
+| :------------ | :----- | :---------------------------------------------------- |
+| shardIterator | string | The shard iterator from which to get records.         |
+| options       | object | Optional configuration for the get records operation. |
+
+#### Options
+
+| Parameter | Type   | Description                              |
+| :-------- | :----- | :--------------------------------------- |
+| limit     | number | The maximum number of records to return. |
+
+### Returns
+
+| Type              | Description                                        |
+| :---------------- | :------------------------------------------------- |
+| `Promise<Object>` | A Promise that fulfills with the records response. |
+
+#### Returns object
+
+| Property           | Type          | Description                                          |
+| :----------------- | :------------ | :--------------------------------------------------- |
+| records            | Array<Object> | An array of records retrieved from the stream.       |
+| nextShardIterator  | string        | The next shard iterator to use for subsequent calls. |
+| millisBehindLatest | number        | The number of milliseconds behind the latest record. |
+
+#### Record object
+
+| Property                    | Type   | Description                                      |
+| :-------------------------- | :----- | :----------------------------------------------- |
+| sequenceNumber              | string | The sequence number of the record.               |
+| approximateArrivalTimestamp | Date   | The approximate arrival timestamp of the record. |
+| data                        | string | The data payload of the record.                  |
+| partitionKey                | string | The partition key of the record.                 |
+
+### Example
+
+{{< code >}}
+
+```javascript
+import {
+  AWSConfig,
+  KinesisClient,
+} from 'https://jslib.k6.io/aws/{{< param "JSLIB_AWS_VERSION" >}}/kinesis.js';
+
+const awsConfig = new AWSConfig({
+  region: __ENV.AWS_REGION,
+  accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+  secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+});
+
+const kinesis = new KinesisClient(awsConfig);
+
+export default async function () {
+  const streamName = 'my-test-stream';
+
+  // First, get the shards for the stream
+  const shards = await kinesis.listShards(streamName);
+
+  if (shards.shards.length > 0) {
+    const shardId = shards.shards[0].shardId;
+
+    // Get a shard iterator for the first shard
+    const shardIteratorResponse = await kinesis.getShardIterator(
+      streamName,
+      shardId,
+      'TRIM_HORIZON'
+    );
+
+    const shardIterator = shardIteratorResponse.shardIterator;
+
+    // Get records from the shard
+    const recordsResponse = await kinesis.getRecords(shardIterator, { limit: 10 });
+
+    console.log('Records retrieved:', recordsResponse.records.length);
+    console.log('Milliseconds behind latest:', recordsResponse.millisBehindLatest);
+
+    // Process the records
+    recordsResponse.records.forEach((record, index) => {
+      console.log(`Record ${index}:`);
+      console.log('  Sequence number:', record.sequenceNumber);
+      console.log('  Partition key:', record.partitionKey);
+      console.log('  Data:', record.data);
+      console.log('  Arrival timestamp:', record.approximateArrivalTimestamp);
+
+      // Parse JSON data if applicable
+      try {
+        const jsonData = JSON.parse(record.data);
+        console.log('  Parsed data:', jsonData);
+      } catch (e) {
+        console.log('  Data is not JSON');
+      }
+    });
+
+    // Continue reading with the next shard iterator
+    if (recordsResponse.nextShardIterator) {
+      const nextBatch = await kinesis.getRecords(recordsResponse.nextShardIterator, { limit: 5 });
+      console.log('Next batch size:', nextBatch.records.length);
+    }
+  }
+}
+```
+
+{{< /code >}}

--- a/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/getRecords.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/getRecords.md
@@ -49,6 +49,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/getShardIterator.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/getShardIterator.md
@@ -1,0 +1,112 @@
+---
+title: 'getShardIterator'
+head_title: 'KinesisClient.getShardIterator(streamName, shardId, shardIteratorType, [options])'
+description: 'KinesisClient.getShardIterator gets a shard iterator for reading records from a Kinesis stream'
+weight: 10
+---
+
+# getShardIterator
+
+`KinesisClient.getShardIterator(streamName, shardId, shardIteratorType, [options])` gets a shard iterator for reading records from a Kinesis stream shard.
+
+### Parameters
+
+| Parameter         | Type   | Description                                    |
+| :---------------- | :----- | :--------------------------------------------- |
+| streamName        | string | The name of the Kinesis stream.                |
+| shardId           | string | The shard ID for which to get the iterator.    |
+| shardIteratorType | string | The type of shard iterator to get.             |
+| options           | object | Optional configuration for the shard iterator. |
+
+#### Shard Iterator Types
+
+| Type                  | Description                                                                   |
+| :-------------------- | :---------------------------------------------------------------------------- |
+| TRIM_HORIZON          | Start reading at the last untrimmed record in the shard.                      |
+| LATEST                | Start reading just after the most recent record in the shard.                 |
+| AT_SEQUENCE_NUMBER    | Start reading from the position denoted by a specific sequence number.        |
+| AFTER_SEQUENCE_NUMBER | Start reading right after the position denoted by a specific sequence number. |
+| AT_TIMESTAMP          | Start reading from the position denoted by a specific timestamp.              |
+
+#### Options
+
+| Parameter              | Type   | Description                                                                                          |
+| :--------------------- | :----- | :--------------------------------------------------------------------------------------------------- |
+| startingSequenceNumber | string | The sequence number to start from (required for AT_SEQUENCE_NUMBER and AFTER_SEQUENCE_NUMBER types). |
+| timestamp              | Date   | The timestamp to start from (required for AT_TIMESTAMP type).                                        |
+
+### Returns
+
+| Type              | Description                                               |
+| :---------------- | :-------------------------------------------------------- |
+| `Promise<Object>` | A Promise that fulfills with the shard iterator response. |
+
+#### Returns object
+
+| Property      | Type   | Description                                    |
+| :------------ | :----- | :--------------------------------------------- |
+| shardIterator | string | The shard iterator to use for reading records. |
+
+### Example
+
+{{< code >}}
+
+```javascript
+import {
+  AWSConfig,
+  KinesisClient,
+} from 'https://jslib.k6.io/aws/{{< param "JSLIB_AWS_VERSION" >}}/kinesis.js';
+
+const awsConfig = new AWSConfig({
+  region: __ENV.AWS_REGION,
+  accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+  secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+});
+
+const kinesis = new KinesisClient(awsConfig);
+
+export default async function () {
+  const streamName = 'my-test-stream';
+
+  // First, get the shards for the stream
+  const shards = await kinesis.listShards(streamName);
+
+  if (shards.shards.length > 0) {
+    const shardId = shards.shards[0].shardId;
+
+    // Get a shard iterator starting from the beginning
+    const trimHorizonIterator = await kinesis.getShardIterator(streamName, shardId, 'TRIM_HORIZON');
+    console.log('Trim horizon iterator:', trimHorizonIterator.shardIterator);
+
+    // Get a shard iterator starting from the latest records
+    const latestIterator = await kinesis.getShardIterator(streamName, shardId, 'LATEST');
+    console.log('Latest iterator:', latestIterator.shardIterator);
+
+    // Get a shard iterator starting from a specific timestamp
+    const timestampIterator = await kinesis.getShardIterator(streamName, shardId, 'AT_TIMESTAMP', {
+      timestamp: new Date(Date.now() - 3600000), // 1 hour ago
+    });
+    console.log('Timestamp iterator:', timestampIterator.shardIterator);
+
+    // Use the iterator to read records
+    const records = await kinesis.getRecords(trimHorizonIterator.shardIterator);
+    console.log('Records retrieved:', records.records.length);
+
+    // If we have records, we can get an iterator starting after a specific sequence number
+    if (records.records.length > 0) {
+      const sequenceNumber = records.records[0].sequenceNumber;
+      const afterSequenceIterator = await kinesis.getShardIterator(
+        streamName,
+        shardId,
+        'AFTER_SEQUENCE_NUMBER',
+        {
+          startingSequenceNumber: sequenceNumber,
+        }
+      );
+      console.log('After sequence iterator:', afterSequenceIterator.shardIterator);
+    }
+  }
+}
+```
+
+{{< /code >}}

--- a/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/getShardIterator.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/getShardIterator.md
@@ -1,6 +1,5 @@
 ---
 title: 'getShardIterator'
-head_title: 'KinesisClient.getShardIterator(streamName, shardId, shardIteratorType, [options])'
 description: 'KinesisClient.getShardIterator gets a shard iterator for reading records from a Kinesis stream'
 weight: 10
 ---
@@ -32,8 +31,8 @@ weight: 10
 
 | Parameter              | Type   | Description                                                                                          |
 | :--------------------- | :----- | :--------------------------------------------------------------------------------------------------- |
-| startingSequenceNumber | string | The sequence number to start from (required for AT_SEQUENCE_NUMBER and AFTER_SEQUENCE_NUMBER types). |
-| timestamp              | Date   | The timestamp to start from (required for AT_TIMESTAMP type).                                        |
+| startingSequenceNumber | string | The sequence number to start from (required for `AT_SEQUENCE_NUMBER` and `AFTER_SEQUENCE_NUMBER` types). |
+| timestamp              | Date   | The timestamp to start from (required for `AT_TIMESTAMP` type).                                        |
 
 ### Returns
 
@@ -49,7 +48,6 @@ weight: 10
 
 ### Example
 
-{{< code >}}
 
 <!-- md-k6:skip -->
 
@@ -111,4 +109,3 @@ export default async function () {
 }
 ```
 
-{{< /code >}}

--- a/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/getShardIterator.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/getShardIterator.md
@@ -51,6 +51,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/listShards.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/listShards.md
@@ -1,0 +1,100 @@
+---
+title: 'listShards'
+head_title: 'KinesisClient.listShards(streamName, [options])'
+description: 'KinesisClient.listShards lists shards in a Kinesis stream'
+weight: 10
+---
+
+# listShards
+
+`KinesisClient.listShards(streamName, [options])` lists the shards in a Kinesis stream.
+
+### Parameters
+
+| Parameter  | Type   | Description                                           |
+| :--------- | :----- | :---------------------------------------------------- |
+| streamName | string | The name of the Kinesis stream.                       |
+| options    | object | Optional configuration for the list shards operation. |
+
+#### Options
+
+| Parameter             | Type   | Description                                     |
+| :-------------------- | :----- | :---------------------------------------------- |
+| nextToken             | string | The token to use for pagination.                |
+| exclusiveStartShardId | string | The shard ID to start listing from (exclusive). |
+| maxResults            | number | The maximum number of shards to return.         |
+
+### Returns
+
+| Type              | Description                                      |
+| :---------------- | :----------------------------------------------- |
+| `Promise<Object>` | A Promise that fulfills with the list of shards. |
+
+#### Returns object
+
+| Property  | Type          | Description                                    |
+| :-------- | :------------ | :--------------------------------------------- |
+| shards    | Array<Object> | An array of shard objects.                     |
+| nextToken | string        | The token to use for the next page of results. |
+
+#### Shard object
+
+| Property              | Type   | Description                                         |
+| :-------------------- | :----- | :-------------------------------------------------- |
+| shardId               | string | The unique identifier of the shard.                 |
+| parentShardId         | string | The shard ID of the parent shard (if any).          |
+| adjacentParentShardId | string | The shard ID of the adjacent parent shard (if any). |
+| hashKeyRange          | Object | The hash key range for the shard.                   |
+| sequenceNumberRange   | Object | The sequence number range for the shard.            |
+
+### Example
+
+{{< code >}}
+
+```javascript
+import {
+  AWSConfig,
+  KinesisClient,
+} from 'https://jslib.k6.io/aws/{{< param "JSLIB_AWS_VERSION" >}}/kinesis.js';
+
+const awsConfig = new AWSConfig({
+  region: __ENV.AWS_REGION,
+  accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+  secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+});
+
+const kinesis = new KinesisClient(awsConfig);
+
+export default async function () {
+  const streamName = 'my-test-stream';
+
+  // List all shards in the stream
+  const shardsResponse = await kinesis.listShards(streamName);
+
+  console.log('Number of shards:', shardsResponse.shards.length);
+
+  // Display information about each shard
+  shardsResponse.shards.forEach((shard, index) => {
+    console.log(`Shard ${index}:`);
+    console.log('  Shard ID:', shard.shardId);
+    console.log('  Parent Shard ID:', shard.parentShardId || 'None');
+    console.log('  Adjacent Parent Shard ID:', shard.adjacentParentShardId || 'None');
+    console.log('  Hash Key Range:', shard.hashKeyRange);
+    console.log('  Sequence Number Range:', shard.sequenceNumberRange);
+  });
+
+  // List shards with pagination
+  const limitedShards = await kinesis.listShards(streamName, { maxResults: 2 });
+  console.log('Limited shards:', limitedShards.shards.length);
+
+  // Continue pagination if there are more shards
+  if (limitedShards.nextToken) {
+    const nextPage = await kinesis.listShards(streamName, {
+      nextToken: limitedShards.nextToken,
+    });
+    console.log('Next page shards:', nextPage.shards.length);
+  }
+}
+```
+
+{{< /code >}}

--- a/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/listShards.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/listShards.md
@@ -1,6 +1,5 @@
 ---
 title: 'listShards'
-head_title: 'KinesisClient.listShards(streamName, [options])'
 description: 'KinesisClient.listShards lists shards in a Kinesis stream'
 weight: 10
 ---
@@ -49,7 +48,6 @@ weight: 10
 
 ### Example
 
-{{< code >}}
 
 <!-- md-k6:skip -->
 
@@ -99,4 +97,3 @@ export default async function () {
 }
 ```
 
-{{< /code >}}

--- a/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/listShards.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/listShards.md
@@ -42,8 +42,8 @@ weight: 10
 | Property              | Type   | Description                                         |
 | :-------------------- | :----- | :-------------------------------------------------- |
 | shardId               | string | The unique identifier of the shard.                 |
-| parentShardId         | string | The shard ID of the parent shard (if any).          |
-| adjacentParentShardId | string | The shard ID of the adjacent parent shard (if any). |
+| parentShardId         | string (optional) | The shard ID of the parent shard (if any).          |
+| adjacentParentShardId | string (optional) | The shard ID of the adjacent parent shard (if any). |
 | hashKeyRange          | Object | The hash key range for the shard.                   |
 | sequenceNumberRange   | Object | The sequence number range for the shard.            |
 

--- a/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/listShards.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/listShards.md
@@ -51,6 +51,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/listStreams.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/listStreams.md
@@ -1,6 +1,5 @@
 ---
 title: 'listStreams'
-head_title: 'KinesisClient.listStreams([options])'
 description: 'KinesisClient.listStreams lists Kinesis streams'
 weight: 10
 ---
@@ -37,7 +36,6 @@ weight: 10
 
 ### Example
 
-{{< code >}}
 
 <!-- md-k6:skip -->
 
@@ -75,4 +73,3 @@ export default async function () {
 }
 ```
 
-{{< /code >}}

--- a/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/listStreams.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/listStreams.md
@@ -1,0 +1,76 @@
+---
+title: 'listStreams'
+head_title: 'KinesisClient.listStreams([options])'
+description: 'KinesisClient.listStreams lists Kinesis streams'
+weight: 10
+---
+
+# listStreams
+
+`KinesisClient.listStreams([options])` lists the Kinesis streams in the current region.
+
+### Parameters
+
+| Parameter | Type   | Description                                       |
+| :-------- | :----- | :------------------------------------------------ |
+| options   | object | Optional configuration for the listing operation. |
+
+#### Options
+
+| Parameter                | Type   | Description                                               |
+| :----------------------- | :----- | :-------------------------------------------------------- |
+| exclusiveStartStreamName | string | The name of the stream to start listing from (exclusive). |
+| limit                    | number | The maximum number of streams to return.                  |
+
+### Returns
+
+| Type              | Description                                       |
+| :---------------- | :------------------------------------------------ |
+| `Promise<Object>` | A Promise that fulfills with the list of streams. |
+
+#### Returns object
+
+| Property       | Type          | Description                                  |
+| :------------- | :------------ | :------------------------------------------- |
+| streamNames    | Array<string> | An array of stream names.                    |
+| hasMoreStreams | boolean       | Indicates if there are more streams to list. |
+
+### Example
+
+{{< code >}}
+
+```javascript
+import {
+  AWSConfig,
+  KinesisClient,
+} from 'https://jslib.k6.io/aws/{{< param "JSLIB_AWS_VERSION" >}}/kinesis.js';
+
+const awsConfig = new AWSConfig({
+  region: __ENV.AWS_REGION,
+  accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+  secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+});
+
+const kinesis = new KinesisClient(awsConfig);
+
+export default async function () {
+  // List all streams
+  const streams = await kinesis.listStreams();
+  console.log('Available streams:', streams.streamNames);
+  console.log('Has more streams:', streams.hasMoreStreams);
+
+  // List streams with pagination
+  const limitedStreams = await kinesis.listStreams({ limit: 5 });
+  console.log('First 5 streams:', limitedStreams.streamNames);
+
+  // List streams starting from a specific stream
+  if (limitedStreams.hasMoreStreams && limitedStreams.streamNames.length > 0) {
+    const nextBatch = await kinesis.listStreams({
+      exclusiveStartStreamName: limitedStreams.streamNames[limitedStreams.streamNames.length - 1],
+    });
+    console.log('Next batch of streams:', nextBatch.streamNames);
+  }
+}
+```
+
+{{< /code >}}

--- a/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/listStreams.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/listStreams.md
@@ -13,7 +13,7 @@ weight: 10
 
 | Parameter | Type   | Description                                       |
 | :-------- | :----- | :------------------------------------------------ |
-| options   | object | Optional configuration for the listing operation. |
+| options   | object (optional) | Configuration for the listing operation. |
 
 #### Options
 

--- a/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/listStreams.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/listStreams.md
@@ -39,6 +39,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/putRecords.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/putRecords.md
@@ -1,6 +1,5 @@
 ---
 title: 'putRecords'
-head_title: 'KinesisClient.putRecords(streamName, records)'
 description: 'KinesisClient.putRecords puts multiple records into a Kinesis stream'
 weight: 10
 ---
@@ -50,7 +49,6 @@ Each record in the `records` array should be an object with the following proper
 
 ### Example
 
-{{< code >}}
 
 <!-- md-k6:skip -->
 
@@ -119,4 +117,3 @@ export default async function () {
 }
 ```
 
-{{< /code >}}

--- a/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/putRecords.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/putRecords.md
@@ -1,0 +1,120 @@
+---
+title: 'putRecords'
+head_title: 'KinesisClient.putRecords(streamName, records)'
+description: 'KinesisClient.putRecords puts multiple records into a Kinesis stream'
+weight: 10
+---
+
+# putRecords
+
+`KinesisClient.putRecords(streamName, records)` puts multiple records into a Kinesis stream.
+
+### Parameters
+
+| Parameter  | Type          | Description                                         |
+| :--------- | :------------ | :-------------------------------------------------- |
+| streamName | string        | The name of the Kinesis stream to put records into. |
+| records    | Array<Object> | An array of records to put into the stream.         |
+
+#### Records
+
+Each record in the `records` array should be an object with the following properties:
+
+| Property        | Type   | Description                                     |
+| :-------------- | :----- | :---------------------------------------------- |
+| data            | string | The data payload of the record.                 |
+| partitionKey    | string | The partition key for the record.               |
+| explicitHashKey | string | Optional. The explicit hash key for the record. |
+
+### Returns
+
+| Type              | Description                                            |
+| :---------------- | :----------------------------------------------------- |
+| `Promise<Object>` | A Promise that fulfills with the put records response. |
+
+#### Returns object
+
+| Property          | Type          | Description                                  |
+| :---------------- | :------------ | :------------------------------------------- |
+| failedRecordCount | number        | The number of records that failed to be put. |
+| records           | Array<Object> | An array of record results.                  |
+
+#### Record result object
+
+| Property       | Type   | Description                                               |
+| :------------- | :----- | :-------------------------------------------------------- |
+| sequenceNumber | string | The sequence number of the record (if successful).        |
+| shardId        | string | The shard ID where the record was placed (if successful). |
+| errorCode      | string | The error code (if the record failed).                    |
+| errorMessage   | string | The error message (if the record failed).                 |
+
+### Example
+
+{{< code >}}
+
+```javascript
+import {
+  AWSConfig,
+  KinesisClient,
+} from 'https://jslib.k6.io/aws/{{< param "JSLIB_AWS_VERSION" >}}/kinesis.js';
+
+const awsConfig = new AWSConfig({
+  region: __ENV.AWS_REGION,
+  accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+  secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+});
+
+const kinesis = new KinesisClient(awsConfig);
+
+export default async function () {
+  const streamName = 'my-test-stream';
+
+  // Create records to put into the stream
+  const records = [
+    {
+      data: JSON.stringify({
+        message: 'Hello from k6!',
+        timestamp: Date.now(),
+        userId: 'user123',
+      }),
+      partitionKey: 'user123',
+    },
+    {
+      data: JSON.stringify({
+        message: 'Another message',
+        timestamp: Date.now(),
+        userId: 'user456',
+      }),
+      partitionKey: 'user456',
+    },
+    {
+      data: JSON.stringify({
+        message: 'Load test data',
+        timestamp: Date.now(),
+        userId: 'user789',
+      }),
+      partitionKey: 'user789',
+      explicitHashKey: '123456789012345678901234567890123456789',
+    },
+  ];
+
+  // Put records into the stream
+  const result = await kinesis.putRecords(streamName, records);
+
+  console.log('Put records result:');
+  console.log('Failed record count:', result.failedRecordCount);
+
+  // Check individual record results
+  result.records.forEach((record, index) => {
+    if (record.errorCode) {
+      console.log(`Record ${index} failed: ${record.errorCode} - ${record.errorMessage}`);
+    } else {
+      console.log(
+        `Record ${index} succeeded: sequence=${record.sequenceNumber}, shard=${record.shardId}`
+      );
+    }
+  });
+}
+```
+
+{{< /code >}}

--- a/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/putRecords.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/KinesisClient/putRecords.md
@@ -52,6 +52,8 @@ Each record in the `records` array should be an object with the following proper
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/KinesisClient/_index.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/KinesisClient/_index.md
@@ -1,0 +1,139 @@
+---
+title: 'KinesisClient'
+description: 'KinesisClient allows interacting with AWS Kinesis streams'
+weight: 00
+---
+
+# KinesisClient
+
+{{< docs/shared source="k6" lookup="blocking-aws-blockquote.md" version="<K6_VERSION>" >}}
+
+`KinesisClient` interacts with the AWS Kinesis service.
+
+With it, you can perform operations such as creating streams, putting records, listing streams, and reading records from streams. For a full list of supported operations, see [Methods](#methods).
+
+Both the dedicated `kinesis.js` jslib bundle and the all-encompassing `aws.js` bundle include the `KinesisClient`.
+
+### Methods
+
+| Function                                                                                                                                                                | Description                                            |
+| :---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------- |
+| [createStream(streamName, [options])](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/aws/kinesisclient/createstream)                                     | Create a new Kinesis stream                            |
+| [deleteStream(streamName)](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/aws/kinesisclient/deletestream)                                                | Delete a Kinesis stream                                |
+| [listStreams([options])](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/aws/kinesisclient/liststreams)                                                   | List available Kinesis streams                         |
+| [putRecords(streamName, records)](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/aws/kinesisclient/putrecords)                                           | Put multiple records into a Kinesis stream             |
+| [getRecords(shardIterator, [options])](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/aws/kinesisclient/getrecords)                                      | Get records from a Kinesis stream shard                |
+| [listShards(streamName, [options])](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/aws/kinesisclient/listshards)                                         | List shards in a Kinesis stream                        |
+| [getShardIterator(streamName, shardId, shardIteratorType, [options])](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jslib/aws/kinesisclient/getsharditerator) | Get a shard iterator for reading records from a stream |
+
+### Throws
+
+KinesisClient methods will throw errors in case of failure.
+
+| Error                 | Condition                                                  |
+| :-------------------- | :--------------------------------------------------------- |
+| InvalidSignatureError | When invalid credentials are provided.                     |
+| KinesisServiceError   | When AWS replies to the requested operation with an error. |
+
+### Examples
+
+<!-- md-k6:skip -->
+
+```javascript
+import { check } from 'k6';
+import exec from 'k6/execution';
+
+import {
+  AWSConfig,
+  KinesisClient,
+} from 'https://jslib.k6.io/aws/{{< param "JSLIB_AWS_VERSION" >}}/kinesis.js';
+
+const awsConfig = new AWSConfig({
+  region: __ENV.AWS_REGION,
+  accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+  secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+});
+
+const kinesis = new KinesisClient(awsConfig);
+const testStreamName = 'test-stream';
+
+export default async function () {
+  // List available streams
+  const streams = await kinesis.listStreams();
+  console.log('Available streams:', streams.streamNames);
+
+  // Check if our test stream exists
+  if (!streams.streamNames.includes(testStreamName)) {
+    // Create the stream if it doesn't exist
+    await kinesis.createStream(testStreamName, { shardCount: 1 });
+    console.log(`Created stream: ${testStreamName}`);
+  }
+
+  // Put some records into the stream
+  const records = [
+    {
+      data: JSON.stringify({ message: 'Hello from k6!', timestamp: Date.now() }),
+      partitionKey: 'test-partition-1',
+    },
+    {
+      data: JSON.stringify({ message: 'Another message', timestamp: Date.now() }),
+      partitionKey: 'test-partition-2',
+    },
+  ];
+
+  const putResult = await kinesis.putRecords(testStreamName, records);
+  console.log('Put records result:', putResult);
+
+  // List shards in the stream
+  const shards = await kinesis.listShards(testStreamName);
+  console.log('Stream shards:', shards.shards);
+
+  // Get a shard iterator for reading records
+  if (shards.shards.length > 0) {
+    const shardId = shards.shards[0].shardId;
+    const shardIterator = await kinesis.getShardIterator(testStreamName, shardId, 'TRIM_HORIZON');
+
+    // Get records from the shard
+    const getResult = await kinesis.getRecords(shardIterator.shardIterator);
+    console.log('Retrieved records:', getResult.records);
+  }
+}
+```
+
+#### Stream management
+
+<!-- md-k6:skip -->
+
+```javascript
+import {
+  AWSConfig,
+  KinesisClient,
+} from 'https://jslib.k6.io/aws/{{< param "JSLIB_AWS_VERSION" >}}/kinesis.js';
+
+const awsConfig = new AWSConfig({
+  region: __ENV.AWS_REGION,
+  accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+  secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+});
+
+const kinesis = new KinesisClient(awsConfig);
+
+export default async function () {
+  const streamName = 'my-test-stream';
+
+  // Create a stream with on-demand billing
+  await kinesis.createStream(streamName, {
+    streamModeDetails: {
+      streamMode: 'ON_DEMAND',
+    },
+  });
+
+  // List all streams
+  const streams = await kinesis.listStreams();
+  console.log('All streams:', streams.streamNames);
+
+  // Clean up - delete the stream
+  await kinesis.deleteStream(streamName);
+  console.log(`Deleted stream: ${streamName}`);
+}
+```

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/KinesisClient/createStream.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/KinesisClient/createStream.md
@@ -1,0 +1,63 @@
+---
+title: 'createStream'
+description: 'KinesisClient.createStream creates a new Kinesis stream'
+weight: 10
+---
+
+# createStream
+
+`KinesisClient.createStream(streamName, [options])` creates a new Kinesis stream.
+
+### Parameters
+
+| Parameter  | Type   | Description                                     |
+| :--------- | :----- | :---------------------------------------------- |
+| streamName | string | The name of the Kinesis stream to create.       |
+| options    | object | Optional configuration for the stream creation. |
+
+#### Options
+
+| Parameter                    | Type   | Description                                                           |
+| :--------------------------- | :----- | :-------------------------------------------------------------------- |
+| shardCount                   | number | The number of shards for the stream (for provisioned mode).           |
+| streamModeDetails            | object | Configuration for the stream mode.                                    |
+| streamModeDetails.streamMode | string | The billing mode for the stream. Either `PROVISIONED` or `ON_DEMAND`. |
+
+### Returns
+
+| Type            | Description                                                           |
+| :-------------- | :-------------------------------------------------------------------- |
+| `Promise<void>` | A Promise that fulfills when the stream creation request is complete. |
+
+### Example
+
+<!-- md-k6:skip -->
+
+```javascript
+import {
+  AWSConfig,
+  KinesisClient,
+} from 'https://jslib.k6.io/aws/{{< param "JSLIB_AWS_VERSION" >}}/kinesis.js';
+
+const awsConfig = new AWSConfig({
+  region: __ENV.AWS_REGION,
+  accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+  secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+});
+
+const kinesis = new KinesisClient(awsConfig);
+
+export default async function () {
+  // Create a stream with provisioned billing and 2 shards
+  await kinesis.createStream('my-provisioned-stream', {
+    shardCount: 2,
+  });
+
+  // Create a stream with on-demand billing
+  await kinesis.createStream('my-on-demand-stream', {
+    streamModeDetails: {
+      streamMode: 'ON_DEMAND',
+    },
+  });
+}
+```

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/KinesisClient/deleteStream.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/KinesisClient/deleteStream.md
@@ -1,0 +1,48 @@
+---
+title: 'deleteStream'
+description: 'KinesisClient.deleteStream deletes a Kinesis stream'
+weight: 10
+---
+
+# deleteStream
+
+`KinesisClient.deleteStream(streamName)` deletes a Kinesis stream.
+
+### Parameters
+
+| Parameter  | Type   | Description                               |
+| :--------- | :----- | :---------------------------------------- |
+| streamName | string | The name of the Kinesis stream to delete. |
+
+### Returns
+
+| Type            | Description                                                           |
+| :-------------- | :-------------------------------------------------------------------- |
+| `Promise<void>` | A Promise that fulfills when the stream deletion request is complete. |
+
+### Example
+
+<!-- md-k6:skip -->
+
+```javascript
+import {
+  AWSConfig,
+  KinesisClient,
+} from 'https://jslib.k6.io/aws/{{< param "JSLIB_AWS_VERSION" >}}/kinesis.js';
+
+const awsConfig = new AWSConfig({
+  region: __ENV.AWS_REGION,
+  accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+  secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+});
+
+const kinesis = new KinesisClient(awsConfig);
+
+export default async function () {
+  const streamName = 'my-test-stream';
+
+  // Delete the stream
+  await kinesis.deleteStream(streamName);
+  console.log(`Stream ${streamName} deleted`);
+}
+```

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/KinesisClient/getRecords.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/KinesisClient/getRecords.md
@@ -1,0 +1,113 @@
+---
+title: 'getRecords'
+description: 'KinesisClient.getRecords gets records from a Kinesis stream shard'
+weight: 10
+---
+
+# getRecords
+
+`KinesisClient.getRecords(shardIterator, [options])` gets records from a Kinesis stream shard using a shard iterator.
+
+### Parameters
+
+| Parameter     | Type   | Description                                           |
+| :------------ | :----- | :---------------------------------------------------- |
+| shardIterator | string | The shard iterator from which to get records.         |
+| options       | object | Optional configuration for the get records operation. |
+
+#### Options
+
+| Parameter | Type   | Description                              |
+| :-------- | :----- | :--------------------------------------- |
+| limit     | number | The maximum number of records to return. |
+
+### Returns
+
+| Type              | Description                                        |
+| :---------------- | :------------------------------------------------- |
+| `Promise<Object>` | A Promise that fulfills with the records response. |
+
+#### Returns object
+
+| Property           | Type          | Description                                          |
+| :----------------- | :------------ | :--------------------------------------------------- |
+| records            | Array<Object> | An array of records retrieved from the stream.       |
+| nextShardIterator  | string        | The next shard iterator to use for subsequent calls. |
+| millisBehindLatest | number        | The number of milliseconds behind the latest record. |
+
+#### Record object
+
+| Property                    | Type   | Description                                      |
+| :-------------------------- | :----- | :----------------------------------------------- |
+| sequenceNumber              | string | The sequence number of the record.               |
+| approximateArrivalTimestamp | Date   | The approximate arrival timestamp of the record. |
+| data                        | string | The data payload of the record.                  |
+| partitionKey                | string | The partition key of the record.                 |
+
+### Example
+
+<!-- md-k6:skip -->
+
+```javascript
+import {
+  AWSConfig,
+  KinesisClient,
+} from 'https://jslib.k6.io/aws/{{< param "JSLIB_AWS_VERSION" >}}/kinesis.js';
+
+const awsConfig = new AWSConfig({
+  region: __ENV.AWS_REGION,
+  accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+  secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+});
+
+const kinesis = new KinesisClient(awsConfig);
+
+export default async function () {
+  const streamName = 'my-test-stream';
+
+  // First, get the shards for the stream
+  const shards = await kinesis.listShards(streamName);
+
+  if (shards.shards.length > 0) {
+    const shardId = shards.shards[0].shardId;
+
+    // Get a shard iterator for the first shard
+    const shardIteratorResponse = await kinesis.getShardIterator(
+      streamName,
+      shardId,
+      'TRIM_HORIZON'
+    );
+
+    const shardIterator = shardIteratorResponse.shardIterator;
+
+    // Get records from the shard
+    const recordsResponse = await kinesis.getRecords(shardIterator, { limit: 10 });
+
+    console.log('Records retrieved:', recordsResponse.records.length);
+    console.log('Milliseconds behind latest:', recordsResponse.millisBehindLatest);
+
+    // Process the records
+    recordsResponse.records.forEach((record, index) => {
+      console.log(`Record ${index}:`);
+      console.log('  Sequence number:', record.sequenceNumber);
+      console.log('  Partition key:', record.partitionKey);
+      console.log('  Data:', record.data);
+      console.log('  Arrival timestamp:', record.approximateArrivalTimestamp);
+
+      // Parse JSON data if applicable
+      try {
+        const jsonData = JSON.parse(record.data);
+        console.log('  Parsed data:', jsonData);
+      } catch (e) {
+        console.log('  Data is not JSON');
+      }
+    });
+
+    // Continue reading with the next shard iterator
+    if (recordsResponse.nextShardIterator) {
+      const nextBatch = await kinesis.getRecords(recordsResponse.nextShardIterator, { limit: 5 });
+      console.log('Next batch size:', nextBatch.records.length);
+    }
+  }
+}
+```

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/KinesisClient/getShardIterator.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/KinesisClient/getShardIterator.md
@@ -1,0 +1,109 @@
+---
+title: 'getShardIterator'
+description: 'KinesisClient.getShardIterator gets a shard iterator for reading records from a Kinesis stream'
+weight: 10
+---
+
+# getShardIterator
+
+`KinesisClient.getShardIterator(streamName, shardId, shardIteratorType, [options])` gets a shard iterator for reading records from a Kinesis stream shard.
+
+### Parameters
+
+| Parameter         | Type   | Description                                    |
+| :---------------- | :----- | :--------------------------------------------- |
+| streamName        | string | The name of the Kinesis stream.                |
+| shardId           | string | The shard ID for which to get the iterator.    |
+| shardIteratorType | string | The type of shard iterator to get.             |
+| options           | object | Optional configuration for the shard iterator. |
+
+#### Shard Iterator Types
+
+| Type                  | Description                                                                   |
+| :-------------------- | :---------------------------------------------------------------------------- |
+| TRIM_HORIZON          | Start reading at the last untrimmed record in the shard.                      |
+| LATEST                | Start reading just after the most recent record in the shard.                 |
+| AT_SEQUENCE_NUMBER    | Start reading from the position denoted by a specific sequence number.        |
+| AFTER_SEQUENCE_NUMBER | Start reading right after the position denoted by a specific sequence number. |
+| AT_TIMESTAMP          | Start reading from the position denoted by a specific timestamp.              |
+
+#### Options
+
+| Parameter              | Type   | Description                                                                                              |
+| :--------------------- | :----- | :------------------------------------------------------------------------------------------------------- |
+| startingSequenceNumber | string | The sequence number to start from (required for `AT_SEQUENCE_NUMBER` and `AFTER_SEQUENCE_NUMBER` types). |
+| timestamp              | Date   | The timestamp to start from (required for `AT_TIMESTAMP` type).                                          |
+
+### Returns
+
+| Type              | Description                                               |
+| :---------------- | :-------------------------------------------------------- |
+| `Promise<Object>` | A Promise that fulfills with the shard iterator response. |
+
+#### Returns object
+
+| Property      | Type   | Description                                    |
+| :------------ | :----- | :--------------------------------------------- |
+| shardIterator | string | The shard iterator to use for reading records. |
+
+### Example
+
+<!-- md-k6:skip -->
+
+```javascript
+import {
+  AWSConfig,
+  KinesisClient,
+} from 'https://jslib.k6.io/aws/{{< param "JSLIB_AWS_VERSION" >}}/kinesis.js';
+
+const awsConfig = new AWSConfig({
+  region: __ENV.AWS_REGION,
+  accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+  secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+});
+
+const kinesis = new KinesisClient(awsConfig);
+
+export default async function () {
+  const streamName = 'my-test-stream';
+
+  // First, get the shards for the stream
+  const shards = await kinesis.listShards(streamName);
+
+  if (shards.shards.length > 0) {
+    const shardId = shards.shards[0].shardId;
+
+    // Get a shard iterator starting from the beginning
+    const trimHorizonIterator = await kinesis.getShardIterator(streamName, shardId, 'TRIM_HORIZON');
+    console.log('Trim horizon iterator:', trimHorizonIterator.shardIterator);
+
+    // Get a shard iterator starting from the latest records
+    const latestIterator = await kinesis.getShardIterator(streamName, shardId, 'LATEST');
+    console.log('Latest iterator:', latestIterator.shardIterator);
+
+    // Get a shard iterator starting from a specific timestamp
+    const timestampIterator = await kinesis.getShardIterator(streamName, shardId, 'AT_TIMESTAMP', {
+      timestamp: new Date(Date.now() - 3600000), // 1 hour ago
+    });
+    console.log('Timestamp iterator:', timestampIterator.shardIterator);
+
+    // Use the iterator to read records
+    const records = await kinesis.getRecords(trimHorizonIterator.shardIterator);
+    console.log('Records retrieved:', records.records.length);
+
+    // If we have records, we can get an iterator starting after a specific sequence number
+    if (records.records.length > 0) {
+      const sequenceNumber = records.records[0].sequenceNumber;
+      const afterSequenceIterator = await kinesis.getShardIterator(
+        streamName,
+        shardId,
+        'AFTER_SEQUENCE_NUMBER',
+        {
+          startingSequenceNumber: sequenceNumber,
+        }
+      );
+      console.log('After sequence iterator:', afterSequenceIterator.shardIterator);
+    }
+  }
+}
+```

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/KinesisClient/listShards.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/KinesisClient/listShards.md
@@ -1,0 +1,97 @@
+---
+title: 'listShards'
+description: 'KinesisClient.listShards lists shards in a Kinesis stream'
+weight: 10
+---
+
+# listShards
+
+`KinesisClient.listShards(streamName, [options])` lists the shards in a Kinesis stream.
+
+### Parameters
+
+| Parameter  | Type   | Description                                           |
+| :--------- | :----- | :---------------------------------------------------- |
+| streamName | string | The name of the Kinesis stream.                       |
+| options    | object | Optional configuration for the list shards operation. |
+
+#### Options
+
+| Parameter             | Type   | Description                                     |
+| :-------------------- | :----- | :---------------------------------------------- |
+| nextToken             | string | The token to use for pagination.                |
+| exclusiveStartShardId | string | The shard ID to start listing from (exclusive). |
+| maxResults            | number | The maximum number of shards to return.         |
+
+### Returns
+
+| Type              | Description                                      |
+| :---------------- | :----------------------------------------------- |
+| `Promise<Object>` | A Promise that fulfills with the list of shards. |
+
+#### Returns object
+
+| Property  | Type          | Description                                    |
+| :-------- | :------------ | :--------------------------------------------- |
+| shards    | Array<Object> | An array of shard objects.                     |
+| nextToken | string        | The token to use for the next page of results. |
+
+#### Shard object
+
+| Property              | Type              | Description                                         |
+| :-------------------- | :---------------- | :-------------------------------------------------- |
+| shardId               | string            | The unique identifier of the shard.                 |
+| parentShardId         | string (optional) | The shard ID of the parent shard (if any).          |
+| adjacentParentShardId | string (optional) | The shard ID of the adjacent parent shard (if any). |
+| hashKeyRange          | Object            | The hash key range for the shard.                   |
+| sequenceNumberRange   | Object            | The sequence number range for the shard.            |
+
+### Example
+
+<!-- md-k6:skip -->
+
+```javascript
+import {
+  AWSConfig,
+  KinesisClient,
+} from 'https://jslib.k6.io/aws/{{< param "JSLIB_AWS_VERSION" >}}/kinesis.js';
+
+const awsConfig = new AWSConfig({
+  region: __ENV.AWS_REGION,
+  accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+  secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+});
+
+const kinesis = new KinesisClient(awsConfig);
+
+export default async function () {
+  const streamName = 'my-test-stream';
+
+  // List all shards in the stream
+  const shardsResponse = await kinesis.listShards(streamName);
+
+  console.log('Number of shards:', shardsResponse.shards.length);
+
+  // Display information about each shard
+  shardsResponse.shards.forEach((shard, index) => {
+    console.log(`Shard ${index}:`);
+    console.log('  Shard ID:', shard.shardId);
+    console.log('  Parent Shard ID:', shard.parentShardId || 'None');
+    console.log('  Adjacent Parent Shard ID:', shard.adjacentParentShardId || 'None');
+    console.log('  Hash Key Range:', shard.hashKeyRange);
+    console.log('  Sequence Number Range:', shard.sequenceNumberRange);
+  });
+
+  // List shards with pagination
+  const limitedShards = await kinesis.listShards(streamName, { maxResults: 2 });
+  console.log('Limited shards:', limitedShards.shards.length);
+
+  // Continue pagination if there are more shards
+  if (limitedShards.nextToken) {
+    const nextPage = await kinesis.listShards(streamName, {
+      nextToken: limitedShards.nextToken,
+    });
+    console.log('Next page shards:', nextPage.shards.length);
+  }
+}
+```

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/KinesisClient/listStreams.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/KinesisClient/listStreams.md
@@ -1,0 +1,73 @@
+---
+title: 'listStreams'
+description: 'KinesisClient.listStreams lists Kinesis streams'
+weight: 10
+---
+
+# listStreams
+
+`KinesisClient.listStreams([options])` lists the Kinesis streams in the current region.
+
+### Parameters
+
+| Parameter | Type              | Description                              |
+| :-------- | :---------------- | :--------------------------------------- |
+| options   | object (optional) | Configuration for the listing operation. |
+
+#### Options
+
+| Parameter                | Type   | Description                                               |
+| :----------------------- | :----- | :-------------------------------------------------------- |
+| exclusiveStartStreamName | string | The name of the stream to start listing from (exclusive). |
+| limit                    | number | The maximum number of streams to return.                  |
+
+### Returns
+
+| Type              | Description                                       |
+| :---------------- | :------------------------------------------------ |
+| `Promise<Object>` | A Promise that fulfills with the list of streams. |
+
+#### Returns object
+
+| Property       | Type          | Description                                  |
+| :------------- | :------------ | :------------------------------------------- |
+| streamNames    | Array<string> | An array of stream names.                    |
+| hasMoreStreams | boolean       | Indicates if there are more streams to list. |
+
+### Example
+
+<!-- md-k6:skip -->
+
+```javascript
+import {
+  AWSConfig,
+  KinesisClient,
+} from 'https://jslib.k6.io/aws/{{< param "JSLIB_AWS_VERSION" >}}/kinesis.js';
+
+const awsConfig = new AWSConfig({
+  region: __ENV.AWS_REGION,
+  accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+  secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+});
+
+const kinesis = new KinesisClient(awsConfig);
+
+export default async function () {
+  // List all streams
+  const streams = await kinesis.listStreams();
+  console.log('Available streams:', streams.streamNames);
+  console.log('Has more streams:', streams.hasMoreStreams);
+
+  // List streams with pagination
+  const limitedStreams = await kinesis.listStreams({ limit: 5 });
+  console.log('First 5 streams:', limitedStreams.streamNames);
+
+  // List streams starting from a specific stream
+  if (limitedStreams.hasMoreStreams && limitedStreams.streamNames.length > 0) {
+    const nextBatch = await kinesis.listStreams({
+      exclusiveStartStreamName: limitedStreams.streamNames[limitedStreams.streamNames.length - 1],
+    });
+    console.log('Next batch of streams:', nextBatch.streamNames);
+  }
+}
+```

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/KinesisClient/putRecords.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/KinesisClient/putRecords.md
@@ -1,0 +1,117 @@
+---
+title: 'putRecords'
+description: 'KinesisClient.putRecords puts multiple records into a Kinesis stream'
+weight: 10
+---
+
+# putRecords
+
+`KinesisClient.putRecords(streamName, records)` puts multiple records into a Kinesis stream.
+
+### Parameters
+
+| Parameter  | Type          | Description                                         |
+| :--------- | :------------ | :-------------------------------------------------- |
+| streamName | string        | The name of the Kinesis stream to put records into. |
+| records    | Array<Object> | An array of records to put into the stream.         |
+
+#### Records
+
+Each record in the `records` array should be an object with the following properties:
+
+| Property        | Type   | Description                                     |
+| :-------------- | :----- | :---------------------------------------------- |
+| data            | string | The data payload of the record.                 |
+| partitionKey    | string | The partition key for the record.               |
+| explicitHashKey | string | Optional. The explicit hash key for the record. |
+
+### Returns
+
+| Type              | Description                                            |
+| :---------------- | :----------------------------------------------------- |
+| `Promise<Object>` | A Promise that fulfills with the put records response. |
+
+#### Returns object
+
+| Property          | Type          | Description                                  |
+| :---------------- | :------------ | :------------------------------------------- |
+| failedRecordCount | number        | The number of records that failed to be put. |
+| records           | Array<Object> | An array of record results.                  |
+
+#### Record result object
+
+| Property       | Type   | Description                                               |
+| :------------- | :----- | :-------------------------------------------------------- |
+| sequenceNumber | string | The sequence number of the record (if successful).        |
+| shardId        | string | The shard ID where the record was placed (if successful). |
+| errorCode      | string | The error code (if the record failed).                    |
+| errorMessage   | string | The error message (if the record failed).                 |
+
+### Example
+
+<!-- md-k6:skip -->
+
+```javascript
+import {
+  AWSConfig,
+  KinesisClient,
+} from 'https://jslib.k6.io/aws/{{< param "JSLIB_AWS_VERSION" >}}/kinesis.js';
+
+const awsConfig = new AWSConfig({
+  region: __ENV.AWS_REGION,
+  accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+  secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+});
+
+const kinesis = new KinesisClient(awsConfig);
+
+export default async function () {
+  const streamName = 'my-test-stream';
+
+  // Create records to put into the stream
+  const records = [
+    {
+      data: JSON.stringify({
+        message: 'Hello from k6!',
+        timestamp: Date.now(),
+        userId: 'user123',
+      }),
+      partitionKey: 'user123',
+    },
+    {
+      data: JSON.stringify({
+        message: 'Another message',
+        timestamp: Date.now(),
+        userId: 'user456',
+      }),
+      partitionKey: 'user456',
+    },
+    {
+      data: JSON.stringify({
+        message: 'Load test data',
+        timestamp: Date.now(),
+        userId: 'user789',
+      }),
+      partitionKey: 'user789',
+      explicitHashKey: '123456789012345678901234567890123456789',
+    },
+  ];
+
+  // Put records into the stream
+  const result = await kinesis.putRecords(streamName, records);
+
+  console.log('Put records result:');
+  console.log('Failed record count:', result.failedRecordCount);
+
+  // Check individual record results
+  result.records.forEach((record, index) => {
+    if (record.errorCode) {
+      console.log(`Record ${index} failed: ${record.errorCode} - ${record.errorMessage}`);
+    } else {
+      console.log(
+        `Record ${index} succeeded: sequence=${record.sequenceNumber}, shard=${record.shardId}`
+      );
+    }
+  });
+}
+```


### PR DESCRIPTION
## What?

Add comprehensive documentation for KinesisClient including all methods:
- createStream, deleteStream, listStreams
- putRecords, getRecords, listShards, getShardIterator
- Include examples for stream management and record operations
- Add KinesisClient to AWS services index


## Checklist

<!-- Please fill in this template: -->
- [X] I have used a meaningful title for the PR.
- [X] I have described the changes I've made in the "What?" section above.
- [X] I have performed a self-review of my changes.
- [X] I have run the `npm start` command locally and verified that the changes look good.
- [X] I have made my changes in the `docs/sources/k6/next` folder of the documentation.

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->
<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->