### PR TITLE
Fix typo in Operator troubleshooting

### DIFF
--- a/docs/sources/k6/next/set-up/set-up-distributed-k6/troubleshooting.md
+++ b/docs/sources/k6/next/set-up/set-up-distributed-k6/troubleshooting.md
@@ -52,7 +52,7 @@ That command is a shortened version of what the initializer Pod is executing. If
 If the standalone `k6 inspect --execution-requirements` executes successfully, then it's likely a problem with `TestRun` deployment specific to your Kubernetes setup. A couple of recommendations here are:
 
 - Review the output of the initializer Pod: is it logged by the k6 process or by something else?
-  - :information_source: k6 Operator expects the initializer logs to contain only the output of `k6 inspect`. If there are any other log lines present, then the k6 Operator will fail to parse it and the test won't start. Refer to this [issue](https://github.com/grafana/k6-operator/issues/193) for more details.
+  - k6 Operator expects the initializer logs to contain only the output of `k6 inspect`. If there are any other log lines present, then the k6 Operator will fail to parse it and the test won't start. Refer to this [issue](https://github.com/grafana/k6-operator/issues/193) for more details.
 - Check events in the initializer Job and Pod as they may contain another hint about what's wrong.
 
 {{< docs/shared source="k6" lookup="k6-operator/troubleshooting-common-scenarios.md" version="<K6_VERSION>" >}}

--- a/docs/sources/k6/v1.0.x/set-up/set-up-distributed-k6/troubleshooting.md
+++ b/docs/sources/k6/v1.0.x/set-up/set-up-distributed-k6/troubleshooting.md
@@ -48,7 +48,7 @@ That command is a shortened version of what the initializer Pod is executing. If
 If the standalone `k6 inspect --execution-requirements` executes successfully, then it's likely a problem with `TestRun` deployment specific to your Kubernetes setup. A couple of recommendations here are:
 
 - Review the output of the initializer Pod: is it logged by the k6 process or by something else?
-  - :information_source: k6 Operator expects the initializer logs to contain only the output of `k6 inspect`. If there are any other log lines present, then the k6 Operator will fail to parse it and the test won't start. Refer to this [issue](https://github.com/grafana/k6-operator/issues/193) for more details.
+  - k6 Operator expects the initializer logs to contain only the output of `k6 inspect`. If there are any other log lines present, then the k6 Operator will fail to parse it and the test won't start. Refer to this [issue](https://github.com/grafana/k6-operator/issues/193) for more details.
 - Check events in the initializer Job and Pod as they may contain another hint about what's wrong.
 
 {{< docs/shared source="k6" lookup="k6-operator/troubleshooting-common-scenarios.md" version="<K6_VERSION>" >}}

--- a/docs/sources/k6/v1.1.x/set-up/set-up-distributed-k6/troubleshooting.md
+++ b/docs/sources/k6/v1.1.x/set-up/set-up-distributed-k6/troubleshooting.md
@@ -52,7 +52,7 @@ That command is a shortened version of what the initializer Pod is executing. If
 If the standalone `k6 inspect --execution-requirements` executes successfully, then it's likely a problem with `TestRun` deployment specific to your Kubernetes setup. A couple of recommendations here are:
 
 - Review the output of the initializer Pod: is it logged by the k6 process or by something else?
-  - :information_source: k6 Operator expects the initializer logs to contain only the output of `k6 inspect`. If there are any other log lines present, then the k6 Operator will fail to parse it and the test won't start. Refer to this [issue](https://github.com/grafana/k6-operator/issues/193) for more details.
+  - k6 Operator expects the initializer logs to contain only the output of `k6 inspect`. If there are any other log lines present, then the k6 Operator will fail to parse it and the test won't start. Refer to this [issue](https://github.com/grafana/k6-operator/issues/193) for more details.
 - Check events in the initializer Job and Pod as they may contain another hint about what's wrong.
 
 {{< docs/shared source="k6" lookup="k6-operator/troubleshooting-common-scenarios.md" version="<K6_VERSION>" >}}


### PR DESCRIPTION
## What?

Remove small typo in the Operator troubleshooting page.

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [x] I have made my changes in the `docs/sources/k6/next` folder of the documentation.
- [x] I have reflected my changes in the `docs/sources/k6/v{most_recent_release}` folder of the documentation.
- [x] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->