### PR TITLE
k6 browser: remove selectOption known issues

### DIFF
--- a/docs/sources/k6/v1.1.x/javascript-api/k6-browser/locator/selectoption.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/k6-browser/locator/selectoption.md
@@ -5,13 +5,6 @@ description: 'Browser module: locator.selectOption method'
 
 # selectOption(values, [options])
 
-{{< admonition type="caution" >}}
-
-This feature has **known issues**. For details, refer to
-[#470](https://github.com/grafana/xk6-browser/issues/470) and [#471](https://github.com/grafana/xk6-browser/issues/471).
-
-{{< /admonition >}}
-
 Select one or more options which match the values.
 
 <TableWithNestedRows>


### PR DESCRIPTION
## What?
Update selectOption documentatio to remove "known issues" as https://github.com/grafana/k6/issues/4430 and https://github.com/grafana/k6/issues/4429 concerns another function and is [already documented in this function](https://github.com/grafana/k6-docs/blob/main/docs/sources/k6/next/javascript-api/k6-browser/locator/tap.md?plain=1#L11).

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.
- [x] I have reflected my changes in the `docs/sources/k6/v{most_recent_release}` folder of the documentation.

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->
<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->