### PR TITLE
refactor: remove jslib/aws head_title frontmatter entries

### DIFF
--- a/docs/sources/k6/next/javascript-api/jslib/aws/EventBridgeClient/_index.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/EventBridgeClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'EventBridgeClient'
-head_title: 'EventBridgeClient'
 description: 'EventBridgeClient allows interacting with AWS EventBridge service'
 description: 'EventBridgeClient class allows sending custom events to Amazon EventBridge so that they can be matched to rules.'
 weight: 00

--- a/docs/sources/k6/next/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
@@ -1,7 +1,5 @@
 ---
 title: 'putEvents'
-head_title: 'EventBridgeClient.putEvents'
-description: 'EventBridgeClient.putEvents sends custom events to Amazon EventBridge'
 description: 'EventBridgeClient.putEvents sends custom events to Amazon EventBridge'
 weight: 10
 ---

--- a/docs/sources/k6/next/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
@@ -1,7 +1,6 @@
 ---
 title: 'KMSDataKey'
 slug: 'kmsdatakey'
-head_title: 'KMSDataKey'
 description: 'KMSDataKey is returned by the KMSClient.*DataKey methods that query KMS data keys'
 weight: 20
 ---

--- a/docs/sources/k6/next/javascript-api/jslib/aws/KMSClient/KMSKey.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/KMSClient/KMSKey.md
@@ -1,7 +1,5 @@
 ---
 title: 'KMSKey'
-head_title: 'KMSKey'
-description: 'KMSKey is returned by the KMSClient.* methods that query KMS keys'
 description: 'KMSKey is returned by the KMSClient.* methods that query KMS keys'
 weight: 20
 ---

--- a/docs/sources/k6/next/javascript-api/jslib/aws/KMSClient/_index.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/KMSClient/_index.md
@@ -1,7 +1,5 @@
 ---
 title: 'KMSClient'
-head_title: 'KMSClient'
-description: 'KMSClient allows interacting with the AWS Key Management Service'
 description: 'KMSClient allows interacting with the AWS Key Management Service'
 weight: 00
 ---

--- a/docs/sources/k6/next/javascript-api/jslib/aws/KMSClient/listKeys.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/KMSClient/listKeys.md
@@ -1,7 +1,5 @@
 ---
 title: 'listKeys'
-head_title: 'KMSClient.listKeys()'
-description: "KMSClient.listKeys lists all the KMS keys in the caller's AWS account and region"
 description: "KMSClient.listKeys lists all the KMS keys in the caller's AWS account and region"
 weight: 10
 ---

--- a/docs/sources/k6/next/javascript-api/jslib/aws/LambdaClient/_index.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/LambdaClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'LambdaClient'
-head_title: 'LambdaClient'
 description: 'LambdaClient allows interacting with the AWS Lambda service'
 weight: 00
 ---

--- a/docs/sources/k6/next/javascript-api/jslib/aws/LambdaClient/invoke.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/LambdaClient/invoke.md
@@ -1,6 +1,5 @@
 ---
 title: 'invoke'
-head_title: 'LambdaClient.invoke(name, payload, [options])'
 description: 'LambdaClient.invoke invokes an AWS Lamba function'
 weight: 10
 ---

--- a/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/Bucket.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/Bucket.md
@@ -1,6 +1,5 @@
 ---
 title: 'Bucket'
-head_title: 'Bucket'
 description: 'Bucket is returned by the S3Client.* methods who query S3 buckets.'
 weight: 20
 ---

--- a/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/Object.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/Object.md
@@ -1,6 +1,5 @@
 ---
 title: 'Object'
-head_title: 'Object'
 description: "Object is returned by the S3Client.* methods who query S3 buckets' objects."
 weight: 20
 ---

--- a/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/S3Part.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/S3Part.md
@@ -1,6 +1,5 @@
 ---
 title: 'S3Part'
-head_title: 'S3Part'
 slug: 's3part'
 description: 'S3Part is returned by the S3Client.uploadPart method when uploading a part to a multipart upload.'
 weight: 20

--- a/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/S3UploadedObject.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/S3UploadedObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'S3UploadedObject'
-head_title: 'S3UploadedObject'
 description: 'S3UploadedObject represents the response from S3 upload operations'
 weight: 20
 ---

--- a/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/_index.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'S3Client'
-head_title: 'S3Client'
 description: 'S3Client allows interacting with AWS S3 buckets and objects'
 description: 'S3Client class allows interacting with AWS S3 buckets and objects'
 weight: 00

--- a/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
@@ -1,6 +1,5 @@
 ---
 title: 'abortMultipartUpload'
-head_title: 'S3Client.abortMultipartUpload(bucketName, objectKey, uploadId)'
 description: 'S3Client.abortMultipartUpload aborts a multipart upload to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/completeMultipartUpload.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/completeMultipartUpload.md
@@ -1,6 +1,5 @@
 ---
 title: 'completeMultipartUpload'
-head_title: 'S3Client.completeMultipartUpload(bucketName, objectKey, uploadId, parts)'
 description: 'S3Client.completeMultipartUpload uploads a multipar object to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/copyObject.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/copyObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'copyObject'
-head_title: 'S3Client.copyObject'
 description: 'S3Client.copyObject copies an object from a bucket to another'
 weight: 10
 ---

--- a/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
@@ -1,6 +1,5 @@
 ---
 title: 'createMultipartUpload'
-head_title: 'S3Client.createMultipartUpload(bucketName, objectKey)'
 description: 'S3Client.createMultipartUpload creates a multipart upload for an object key to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/deleteObject.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/deleteObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'deleteObject'
-head_title: 'S3Client.deleteObject(bucketName, objectKey)'
 description: 'S3Client.deleteObject deletes an object from a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/getObject.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/getObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'getObject'
-head_title: 'S3Client.getObject(bucketName, objectKey)'
 description: 'S3Client.getObject downloads an object from a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/listBuckets.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/listBuckets.md
@@ -1,6 +1,5 @@
 ---
 title: 'listBuckets'
-head_title: 'S3Client.listBuckets()'
 description: 'S3Client.listBuckets lists the buckets the authenticated user has access to'
 weight: 10
 ---

--- a/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/listObjects.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/listObjects.md
@@ -1,6 +1,5 @@
 ---
 title: 'listObjects'
-head_title: 'S3Client.listObjects(bucketName, [prefix])'
 description: 'S3Client.listObjects lists the objects contained in a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/putObject.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/putObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'putObject'
-head_title: 'S3Client.putObject(bucketName, objectKey, data)'
 description: 'S3Client.putObject uploads an object to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/uploadPart.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/uploadPart.md
@@ -1,6 +1,5 @@
 ---
 title: 'uploadPart'
-head_title: 'S3Client.uploadPart(bucketName, objectKey, uploadId,partNumber, data)'
 description: 'S3Client.uploadPart a part in a multipart upload to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/next/javascript-api/jslib/aws/SQSClient/_index.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/SQSClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SQSClient'
-head_title: 'SQSClient'
 description: 'SQSClient enables interaction with the AWS Simple Queue Service (SQS)'
 description: 'SQSClient allows interacting with the AWS Simple Queue Service (SQS)'
 weight: 00

--- a/docs/sources/k6/next/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
@@ -1,6 +1,5 @@
 ---
 title: 'Secret'
-head_title: 'Secret'
 description: 'Secret is returned by the SecretsManagerClient.* methods who query secrets from AWS secrets manager.'
 weight: 20
 ---

--- a/docs/sources/k6/next/javascript-api/jslib/aws/SecretsManagerClient/_index.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/SecretsManagerClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SecretsManagerClient'
-head_title: 'SecretsManagerClient'
 description: 'SecretsManagerClient allows interacting with AWS secrets stored in Secrets Manager'
 weight: 00
 ---

--- a/docs/sources/k6/next/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
@@ -1,6 +1,5 @@
 ---
 title: 'createSecret'
-head_title: 'SecretsManagerClient.createSecret(name, secretString, description, [versionID], [tags])'
 description: 'SecretsManagerClient.createSecret creates a new secret'
 weight: 10
 ---

--- a/docs/sources/k6/next/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
@@ -1,6 +1,5 @@
 ---
 title: 'deleteSecret'
-head_title: 'SecretsManagerClient.deleteSecret(secretID, { recoveryWindow: 30, noRecovery: false}})'
 description: 'SecretsManagerClient.deleteSecret deletes a secret'
 weight: 10
 ---

--- a/docs/sources/k6/next/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
@@ -1,6 +1,5 @@
 ---
 title: 'getSecret'
-head_title: 'SecretsManagerClient.getSecret(secretID)'
 description: 'SecretsManagerClient.getSecret(secretID) downloads a secret from AWS secrets manager'
 weight: 10
 ---

--- a/docs/sources/k6/next/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
@@ -1,6 +1,5 @@
 ---
 title: 'listSecrets'
-head_title: 'SecretsManagerClient.listSecrets()'
 description: 'SecretsManagerClient.listSecrets lists the secrets the authenticated user has access to'
 weight: 10
 ---

--- a/docs/sources/k6/next/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
@@ -1,6 +1,5 @@
 ---
 title: 'putSecretValue'
-head_title: 'SecretsManagerClient.putSecretValue(secretID, secretString, [versionID], [tags])'
 description: "SecretsManagerClient.putSecretValue updates an existing secret's value"
 weight: 10
 ---

--- a/docs/sources/k6/next/javascript-api/jslib/aws/SignatureV4/_index.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/SignatureV4/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SignatureV4'
-head_title: 'SignatureV4'
 description: 'SignatureV4 is used to sign or pre-sign requests to AWS services using the Signature V4 algorithm'
 description: 'SignatureV4 is used to sign and pre-sign requests to AWS services using the Signature V4 algorithm'
 weight: 00

--- a/docs/sources/k6/next/javascript-api/jslib/aws/SignatureV4/presign.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/SignatureV4/presign.md
@@ -1,6 +1,5 @@
 ---
 title: 'presign'
-head_title: 'presign'
 slug: 'presign'
 description: 'Signaturev4.presign pre-signs a URL with the AWS Signature V4 algorithm'
 description: 'SignatureV4.sign pre-signs a URL with the AWS Signature V4 algorithm'

--- a/docs/sources/k6/next/javascript-api/jslib/aws/SignatureV4/sign.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/SignatureV4/sign.md
@@ -1,6 +1,5 @@
 ---
 title: 'sign'
-head_title: 'sign'
 slug: 'sign'
 description: 'Signaturev4.sign signs an HTTP request with the AWS Signature V4 algorithm'
 description: 'SignatureV4.sign signs an HTTP request with the AWS Signature V4 algorithm'

--- a/docs/sources/k6/next/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
@@ -1,6 +1,5 @@
 ---
 title: 'SystemsManagerParameter'
-head_title: 'SystemsManagerParameter'
 slug: 'systemsmanagerparameter'
 description: 'SystemsManagerParameter is returned by the SystemsManagerClient.* methods that query parameters'
 weight: 20

--- a/docs/sources/k6/next/javascript-api/jslib/aws/SystemsManagerClient/_index.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/SystemsManagerClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SystemsManagerClient'
-head_title: 'SystemsManagerClient'
 description: 'SystemsManagerClient allows interacting with the AWS Systems Manager Service'
 weight: 00
 ---

--- a/docs/sources/k6/next/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
@@ -1,6 +1,5 @@
 ---
 title: 'getParameter'
-head_title: 'SystemsManagerClient.getParameter()'
 description: "SystemsManagerClient.getParameter gets a Systems Manager parameter in the caller's AWS account and region"
 weight: 10
 ---

--- a/docs/sources/k6/next/javascript-api/jslib/aws/awsconfig.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/awsconfig.md
@@ -1,7 +1,5 @@
 ---
 title: 'AWSConfig'
-head_title: 'AWSConfig'
-description: 'AWSConfig is used to configure an AWS service client instances'
 description: 'AWSConfig is used to configure an AWS service client instances'
 weight: 00
 ---

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'EventBridgeClient'
-head_title: 'EventBridgeClient'
 description: 'EventBridgeClient allows interacting with AWS EventBridge service'
 description: 'EventBridgeClient class allows sending custom events to Amazon EventBridge so that they can be matched to rules.'
 weight: 00

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
@@ -1,7 +1,5 @@
 ---
 title: 'putEvents'
-head_title: 'EventBridgeClient.putEvents'
-description: 'EventBridgeClient.putEvents sends custom events to Amazon EventBridge'
 description: 'EventBridgeClient.putEvents sends custom events to Amazon EventBridge'
 weight: 10
 ---

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
@@ -1,7 +1,6 @@
 ---
 title: 'KMSDataKey'
 slug: 'kmsdatakey'
-head_title: 'KMSDataKey'
 description: 'KMSDataKey is returned by the KMSClient.*DataKey methods that query KMS data keys'
 weight: 20
 ---

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
@@ -1,7 +1,5 @@
 ---
 title: 'KMSKey'
-head_title: 'KMSKey'
-description: 'KMSKey is returned by the KMSClient.* methods that query KMS keys'
 description: 'KMSKey is returned by the KMSClient.* methods that query KMS keys'
 weight: 20
 ---

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/KMSClient/_index.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/KMSClient/_index.md
@@ -1,7 +1,5 @@
 ---
 title: 'KMSClient'
-head_title: 'KMSClient'
-description: 'KMSClient allows interacting with the AWS Key Management Service'
 description: 'KMSClient allows interacting with the AWS Key Management Service'
 weight: 00
 ---

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/KMSClient/listKeys.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/KMSClient/listKeys.md
@@ -1,7 +1,5 @@
 ---
 title: 'listKeys'
-head_title: 'KMSClient.listKeys()'
-description: "KMSClient.listKeys lists all the KMS keys in the caller's AWS account and region"
 description: "KMSClient.listKeys lists all the KMS keys in the caller's AWS account and region"
 weight: 10
 ---

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/LambdaClient/_index.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/LambdaClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'LambdaClient'
-head_title: 'LambdaClient'
 description: 'LambdaClient allows interacting with the AWS Lambda service'
 weight: 00
 ---

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/LambdaClient/invoke.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/LambdaClient/invoke.md
@@ -1,6 +1,5 @@
 ---
 title: 'invoke'
-head_title: 'LambdaClient.invoke(name, payload, [options])'
 description: 'LambdaClient.invoke invokes an AWS Lamba function'
 weight: 10
 ---

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/Bucket.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/Bucket.md
@@ -1,6 +1,5 @@
 ---
 title: 'Bucket'
-head_title: 'Bucket'
 description: 'Bucket is returned by the S3Client.* methods who query S3 buckets.'
 weight: 20
 ---

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/Object.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/Object.md
@@ -1,6 +1,5 @@
 ---
 title: 'Object'
-head_title: 'Object'
 description: "Object is returned by the S3Client.* methods who query S3 buckets' objects."
 weight: 20
 ---

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/S3Part.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/S3Part.md
@@ -1,6 +1,5 @@
 ---
 title: 'S3Part'
-head_title: 'S3Part'
 slug: 's3part'
 description: 'S3Part is returned by the S3Client.uploadPart method when uploading a part to a multipart upload.'
 weight: 20

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/S3UploadedObject.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/S3UploadedObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'S3UploadedObject'
-head_title: 'S3UploadedObject'
 description: 'S3UploadedObject represents the response from S3 upload operations'
 weight: 20
 ---

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/_index.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'S3Client'
-head_title: 'S3Client'
 description: 'S3Client allows interacting with AWS S3 buckets and objects'
 description: 'S3Client class allows interacting with AWS S3 buckets and objects'
 weight: 00

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
@@ -1,6 +1,5 @@
 ---
 title: 'abortMultipartUpload'
-head_title: 'S3Client.abortMultipartUpload(bucketName, objectKey, uploadId)'
 description: 'S3Client.abortMultipartUpload aborts a multipart upload to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/completeMultipartUpload.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/completeMultipartUpload.md
@@ -1,6 +1,5 @@
 ---
 title: 'completeMultipartUpload'
-head_title: 'S3Client.completeMultipartUpload(bucketName, objectKey, uploadId, parts)'
 description: 'S3Client.completeMultipartUpload uploads a multipar object to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/copyObject.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/copyObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'copyObject'
-head_title: 'S3Client.copyObject'
 description: 'S3Client.copyObject copies an object from a bucket to another'
 weight: 10
 ---

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
@@ -1,6 +1,5 @@
 ---
 title: 'createMultipartUpload'
-head_title: 'S3Client.createMultipartUpload(bucketName, objectKey)'
 description: 'S3Client.createMultipartUpload creates a multipart upload for an object key to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/deleteObject.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/deleteObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'deleteObject'
-head_title: 'S3Client.deleteObject(bucketName, objectKey)'
 description: 'S3Client.deleteObject deletes an object from a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/getObject.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/getObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'getObject'
-head_title: 'S3Client.getObject(bucketName, objectKey)'
 description: 'S3Client.getObject downloads an object from a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/listBuckets.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/listBuckets.md
@@ -1,6 +1,5 @@
 ---
 title: 'listBuckets'
-head_title: 'S3Client.listBuckets()'
 description: 'S3Client.listBuckets lists the buckets the authenticated user has access to'
 weight: 10
 ---

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/listObjects.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/listObjects.md
@@ -1,6 +1,5 @@
 ---
 title: 'listObjects'
-head_title: 'S3Client.listObjects(bucketName, [prefix])'
 description: 'S3Client.listObjects lists the objects contained in a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/putObject.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/putObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'putObject'
-head_title: 'S3Client.putObject(bucketName, objectKey, data)'
 description: 'S3Client.putObject uploads an object to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/uploadPart.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/uploadPart.md
@@ -1,6 +1,5 @@
 ---
 title: 'uploadPart'
-head_title: 'S3Client.uploadPart(bucketName, objectKey, uploadId,partNumber, data)'
 description: 'S3Client.uploadPart a part in a multipart upload to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SQSClient/_index.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SQSClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SQSClient'
-head_title: 'SQSClient'
 description: 'SQSClient enables interaction with the AWS Simple Queue Service (SQS)'
 description: 'SQSClient allows interacting with the AWS Simple Queue Service (SQS)'
 weight: 00

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
@@ -1,6 +1,5 @@
 ---
 title: 'Secret'
-head_title: 'Secret'
 description: 'Secret is returned by the SecretsManagerClient.* methods who query secrets from AWS secrets manager.'
 weight: 20
 ---

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SecretsManagerClient'
-head_title: 'SecretsManagerClient'
 description: 'SecretsManagerClient allows interacting with AWS secrets stored in Secrets Manager'
 weight: 00
 ---

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
@@ -1,6 +1,5 @@
 ---
 title: 'createSecret'
-head_title: 'SecretsManagerClient.createSecret(name, secretString, description, [versionID], [tags])'
 description: 'SecretsManagerClient.createSecret creates a new secret'
 weight: 10
 ---

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
@@ -1,6 +1,5 @@
 ---
 title: 'deleteSecret'
-head_title: 'SecretsManagerClient.deleteSecret(secretID, { recoveryWindow: 30, noRecovery: false}})'
 description: 'SecretsManagerClient.deleteSecret deletes a secret'
 weight: 10
 ---

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
@@ -1,6 +1,5 @@
 ---
 title: 'getSecret'
-head_title: 'SecretsManagerClient.getSecret(secretID)'
 description: 'SecretsManagerClient.getSecret(secretID) downloads a secret from AWS secrets manager'
 weight: 10
 ---

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
@@ -1,6 +1,5 @@
 ---
 title: 'listSecrets'
-head_title: 'SecretsManagerClient.listSecrets()'
 description: 'SecretsManagerClient.listSecrets lists the secrets the authenticated user has access to'
 weight: 10
 ---

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
@@ -1,6 +1,5 @@
 ---
 title: 'putSecretValue'
-head_title: 'SecretsManagerClient.putSecretValue(secretID, secretString, [versionID], [tags])'
 description: "SecretsManagerClient.putSecretValue updates an existing secret's value"
 weight: 10
 ---

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SignatureV4/_index.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SignatureV4/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SignatureV4'
-head_title: 'SignatureV4'
 description: 'SignatureV4 is used to sign or pre-sign requests to AWS services using the Signature V4 algorithm'
 description: 'SignatureV4 is used to sign and pre-sign requests to AWS services using the Signature V4 algorithm'
 weight: 00

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SignatureV4/presign.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SignatureV4/presign.md
@@ -1,6 +1,5 @@
 ---
 title: 'presign'
-head_title: 'presign'
 slug: 'presign'
 description: 'Signaturev4.presign pre-signs a URL with the AWS Signature V4 algorithm'
 description: 'SignatureV4.sign pre-signs a URL with the AWS Signature V4 algorithm'

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SignatureV4/sign.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SignatureV4/sign.md
@@ -1,6 +1,5 @@
 ---
 title: 'sign'
-head_title: 'sign'
 slug: 'sign'
 description: 'Signaturev4.sign signs an HTTP request with the AWS Signature V4 algorithm'
 description: 'SignatureV4.sign signs an HTTP request with the AWS Signature V4 algorithm'

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
@@ -1,6 +1,5 @@
 ---
 title: 'SystemsManagerParameter'
-head_title: 'SystemsManagerParameter'
 slug: 'systemsmanagerparameter'
 description: 'SystemsManagerParameter is returned by the SystemsManagerClient.* methods that query parameters'
 weight: 20

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SystemsManagerClient'
-head_title: 'SystemsManagerClient'
 description: 'SystemsManagerClient allows interacting with the AWS Systems Manager Service'
 weight: 00
 ---

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
@@ -1,6 +1,5 @@
 ---
 title: 'getParameter'
-head_title: 'SystemsManagerClient.getParameter()'
 description: "SystemsManagerClient.getParameter gets a Systems Manager parameter in the caller's AWS account and region"
 weight: 10
 ---

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/awsconfig.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/awsconfig.md
@@ -1,7 +1,5 @@
 ---
 title: 'AWSConfig'
-head_title: 'AWSConfig'
-description: 'AWSConfig is used to configure an AWS service client instances'
 description: 'AWSConfig is used to configure an AWS service client instances'
 weight: 00
 ---

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'EventBridgeClient'
-head_title: 'EventBridgeClient'
 description: 'EventBridgeClient allows interacting with AWS EventBridge service'
 description: 'EventBridgeClient class allows sending custom events to Amazon EventBridge so that they can be matched to rules.'
 weight: 00

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
@@ -1,7 +1,5 @@
 ---
 title: 'putEvents'
-head_title: 'EventBridgeClient.putEvents'
-description: 'EventBridgeClient.putEvents sends custom events to Amazon EventBridge'
 description: 'EventBridgeClient.putEvents sends custom events to Amazon EventBridge'
 weight: 10
 ---

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
@@ -1,7 +1,6 @@
 ---
 title: 'KMSDataKey'
 slug: 'kmsdatakey'
-head_title: 'KMSDataKey'
 description: 'KMSDataKey is returned by the KMSClient.*DataKey methods that query KMS data keys'
 weight: 20
 ---

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
@@ -1,7 +1,5 @@
 ---
 title: 'KMSKey'
-head_title: 'KMSKey'
-description: 'KMSKey is returned by the KMSClient.* methods that query KMS keys'
 description: 'KMSKey is returned by the KMSClient.* methods that query KMS keys'
 weight: 20
 ---

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/KMSClient/_index.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/KMSClient/_index.md
@@ -1,7 +1,5 @@
 ---
 title: 'KMSClient'
-head_title: 'KMSClient'
-description: 'KMSClient allows interacting with the AWS Key Management Service'
 description: 'KMSClient allows interacting with the AWS Key Management Service'
 weight: 00
 ---

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/KMSClient/listKeys.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/KMSClient/listKeys.md
@@ -1,7 +1,5 @@
 ---
 title: 'listKeys'
-head_title: 'KMSClient.listKeys()'
-description: "KMSClient.listKeys lists all the KMS keys in the caller's AWS account and region"
 description: "KMSClient.listKeys lists all the KMS keys in the caller's AWS account and region"
 weight: 10
 ---

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/LambdaClient/_index.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/LambdaClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'LambdaClient'
-head_title: 'LambdaClient'
 description: 'LambdaClient allows interacting with the AWS Lambda service'
 weight: 00
 ---

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/LambdaClient/invoke.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/LambdaClient/invoke.md
@@ -1,6 +1,5 @@
 ---
 title: 'invoke'
-head_title: 'LambdaClient.invoke(name, payload, [options])'
 description: 'LambdaClient.invoke invokes an AWS Lamba function'
 weight: 10
 ---

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/Bucket.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/Bucket.md
@@ -1,6 +1,5 @@
 ---
 title: 'Bucket'
-head_title: 'Bucket'
 description: 'Bucket is returned by the S3Client.* methods who query S3 buckets.'
 weight: 20
 ---

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/Object.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/Object.md
@@ -1,6 +1,5 @@
 ---
 title: 'Object'
-head_title: 'Object'
 description: "Object is returned by the S3Client.* methods who query S3 buckets' objects."
 weight: 20
 ---

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/S3Part.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/S3Part.md
@@ -1,6 +1,5 @@
 ---
 title: 'S3Part'
-head_title: 'S3Part'
 slug: 's3part'
 description: 'S3Part is returned by the S3Client.uploadPart method when uploading a part to a multipart upload.'
 weight: 20

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/S3UploadedObject.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/S3UploadedObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'S3UploadedObject'
-head_title: 'S3UploadedObject'
 description: 'S3UploadedObject represents the response from S3 upload operations'
 weight: 20
 ---

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/_index.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'S3Client'
-head_title: 'S3Client'
 description: 'S3Client allows interacting with AWS S3 buckets and objects'
 description: 'S3Client class allows interacting with AWS S3 buckets and objects'
 weight: 00

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
@@ -1,6 +1,5 @@
 ---
 title: 'abortMultipartUpload'
-head_title: 'S3Client.abortMultipartUpload(bucketName, objectKey, uploadId)'
 description: 'S3Client.abortMultipartUpload aborts a multipart upload to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/completeMultipartUpload.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/completeMultipartUpload.md
@@ -1,6 +1,5 @@
 ---
 title: 'completeMultipartUpload'
-head_title: 'S3Client.completeMultipartUpload(bucketName, objectKey, uploadId, parts)'
 description: 'S3Client.completeMultipartUpload uploads a multipar object to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/copyObject.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/copyObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'copyObject'
-head_title: 'S3Client.copyObject'
 description: 'S3Client.copyObject copies an object from a bucket to another'
 weight: 10
 ---

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
@@ -1,6 +1,5 @@
 ---
 title: 'createMultipartUpload'
-head_title: 'S3Client.createMultipartUpload(bucketName, objectKey)'
 description: 'S3Client.createMultipartUpload creates a multipart upload for an object key to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/deleteObject.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/deleteObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'deleteObject'
-head_title: 'S3Client.deleteObject(bucketName, objectKey)'
 description: 'S3Client.deleteObject deletes an object from a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/getObject.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/getObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'getObject'
-head_title: 'S3Client.getObject(bucketName, objectKey)'
 description: 'S3Client.getObject downloads an object from a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/listBuckets.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/listBuckets.md
@@ -1,6 +1,5 @@
 ---
 title: 'listBuckets'
-head_title: 'S3Client.listBuckets()'
 description: 'S3Client.listBuckets lists the buckets the authenticated user has access to'
 weight: 10
 ---

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/listObjects.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/listObjects.md
@@ -1,6 +1,5 @@
 ---
 title: 'listObjects'
-head_title: 'S3Client.listObjects(bucketName, [prefix])'
 description: 'S3Client.listObjects lists the objects contained in a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/putObject.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/putObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'putObject'
-head_title: 'S3Client.putObject(bucketName, objectKey, data)'
 description: 'S3Client.putObject uploads an object to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/uploadPart.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/uploadPart.md
@@ -1,6 +1,5 @@
 ---
 title: 'uploadPart'
-head_title: 'S3Client.uploadPart(bucketName, objectKey, uploadId,partNumber, data)'
 description: 'S3Client.uploadPart a part in a multipart upload to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SQSClient/_index.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SQSClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SQSClient'
-head_title: 'SQSClient'
 description: 'SQSClient enables interaction with the AWS Simple Queue Service (SQS)'
 description: 'SQSClient allows interacting with the AWS Simple Queue Service (SQS)'
 weight: 00

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
@@ -1,6 +1,5 @@
 ---
 title: 'Secret'
-head_title: 'Secret'
 description: 'Secret is returned by the SecretsManagerClient.* methods who query secrets from AWS secrets manager.'
 weight: 20
 ---

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SecretsManagerClient'
-head_title: 'SecretsManagerClient'
 description: 'SecretsManagerClient allows interacting with AWS secrets stored in Secrets Manager'
 weight: 00
 ---

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
@@ -1,6 +1,5 @@
 ---
 title: 'createSecret'
-head_title: 'SecretsManagerClient.createSecret(name, secretString, description, [versionID], [tags])'
 description: 'SecretsManagerClient.createSecret creates a new secret'
 weight: 10
 ---

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
@@ -1,6 +1,5 @@
 ---
 title: 'deleteSecret'
-head_title: 'SecretsManagerClient.deleteSecret(secretID, { recoveryWindow: 30, noRecovery: false}})'
 description: 'SecretsManagerClient.deleteSecret deletes a secret'
 weight: 10
 ---

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
@@ -1,6 +1,5 @@
 ---
 title: 'getSecret'
-head_title: 'SecretsManagerClient.getSecret(secretID)'
 description: 'SecretsManagerClient.getSecret(secretID) downloads a secret from AWS secrets manager'
 weight: 10
 ---

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
@@ -1,6 +1,5 @@
 ---
 title: 'listSecrets'
-head_title: 'SecretsManagerClient.listSecrets()'
 description: 'SecretsManagerClient.listSecrets lists the secrets the authenticated user has access to'
 weight: 10
 ---

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
@@ -1,6 +1,5 @@
 ---
 title: 'putSecretValue'
-head_title: 'SecretsManagerClient.putSecretValue(secretID, secretString, [versionID], [tags])'
 description: "SecretsManagerClient.putSecretValue updates an existing secret's value"
 weight: 10
 ---

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SignatureV4/_index.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SignatureV4/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SignatureV4'
-head_title: 'SignatureV4'
 description: 'SignatureV4 is used to sign or pre-sign requests to AWS services using the Signature V4 algorithm'
 description: 'SignatureV4 is used to sign and pre-sign requests to AWS services using the Signature V4 algorithm'
 weight: 00

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SignatureV4/presign.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SignatureV4/presign.md
@@ -1,6 +1,5 @@
 ---
 title: 'presign'
-head_title: 'presign'
 slug: 'presign'
 description: 'Signaturev4.presign pre-signs a URL with the AWS Signature V4 algorithm'
 description: 'SignatureV4.sign pre-signs a URL with the AWS Signature V4 algorithm'

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SignatureV4/sign.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SignatureV4/sign.md
@@ -1,6 +1,5 @@
 ---
 title: 'sign'
-head_title: 'sign'
 slug: 'sign'
 description: 'Signaturev4.sign signs an HTTP request with the AWS Signature V4 algorithm'
 description: 'SignatureV4.sign signs an HTTP request with the AWS Signature V4 algorithm'

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
@@ -1,6 +1,5 @@
 ---
 title: 'SystemsManagerParameter'
-head_title: 'SystemsManagerParameter'
 slug: 'systemsmanagerparameter'
 description: 'SystemsManagerParameter is returned by the SystemsManagerClient.* methods that query parameters'
 weight: 20

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SystemsManagerClient'
-head_title: 'SystemsManagerClient'
 description: 'SystemsManagerClient allows interacting with the AWS Systems Manager Service'
 weight: 00
 ---

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
@@ -1,6 +1,5 @@
 ---
 title: 'getParameter'
-head_title: 'SystemsManagerClient.getParameter()'
 description: "SystemsManagerClient.getParameter gets a Systems Manager parameter in the caller's AWS account and region"
 weight: 10
 ---

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/awsconfig.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/awsconfig.md
@@ -1,7 +1,5 @@
 ---
 title: 'AWSConfig'
-head_title: 'AWSConfig'
-description: 'AWSConfig is used to configure an AWS service client instances'
 description: 'AWSConfig is used to configure an AWS service client instances'
 weight: 00
 ---

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'EventBridgeClient'
-head_title: 'EventBridgeClient'
 description: 'EventBridgeClient allows interacting with AWS EventBridge service'
 description: 'EventBridgeClient class allows sending custom events to Amazon EventBridge so that they can be matched to rules.'
 weight: 00

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
@@ -1,7 +1,5 @@
 ---
 title: 'putEvents'
-head_title: 'EventBridgeClient.putEvents'
-description: 'EventBridgeClient.putEvents sends custom events to Amazon EventBridge'
 description: 'EventBridgeClient.putEvents sends custom events to Amazon EventBridge'
 weight: 10
 ---

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
@@ -1,7 +1,6 @@
 ---
 title: 'KMSDataKey'
 slug: 'kmsdatakey'
-head_title: 'KMSDataKey'
 description: 'KMSDataKey is returned by the KMSClient.*DataKey methods that query KMS data keys'
 weight: 20
 ---

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
@@ -1,7 +1,5 @@
 ---
 title: 'KMSKey'
-head_title: 'KMSKey'
-description: 'KMSKey is returned by the KMSClient.* methods that query KMS keys'
 description: 'KMSKey is returned by the KMSClient.* methods that query KMS keys'
 weight: 20
 ---

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/KMSClient/_index.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/KMSClient/_index.md
@@ -1,7 +1,5 @@
 ---
 title: 'KMSClient'
-head_title: 'KMSClient'
-description: 'KMSClient allows interacting with the AWS Key Management Service'
 description: 'KMSClient allows interacting with the AWS Key Management Service'
 weight: 00
 ---

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/KMSClient/listKeys.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/KMSClient/listKeys.md
@@ -1,7 +1,5 @@
 ---
 title: 'listKeys'
-head_title: 'KMSClient.listKeys()'
-description: "KMSClient.listKeys lists all the KMS keys in the caller's AWS account and region"
 description: "KMSClient.listKeys lists all the KMS keys in the caller's AWS account and region"
 weight: 10
 ---

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/LambdaClient/_index.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/LambdaClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'LambdaClient'
-head_title: 'LambdaClient'
 description: 'LambdaClient allows interacting with the AWS Lambda service'
 weight: 00
 ---

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/LambdaClient/invoke.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/LambdaClient/invoke.md
@@ -1,6 +1,5 @@
 ---
 title: 'invoke'
-head_title: 'LambdaClient.invoke(name, payload, [options])'
 description: 'LambdaClient.invoke invokes an AWS Lamba function'
 weight: 10
 ---

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/Bucket.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/Bucket.md
@@ -1,6 +1,5 @@
 ---
 title: 'Bucket'
-head_title: 'Bucket'
 description: 'Bucket is returned by the S3Client.* methods who query S3 buckets.'
 weight: 20
 ---

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/Object.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/Object.md
@@ -1,6 +1,5 @@
 ---
 title: 'Object'
-head_title: 'Object'
 description: "Object is returned by the S3Client.* methods who query S3 buckets' objects."
 weight: 20
 ---

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/S3Part.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/S3Part.md
@@ -1,6 +1,5 @@
 ---
 title: 'S3Part'
-head_title: 'S3Part'
 slug: 's3part'
 description: 'S3Part is returned by the S3Client.uploadPart method when uploading a part to a multipart upload.'
 weight: 20

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/S3UploadedObject.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/S3UploadedObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'S3UploadedObject'
-head_title: 'S3UploadedObject'
 description: 'S3UploadedObject represents the response from S3 upload operations'
 weight: 20
 ---

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/_index.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'S3Client'
-head_title: 'S3Client'
 description: 'S3Client allows interacting with AWS S3 buckets and objects'
 description: 'S3Client class allows interacting with AWS S3 buckets and objects'
 weight: 00

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
@@ -1,6 +1,5 @@
 ---
 title: 'abortMultipartUpload'
-head_title: 'S3Client.abortMultipartUpload(bucketName, objectKey, uploadId)'
 description: 'S3Client.abortMultipartUpload aborts a multipart upload to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/completeMultipartUpload.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/completeMultipartUpload.md
@@ -1,6 +1,5 @@
 ---
 title: 'completeMultipartUpload'
-head_title: 'S3Client.completeMultipartUpload(bucketName, objectKey, uploadId, parts)'
 description: 'S3Client.completeMultipartUpload uploads a multipar object to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/copyObject.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/copyObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'copyObject'
-head_title: 'S3Client.copyObject'
 description: 'S3Client.copyObject copies an object from a bucket to another'
 weight: 10
 ---

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
@@ -1,6 +1,5 @@
 ---
 title: 'createMultipartUpload'
-head_title: 'S3Client.createMultipartUpload(bucketName, objectKey)'
 description: 'S3Client.createMultipartUpload creates a multipart upload for an object key to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/deleteObject.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/deleteObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'deleteObject'
-head_title: 'S3Client.deleteObject(bucketName, objectKey)'
 description: 'S3Client.deleteObject deletes an object from a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/getObject.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/getObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'getObject'
-head_title: 'S3Client.getObject(bucketName, objectKey)'
 description: 'S3Client.getObject downloads an object from a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/listBuckets.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/listBuckets.md
@@ -1,6 +1,5 @@
 ---
 title: 'listBuckets'
-head_title: 'S3Client.listBuckets()'
 description: 'S3Client.listBuckets lists the buckets the authenticated user has access to'
 weight: 10
 ---

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/listObjects.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/listObjects.md
@@ -1,6 +1,5 @@
 ---
 title: 'listObjects'
-head_title: 'S3Client.listObjects(bucketName, [prefix])'
 description: 'S3Client.listObjects lists the objects contained in a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/putObject.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/putObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'putObject'
-head_title: 'S3Client.putObject(bucketName, objectKey, data)'
 description: 'S3Client.putObject uploads an object to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/uploadPart.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/uploadPart.md
@@ -1,6 +1,5 @@
 ---
 title: 'uploadPart'
-head_title: 'S3Client.uploadPart(bucketName, objectKey, uploadId,partNumber, data)'
 description: 'S3Client.uploadPart a part in a multipart upload to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SQSClient/_index.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SQSClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SQSClient'
-head_title: 'SQSClient'
 description: 'SQSClient enables interaction with the AWS Simple Queue Service (SQS)'
 description: 'SQSClient allows interacting with the AWS Simple Queue Service (SQS)'
 weight: 00

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
@@ -1,6 +1,5 @@
 ---
 title: 'Secret'
-head_title: 'Secret'
 description: 'Secret is returned by the SecretsManagerClient.* methods who query secrets from AWS secrets manager.'
 weight: 20
 ---

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SecretsManagerClient'
-head_title: 'SecretsManagerClient'
 description: 'SecretsManagerClient allows interacting with AWS secrets stored in Secrets Manager'
 weight: 00
 ---

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
@@ -1,6 +1,5 @@
 ---
 title: 'createSecret'
-head_title: 'SecretsManagerClient.createSecret(name, secretString, description, [versionID], [tags])'
 description: 'SecretsManagerClient.createSecret creates a new secret'
 weight: 10
 ---

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
@@ -1,6 +1,5 @@
 ---
 title: 'deleteSecret'
-head_title: 'SecretsManagerClient.deleteSecret(secretID, { recoveryWindow: 30, noRecovery: false}})'
 description: 'SecretsManagerClient.deleteSecret deletes a secret'
 weight: 10
 ---

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
@@ -1,6 +1,5 @@
 ---
 title: 'getSecret'
-head_title: 'SecretsManagerClient.getSecret(secretID)'
 description: 'SecretsManagerClient.getSecret(secretID) downloads a secret from AWS secrets manager'
 weight: 10
 ---

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
@@ -1,6 +1,5 @@
 ---
 title: 'listSecrets'
-head_title: 'SecretsManagerClient.listSecrets()'
 description: 'SecretsManagerClient.listSecrets lists the secrets the authenticated user has access to'
 weight: 10
 ---

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
@@ -1,6 +1,5 @@
 ---
 title: 'putSecretValue'
-head_title: 'SecretsManagerClient.putSecretValue(secretID, secretString, [versionID], [tags])'
 description: "SecretsManagerClient.putSecretValue updates an existing secret's value"
 weight: 10
 ---

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SignatureV4/_index.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SignatureV4/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SignatureV4'
-head_title: 'SignatureV4'
 description: 'SignatureV4 is used to sign or pre-sign requests to AWS services using the Signature V4 algorithm'
 description: 'SignatureV4 is used to sign and pre-sign requests to AWS services using the Signature V4 algorithm'
 weight: 00

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SignatureV4/presign.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SignatureV4/presign.md
@@ -1,6 +1,5 @@
 ---
 title: 'presign'
-head_title: 'presign'
 slug: 'presign'
 description: 'Signaturev4.presign pre-signs a URL with the AWS Signature V4 algorithm'
 description: 'SignatureV4.sign pre-signs a URL with the AWS Signature V4 algorithm'

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SignatureV4/sign.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SignatureV4/sign.md
@@ -1,6 +1,5 @@
 ---
 title: 'sign'
-head_title: 'sign'
 slug: 'sign'
 description: 'Signaturev4.sign signs an HTTP request with the AWS Signature V4 algorithm'
 description: 'SignatureV4.sign signs an HTTP request with the AWS Signature V4 algorithm'

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
@@ -1,6 +1,5 @@
 ---
 title: 'SystemsManagerParameter'
-head_title: 'SystemsManagerParameter'
 slug: 'systemsmanagerparameter'
 description: 'SystemsManagerParameter is returned by the SystemsManagerClient.* methods that query parameters'
 weight: 20

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SystemsManagerClient'
-head_title: 'SystemsManagerClient'
 description: 'SystemsManagerClient allows interacting with the AWS Systems Manager Service'
 weight: 00
 ---

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
@@ -1,6 +1,5 @@
 ---
 title: 'getParameter'
-head_title: 'SystemsManagerClient.getParameter()'
 description: "SystemsManagerClient.getParameter gets a Systems Manager parameter in the caller's AWS account and region"
 weight: 10
 ---

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/awsconfig.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/awsconfig.md
@@ -1,7 +1,5 @@
 ---
 title: 'AWSConfig'
-head_title: 'AWSConfig'
-description: 'AWSConfig is used to configure an AWS service client instances'
 description: 'AWSConfig is used to configure an AWS service client instances'
 weight: 00
 ---

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'EventBridgeClient'
-head_title: 'EventBridgeClient'
 description: 'EventBridgeClient allows interacting with AWS EventBridge service'
 description: 'EventBridgeClient class allows sending custom events to Amazon EventBridge so that they can be matched to rules.'
 weight: 00

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
@@ -1,7 +1,5 @@
 ---
 title: 'putEvents'
-head_title: 'EventBridgeClient.putEvents'
-description: 'EventBridgeClient.putEvents sends custom events to Amazon EventBridge'
 description: 'EventBridgeClient.putEvents sends custom events to Amazon EventBridge'
 weight: 10
 ---

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
@@ -1,7 +1,6 @@
 ---
 title: 'KMSDataKey'
 slug: 'kmsdatakey'
-head_title: 'KMSDataKey'
 description: 'KMSDataKey is returned by the KMSClient.*DataKey methods that query KMS data keys'
 weight: 20
 ---

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
@@ -1,7 +1,5 @@
 ---
 title: 'KMSKey'
-head_title: 'KMSKey'
-description: 'KMSKey is returned by the KMSClient.* methods that query KMS keys'
 description: 'KMSKey is returned by the KMSClient.* methods that query KMS keys'
 weight: 20
 ---

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/KMSClient/_index.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/KMSClient/_index.md
@@ -1,7 +1,5 @@
 ---
 title: 'KMSClient'
-head_title: 'KMSClient'
-description: 'KMSClient allows interacting with the AWS Key Management Service'
 description: 'KMSClient allows interacting with the AWS Key Management Service'
 weight: 00
 ---

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/KMSClient/listKeys.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/KMSClient/listKeys.md
@@ -1,7 +1,5 @@
 ---
 title: 'listKeys'
-head_title: 'KMSClient.listKeys()'
-description: "KMSClient.listKeys lists all the KMS keys in the caller's AWS account and region"
 description: "KMSClient.listKeys lists all the KMS keys in the caller's AWS account and region"
 weight: 10
 ---

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/LambdaClient/_index.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/LambdaClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'LambdaClient'
-head_title: 'LambdaClient'
 description: 'LambdaClient allows interacting with the AWS Lambda service'
 weight: 00
 ---

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/LambdaClient/invoke.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/LambdaClient/invoke.md
@@ -1,6 +1,5 @@
 ---
 title: 'invoke'
-head_title: 'LambdaClient.invoke(name, payload, [options])'
 description: 'LambdaClient.invoke invokes an AWS Lamba function'
 weight: 10
 ---

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/Bucket.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/Bucket.md
@@ -1,6 +1,5 @@
 ---
 title: 'Bucket'
-head_title: 'Bucket'
 description: 'Bucket is returned by the S3Client.* methods who query S3 buckets.'
 weight: 20
 ---

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/Object.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/Object.md
@@ -1,6 +1,5 @@
 ---
 title: 'Object'
-head_title: 'Object'
 description: "Object is returned by the S3Client.* methods who query S3 buckets' objects."
 weight: 20
 ---

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/S3Part.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/S3Part.md
@@ -1,6 +1,5 @@
 ---
 title: 'S3Part'
-head_title: 'S3Part'
 slug: 's3part'
 description: 'S3Part is returned by the S3Client.uploadPart method when uploading a part to a multipart upload.'
 weight: 20

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/S3UploadedObject.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/S3UploadedObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'S3UploadedObject'
-head_title: 'S3UploadedObject'
 description: 'S3UploadedObject represents the response from S3 upload operations'
 weight: 20
 ---

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/_index.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'S3Client'
-head_title: 'S3Client'
 description: 'S3Client allows interacting with AWS S3 buckets and objects'
 description: 'S3Client class allows interacting with AWS S3 buckets and objects'
 weight: 00

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
@@ -1,6 +1,5 @@
 ---
 title: 'abortMultipartUpload'
-head_title: 'S3Client.abortMultipartUpload(bucketName, objectKey, uploadId)'
 description: 'S3Client.abortMultipartUpload aborts a multipart upload to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/completeMultipartUpload.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/completeMultipartUpload.md
@@ -1,6 +1,5 @@
 ---
 title: 'completeMultipartUpload'
-head_title: 'S3Client.completeMultipartUpload(bucketName, objectKey, uploadId, parts)'
 description: 'S3Client.completeMultipartUpload uploads a multipar object to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/copyObject.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/copyObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'copyObject'
-head_title: 'S3Client.copyObject'
 description: 'S3Client.copyObject copies an object from a bucket to another'
 weight: 10
 ---

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
@@ -1,6 +1,5 @@
 ---
 title: 'createMultipartUpload'
-head_title: 'S3Client.createMultipartUpload(bucketName, objectKey)'
 description: 'S3Client.createMultipartUpload creates a multipart upload for an object key to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/deleteObject.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/deleteObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'deleteObject'
-head_title: 'S3Client.deleteObject(bucketName, objectKey)'
 description: 'S3Client.deleteObject deletes an object from a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/getObject.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/getObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'getObject'
-head_title: 'S3Client.getObject(bucketName, objectKey)'
 description: 'S3Client.getObject downloads an object from a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/listBuckets.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/listBuckets.md
@@ -1,6 +1,5 @@
 ---
 title: 'listBuckets'
-head_title: 'S3Client.listBuckets()'
 description: 'S3Client.listBuckets lists the buckets the authenticated user has access to'
 weight: 10
 ---

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/listObjects.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/listObjects.md
@@ -1,6 +1,5 @@
 ---
 title: 'listObjects'
-head_title: 'S3Client.listObjects(bucketName, [prefix])'
 description: 'S3Client.listObjects lists the objects contained in a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/putObject.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/putObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'putObject'
-head_title: 'S3Client.putObject(bucketName, objectKey, data)'
 description: 'S3Client.putObject uploads an object to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/uploadPart.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/uploadPart.md
@@ -1,6 +1,5 @@
 ---
 title: 'uploadPart'
-head_title: 'S3Client.uploadPart(bucketName, objectKey, uploadId,partNumber, data)'
 description: 'S3Client.uploadPart a part in a multipart upload to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SQSClient/_index.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SQSClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SQSClient'
-head_title: 'SQSClient'
 description: 'SQSClient enables interaction with the AWS Simple Queue Service (SQS)'
 description: 'SQSClient allows interacting with the AWS Simple Queue Service (SQS)'
 weight: 00

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
@@ -1,6 +1,5 @@
 ---
 title: 'Secret'
-head_title: 'Secret'
 description: 'Secret is returned by the SecretsManagerClient.* methods who query secrets from AWS secrets manager.'
 weight: 20
 ---

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SecretsManagerClient'
-head_title: 'SecretsManagerClient'
 description: 'SecretsManagerClient allows interacting with AWS secrets stored in Secrets Manager'
 weight: 00
 ---

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
@@ -1,6 +1,5 @@
 ---
 title: 'createSecret'
-head_title: 'SecretsManagerClient.createSecret(name, secretString, description, [versionID], [tags])'
 description: 'SecretsManagerClient.createSecret creates a new secret'
 weight: 10
 ---

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
@@ -1,6 +1,5 @@
 ---
 title: 'deleteSecret'
-head_title: 'SecretsManagerClient.deleteSecret(secretID, { recoveryWindow: 30, noRecovery: false}})'
 description: 'SecretsManagerClient.deleteSecret deletes a secret'
 weight: 10
 ---

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
@@ -1,6 +1,5 @@
 ---
 title: 'getSecret'
-head_title: 'SecretsManagerClient.getSecret(secretID)'
 description: 'SecretsManagerClient.getSecret(secretID) downloads a secret from AWS secrets manager'
 weight: 10
 ---

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
@@ -1,6 +1,5 @@
 ---
 title: 'listSecrets'
-head_title: 'SecretsManagerClient.listSecrets()'
 description: 'SecretsManagerClient.listSecrets lists the secrets the authenticated user has access to'
 weight: 10
 ---

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
@@ -1,6 +1,5 @@
 ---
 title: 'putSecretValue'
-head_title: 'SecretsManagerClient.putSecretValue(secretID, secretString, [versionID], [tags])'
 description: "SecretsManagerClient.putSecretValue updates an existing secret's value"
 weight: 10
 ---

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SignatureV4/_index.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SignatureV4/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SignatureV4'
-head_title: 'SignatureV4'
 description: 'SignatureV4 is used to sign or pre-sign requests to AWS services using the Signature V4 algorithm'
 description: 'SignatureV4 is used to sign and pre-sign requests to AWS services using the Signature V4 algorithm'
 weight: 00

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SignatureV4/presign.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SignatureV4/presign.md
@@ -1,6 +1,5 @@
 ---
 title: 'presign'
-head_title: 'presign'
 slug: 'presign'
 description: 'Signaturev4.presign pre-signs a URL with the AWS Signature V4 algorithm'
 description: 'SignatureV4.sign pre-signs a URL with the AWS Signature V4 algorithm'

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SignatureV4/sign.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SignatureV4/sign.md
@@ -1,6 +1,5 @@
 ---
 title: 'sign'
-head_title: 'sign'
 slug: 'sign'
 description: 'Signaturev4.sign signs an HTTP request with the AWS Signature V4 algorithm'
 description: 'SignatureV4.sign signs an HTTP request with the AWS Signature V4 algorithm'

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
@@ -1,6 +1,5 @@
 ---
 title: 'SystemsManagerParameter'
-head_title: 'SystemsManagerParameter'
 slug: 'systemsmanagerparameter'
 description: 'SystemsManagerParameter is returned by the SystemsManagerClient.* methods that query parameters'
 weight: 20

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SystemsManagerClient'
-head_title: 'SystemsManagerClient'
 description: 'SystemsManagerClient allows interacting with the AWS Systems Manager Service'
 weight: 00
 ---

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
@@ -1,6 +1,5 @@
 ---
 title: 'getParameter'
-head_title: 'SystemsManagerClient.getParameter()'
 description: "SystemsManagerClient.getParameter gets a Systems Manager parameter in the caller's AWS account and region"
 weight: 10
 ---

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/awsconfig.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/awsconfig.md
@@ -1,7 +1,5 @@
 ---
 title: 'AWSConfig'
-head_title: 'AWSConfig'
-description: 'AWSConfig is used to configure an AWS service client instances'
 description: 'AWSConfig is used to configure an AWS service client instances'
 weight: 00
 ---

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'EventBridgeClient'
-head_title: 'EventBridgeClient'
 description: 'EventBridgeClient allows interacting with AWS EventBridge service'
 description: 'EventBridgeClient class allows sending custom events to Amazon EventBridge so that they can be matched to rules.'
 weight: 00

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
@@ -1,7 +1,5 @@
 ---
 title: 'putEvents'
-head_title: 'EventBridgeClient.putEvents'
-description: 'EventBridgeClient.putEvents sends custom events to Amazon EventBridge'
 description: 'EventBridgeClient.putEvents sends custom events to Amazon EventBridge'
 weight: 10
 ---

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
@@ -1,7 +1,6 @@
 ---
 title: 'KMSDataKey'
 slug: 'kmsdatakey'
-head_title: 'KMSDataKey'
 description: 'KMSDataKey is returned by the KMSClient.*DataKey methods that query KMS data keys'
 weight: 20
 ---

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
@@ -1,7 +1,5 @@
 ---
 title: 'KMSKey'
-head_title: 'KMSKey'
-description: 'KMSKey is returned by the KMSClient.* methods that query KMS keys'
 description: 'KMSKey is returned by the KMSClient.* methods that query KMS keys'
 weight: 20
 ---

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/KMSClient/_index.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/KMSClient/_index.md
@@ -1,7 +1,5 @@
 ---
 title: 'KMSClient'
-head_title: 'KMSClient'
-description: 'KMSClient allows interacting with the AWS Key Management Service'
 description: 'KMSClient allows interacting with the AWS Key Management Service'
 weight: 00
 ---

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/KMSClient/listKeys.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/KMSClient/listKeys.md
@@ -1,7 +1,5 @@
 ---
 title: 'listKeys'
-head_title: 'KMSClient.listKeys()'
-description: "KMSClient.listKeys lists all the KMS keys in the caller's AWS account and region"
 description: "KMSClient.listKeys lists all the KMS keys in the caller's AWS account and region"
 weight: 10
 ---

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/LambdaClient/_index.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/LambdaClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'LambdaClient'
-head_title: 'LambdaClient'
 description: 'LambdaClient allows interacting with the AWS Lambda service'
 weight: 00
 ---

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/LambdaClient/invoke.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/LambdaClient/invoke.md
@@ -1,6 +1,5 @@
 ---
 title: 'invoke'
-head_title: 'LambdaClient.invoke(name, payload, [options])'
 description: 'LambdaClient.invoke invokes an AWS Lamba function'
 weight: 10
 ---

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/Bucket.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/Bucket.md
@@ -1,6 +1,5 @@
 ---
 title: 'Bucket'
-head_title: 'Bucket'
 description: 'Bucket is returned by the S3Client.* methods who query S3 buckets.'
 weight: 20
 ---

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/Object.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/Object.md
@@ -1,6 +1,5 @@
 ---
 title: 'Object'
-head_title: 'Object'
 description: "Object is returned by the S3Client.* methods who query S3 buckets' objects."
 weight: 20
 ---

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/S3Part.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/S3Part.md
@@ -1,6 +1,5 @@
 ---
 title: 'S3Part'
-head_title: 'S3Part'
 slug: 's3part'
 description: 'S3Part is returned by the S3Client.uploadPart method when uploading a part to a multipart upload.'
 weight: 20

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/S3UploadedObject.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/S3UploadedObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'S3UploadedObject'
-head_title: 'S3UploadedObject'
 description: 'S3UploadedObject represents the response from S3 upload operations'
 weight: 20
 ---

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/_index.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'S3Client'
-head_title: 'S3Client'
 description: 'S3Client allows interacting with AWS S3 buckets and objects'
 description: 'S3Client class allows interacting with AWS S3 buckets and objects'
 weight: 00

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
@@ -1,6 +1,5 @@
 ---
 title: 'abortMultipartUpload'
-head_title: 'S3Client.abortMultipartUpload(bucketName, objectKey, uploadId)'
 description: 'S3Client.abortMultipartUpload aborts a multipart upload to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/completeMultipartUpload.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/completeMultipartUpload.md
@@ -1,6 +1,5 @@
 ---
 title: 'completeMultipartUpload'
-head_title: 'S3Client.completeMultipartUpload(bucketName, objectKey, uploadId, parts)'
 description: 'S3Client.completeMultipartUpload uploads a multipar object to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/copyObject.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/copyObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'copyObject'
-head_title: 'S3Client.copyObject'
 description: 'S3Client.copyObject copies an object from a bucket to another'
 weight: 10
 ---

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
@@ -1,6 +1,5 @@
 ---
 title: 'createMultipartUpload'
-head_title: 'S3Client.createMultipartUpload(bucketName, objectKey)'
 description: 'S3Client.createMultipartUpload creates a multipart upload for an object key to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/deleteObject.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/deleteObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'deleteObject'
-head_title: 'S3Client.deleteObject(bucketName, objectKey)'
 description: 'S3Client.deleteObject deletes an object from a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/getObject.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/getObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'getObject'
-head_title: 'S3Client.getObject(bucketName, objectKey)'
 description: 'S3Client.getObject downloads an object from a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/listBuckets.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/listBuckets.md
@@ -1,6 +1,5 @@
 ---
 title: 'listBuckets'
-head_title: 'S3Client.listBuckets()'
 description: 'S3Client.listBuckets lists the buckets the authenticated user has access to'
 weight: 10
 ---

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/listObjects.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/listObjects.md
@@ -1,6 +1,5 @@
 ---
 title: 'listObjects'
-head_title: 'S3Client.listObjects(bucketName, [prefix])'
 description: 'S3Client.listObjects lists the objects contained in a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/putObject.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/putObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'putObject'
-head_title: 'S3Client.putObject(bucketName, objectKey, data)'
 description: 'S3Client.putObject uploads an object to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/uploadPart.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/uploadPart.md
@@ -1,6 +1,5 @@
 ---
 title: 'uploadPart'
-head_title: 'S3Client.uploadPart(bucketName, objectKey, uploadId,partNumber, data)'
 description: 'S3Client.uploadPart a part in a multipart upload to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SQSClient/_index.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SQSClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SQSClient'
-head_title: 'SQSClient'
 description: 'SQSClient enables interaction with the AWS Simple Queue Service (SQS)'
 description: 'SQSClient allows interacting with the AWS Simple Queue Service (SQS)'
 weight: 00

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
@@ -1,6 +1,5 @@
 ---
 title: 'Secret'
-head_title: 'Secret'
 description: 'Secret is returned by the SecretsManagerClient.* methods who query secrets from AWS secrets manager.'
 weight: 20
 ---

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SecretsManagerClient'
-head_title: 'SecretsManagerClient'
 description: 'SecretsManagerClient allows interacting with AWS secrets stored in Secrets Manager'
 weight: 00
 ---

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
@@ -1,6 +1,5 @@
 ---
 title: 'createSecret'
-head_title: 'SecretsManagerClient.createSecret(name, secretString, description, [versionID], [tags])'
 description: 'SecretsManagerClient.createSecret creates a new secret'
 weight: 10
 ---

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
@@ -1,6 +1,5 @@
 ---
 title: 'deleteSecret'
-head_title: 'SecretsManagerClient.deleteSecret(secretID, { recoveryWindow: 30, noRecovery: false}})'
 description: 'SecretsManagerClient.deleteSecret deletes a secret'
 weight: 10
 ---

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
@@ -1,6 +1,5 @@
 ---
 title: 'getSecret'
-head_title: 'SecretsManagerClient.getSecret(secretID)'
 description: 'SecretsManagerClient.getSecret(secretID) downloads a secret from AWS secrets manager'
 weight: 10
 ---

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
@@ -1,6 +1,5 @@
 ---
 title: 'listSecrets'
-head_title: 'SecretsManagerClient.listSecrets()'
 description: 'SecretsManagerClient.listSecrets lists the secrets the authenticated user has access to'
 weight: 10
 ---

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
@@ -1,6 +1,5 @@
 ---
 title: 'putSecretValue'
-head_title: 'SecretsManagerClient.putSecretValue(secretID, secretString, [versionID], [tags])'
 description: "SecretsManagerClient.putSecretValue updates an existing secret's value"
 weight: 10
 ---

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SignatureV4/_index.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SignatureV4/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SignatureV4'
-head_title: 'SignatureV4'
 description: 'SignatureV4 is used to sign or pre-sign requests to AWS services using the Signature V4 algorithm'
 description: 'SignatureV4 is used to sign and pre-sign requests to AWS services using the Signature V4 algorithm'
 weight: 00

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SignatureV4/presign.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SignatureV4/presign.md
@@ -1,6 +1,5 @@
 ---
 title: 'presign'
-head_title: 'presign'
 slug: 'presign'
 description: 'Signaturev4.presign pre-signs a URL with the AWS Signature V4 algorithm'
 description: 'SignatureV4.sign pre-signs a URL with the AWS Signature V4 algorithm'

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SignatureV4/sign.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SignatureV4/sign.md
@@ -1,6 +1,5 @@
 ---
 title: 'sign'
-head_title: 'sign'
 slug: 'sign'
 description: 'Signaturev4.sign signs an HTTP request with the AWS Signature V4 algorithm'
 description: 'SignatureV4.sign signs an HTTP request with the AWS Signature V4 algorithm'

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
@@ -1,6 +1,5 @@
 ---
 title: 'SystemsManagerParameter'
-head_title: 'SystemsManagerParameter'
 slug: 'systemsmanagerparameter'
 description: 'SystemsManagerParameter is returned by the SystemsManagerClient.* methods that query parameters'
 weight: 20

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SystemsManagerClient'
-head_title: 'SystemsManagerClient'
 description: 'SystemsManagerClient allows interacting with the AWS Systems Manager Service'
 weight: 00
 ---

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
@@ -1,6 +1,5 @@
 ---
 title: 'getParameter'
-head_title: 'SystemsManagerClient.getParameter()'
 description: "SystemsManagerClient.getParameter gets a Systems Manager parameter in the caller's AWS account and region"
 weight: 10
 ---

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/awsconfig.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/awsconfig.md
@@ -1,7 +1,5 @@
 ---
 title: 'AWSConfig'
-head_title: 'AWSConfig'
-description: 'AWSConfig is used to configure an AWS service client instances'
 description: 'AWSConfig is used to configure an AWS service client instances'
 weight: 00
 ---

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'EventBridgeClient'
-head_title: 'EventBridgeClient'
 description: 'EventBridgeClient allows interacting with AWS EventBridge service'
 description: 'EventBridgeClient class allows sending custom events to Amazon EventBridge so that they can be matched to rules.'
 weight: 00

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
@@ -1,7 +1,5 @@
 ---
 title: 'putEvents'
-head_title: 'EventBridgeClient.putEvents'
-description: 'EventBridgeClient.putEvents sends custom events to Amazon EventBridge'
 description: 'EventBridgeClient.putEvents sends custom events to Amazon EventBridge'
 weight: 10
 ---

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
@@ -1,7 +1,6 @@
 ---
 title: 'KMSDataKey'
 slug: 'kmsdatakey'
-head_title: 'KMSDataKey'
 description: 'KMSDataKey is returned by the KMSClient.*DataKey methods that query KMS data keys'
 weight: 20
 ---

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
@@ -1,7 +1,5 @@
 ---
 title: 'KMSKey'
-head_title: 'KMSKey'
-description: 'KMSKey is returned by the KMSClient.* methods that query KMS keys'
 description: 'KMSKey is returned by the KMSClient.* methods that query KMS keys'
 weight: 20
 ---

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/KMSClient/_index.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/KMSClient/_index.md
@@ -1,7 +1,5 @@
 ---
 title: 'KMSClient'
-head_title: 'KMSClient'
-description: 'KMSClient allows interacting with the AWS Key Management Service'
 description: 'KMSClient allows interacting with the AWS Key Management Service'
 weight: 00
 ---

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/KMSClient/listKeys.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/KMSClient/listKeys.md
@@ -1,7 +1,5 @@
 ---
 title: 'listKeys'
-head_title: 'KMSClient.listKeys()'
-description: "KMSClient.listKeys lists all the KMS keys in the caller's AWS account and region"
 description: "KMSClient.listKeys lists all the KMS keys in the caller's AWS account and region"
 weight: 10
 ---

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/LambdaClient/_index.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/LambdaClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'LambdaClient'
-head_title: 'LambdaClient'
 description: 'LambdaClient allows interacting with the AWS Lambda service'
 weight: 00
 ---

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/LambdaClient/invoke.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/LambdaClient/invoke.md
@@ -1,6 +1,5 @@
 ---
 title: 'invoke'
-head_title: 'LambdaClient.invoke(name, payload, [options])'
 description: 'LambdaClient.invoke invokes an AWS Lamba function'
 weight: 10
 ---

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/Bucket.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/Bucket.md
@@ -1,6 +1,5 @@
 ---
 title: 'Bucket'
-head_title: 'Bucket'
 description: 'Bucket is returned by the S3Client.* methods who query S3 buckets.'
 weight: 20
 ---

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/Object.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/Object.md
@@ -1,6 +1,5 @@
 ---
 title: 'Object'
-head_title: 'Object'
 description: "Object is returned by the S3Client.* methods who query S3 buckets' objects."
 weight: 20
 ---

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/S3Part.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/S3Part.md
@@ -1,6 +1,5 @@
 ---
 title: 'S3Part'
-head_title: 'S3Part'
 slug: 's3part'
 description: 'S3Part is returned by the S3Client.uploadPart method when uploading a part to a multipart upload.'
 weight: 20

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/S3UploadedObject.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/S3UploadedObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'S3UploadedObject'
-head_title: 'S3UploadedObject'
 description: 'S3UploadedObject represents the response from S3 upload operations'
 weight: 20
 ---

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/_index.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'S3Client'
-head_title: 'S3Client'
 description: 'S3Client allows interacting with AWS S3 buckets and objects'
 description: 'S3Client class allows interacting with AWS S3 buckets and objects'
 weight: 00

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
@@ -1,6 +1,5 @@
 ---
 title: 'abortMultipartUpload'
-head_title: 'S3Client.abortMultipartUpload(bucketName, objectKey, uploadId)'
 description: 'S3Client.abortMultipartUpload aborts a multipart upload to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/completeMultipartUpload.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/completeMultipartUpload.md
@@ -1,6 +1,5 @@
 ---
 title: 'completeMultipartUpload'
-head_title: 'S3Client.completeMultipartUpload(bucketName, objectKey, uploadId, parts)'
 description: 'S3Client.completeMultipartUpload uploads a multipar object to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/copyObject.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/copyObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'copyObject'
-head_title: 'S3Client.copyObject'
 description: 'S3Client.copyObject copies an object from a bucket to another'
 weight: 10
 ---

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
@@ -1,6 +1,5 @@
 ---
 title: 'createMultipartUpload'
-head_title: 'S3Client.createMultipartUpload(bucketName, objectKey)'
 description: 'S3Client.createMultipartUpload creates a multipart upload for an object key to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/deleteObject.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/deleteObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'deleteObject'
-head_title: 'S3Client.deleteObject(bucketName, objectKey)'
 description: 'S3Client.deleteObject deletes an object from a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/getObject.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/getObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'getObject'
-head_title: 'S3Client.getObject(bucketName, objectKey)'
 description: 'S3Client.getObject downloads an object from a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/listBuckets.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/listBuckets.md
@@ -1,6 +1,5 @@
 ---
 title: 'listBuckets'
-head_title: 'S3Client.listBuckets()'
 description: 'S3Client.listBuckets lists the buckets the authenticated user has access to'
 weight: 10
 ---

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/listObjects.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/listObjects.md
@@ -1,6 +1,5 @@
 ---
 title: 'listObjects'
-head_title: 'S3Client.listObjects(bucketName, [prefix])'
 description: 'S3Client.listObjects lists the objects contained in a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/putObject.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/putObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'putObject'
-head_title: 'S3Client.putObject(bucketName, objectKey, data)'
 description: 'S3Client.putObject uploads an object to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/uploadPart.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/uploadPart.md
@@ -1,6 +1,5 @@
 ---
 title: 'uploadPart'
-head_title: 'S3Client.uploadPart(bucketName, objectKey, uploadId,partNumber, data)'
 description: 'S3Client.uploadPart a part in a multipart upload to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SQSClient/_index.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SQSClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SQSClient'
-head_title: 'SQSClient'
 description: 'SQSClient enables interaction with the AWS Simple Queue Service (SQS)'
 description: 'SQSClient allows interacting with the AWS Simple Queue Service (SQS)'
 weight: 00

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
@@ -1,6 +1,5 @@
 ---
 title: 'Secret'
-head_title: 'Secret'
 description: 'Secret is returned by the SecretsManagerClient.* methods who query secrets from AWS secrets manager.'
 weight: 20
 ---

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SecretsManagerClient'
-head_title: 'SecretsManagerClient'
 description: 'SecretsManagerClient allows interacting with AWS secrets stored in Secrets Manager'
 weight: 00
 ---

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
@@ -1,6 +1,5 @@
 ---
 title: 'createSecret'
-head_title: 'SecretsManagerClient.createSecret(name, secretString, description, [versionID], [tags])'
 description: 'SecretsManagerClient.createSecret creates a new secret'
 weight: 10
 ---

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
@@ -1,6 +1,5 @@
 ---
 title: 'deleteSecret'
-head_title: 'SecretsManagerClient.deleteSecret(secretID, { recoveryWindow: 30, noRecovery: false}})'
 description: 'SecretsManagerClient.deleteSecret deletes a secret'
 weight: 10
 ---

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
@@ -1,6 +1,5 @@
 ---
 title: 'getSecret'
-head_title: 'SecretsManagerClient.getSecret(secretID)'
 description: 'SecretsManagerClient.getSecret(secretID) downloads a secret from AWS secrets manager'
 weight: 10
 ---

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
@@ -1,6 +1,5 @@
 ---
 title: 'listSecrets'
-head_title: 'SecretsManagerClient.listSecrets()'
 description: 'SecretsManagerClient.listSecrets lists the secrets the authenticated user has access to'
 weight: 10
 ---

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
@@ -1,6 +1,5 @@
 ---
 title: 'putSecretValue'
-head_title: 'SecretsManagerClient.putSecretValue(secretID, secretString, [versionID], [tags])'
 description: "SecretsManagerClient.putSecretValue updates an existing secret's value"
 weight: 10
 ---

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SignatureV4/_index.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SignatureV4/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SignatureV4'
-head_title: 'SignatureV4'
 description: 'SignatureV4 is used to sign or pre-sign requests to AWS services using the Signature V4 algorithm'
 description: 'SignatureV4 is used to sign and pre-sign requests to AWS services using the Signature V4 algorithm'
 weight: 00

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SignatureV4/presign.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SignatureV4/presign.md
@@ -1,6 +1,5 @@
 ---
 title: 'presign'
-head_title: 'presign'
 slug: 'presign'
 description: 'Signaturev4.presign pre-signs a URL with the AWS Signature V4 algorithm'
 description: 'SignatureV4.sign pre-signs a URL with the AWS Signature V4 algorithm'

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SignatureV4/sign.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SignatureV4/sign.md
@@ -1,6 +1,5 @@
 ---
 title: 'sign'
-head_title: 'sign'
 slug: 'sign'
 description: 'Signaturev4.sign signs an HTTP request with the AWS Signature V4 algorithm'
 description: 'SignatureV4.sign signs an HTTP request with the AWS Signature V4 algorithm'

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
@@ -1,6 +1,5 @@
 ---
 title: 'SystemsManagerParameter'
-head_title: 'SystemsManagerParameter'
 slug: 'systemsmanagerparameter'
 description: 'SystemsManagerParameter is returned by the SystemsManagerClient.* methods that query parameters'
 weight: 20

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SystemsManagerClient'
-head_title: 'SystemsManagerClient'
 description: 'SystemsManagerClient allows interacting with the AWS Systems Manager Service'
 weight: 00
 ---

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
@@ -1,6 +1,5 @@
 ---
 title: 'getParameter'
-head_title: 'SystemsManagerClient.getParameter()'
 description: "SystemsManagerClient.getParameter gets a Systems Manager parameter in the caller's AWS account and region"
 weight: 10
 ---

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/awsconfig.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/awsconfig.md
@@ -1,7 +1,5 @@
 ---
 title: 'AWSConfig'
-head_title: 'AWSConfig'
-description: 'AWSConfig is used to configure an AWS service client instances'
 description: 'AWSConfig is used to configure an AWS service client instances'
 weight: 00
 ---

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'EventBridgeClient'
-head_title: 'EventBridgeClient'
 description: 'EventBridgeClient allows interacting with AWS EventBridge service'
 description: 'EventBridgeClient class allows sending custom events to Amazon EventBridge so that they can be matched to rules.'
 weight: 00

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
@@ -1,7 +1,5 @@
 ---
 title: 'putEvents'
-head_title: 'EventBridgeClient.putEvents'
-description: 'EventBridgeClient.putEvents sends custom events to Amazon EventBridge'
 description: 'EventBridgeClient.putEvents sends custom events to Amazon EventBridge'
 weight: 10
 ---

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
@@ -1,7 +1,6 @@
 ---
 title: 'KMSDataKey'
 slug: 'kmsdatakey'
-head_title: 'KMSDataKey'
 description: 'KMSDataKey is returned by the KMSClient.*DataKey methods that query KMS data keys'
 weight: 20
 ---

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
@@ -1,7 +1,5 @@
 ---
 title: 'KMSKey'
-head_title: 'KMSKey'
-description: 'KMSKey is returned by the KMSClient.* methods that query KMS keys'
 description: 'KMSKey is returned by the KMSClient.* methods that query KMS keys'
 weight: 20
 ---

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/KMSClient/_index.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/KMSClient/_index.md
@@ -1,7 +1,5 @@
 ---
 title: 'KMSClient'
-head_title: 'KMSClient'
-description: 'KMSClient allows interacting with the AWS Key Management Service'
 description: 'KMSClient allows interacting with the AWS Key Management Service'
 weight: 00
 ---

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/KMSClient/listKeys.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/KMSClient/listKeys.md
@@ -1,7 +1,5 @@
 ---
 title: 'listKeys'
-head_title: 'KMSClient.listKeys()'
-description: "KMSClient.listKeys lists all the KMS keys in the caller's AWS account and region"
 description: "KMSClient.listKeys lists all the KMS keys in the caller's AWS account and region"
 weight: 10
 ---

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/LambdaClient/_index.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/LambdaClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'LambdaClient'
-head_title: 'LambdaClient'
 description: 'LambdaClient allows interacting with the AWS Lambda service'
 weight: 00
 ---

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/LambdaClient/invoke.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/LambdaClient/invoke.md
@@ -1,6 +1,5 @@
 ---
 title: 'invoke'
-head_title: 'LambdaClient.invoke(name, payload, [options])'
 description: 'LambdaClient.invoke invokes an AWS Lamba function'
 weight: 10
 ---

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/Bucket.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/Bucket.md
@@ -1,6 +1,5 @@
 ---
 title: 'Bucket'
-head_title: 'Bucket'
 description: 'Bucket is returned by the S3Client.* methods who query S3 buckets.'
 weight: 20
 ---

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/Object.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/Object.md
@@ -1,6 +1,5 @@
 ---
 title: 'Object'
-head_title: 'Object'
 description: "Object is returned by the S3Client.* methods who query S3 buckets' objects."
 weight: 20
 ---

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/S3Part.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/S3Part.md
@@ -1,6 +1,5 @@
 ---
 title: 'S3Part'
-head_title: 'S3Part'
 slug: 's3part'
 description: 'S3Part is returned by the S3Client.uploadPart method when uploading a part to a multipart upload.'
 weight: 20

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/S3UploadedObject.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/S3UploadedObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'S3UploadedObject'
-head_title: 'S3UploadedObject'
 description: 'S3UploadedObject represents the response from S3 upload operations'
 weight: 20
 ---

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/_index.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'S3Client'
-head_title: 'S3Client'
 description: 'S3Client allows interacting with AWS S3 buckets and objects'
 description: 'S3Client class allows interacting with AWS S3 buckets and objects'
 weight: 00

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
@@ -1,6 +1,5 @@
 ---
 title: 'abortMultipartUpload'
-head_title: 'S3Client.abortMultipartUpload(bucketName, objectKey, uploadId)'
 description: 'S3Client.abortMultipartUpload aborts a multipart upload to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/completeMultipartUpload.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/completeMultipartUpload.md
@@ -1,6 +1,5 @@
 ---
 title: 'completeMultipartUpload'
-head_title: 'S3Client.completeMultipartUpload(bucketName, objectKey, uploadId, parts)'
 description: 'S3Client.completeMultipartUpload uploads a multipar object to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/copyObject.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/copyObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'copyObject'
-head_title: 'S3Client.copyObject'
 description: 'S3Client.copyObject copies an object from a bucket to another'
 weight: 10
 ---

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
@@ -1,6 +1,5 @@
 ---
 title: 'createMultipartUpload'
-head_title: 'S3Client.createMultipartUpload(bucketName, objectKey)'
 description: 'S3Client.createMultipartUpload creates a multipart upload for an object key to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/deleteObject.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/deleteObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'deleteObject'
-head_title: 'S3Client.deleteObject(bucketName, objectKey)'
 description: 'S3Client.deleteObject deletes an object from a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/getObject.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/getObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'getObject'
-head_title: 'S3Client.getObject(bucketName, objectKey)'
 description: 'S3Client.getObject downloads an object from a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/listBuckets.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/listBuckets.md
@@ -1,6 +1,5 @@
 ---
 title: 'listBuckets'
-head_title: 'S3Client.listBuckets()'
 description: 'S3Client.listBuckets lists the buckets the authenticated user has access to'
 weight: 10
 ---

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/listObjects.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/listObjects.md
@@ -1,6 +1,5 @@
 ---
 title: 'listObjects'
-head_title: 'S3Client.listObjects(bucketName, [prefix])'
 description: 'S3Client.listObjects lists the objects contained in a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/putObject.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/putObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'putObject'
-head_title: 'S3Client.putObject(bucketName, objectKey, data)'
 description: 'S3Client.putObject uploads an object to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/uploadPart.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/uploadPart.md
@@ -1,6 +1,5 @@
 ---
 title: 'uploadPart'
-head_title: 'S3Client.uploadPart(bucketName, objectKey, uploadId,partNumber, data)'
 description: 'S3Client.uploadPart a part in a multipart upload to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SQSClient/_index.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SQSClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SQSClient'
-head_title: 'SQSClient'
 description: 'SQSClient enables interaction with the AWS Simple Queue Service (SQS)'
 description: 'SQSClient allows interacting with the AWS Simple Queue Service (SQS)'
 weight: 00

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
@@ -1,6 +1,5 @@
 ---
 title: 'Secret'
-head_title: 'Secret'
 description: 'Secret is returned by the SecretsManagerClient.* methods who query secrets from AWS secrets manager.'
 weight: 20
 ---

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SecretsManagerClient'
-head_title: 'SecretsManagerClient'
 description: 'SecretsManagerClient allows interacting with AWS secrets stored in Secrets Manager'
 weight: 00
 ---

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
@@ -1,6 +1,5 @@
 ---
 title: 'createSecret'
-head_title: 'SecretsManagerClient.createSecret(name, secretString, description, [versionID], [tags])'
 description: 'SecretsManagerClient.createSecret creates a new secret'
 weight: 10
 ---

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
@@ -1,6 +1,5 @@
 ---
 title: 'deleteSecret'
-head_title: 'SecretsManagerClient.deleteSecret(secretID, { recoveryWindow: 30, noRecovery: false}})'
 description: 'SecretsManagerClient.deleteSecret deletes a secret'
 weight: 10
 ---

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
@@ -1,6 +1,5 @@
 ---
 title: 'getSecret'
-head_title: 'SecretsManagerClient.getSecret(secretID)'
 description: 'SecretsManagerClient.getSecret(secretID) downloads a secret from AWS secrets manager'
 weight: 10
 ---

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
@@ -1,6 +1,5 @@
 ---
 title: 'listSecrets'
-head_title: 'SecretsManagerClient.listSecrets()'
 description: 'SecretsManagerClient.listSecrets lists the secrets the authenticated user has access to'
 weight: 10
 ---

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
@@ -1,6 +1,5 @@
 ---
 title: 'putSecretValue'
-head_title: 'SecretsManagerClient.putSecretValue(secretID, secretString, [versionID], [tags])'
 description: "SecretsManagerClient.putSecretValue updates an existing secret's value"
 weight: 10
 ---

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SignatureV4/_index.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SignatureV4/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SignatureV4'
-head_title: 'SignatureV4'
 description: 'SignatureV4 is used to sign or pre-sign requests to AWS services using the Signature V4 algorithm'
 description: 'SignatureV4 is used to sign and pre-sign requests to AWS services using the Signature V4 algorithm'
 weight: 00

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SignatureV4/presign.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SignatureV4/presign.md
@@ -1,6 +1,5 @@
 ---
 title: 'presign'
-head_title: 'presign'
 slug: 'presign'
 description: 'Signaturev4.presign pre-signs a URL with the AWS Signature V4 algorithm'
 description: 'SignatureV4.sign pre-signs a URL with the AWS Signature V4 algorithm'

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SignatureV4/sign.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SignatureV4/sign.md
@@ -1,6 +1,5 @@
 ---
 title: 'sign'
-head_title: 'sign'
 slug: 'sign'
 description: 'Signaturev4.sign signs an HTTP request with the AWS Signature V4 algorithm'
 description: 'SignatureV4.sign signs an HTTP request with the AWS Signature V4 algorithm'

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
@@ -1,6 +1,5 @@
 ---
 title: 'SystemsManagerParameter'
-head_title: 'SystemsManagerParameter'
 slug: 'systemsmanagerparameter'
 description: 'SystemsManagerParameter is returned by the SystemsManagerClient.* methods that query parameters'
 weight: 20

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SystemsManagerClient'
-head_title: 'SystemsManagerClient'
 description: 'SystemsManagerClient allows interacting with the AWS Systems Manager Service'
 weight: 00
 ---

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
@@ -1,6 +1,5 @@
 ---
 title: 'getParameter'
-head_title: 'SystemsManagerClient.getParameter()'
 description: "SystemsManagerClient.getParameter gets a Systems Manager parameter in the caller's AWS account and region"
 weight: 10
 ---

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/awsconfig.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/awsconfig.md
@@ -1,7 +1,5 @@
 ---
 title: 'AWSConfig'
-head_title: 'AWSConfig'
-description: 'AWSConfig is used to configure an AWS service client instances'
 description: 'AWSConfig is used to configure an AWS service client instances'
 weight: 00
 ---

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'EventBridgeClient'
-head_title: 'EventBridgeClient'
 description: 'EventBridgeClient allows interacting with AWS EventBridge service'
 description: 'EventBridgeClient class allows sending custom events to Amazon EventBridge so that they can be matched to rules.'
 weight: 00

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
@@ -1,7 +1,5 @@
 ---
 title: 'putEvents'
-head_title: 'EventBridgeClient.putEvents'
-description: 'EventBridgeClient.putEvents sends custom events to Amazon EventBridge'
 description: 'EventBridgeClient.putEvents sends custom events to Amazon EventBridge'
 weight: 10
 ---

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
@@ -1,7 +1,6 @@
 ---
 title: 'KMSDataKey'
 slug: 'kmsdatakey'
-head_title: 'KMSDataKey'
 description: 'KMSDataKey is returned by the KMSClient.*DataKey methods that query KMS data keys'
 weight: 20
 ---

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
@@ -1,7 +1,5 @@
 ---
 title: 'KMSKey'
-head_title: 'KMSKey'
-description: 'KMSKey is returned by the KMSClient.* methods that query KMS keys'
 description: 'KMSKey is returned by the KMSClient.* methods that query KMS keys'
 weight: 20
 ---

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/KMSClient/_index.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/KMSClient/_index.md
@@ -1,7 +1,5 @@
 ---
 title: 'KMSClient'
-head_title: 'KMSClient'
-description: 'KMSClient allows interacting with the AWS Key Management Service'
 description: 'KMSClient allows interacting with the AWS Key Management Service'
 weight: 00
 ---

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/KMSClient/listKeys.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/KMSClient/listKeys.md
@@ -1,7 +1,5 @@
 ---
 title: 'listKeys'
-head_title: 'KMSClient.listKeys()'
-description: "KMSClient.listKeys lists all the KMS keys in the caller's AWS account and region"
 description: "KMSClient.listKeys lists all the KMS keys in the caller's AWS account and region"
 weight: 10
 ---

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/LambdaClient/_index.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/LambdaClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'LambdaClient'
-head_title: 'LambdaClient'
 description: 'LambdaClient allows interacting with the AWS Lambda service'
 weight: 00
 ---

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/LambdaClient/invoke.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/LambdaClient/invoke.md
@@ -1,6 +1,5 @@
 ---
 title: 'invoke'
-head_title: 'LambdaClient.invoke(name, payload, [options])'
 description: 'LambdaClient.invoke invokes an AWS Lamba function'
 weight: 10
 ---

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/Bucket.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/Bucket.md
@@ -1,6 +1,5 @@
 ---
 title: 'Bucket'
-head_title: 'Bucket'
 description: 'Bucket is returned by the S3Client.* methods who query S3 buckets.'
 weight: 20
 ---

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/Object.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/Object.md
@@ -1,6 +1,5 @@
 ---
 title: 'Object'
-head_title: 'Object'
 description: "Object is returned by the S3Client.* methods who query S3 buckets' objects."
 weight: 20
 ---

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/S3Part.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/S3Part.md
@@ -1,6 +1,5 @@
 ---
 title: 'S3Part'
-head_title: 'S3Part'
 slug: 's3part'
 description: 'S3Part is returned by the S3Client.uploadPart method when uploading a part to a multipart upload.'
 weight: 20

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/S3UploadedObject.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/S3UploadedObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'S3UploadedObject'
-head_title: 'S3UploadedObject'
 description: 'S3UploadedObject represents the response from S3 upload operations'
 weight: 20
 ---

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/_index.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'S3Client'
-head_title: 'S3Client'
 description: 'S3Client allows interacting with AWS S3 buckets and objects'
 description: 'S3Client class allows interacting with AWS S3 buckets and objects'
 weight: 00

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
@@ -1,6 +1,5 @@
 ---
 title: 'abortMultipartUpload'
-head_title: 'S3Client.abortMultipartUpload(bucketName, objectKey, uploadId)'
 description: 'S3Client.abortMultipartUpload aborts a multipart upload to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/completeMultipartUpload.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/completeMultipartUpload.md
@@ -1,6 +1,5 @@
 ---
 title: 'completeMultipartUpload'
-head_title: 'S3Client.completeMultipartUpload(bucketName, objectKey, uploadId, parts)'
 description: 'S3Client.completeMultipartUpload uploads a multipar object to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/copyObject.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/copyObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'copyObject'
-head_title: 'S3Client.copyObject'
 description: 'S3Client.copyObject copies an object from a bucket to another'
 weight: 10
 ---

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
@@ -1,6 +1,5 @@
 ---
 title: 'createMultipartUpload'
-head_title: 'S3Client.createMultipartUpload(bucketName, objectKey)'
 description: 'S3Client.createMultipartUpload creates a multipart upload for an object key to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/deleteObject.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/deleteObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'deleteObject'
-head_title: 'S3Client.deleteObject(bucketName, objectKey)'
 description: 'S3Client.deleteObject deletes an object from a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/getObject.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/getObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'getObject'
-head_title: 'S3Client.getObject(bucketName, objectKey)'
 description: 'S3Client.getObject downloads an object from a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/listBuckets.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/listBuckets.md
@@ -1,6 +1,5 @@
 ---
 title: 'listBuckets'
-head_title: 'S3Client.listBuckets()'
 description: 'S3Client.listBuckets lists the buckets the authenticated user has access to'
 weight: 10
 ---

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/listObjects.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/listObjects.md
@@ -1,6 +1,5 @@
 ---
 title: 'listObjects'
-head_title: 'S3Client.listObjects(bucketName, [prefix])'
 description: 'S3Client.listObjects lists the objects contained in a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/putObject.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/putObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'putObject'
-head_title: 'S3Client.putObject(bucketName, objectKey, data)'
 description: 'S3Client.putObject uploads an object to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/uploadPart.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/uploadPart.md
@@ -1,6 +1,5 @@
 ---
 title: 'uploadPart'
-head_title: 'S3Client.uploadPart(bucketName, objectKey, uploadId,partNumber, data)'
 description: 'S3Client.uploadPart a part in a multipart upload to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SQSClient/_index.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SQSClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SQSClient'
-head_title: 'SQSClient'
 description: 'SQSClient enables interaction with the AWS Simple Queue Service (SQS)'
 description: 'SQSClient allows interacting with the AWS Simple Queue Service (SQS)'
 weight: 00

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
@@ -1,6 +1,5 @@
 ---
 title: 'Secret'
-head_title: 'Secret'
 description: 'Secret is returned by the SecretsManagerClient.* methods who query secrets from AWS secrets manager.'
 weight: 20
 ---

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SecretsManagerClient'
-head_title: 'SecretsManagerClient'
 description: 'SecretsManagerClient allows interacting with AWS secrets stored in Secrets Manager'
 weight: 00
 ---

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
@@ -1,6 +1,5 @@
 ---
 title: 'createSecret'
-head_title: 'SecretsManagerClient.createSecret(name, secretString, description, [versionID], [tags])'
 description: 'SecretsManagerClient.createSecret creates a new secret'
 weight: 10
 ---

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
@@ -1,6 +1,5 @@
 ---
 title: 'deleteSecret'
-head_title: 'SecretsManagerClient.deleteSecret(secretID, { recoveryWindow: 30, noRecovery: false}})'
 description: 'SecretsManagerClient.deleteSecret deletes a secret'
 weight: 10
 ---

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
@@ -1,6 +1,5 @@
 ---
 title: 'getSecret'
-head_title: 'SecretsManagerClient.getSecret(secretID)'
 description: 'SecretsManagerClient.getSecret(secretID) downloads a secret from AWS secrets manager'
 weight: 10
 ---

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
@@ -1,6 +1,5 @@
 ---
 title: 'listSecrets'
-head_title: 'SecretsManagerClient.listSecrets()'
 description: 'SecretsManagerClient.listSecrets lists the secrets the authenticated user has access to'
 weight: 10
 ---

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
@@ -1,6 +1,5 @@
 ---
 title: 'putSecretValue'
-head_title: 'SecretsManagerClient.putSecretValue(secretID, secretString, [versionID], [tags])'
 description: "SecretsManagerClient.putSecretValue updates an existing secret's value"
 weight: 10
 ---

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SignatureV4/_index.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SignatureV4/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SignatureV4'
-head_title: 'SignatureV4'
 description: 'SignatureV4 is used to sign or pre-sign requests to AWS services using the Signature V4 algorithm'
 description: 'SignatureV4 is used to sign and pre-sign requests to AWS services using the Signature V4 algorithm'
 weight: 00

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SignatureV4/presign.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SignatureV4/presign.md
@@ -1,6 +1,5 @@
 ---
 title: 'presign'
-head_title: 'presign'
 slug: 'presign'
 description: 'Signaturev4.presign pre-signs a URL with the AWS Signature V4 algorithm'
 description: 'SignatureV4.sign pre-signs a URL with the AWS Signature V4 algorithm'

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SignatureV4/sign.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SignatureV4/sign.md
@@ -1,6 +1,5 @@
 ---
 title: 'sign'
-head_title: 'sign'
 slug: 'sign'
 description: 'Signaturev4.sign signs an HTTP request with the AWS Signature V4 algorithm'
 description: 'SignatureV4.sign signs an HTTP request with the AWS Signature V4 algorithm'

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
@@ -1,6 +1,5 @@
 ---
 title: 'SystemsManagerParameter'
-head_title: 'SystemsManagerParameter'
 slug: 'systemsmanagerparameter'
 description: 'SystemsManagerParameter is returned by the SystemsManagerClient.* methods that query parameters'
 weight: 20

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SystemsManagerClient'
-head_title: 'SystemsManagerClient'
 description: 'SystemsManagerClient allows interacting with the AWS Systems Manager Service'
 weight: 00
 ---

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
@@ -1,6 +1,5 @@
 ---
 title: 'getParameter'
-head_title: 'SystemsManagerClient.getParameter()'
 description: "SystemsManagerClient.getParameter gets a Systems Manager parameter in the caller's AWS account and region"
 weight: 10
 ---

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/awsconfig.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/awsconfig.md
@@ -1,7 +1,5 @@
 ---
 title: 'AWSConfig'
-head_title: 'AWSConfig'
-description: 'AWSConfig is used to configure an AWS service client instances'
 description: 'AWSConfig is used to configure an AWS service client instances'
 weight: 00
 ---

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'EventBridgeClient'
-head_title: 'EventBridgeClient'
 description: 'EventBridgeClient allows interacting with AWS EventBridge service'
 description: 'EventBridgeClient class allows sending custom events to Amazon EventBridge so that they can be matched to rules.'
 weight: 00

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
@@ -1,7 +1,5 @@
 ---
 title: 'putEvents'
-head_title: 'EventBridgeClient.putEvents'
-description: 'EventBridgeClient.putEvents sends custom events to Amazon EventBridge'
 description: 'EventBridgeClient.putEvents sends custom events to Amazon EventBridge'
 weight: 10
 ---

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
@@ -1,7 +1,6 @@
 ---
 title: 'KMSDataKey'
 slug: 'kmsdatakey'
-head_title: 'KMSDataKey'
 description: 'KMSDataKey is returned by the KMSClient.*DataKey methods that query KMS data keys'
 weight: 20
 ---

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
@@ -1,7 +1,5 @@
 ---
 title: 'KMSKey'
-head_title: 'KMSKey'
-description: 'KMSKey is returned by the KMSClient.* methods that query KMS keys'
 description: 'KMSKey is returned by the KMSClient.* methods that query KMS keys'
 weight: 20
 ---

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/KMSClient/_index.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/KMSClient/_index.md
@@ -1,7 +1,5 @@
 ---
 title: 'KMSClient'
-head_title: 'KMSClient'
-description: 'KMSClient allows interacting with the AWS Key Management Service'
 description: 'KMSClient allows interacting with the AWS Key Management Service'
 weight: 00
 ---

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/KMSClient/listKeys.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/KMSClient/listKeys.md
@@ -1,7 +1,5 @@
 ---
 title: 'listKeys'
-head_title: 'KMSClient.listKeys()'
-description: "KMSClient.listKeys lists all the KMS keys in the caller's AWS account and region"
 description: "KMSClient.listKeys lists all the KMS keys in the caller's AWS account and region"
 weight: 10
 ---

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/LambdaClient/_index.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/LambdaClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'LambdaClient'
-head_title: 'LambdaClient'
 description: 'LambdaClient allows interacting with the AWS Lambda service'
 weight: 00
 ---

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/LambdaClient/invoke.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/LambdaClient/invoke.md
@@ -1,6 +1,5 @@
 ---
 title: 'invoke'
-head_title: 'LambdaClient.invoke(name, payload, [options])'
 description: 'LambdaClient.invoke invokes an AWS Lamba function'
 weight: 10
 ---

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/Bucket.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/Bucket.md
@@ -1,6 +1,5 @@
 ---
 title: 'Bucket'
-head_title: 'Bucket'
 description: 'Bucket is returned by the S3Client.* methods who query S3 buckets.'
 weight: 20
 ---

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/Object.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/Object.md
@@ -1,6 +1,5 @@
 ---
 title: 'Object'
-head_title: 'Object'
 description: "Object is returned by the S3Client.* methods who query S3 buckets' objects."
 weight: 20
 ---

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/S3Part.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/S3Part.md
@@ -1,6 +1,5 @@
 ---
 title: 'S3Part'
-head_title: 'S3Part'
 slug: 's3part'
 description: 'S3Part is returned by the S3Client.uploadPart method when uploading a part to a multipart upload.'
 weight: 20

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/S3UploadedObject.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/S3UploadedObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'S3UploadedObject'
-head_title: 'S3UploadedObject'
 description: 'S3UploadedObject represents the response from S3 upload operations'
 weight: 20
 ---

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/_index.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'S3Client'
-head_title: 'S3Client'
 description: 'S3Client allows interacting with AWS S3 buckets and objects'
 description: 'S3Client class allows interacting with AWS S3 buckets and objects'
 weight: 00

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
@@ -1,6 +1,5 @@
 ---
 title: 'abortMultipartUpload'
-head_title: 'S3Client.abortMultipartUpload(bucketName, objectKey, uploadId)'
 description: 'S3Client.abortMultipartUpload aborts a multipart upload to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/completeMultipartUpload.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/completeMultipartUpload.md
@@ -1,6 +1,5 @@
 ---
 title: 'completeMultipartUpload'
-head_title: 'S3Client.completeMultipartUpload(bucketName, objectKey, uploadId, parts)'
 description: 'S3Client.completeMultipartUpload uploads a multipar object to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/copyObject.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/copyObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'copyObject'
-head_title: 'S3Client.copyObject'
 description: 'S3Client.copyObject copies an object from a bucket to another'
 weight: 10
 ---

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
@@ -1,6 +1,5 @@
 ---
 title: 'createMultipartUpload'
-head_title: 'S3Client.createMultipartUpload(bucketName, objectKey)'
 description: 'S3Client.createMultipartUpload creates a multipart upload for an object key to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/deleteObject.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/deleteObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'deleteObject'
-head_title: 'S3Client.deleteObject(bucketName, objectKey)'
 description: 'S3Client.deleteObject deletes an object from a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/getObject.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/getObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'getObject'
-head_title: 'S3Client.getObject(bucketName, objectKey)'
 description: 'S3Client.getObject downloads an object from a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/listBuckets.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/listBuckets.md
@@ -1,6 +1,5 @@
 ---
 title: 'listBuckets'
-head_title: 'S3Client.listBuckets()'
 description: 'S3Client.listBuckets lists the buckets the authenticated user has access to'
 weight: 10
 ---

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/listObjects.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/listObjects.md
@@ -1,6 +1,5 @@
 ---
 title: 'listObjects'
-head_title: 'S3Client.listObjects(bucketName, [prefix])'
 description: 'S3Client.listObjects lists the objects contained in a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/putObject.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/putObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'putObject'
-head_title: 'S3Client.putObject(bucketName, objectKey, data)'
 description: 'S3Client.putObject uploads an object to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/uploadPart.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/uploadPart.md
@@ -1,6 +1,5 @@
 ---
 title: 'uploadPart'
-head_title: 'S3Client.uploadPart(bucketName, objectKey, uploadId,partNumber, data)'
 description: 'S3Client.uploadPart a part in a multipart upload to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SQSClient/_index.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SQSClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SQSClient'
-head_title: 'SQSClient'
 description: 'SQSClient enables interaction with the AWS Simple Queue Service (SQS)'
 description: 'SQSClient allows interacting with the AWS Simple Queue Service (SQS)'
 weight: 00

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
@@ -1,6 +1,5 @@
 ---
 title: 'Secret'
-head_title: 'Secret'
 description: 'Secret is returned by the SecretsManagerClient.* methods who query secrets from AWS secrets manager.'
 weight: 20
 ---

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SecretsManagerClient'
-head_title: 'SecretsManagerClient'
 description: 'SecretsManagerClient allows interacting with AWS secrets stored in Secrets Manager'
 weight: 00
 ---

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
@@ -1,6 +1,5 @@
 ---
 title: 'createSecret'
-head_title: 'SecretsManagerClient.createSecret(name, secretString, description, [versionID], [tags])'
 description: 'SecretsManagerClient.createSecret creates a new secret'
 weight: 10
 ---

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
@@ -1,6 +1,5 @@
 ---
 title: 'deleteSecret'
-head_title: 'SecretsManagerClient.deleteSecret(secretID, { recoveryWindow: 30, noRecovery: false}})'
 description: 'SecretsManagerClient.deleteSecret deletes a secret'
 weight: 10
 ---

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
@@ -1,6 +1,5 @@
 ---
 title: 'getSecret'
-head_title: 'SecretsManagerClient.getSecret(secretID)'
 description: 'SecretsManagerClient.getSecret(secretID) downloads a secret from AWS secrets manager'
 weight: 10
 ---

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
@@ -1,6 +1,5 @@
 ---
 title: 'listSecrets'
-head_title: 'SecretsManagerClient.listSecrets()'
 description: 'SecretsManagerClient.listSecrets lists the secrets the authenticated user has access to'
 weight: 10
 ---

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
@@ -1,6 +1,5 @@
 ---
 title: 'putSecretValue'
-head_title: 'SecretsManagerClient.putSecretValue(secretID, secretString, [versionID], [tags])'
 description: "SecretsManagerClient.putSecretValue updates an existing secret's value"
 weight: 10
 ---

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SignatureV4/_index.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SignatureV4/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SignatureV4'
-head_title: 'SignatureV4'
 description: 'SignatureV4 is used to sign or pre-sign requests to AWS services using the Signature V4 algorithm'
 description: 'SignatureV4 is used to sign and pre-sign requests to AWS services using the Signature V4 algorithm'
 weight: 00

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SignatureV4/presign.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SignatureV4/presign.md
@@ -1,6 +1,5 @@
 ---
 title: 'presign'
-head_title: 'presign'
 slug: 'presign'
 description: 'Signaturev4.presign pre-signs a URL with the AWS Signature V4 algorithm'
 description: 'SignatureV4.sign pre-signs a URL with the AWS Signature V4 algorithm'

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SignatureV4/sign.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SignatureV4/sign.md
@@ -1,6 +1,5 @@
 ---
 title: 'sign'
-head_title: 'sign'
 slug: 'sign'
 description: 'Signaturev4.sign signs an HTTP request with the AWS Signature V4 algorithm'
 description: 'SignatureV4.sign signs an HTTP request with the AWS Signature V4 algorithm'

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
@@ -1,6 +1,5 @@
 ---
 title: 'SystemsManagerParameter'
-head_title: 'SystemsManagerParameter'
 slug: 'systemsmanagerparameter'
 description: 'SystemsManagerParameter is returned by the SystemsManagerClient.* methods that query parameters'
 weight: 20

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SystemsManagerClient'
-head_title: 'SystemsManagerClient'
 description: 'SystemsManagerClient allows interacting with the AWS Systems Manager Service'
 weight: 00
 ---

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
@@ -1,6 +1,5 @@
 ---
 title: 'getParameter'
-head_title: 'SystemsManagerClient.getParameter()'
 description: "SystemsManagerClient.getParameter gets a Systems Manager parameter in the caller's AWS account and region"
 weight: 10
 ---

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/awsconfig.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/awsconfig.md
@@ -1,7 +1,5 @@
 ---
 title: 'AWSConfig'
-head_title: 'AWSConfig'
-description: 'AWSConfig is used to configure an AWS service client instances'
 description: 'AWSConfig is used to configure an AWS service client instances'
 weight: 00
 ---

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'EventBridgeClient'
-head_title: 'EventBridgeClient'
 description: 'EventBridgeClient allows interacting with AWS EventBridge service'
 description: 'EventBridgeClient class allows sending custom events to Amazon EventBridge so that they can be matched to rules.'
 weight: 00

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
@@ -1,7 +1,5 @@
 ---
 title: 'putEvents'
-head_title: 'EventBridgeClient.putEvents'
-description: 'EventBridgeClient.putEvents sends custom events to Amazon EventBridge'
 description: 'EventBridgeClient.putEvents sends custom events to Amazon EventBridge'
 weight: 10
 ---

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
@@ -1,7 +1,6 @@
 ---
 title: 'KMSDataKey'
 slug: 'kmsdatakey'
-head_title: 'KMSDataKey'
 description: 'KMSDataKey is returned by the KMSClient.*DataKey methods that query KMS data keys'
 weight: 20
 ---

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
@@ -1,7 +1,5 @@
 ---
 title: 'KMSKey'
-head_title: 'KMSKey'
-description: 'KMSKey is returned by the KMSClient.* methods that query KMS keys'
 description: 'KMSKey is returned by the KMSClient.* methods that query KMS keys'
 weight: 20
 ---

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/KMSClient/_index.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/KMSClient/_index.md
@@ -1,7 +1,5 @@
 ---
 title: 'KMSClient'
-head_title: 'KMSClient'
-description: 'KMSClient allows interacting with the AWS Key Management Service'
 description: 'KMSClient allows interacting with the AWS Key Management Service'
 weight: 00
 ---

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/KMSClient/listKeys.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/KMSClient/listKeys.md
@@ -1,7 +1,5 @@
 ---
 title: 'listKeys'
-head_title: 'KMSClient.listKeys()'
-description: "KMSClient.listKeys lists all the KMS keys in the caller's AWS account and region"
 description: "KMSClient.listKeys lists all the KMS keys in the caller's AWS account and region"
 weight: 10
 ---

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/LambdaClient/_index.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/LambdaClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'LambdaClient'
-head_title: 'LambdaClient'
 description: 'LambdaClient allows interacting with the AWS Lambda service'
 weight: 00
 ---

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/LambdaClient/invoke.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/LambdaClient/invoke.md
@@ -1,6 +1,5 @@
 ---
 title: 'invoke'
-head_title: 'LambdaClient.invoke(name, payload, [options])'
 description: 'LambdaClient.invoke invokes an AWS Lamba function'
 weight: 10
 ---

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/Bucket.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/Bucket.md
@@ -1,6 +1,5 @@
 ---
 title: 'Bucket'
-head_title: 'Bucket'
 description: 'Bucket is returned by the S3Client.* methods who query S3 buckets.'
 weight: 20
 ---

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/Object.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/Object.md
@@ -1,6 +1,5 @@
 ---
 title: 'Object'
-head_title: 'Object'
 description: "Object is returned by the S3Client.* methods who query S3 buckets' objects."
 weight: 20
 ---

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/S3Part.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/S3Part.md
@@ -1,6 +1,5 @@
 ---
 title: 'S3Part'
-head_title: 'S3Part'
 slug: 's3part'
 description: 'S3Part is returned by the S3Client.uploadPart method when uploading a part to a multipart upload.'
 weight: 20

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/S3UploadedObject.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/S3UploadedObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'S3UploadedObject'
-head_title: 'S3UploadedObject'
 description: 'S3UploadedObject represents the response from S3 upload operations'
 weight: 20
 ---

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/_index.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'S3Client'
-head_title: 'S3Client'
 description: 'S3Client allows interacting with AWS S3 buckets and objects'
 description: 'S3Client class allows interacting with AWS S3 buckets and objects'
 weight: 00

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
@@ -1,6 +1,5 @@
 ---
 title: 'abortMultipartUpload'
-head_title: 'S3Client.abortMultipartUpload(bucketName, objectKey, uploadId)'
 description: 'S3Client.abortMultipartUpload aborts a multipart upload to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/completeMultipartUpload.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/completeMultipartUpload.md
@@ -1,6 +1,5 @@
 ---
 title: 'completeMultipartUpload'
-head_title: 'S3Client.completeMultipartUpload(bucketName, objectKey, uploadId, parts)'
 description: 'S3Client.completeMultipartUpload uploads a multipar object to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/copyObject.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/copyObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'copyObject'
-head_title: 'S3Client.copyObject'
 description: 'S3Client.copyObject copies an object from a bucket to another'
 weight: 10
 ---

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
@@ -1,6 +1,5 @@
 ---
 title: 'createMultipartUpload'
-head_title: 'S3Client.createMultipartUpload(bucketName, objectKey)'
 description: 'S3Client.createMultipartUpload creates a multipart upload for an object key to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/deleteObject.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/deleteObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'deleteObject'
-head_title: 'S3Client.deleteObject(bucketName, objectKey)'
 description: 'S3Client.deleteObject deletes an object from a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/getObject.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/getObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'getObject'
-head_title: 'S3Client.getObject(bucketName, objectKey)'
 description: 'S3Client.getObject downloads an object from a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/listBuckets.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/listBuckets.md
@@ -1,6 +1,5 @@
 ---
 title: 'listBuckets'
-head_title: 'S3Client.listBuckets()'
 description: 'S3Client.listBuckets lists the buckets the authenticated user has access to'
 weight: 10
 ---

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/listObjects.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/listObjects.md
@@ -1,6 +1,5 @@
 ---
 title: 'listObjects'
-head_title: 'S3Client.listObjects(bucketName, [prefix])'
 description: 'S3Client.listObjects lists the objects contained in a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/putObject.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/putObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'putObject'
-head_title: 'S3Client.putObject(bucketName, objectKey, data)'
 description: 'S3Client.putObject uploads an object to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/uploadPart.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/uploadPart.md
@@ -1,6 +1,5 @@
 ---
 title: 'uploadPart'
-head_title: 'S3Client.uploadPart(bucketName, objectKey, uploadId,partNumber, data)'
 description: 'S3Client.uploadPart a part in a multipart upload to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SQSClient/_index.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SQSClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SQSClient'
-head_title: 'SQSClient'
 description: 'SQSClient enables interaction with the AWS Simple Queue Service (SQS)'
 description: 'SQSClient allows interacting with the AWS Simple Queue Service (SQS)'
 weight: 00

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
@@ -1,6 +1,5 @@
 ---
 title: 'Secret'
-head_title: 'Secret'
 description: 'Secret is returned by the SecretsManagerClient.* methods who query secrets from AWS secrets manager.'
 weight: 20
 ---

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SecretsManagerClient'
-head_title: 'SecretsManagerClient'
 description: 'SecretsManagerClient allows interacting with AWS secrets stored in Secrets Manager'
 weight: 00
 ---

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
@@ -1,6 +1,5 @@
 ---
 title: 'createSecret'
-head_title: 'SecretsManagerClient.createSecret(name, secretString, description, [versionID], [tags])'
 description: 'SecretsManagerClient.createSecret creates a new secret'
 weight: 10
 ---

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
@@ -1,6 +1,5 @@
 ---
 title: 'deleteSecret'
-head_title: 'SecretsManagerClient.deleteSecret(secretID, { recoveryWindow: 30, noRecovery: false}})'
 description: 'SecretsManagerClient.deleteSecret deletes a secret'
 weight: 10
 ---

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
@@ -1,6 +1,5 @@
 ---
 title: 'getSecret'
-head_title: 'SecretsManagerClient.getSecret(secretID)'
 description: 'SecretsManagerClient.getSecret(secretID) downloads a secret from AWS secrets manager'
 weight: 10
 ---

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
@@ -1,6 +1,5 @@
 ---
 title: 'listSecrets'
-head_title: 'SecretsManagerClient.listSecrets()'
 description: 'SecretsManagerClient.listSecrets lists the secrets the authenticated user has access to'
 weight: 10
 ---

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
@@ -1,6 +1,5 @@
 ---
 title: 'putSecretValue'
-head_title: 'SecretsManagerClient.putSecretValue(secretID, secretString, [versionID], [tags])'
 description: "SecretsManagerClient.putSecretValue updates an existing secret's value"
 weight: 10
 ---

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SignatureV4/_index.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SignatureV4/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SignatureV4'
-head_title: 'SignatureV4'
 description: 'SignatureV4 is used to sign or pre-sign requests to AWS services using the Signature V4 algorithm'
 description: 'SignatureV4 is used to sign and pre-sign requests to AWS services using the Signature V4 algorithm'
 weight: 00

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SignatureV4/presign.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SignatureV4/presign.md
@@ -1,6 +1,5 @@
 ---
 title: 'presign'
-head_title: 'presign'
 slug: 'presign'
 description: 'Signaturev4.presign pre-signs a URL with the AWS Signature V4 algorithm'
 description: 'SignatureV4.sign pre-signs a URL with the AWS Signature V4 algorithm'

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SignatureV4/sign.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SignatureV4/sign.md
@@ -1,6 +1,5 @@
 ---
 title: 'sign'
-head_title: 'sign'
 slug: 'sign'
 description: 'Signaturev4.sign signs an HTTP request with the AWS Signature V4 algorithm'
 description: 'SignatureV4.sign signs an HTTP request with the AWS Signature V4 algorithm'

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
@@ -1,6 +1,5 @@
 ---
 title: 'SystemsManagerParameter'
-head_title: 'SystemsManagerParameter'
 slug: 'systemsmanagerparameter'
 description: 'SystemsManagerParameter is returned by the SystemsManagerClient.* methods that query parameters'
 weight: 20

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SystemsManagerClient'
-head_title: 'SystemsManagerClient'
 description: 'SystemsManagerClient allows interacting with the AWS Systems Manager Service'
 weight: 00
 ---

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
@@ -1,6 +1,5 @@
 ---
 title: 'getParameter'
-head_title: 'SystemsManagerClient.getParameter()'
 description: "SystemsManagerClient.getParameter gets a Systems Manager parameter in the caller's AWS account and region"
 weight: 10
 ---

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/awsconfig.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/awsconfig.md
@@ -1,7 +1,5 @@
 ---
 title: 'AWSConfig'
-head_title: 'AWSConfig'
-description: 'AWSConfig is used to configure an AWS service client instances'
 description: 'AWSConfig is used to configure an AWS service client instances'
 weight: 00
 ---

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'EventBridgeClient'
-head_title: 'EventBridgeClient'
 description: 'EventBridgeClient allows interacting with AWS EventBridge service'
 description: 'EventBridgeClient class allows sending custom events to Amazon EventBridge so that they can be matched to rules.'
 weight: 00

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
@@ -1,7 +1,5 @@
 ---
 title: 'putEvents'
-head_title: 'EventBridgeClient.putEvents'
-description: 'EventBridgeClient.putEvents sends custom events to Amazon EventBridge'
 description: 'EventBridgeClient.putEvents sends custom events to Amazon EventBridge'
 weight: 10
 ---

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
@@ -1,7 +1,6 @@
 ---
 title: 'KMSDataKey'
 slug: 'kmsdatakey'
-head_title: 'KMSDataKey'
 description: 'KMSDataKey is returned by the KMSClient.*DataKey methods that query KMS data keys'
 weight: 20
 ---

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
@@ -1,7 +1,5 @@
 ---
 title: 'KMSKey'
-head_title: 'KMSKey'
-description: 'KMSKey is returned by the KMSClient.* methods that query KMS keys'
 description: 'KMSKey is returned by the KMSClient.* methods that query KMS keys'
 weight: 20
 ---

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/KMSClient/_index.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/KMSClient/_index.md
@@ -1,7 +1,5 @@
 ---
 title: 'KMSClient'
-head_title: 'KMSClient'
-description: 'KMSClient allows interacting with the AWS Key Management Service'
 description: 'KMSClient allows interacting with the AWS Key Management Service'
 weight: 00
 ---

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/KMSClient/listKeys.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/KMSClient/listKeys.md
@@ -1,7 +1,5 @@
 ---
 title: 'listKeys'
-head_title: 'KMSClient.listKeys()'
-description: "KMSClient.listKeys lists all the KMS keys in the caller's AWS account and region"
 description: "KMSClient.listKeys lists all the KMS keys in the caller's AWS account and region"
 weight: 10
 ---

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/LambdaClient/_index.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/LambdaClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'LambdaClient'
-head_title: 'LambdaClient'
 description: 'LambdaClient allows interacting with the AWS Lambda service'
 weight: 00
 ---

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/LambdaClient/invoke.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/LambdaClient/invoke.md
@@ -1,6 +1,5 @@
 ---
 title: 'invoke'
-head_title: 'LambdaClient.invoke(name, payload, [options])'
 description: 'LambdaClient.invoke invokes an AWS Lamba function'
 weight: 10
 ---

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/Bucket.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/Bucket.md
@@ -1,6 +1,5 @@
 ---
 title: 'Bucket'
-head_title: 'Bucket'
 description: 'Bucket is returned by the S3Client.* methods who query S3 buckets.'
 weight: 20
 ---

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/Object.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/Object.md
@@ -1,6 +1,5 @@
 ---
 title: 'Object'
-head_title: 'Object'
 description: "Object is returned by the S3Client.* methods who query S3 buckets' objects."
 weight: 20
 ---

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/S3Part.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/S3Part.md
@@ -1,6 +1,5 @@
 ---
 title: 'S3Part'
-head_title: 'S3Part'
 slug: 's3part'
 description: 'S3Part is returned by the S3Client.uploadPart method when uploading a part to a multipart upload.'
 weight: 20

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/S3UploadedObject.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/S3UploadedObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'S3UploadedObject'
-head_title: 'S3UploadedObject'
 description: 'S3UploadedObject represents the response from S3 upload operations'
 weight: 20
 ---

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/_index.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'S3Client'
-head_title: 'S3Client'
 description: 'S3Client allows interacting with AWS S3 buckets and objects'
 description: 'S3Client class allows interacting with AWS S3 buckets and objects'
 weight: 00

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
@@ -1,6 +1,5 @@
 ---
 title: 'abortMultipartUpload'
-head_title: 'S3Client.abortMultipartUpload(bucketName, objectKey, uploadId)'
 description: 'S3Client.abortMultipartUpload aborts a multipart upload to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/completeMultipartUpload.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/completeMultipartUpload.md
@@ -1,6 +1,5 @@
 ---
 title: 'completeMultipartUpload'
-head_title: 'S3Client.completeMultipartUpload(bucketName, objectKey, uploadId, parts)'
 description: 'S3Client.completeMultipartUpload uploads a multipar object to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/copyObject.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/copyObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'copyObject'
-head_title: 'S3Client.copyObject'
 description: 'S3Client.copyObject copies an object from a bucket to another'
 weight: 10
 ---

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
@@ -1,6 +1,5 @@
 ---
 title: 'createMultipartUpload'
-head_title: 'S3Client.createMultipartUpload(bucketName, objectKey)'
 description: 'S3Client.createMultipartUpload creates a multipart upload for an object key to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/deleteObject.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/deleteObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'deleteObject'
-head_title: 'S3Client.deleteObject(bucketName, objectKey)'
 description: 'S3Client.deleteObject deletes an object from a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/getObject.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/getObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'getObject'
-head_title: 'S3Client.getObject(bucketName, objectKey)'
 description: 'S3Client.getObject downloads an object from a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/listBuckets.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/listBuckets.md
@@ -1,6 +1,5 @@
 ---
 title: 'listBuckets'
-head_title: 'S3Client.listBuckets()'
 description: 'S3Client.listBuckets lists the buckets the authenticated user has access to'
 weight: 10
 ---

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/listObjects.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/listObjects.md
@@ -1,6 +1,5 @@
 ---
 title: 'listObjects'
-head_title: 'S3Client.listObjects(bucketName, [prefix])'
 description: 'S3Client.listObjects lists the objects contained in a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/putObject.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/putObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'putObject'
-head_title: 'S3Client.putObject(bucketName, objectKey, data)'
 description: 'S3Client.putObject uploads an object to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/uploadPart.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/uploadPart.md
@@ -1,6 +1,5 @@
 ---
 title: 'uploadPart'
-head_title: 'S3Client.uploadPart(bucketName, objectKey, uploadId,partNumber, data)'
 description: 'S3Client.uploadPart a part in a multipart upload to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SQSClient/_index.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SQSClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SQSClient'
-head_title: 'SQSClient'
 description: 'SQSClient enables interaction with the AWS Simple Queue Service (SQS)'
 description: 'SQSClient allows interacting with the AWS Simple Queue Service (SQS)'
 weight: 00

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
@@ -1,6 +1,5 @@
 ---
 title: 'Secret'
-head_title: 'Secret'
 description: 'Secret is returned by the SecretsManagerClient.* methods who query secrets from AWS secrets manager.'
 weight: 20
 ---

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SecretsManagerClient'
-head_title: 'SecretsManagerClient'
 description: 'SecretsManagerClient allows interacting with AWS secrets stored in Secrets Manager'
 weight: 00
 ---

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
@@ -1,6 +1,5 @@
 ---
 title: 'createSecret'
-head_title: 'SecretsManagerClient.createSecret(name, secretString, description, [versionID], [tags])'
 description: 'SecretsManagerClient.createSecret creates a new secret'
 weight: 10
 ---

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
@@ -1,6 +1,5 @@
 ---
 title: 'deleteSecret'
-head_title: 'SecretsManagerClient.deleteSecret(secretID, { recoveryWindow: 30, noRecovery: false}})'
 description: 'SecretsManagerClient.deleteSecret deletes a secret'
 weight: 10
 ---

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
@@ -1,6 +1,5 @@
 ---
 title: 'getSecret'
-head_title: 'SecretsManagerClient.getSecret(secretID)'
 description: 'SecretsManagerClient.getSecret(secretID) downloads a secret from AWS secrets manager'
 weight: 10
 ---

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
@@ -1,6 +1,5 @@
 ---
 title: 'listSecrets'
-head_title: 'SecretsManagerClient.listSecrets()'
 description: 'SecretsManagerClient.listSecrets lists the secrets the authenticated user has access to'
 weight: 10
 ---

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
@@ -1,6 +1,5 @@
 ---
 title: 'putSecretValue'
-head_title: 'SecretsManagerClient.putSecretValue(secretID, secretString, [versionID], [tags])'
 description: "SecretsManagerClient.putSecretValue updates an existing secret's value"
 weight: 10
 ---

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SignatureV4/_index.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SignatureV4/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SignatureV4'
-head_title: 'SignatureV4'
 description: 'SignatureV4 is used to sign or pre-sign requests to AWS services using the Signature V4 algorithm'
 description: 'SignatureV4 is used to sign and pre-sign requests to AWS services using the Signature V4 algorithm'
 weight: 00

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SignatureV4/presign.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SignatureV4/presign.md
@@ -1,6 +1,5 @@
 ---
 title: 'presign'
-head_title: 'presign'
 slug: 'presign'
 description: 'Signaturev4.presign pre-signs a URL with the AWS Signature V4 algorithm'
 description: 'SignatureV4.sign pre-signs a URL with the AWS Signature V4 algorithm'

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SignatureV4/sign.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SignatureV4/sign.md
@@ -1,6 +1,5 @@
 ---
 title: 'sign'
-head_title: 'sign'
 slug: 'sign'
 description: 'Signaturev4.sign signs an HTTP request with the AWS Signature V4 algorithm'
 description: 'SignatureV4.sign signs an HTTP request with the AWS Signature V4 algorithm'

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
@@ -1,6 +1,5 @@
 ---
 title: 'SystemsManagerParameter'
-head_title: 'SystemsManagerParameter'
 slug: 'systemsmanagerparameter'
 description: 'SystemsManagerParameter is returned by the SystemsManagerClient.* methods that query parameters'
 weight: 20

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SystemsManagerClient'
-head_title: 'SystemsManagerClient'
 description: 'SystemsManagerClient allows interacting with the AWS Systems Manager Service'
 weight: 00
 ---

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
@@ -1,6 +1,5 @@
 ---
 title: 'getParameter'
-head_title: 'SystemsManagerClient.getParameter()'
 description: "SystemsManagerClient.getParameter gets a Systems Manager parameter in the caller's AWS account and region"
 weight: 10
 ---

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/awsconfig.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/awsconfig.md
@@ -1,7 +1,5 @@
 ---
 title: 'AWSConfig'
-head_title: 'AWSConfig'
-description: 'AWSConfig is used to configure an AWS service client instances'
 description: 'AWSConfig is used to configure an AWS service client instances'
 weight: 00
 ---

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'EventBridgeClient'
-head_title: 'EventBridgeClient'
 description: 'EventBridgeClient allows interacting with AWS EventBridge service'
 description: 'EventBridgeClient class allows sending custom events to Amazon EventBridge so that they can be matched to rules.'
 weight: 00

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
@@ -1,7 +1,5 @@
 ---
 title: 'putEvents'
-head_title: 'EventBridgeClient.putEvents'
-description: 'EventBridgeClient.putEvents sends custom events to Amazon EventBridge'
 description: 'EventBridgeClient.putEvents sends custom events to Amazon EventBridge'
 weight: 10
 ---

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
@@ -1,7 +1,6 @@
 ---
 title: 'KMSDataKey'
 slug: 'kmsdatakey'
-head_title: 'KMSDataKey'
 description: 'KMSDataKey is returned by the KMSClient.*DataKey methods that query KMS data keys'
 weight: 20
 ---

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
@@ -1,7 +1,5 @@
 ---
 title: 'KMSKey'
-head_title: 'KMSKey'
-description: 'KMSKey is returned by the KMSClient.* methods that query KMS keys'
 description: 'KMSKey is returned by the KMSClient.* methods that query KMS keys'
 weight: 20
 ---

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/KMSClient/_index.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/KMSClient/_index.md
@@ -1,7 +1,5 @@
 ---
 title: 'KMSClient'
-head_title: 'KMSClient'
-description: 'KMSClient allows interacting with the AWS Key Management Service'
 description: 'KMSClient allows interacting with the AWS Key Management Service'
 weight: 00
 ---

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/KMSClient/listKeys.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/KMSClient/listKeys.md
@@ -1,7 +1,5 @@
 ---
 title: 'listKeys'
-head_title: 'KMSClient.listKeys()'
-description: "KMSClient.listKeys lists all the KMS keys in the caller's AWS account and region"
 description: "KMSClient.listKeys lists all the KMS keys in the caller's AWS account and region"
 weight: 10
 ---

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/LambdaClient/_index.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/LambdaClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'LambdaClient'
-head_title: 'LambdaClient'
 description: 'LambdaClient allows interacting with the AWS Lambda service'
 weight: 00
 ---

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/LambdaClient/invoke.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/LambdaClient/invoke.md
@@ -1,6 +1,5 @@
 ---
 title: 'invoke'
-head_title: 'LambdaClient.invoke(name, payload, [options])'
 description: 'LambdaClient.invoke invokes an AWS Lamba function'
 weight: 10
 ---

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/Bucket.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/Bucket.md
@@ -1,6 +1,5 @@
 ---
 title: 'Bucket'
-head_title: 'Bucket'
 description: 'Bucket is returned by the S3Client.* methods who query S3 buckets.'
 weight: 20
 ---

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/Object.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/Object.md
@@ -1,6 +1,5 @@
 ---
 title: 'Object'
-head_title: 'Object'
 description: "Object is returned by the S3Client.* methods who query S3 buckets' objects."
 weight: 20
 ---

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/S3Part.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/S3Part.md
@@ -1,6 +1,5 @@
 ---
 title: 'S3Part'
-head_title: 'S3Part'
 slug: 's3part'
 description: 'S3Part is returned by the S3Client.uploadPart method when uploading a part to a multipart upload.'
 weight: 20

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/S3UploadedObject.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/S3UploadedObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'S3UploadedObject'
-head_title: 'S3UploadedObject'
 description: 'S3UploadedObject represents the response from S3 upload operations'
 weight: 20
 ---

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/_index.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'S3Client'
-head_title: 'S3Client'
 description: 'S3Client allows interacting with AWS S3 buckets and objects'
 description: 'S3Client class allows interacting with AWS S3 buckets and objects'
 weight: 00

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
@@ -1,6 +1,5 @@
 ---
 title: 'abortMultipartUpload'
-head_title: 'S3Client.abortMultipartUpload(bucketName, objectKey, uploadId)'
 description: 'S3Client.abortMultipartUpload aborts a multipart upload to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/completeMultipartUpload.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/completeMultipartUpload.md
@@ -1,6 +1,5 @@
 ---
 title: 'completeMultipartUpload'
-head_title: 'S3Client.completeMultipartUpload(bucketName, objectKey, uploadId, parts)'
 description: 'S3Client.completeMultipartUpload uploads a multipar object to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/copyObject.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/copyObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'copyObject'
-head_title: 'S3Client.copyObject'
 description: 'S3Client.copyObject copies an object from a bucket to another'
 weight: 10
 ---

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
@@ -1,6 +1,5 @@
 ---
 title: 'createMultipartUpload'
-head_title: 'S3Client.createMultipartUpload(bucketName, objectKey)'
 description: 'S3Client.createMultipartUpload creates a multipart upload for an object key to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/deleteObject.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/deleteObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'deleteObject'
-head_title: 'S3Client.deleteObject(bucketName, objectKey)'
 description: 'S3Client.deleteObject deletes an object from a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/getObject.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/getObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'getObject'
-head_title: 'S3Client.getObject(bucketName, objectKey)'
 description: 'S3Client.getObject downloads an object from a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/listBuckets.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/listBuckets.md
@@ -1,6 +1,5 @@
 ---
 title: 'listBuckets'
-head_title: 'S3Client.listBuckets()'
 description: 'S3Client.listBuckets lists the buckets the authenticated user has access to'
 weight: 10
 ---

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/listObjects.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/listObjects.md
@@ -1,6 +1,5 @@
 ---
 title: 'listObjects'
-head_title: 'S3Client.listObjects(bucketName, [prefix])'
 description: 'S3Client.listObjects lists the objects contained in a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/putObject.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/putObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'putObject'
-head_title: 'S3Client.putObject(bucketName, objectKey, data)'
 description: 'S3Client.putObject uploads an object to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/uploadPart.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/uploadPart.md
@@ -1,6 +1,5 @@
 ---
 title: 'uploadPart'
-head_title: 'S3Client.uploadPart(bucketName, objectKey, uploadId,partNumber, data)'
 description: 'S3Client.uploadPart a part in a multipart upload to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SQSClient/_index.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SQSClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SQSClient'
-head_title: 'SQSClient'
 description: 'SQSClient enables interaction with the AWS Simple Queue Service (SQS)'
 description: 'SQSClient allows interacting with the AWS Simple Queue Service (SQS)'
 weight: 00

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
@@ -1,6 +1,5 @@
 ---
 title: 'Secret'
-head_title: 'Secret'
 description: 'Secret is returned by the SecretsManagerClient.* methods who query secrets from AWS secrets manager.'
 weight: 20
 ---

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SecretsManagerClient'
-head_title: 'SecretsManagerClient'
 description: 'SecretsManagerClient allows interacting with AWS secrets stored in Secrets Manager'
 weight: 00
 ---

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
@@ -1,6 +1,5 @@
 ---
 title: 'createSecret'
-head_title: 'SecretsManagerClient.createSecret(name, secretString, description, [versionID], [tags])'
 description: 'SecretsManagerClient.createSecret creates a new secret'
 weight: 10
 ---

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
@@ -1,6 +1,5 @@
 ---
 title: 'deleteSecret'
-head_title: 'SecretsManagerClient.deleteSecret(secretID, { recoveryWindow: 30, noRecovery: false}})'
 description: 'SecretsManagerClient.deleteSecret deletes a secret'
 weight: 10
 ---

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
@@ -1,6 +1,5 @@
 ---
 title: 'getSecret'
-head_title: 'SecretsManagerClient.getSecret(secretID)'
 description: 'SecretsManagerClient.getSecret(secretID) downloads a secret from AWS secrets manager'
 weight: 10
 ---

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
@@ -1,6 +1,5 @@
 ---
 title: 'listSecrets'
-head_title: 'SecretsManagerClient.listSecrets()'
 description: 'SecretsManagerClient.listSecrets lists the secrets the authenticated user has access to'
 weight: 10
 ---

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
@@ -1,6 +1,5 @@
 ---
 title: 'putSecretValue'
-head_title: 'SecretsManagerClient.putSecretValue(secretID, secretString, [versionID], [tags])'
 description: "SecretsManagerClient.putSecretValue updates an existing secret's value"
 weight: 10
 ---

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SignatureV4/_index.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SignatureV4/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SignatureV4'
-head_title: 'SignatureV4'
 description: 'SignatureV4 is used to sign or pre-sign requests to AWS services using the Signature V4 algorithm'
 description: 'SignatureV4 is used to sign and pre-sign requests to AWS services using the Signature V4 algorithm'
 weight: 00

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SignatureV4/presign.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SignatureV4/presign.md
@@ -1,6 +1,5 @@
 ---
 title: 'presign'
-head_title: 'presign'
 slug: 'presign'
 description: 'Signaturev4.presign pre-signs a URL with the AWS Signature V4 algorithm'
 description: 'SignatureV4.sign pre-signs a URL with the AWS Signature V4 algorithm'

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SignatureV4/sign.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SignatureV4/sign.md
@@ -1,6 +1,5 @@
 ---
 title: 'sign'
-head_title: 'sign'
 slug: 'sign'
 description: 'Signaturev4.sign signs an HTTP request with the AWS Signature V4 algorithm'
 description: 'SignatureV4.sign signs an HTTP request with the AWS Signature V4 algorithm'

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
@@ -1,6 +1,5 @@
 ---
 title: 'SystemsManagerParameter'
-head_title: 'SystemsManagerParameter'
 slug: 'systemsmanagerparameter'
 description: 'SystemsManagerParameter is returned by the SystemsManagerClient.* methods that query parameters'
 weight: 20

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SystemsManagerClient'
-head_title: 'SystemsManagerClient'
 description: 'SystemsManagerClient allows interacting with the AWS Systems Manager Service'
 weight: 00
 ---

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
@@ -1,6 +1,5 @@
 ---
 title: 'getParameter'
-head_title: 'SystemsManagerClient.getParameter()'
 description: "SystemsManagerClient.getParameter gets a Systems Manager parameter in the caller's AWS account and region"
 weight: 10
 ---

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/awsconfig.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/awsconfig.md
@@ -1,7 +1,5 @@
 ---
 title: 'AWSConfig'
-head_title: 'AWSConfig'
-description: 'AWSConfig is used to configure an AWS service client instances'
 description: 'AWSConfig is used to configure an AWS service client instances'
 weight: 00
 ---

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'EventBridgeClient'
-head_title: 'EventBridgeClient'
 description: 'EventBridgeClient allows interacting with AWS EventBridge service'
 description: 'EventBridgeClient class allows sending custom events to Amazon EventBridge so that they can be matched to rules.'
 weight: 00

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
@@ -1,7 +1,5 @@
 ---
 title: 'putEvents'
-head_title: 'EventBridgeClient.putEvents'
-description: 'EventBridgeClient.putEvents sends custom events to Amazon EventBridge'
 description: 'EventBridgeClient.putEvents sends custom events to Amazon EventBridge'
 weight: 10
 ---

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
@@ -1,7 +1,6 @@
 ---
 title: 'KMSDataKey'
 slug: 'kmsdatakey'
-head_title: 'KMSDataKey'
 description: 'KMSDataKey is returned by the KMSClient.*DataKey methods that query KMS data keys'
 weight: 20
 ---

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
@@ -1,7 +1,5 @@
 ---
 title: 'KMSKey'
-head_title: 'KMSKey'
-description: 'KMSKey is returned by the KMSClient.* methods that query KMS keys'
 description: 'KMSKey is returned by the KMSClient.* methods that query KMS keys'
 weight: 20
 ---

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/KMSClient/_index.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/KMSClient/_index.md
@@ -1,7 +1,5 @@
 ---
 title: 'KMSClient'
-head_title: 'KMSClient'
-description: 'KMSClient allows interacting with the AWS Key Management Service'
 description: 'KMSClient allows interacting with the AWS Key Management Service'
 weight: 00
 ---

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/KMSClient/listKeys.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/KMSClient/listKeys.md
@@ -1,7 +1,5 @@
 ---
 title: 'listKeys'
-head_title: 'KMSClient.listKeys()'
-description: "KMSClient.listKeys lists all the KMS keys in the caller's AWS account and region"
 description: "KMSClient.listKeys lists all the KMS keys in the caller's AWS account and region"
 weight: 10
 ---

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/LambdaClient/_index.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/LambdaClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'LambdaClient'
-head_title: 'LambdaClient'
 description: 'LambdaClient allows interacting with the AWS Lambda service'
 weight: 00
 ---

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/LambdaClient/invoke.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/LambdaClient/invoke.md
@@ -1,6 +1,5 @@
 ---
 title: 'invoke'
-head_title: 'LambdaClient.invoke(name, payload, [options])'
 description: 'LambdaClient.invoke invokes an AWS Lamba function'
 weight: 10
 ---

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/Bucket.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/Bucket.md
@@ -1,6 +1,5 @@
 ---
 title: 'Bucket'
-head_title: 'Bucket'
 description: 'Bucket is returned by the S3Client.* methods who query S3 buckets.'
 weight: 20
 ---

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/Object.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/Object.md
@@ -1,6 +1,5 @@
 ---
 title: 'Object'
-head_title: 'Object'
 description: "Object is returned by the S3Client.* methods who query S3 buckets' objects."
 weight: 20
 ---

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/S3Part.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/S3Part.md
@@ -1,6 +1,5 @@
 ---
 title: 'S3Part'
-head_title: 'S3Part'
 slug: 's3part'
 description: 'S3Part is returned by the S3Client.uploadPart method when uploading a part to a multipart upload.'
 weight: 20

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/S3UploadedObject.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/S3UploadedObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'S3UploadedObject'
-head_title: 'S3UploadedObject'
 description: 'S3UploadedObject represents the response from S3 upload operations'
 weight: 20
 ---

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/_index.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'S3Client'
-head_title: 'S3Client'
 description: 'S3Client allows interacting with AWS S3 buckets and objects'
 description: 'S3Client class allows interacting with AWS S3 buckets and objects'
 weight: 00

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
@@ -1,6 +1,5 @@
 ---
 title: 'abortMultipartUpload'
-head_title: 'S3Client.abortMultipartUpload(bucketName, objectKey, uploadId)'
 description: 'S3Client.abortMultipartUpload aborts a multipart upload to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/completeMultipartUpload.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/completeMultipartUpload.md
@@ -1,6 +1,5 @@
 ---
 title: 'completeMultipartUpload'
-head_title: 'S3Client.completeMultipartUpload(bucketName, objectKey, uploadId, parts)'
 description: 'S3Client.completeMultipartUpload uploads a multipar object to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/copyObject.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/copyObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'copyObject'
-head_title: 'S3Client.copyObject'
 description: 'S3Client.copyObject copies an object from a bucket to another'
 weight: 10
 ---

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
@@ -1,6 +1,5 @@
 ---
 title: 'createMultipartUpload'
-head_title: 'S3Client.createMultipartUpload(bucketName, objectKey)'
 description: 'S3Client.createMultipartUpload creates a multipart upload for an object key to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/deleteObject.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/deleteObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'deleteObject'
-head_title: 'S3Client.deleteObject(bucketName, objectKey)'
 description: 'S3Client.deleteObject deletes an object from a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/getObject.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/getObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'getObject'
-head_title: 'S3Client.getObject(bucketName, objectKey)'
 description: 'S3Client.getObject downloads an object from a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/listBuckets.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/listBuckets.md
@@ -1,6 +1,5 @@
 ---
 title: 'listBuckets'
-head_title: 'S3Client.listBuckets()'
 description: 'S3Client.listBuckets lists the buckets the authenticated user has access to'
 weight: 10
 ---

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/listObjects.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/listObjects.md
@@ -1,6 +1,5 @@
 ---
 title: 'listObjects'
-head_title: 'S3Client.listObjects(bucketName, [prefix])'
 description: 'S3Client.listObjects lists the objects contained in a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/putObject.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/putObject.md
@@ -1,6 +1,5 @@
 ---
 title: 'putObject'
-head_title: 'S3Client.putObject(bucketName, objectKey, data)'
 description: 'S3Client.putObject uploads an object to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/uploadPart.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/uploadPart.md
@@ -1,6 +1,5 @@
 ---
 title: 'uploadPart'
-head_title: 'S3Client.uploadPart(bucketName, objectKey, uploadId,partNumber, data)'
 description: 'S3Client.uploadPart a part in a multipart upload to a bucket'
 weight: 10
 ---

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SQSClient/_index.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SQSClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SQSClient'
-head_title: 'SQSClient'
 description: 'SQSClient enables interaction with the AWS Simple Queue Service (SQS)'
 description: 'SQSClient allows interacting with the AWS Simple Queue Service (SQS)'
 weight: 00

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
@@ -1,6 +1,5 @@
 ---
 title: 'Secret'
-head_title: 'Secret'
 description: 'Secret is returned by the SecretsManagerClient.* methods who query secrets from AWS secrets manager.'
 weight: 20
 ---

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SecretsManagerClient'
-head_title: 'SecretsManagerClient'
 description: 'SecretsManagerClient allows interacting with AWS secrets stored in Secrets Manager'
 weight: 00
 ---

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
@@ -1,6 +1,5 @@
 ---
 title: 'createSecret'
-head_title: 'SecretsManagerClient.createSecret(name, secretString, description, [versionID], [tags])'
 description: 'SecretsManagerClient.createSecret creates a new secret'
 weight: 10
 ---

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
@@ -1,6 +1,5 @@
 ---
 title: 'deleteSecret'
-head_title: 'SecretsManagerClient.deleteSecret(secretID, { recoveryWindow: 30, noRecovery: false}})'
 description: 'SecretsManagerClient.deleteSecret deletes a secret'
 weight: 10
 ---

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
@@ -1,6 +1,5 @@
 ---
 title: 'getSecret'
-head_title: 'SecretsManagerClient.getSecret(secretID)'
 description: 'SecretsManagerClient.getSecret(secretID) downloads a secret from AWS secrets manager'
 weight: 10
 ---

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
@@ -1,6 +1,5 @@
 ---
 title: 'listSecrets'
-head_title: 'SecretsManagerClient.listSecrets()'
 description: 'SecretsManagerClient.listSecrets lists the secrets the authenticated user has access to'
 weight: 10
 ---

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
@@ -1,6 +1,5 @@
 ---
 title: 'putSecretValue'
-head_title: 'SecretsManagerClient.putSecretValue(secretID, secretString, [versionID], [tags])'
 description: "SecretsManagerClient.putSecretValue updates an existing secret's value"
 weight: 10
 ---

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SignatureV4/_index.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SignatureV4/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SignatureV4'
-head_title: 'SignatureV4'
 description: 'SignatureV4 is used to sign or pre-sign requests to AWS services using the Signature V4 algorithm'
 description: 'SignatureV4 is used to sign and pre-sign requests to AWS services using the Signature V4 algorithm'
 weight: 00

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SignatureV4/presign.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SignatureV4/presign.md
@@ -1,6 +1,5 @@
 ---
 title: 'presign'
-head_title: 'presign'
 slug: 'presign'
 description: 'Signaturev4.presign pre-signs a URL with the AWS Signature V4 algorithm'
 description: 'SignatureV4.sign pre-signs a URL with the AWS Signature V4 algorithm'

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SignatureV4/sign.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SignatureV4/sign.md
@@ -1,6 +1,5 @@
 ---
 title: 'sign'
-head_title: 'sign'
 slug: 'sign'
 description: 'Signaturev4.sign signs an HTTP request with the AWS Signature V4 algorithm'
 description: 'SignatureV4.sign signs an HTTP request with the AWS Signature V4 algorithm'

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
@@ -1,6 +1,5 @@
 ---
 title: 'SystemsManagerParameter'
-head_title: 'SystemsManagerParameter'
 slug: 'systemsmanagerparameter'
 description: 'SystemsManagerParameter is returned by the SystemsManagerClient.* methods that query parameters'
 weight: 20

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 'SystemsManagerClient'
-head_title: 'SystemsManagerClient'
 description: 'SystemsManagerClient allows interacting with the AWS Systems Manager Service'
 weight: 00
 ---

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
@@ -1,6 +1,5 @@
 ---
 title: 'getParameter'
-head_title: 'SystemsManagerClient.getParameter()'
 description: "SystemsManagerClient.getParameter gets a Systems Manager parameter in the caller's AWS account and region"
 weight: 10
 ---

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/awsconfig.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/awsconfig.md
@@ -1,7 +1,5 @@
 ---
 title: 'AWSConfig'
-head_title: 'AWSConfig'
-description: 'AWSConfig is used to configure an AWS service client instances'
 description: 'AWSConfig is used to configure an AWS service client instances'
 weight: 00
 ---


### PR DESCRIPTION
## What?

This PR drops the `head_title` frontmatter properties from the jslib/aws documentation pages.

## Checklist

- [X] I have used a meaningful title for the PR.
- [X] I have described the changes I've made in the "What?" section above.
- [X] I have performed a self-review of my changes.
- [X] I have run the `npm start` command locally and verified that the changes look good.
- [X] I have made my changes in the `docs/sources/k6/next` folder of the documentation.
- [X] I have reflected my changes in the `docs/sources/k6/v{most_recent_release}` folder of the documentation.
- [X] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
