### PR TITLE
Add md-k6:skip tags to jslib/aws bodeblocks

### DIFF
--- a/docs/sources/k6/next/javascript-api/jslib/aws/EventBridgeClient/_index.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/EventBridgeClient/_index.md
@@ -31,6 +31,8 @@ EventBridgeClient methods will throw errors in case of failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/next/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
@@ -41,6 +41,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/next/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
@@ -21,6 +21,8 @@ For instance, the [`generateDataKey`](https://grafana.com/docs/k6/<K6_VERSION>/j
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/next/javascript-api/jslib/aws/KMSClient/KMSKey.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/KMSClient/KMSKey.md
@@ -17,6 +17,8 @@ weight: 20
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/next/javascript-api/jslib/aws/KMSClient/_index.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/KMSClient/_index.md
@@ -34,6 +34,8 @@ Both the dedicated `kms.js` jslib bundle and the all-encompassing `aws.js` bundl
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.2/index.js';
 

--- a/docs/sources/k6/next/javascript-api/jslib/aws/KMSClient/generateDataKey.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/KMSClient/generateDataKey.md
@@ -27,6 +27,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/next/javascript-api/jslib/aws/KMSClient/listKeys.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/KMSClient/listKeys.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/next/javascript-api/jslib/aws/LambdaClient/_index.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/LambdaClient/_index.md
@@ -31,6 +31,8 @@ Both the dedicated `lambda.js` jslib bundle and the all-encompassing `aws.js` bu
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/next/javascript-api/jslib/aws/LambdaClient/invoke.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/LambdaClient/invoke.md
@@ -49,6 +49,8 @@ InvocationResponse is an object that represents the response of an invocation. I
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/Bucket.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/Bucket.md
@@ -17,6 +17,8 @@ Bucket is returned by the S3Client.\* methods that query S3 buckets. Namely, `li
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/Object.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/Object.md
@@ -22,6 +22,8 @@ and [`deleteObject`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jsl
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/S3MultipartUpload.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/S3MultipartUpload.md
@@ -17,6 +17,8 @@ S3MultipartUpload is returned by the [`createMultipartUpload(bucketName, objectK
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/S3Part.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/S3Part.md
@@ -18,6 +18,8 @@ S3Part is returned by the [`uploadPart(bucketName, objectKey, uploadId, partNumb
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import crypto from 'k6/crypto';
 import exec from 'k6/execution';

--- a/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/_index.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/_index.md
@@ -42,6 +42,8 @@ S3 Client methods will throw errors in case of failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import { check } from 'k6';
 import exec from 'k6/execution';
@@ -107,6 +109,8 @@ export async function handleSummary(data) {
 #### Multipart uploads
 
 {{< code >}}
+
+<!-- md-k6:skip -->
 
 ```javascript
 import crypto from 'k6/crypto';

--- a/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
@@ -26,6 +26,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/copyObject.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/copyObject.md
@@ -27,6 +27,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
@@ -23,6 +23,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/deleteObject.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/deleteObject.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/getObject.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/getObject.md
@@ -32,6 +32,8 @@ receive the data as an `ArrayBuffer`, you can pass [`additionalHeaders`](#parame
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 
@@ -71,6 +73,8 @@ _A k6 script that will download an object from a bucket_
 #### Downloading a binary file from AWS S3
 
 {{< code >}}
+
+<!-- md-k6:skip -->
 
 ```javascript
 import exec from 'k6/execution';

--- a/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/listBuckets.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/listBuckets.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/listObjects.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/listObjects.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/uploadPart.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/S3Client/uploadPart.md
@@ -26,6 +26,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import crypto from 'k6/crypto';
 import exec from 'k6/execution';

--- a/docs/sources/k6/next/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
@@ -24,6 +24,8 @@ Secret is returned by the SecretsManagerClient.\* methods that query secrets. Na
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/next/javascript-api/jslib/aws/SecretsManagerClient/_index.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/SecretsManagerClient/_index.md
@@ -35,6 +35,8 @@ S3 Client methods will throw errors in case of failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/next/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
@@ -28,6 +28,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/next/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/next/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
@@ -22,6 +22,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/next/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/next/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/next/javascript-api/jslib/aws/SignatureV4/_index.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/SignatureV4/_index.md
@@ -46,6 +46,8 @@ SignatureV4 methods throw errors on failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 

--- a/docs/sources/k6/next/javascript-api/jslib/aws/SignatureV4/presign.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/SignatureV4/presign.md
@@ -44,6 +44,8 @@ The `presign` operation returns an Object with the following properties.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 import { check } from 'k6';

--- a/docs/sources/k6/next/javascript-api/jslib/aws/SignatureV4/sign.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/SignatureV4/sign.md
@@ -42,6 +42,8 @@ You can override SignatureV4 options in the context of this specific request. To
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 

--- a/docs/sources/k6/next/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
@@ -25,6 +25,8 @@ weight: 20
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/next/javascript-api/jslib/aws/SystemsManagerClient/_index.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/SystemsManagerClient/_index.md
@@ -31,6 +31,8 @@ Both the dedicated `ssm.js` jslib bundle and the all-encompassing `aws.js` bundl
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/next/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
+++ b/docs/sources/k6/next/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
@@ -32,6 +32,8 @@ EventBridgeClient methods will throw errors in case of failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
@@ -41,6 +41,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
@@ -21,6 +21,8 @@ For instance, the [`generateDataKey`](https://grafana.com/docs/k6/<K6_VERSION>/j
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
@@ -17,6 +17,8 @@ weight: 20
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/KMSClient/_index.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/KMSClient/_index.md
@@ -34,6 +34,8 @@ Both the dedicated `kms.js` jslib bundle and the all-encompassing `aws.js` bundl
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.2/index.js';
 

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/KMSClient/generateDataKey.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/KMSClient/generateDataKey.md
@@ -27,6 +27,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/KMSClient/listKeys.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/KMSClient/listKeys.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/LambdaClient/_index.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/LambdaClient/_index.md
@@ -31,6 +31,8 @@ Both the dedicated `lambda.js` jslib bundle and the all-encompassing `aws.js` bu
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/LambdaClient/invoke.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/LambdaClient/invoke.md
@@ -49,6 +49,8 @@ InvocationResponse is an object that represents the response of an invocation. I
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/Bucket.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/Bucket.md
@@ -17,6 +17,8 @@ Bucket is returned by the S3Client.\* methods that query S3 buckets. Namely, `li
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/Object.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/Object.md
@@ -22,6 +22,8 @@ and [`deleteObject`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jsl
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/S3MultipartUpload.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/S3MultipartUpload.md
@@ -17,6 +17,8 @@ S3MultipartUpload is returned by the [`createMultipartUpload(bucketName, objectK
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/S3Part.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/S3Part.md
@@ -18,6 +18,8 @@ S3Part is returned by the [`uploadPart(bucketName, objectKey, uploadId, partNumb
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import crypto from 'k6/crypto';
 import exec from 'k6/execution';

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/_index.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/_index.md
@@ -42,6 +42,8 @@ S3 Client methods will throw errors in case of failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import { check } from 'k6';
 import exec from 'k6/execution';
@@ -107,6 +109,8 @@ export async function handleSummary(data) {
 #### Multipart uploads
 
 {{< code >}}
+
+<!-- md-k6:skip -->
 
 ```javascript
 import crypto from 'k6/crypto';

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
@@ -26,6 +26,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/copyObject.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/copyObject.md
@@ -27,6 +27,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
@@ -23,6 +23,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/deleteObject.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/deleteObject.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/getObject.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/getObject.md
@@ -32,6 +32,8 @@ receive the data as an `ArrayBuffer`, you can pass [`additionalHeaders`](#parame
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 
@@ -71,6 +73,8 @@ _A k6 script that will download an object from a bucket_
 #### Downloading a binary file from AWS S3
 
 {{< code >}}
+
+<!-- md-k6:skip -->
 
 ```javascript
 import exec from 'k6/execution';

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/listBuckets.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/listBuckets.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/listObjects.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/listObjects.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/uploadPart.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/S3Client/uploadPart.md
@@ -26,6 +26,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import crypto from 'k6/crypto';
 import exec from 'k6/execution';

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
@@ -24,6 +24,8 @@ Secret is returned by the SecretsManagerClient.\* methods that query secrets. Na
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
@@ -35,6 +35,8 @@ S3 Client methods will throw errors in case of failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
@@ -28,6 +28,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
@@ -22,6 +22,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SignatureV4/_index.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SignatureV4/_index.md
@@ -46,6 +46,8 @@ SignatureV4 methods throw errors on failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SignatureV4/presign.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SignatureV4/presign.md
@@ -45,6 +45,8 @@ The `presign` operation returns an Object with the following properties.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 import { check } from 'k6';

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SignatureV4/sign.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SignatureV4/sign.md
@@ -43,6 +43,8 @@ You can override SignatureV4 options in the context of this specific request. To
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
@@ -25,6 +25,8 @@ weight: 20
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
@@ -31,6 +31,8 @@ Both the dedicated `ssm.js` jslib bundle and the all-encompassing `aws.js` bundl
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
+++ b/docs/sources/k6/v0.47.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
@@ -31,6 +31,8 @@ EventBridgeClient methods will throw errors in case of failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
@@ -41,6 +41,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
@@ -21,6 +21,8 @@ For instance, the [`generateDataKey`](https://grafana.com/docs/k6/<K6_VERSION>/j
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
@@ -17,6 +17,8 @@ weight: 20
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/KMSClient/_index.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/KMSClient/_index.md
@@ -34,6 +34,8 @@ Both the dedicated `kms.js` jslib bundle and the all-encompassing `aws.js` bundl
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.2/index.js';
 

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/KMSClient/generateDataKey.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/KMSClient/generateDataKey.md
@@ -27,6 +27,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/KMSClient/listKeys.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/KMSClient/listKeys.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/LambdaClient/_index.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/LambdaClient/_index.md
@@ -31,6 +31,8 @@ Both the dedicated `lambda.js` jslib bundle and the all-encompassing `aws.js` bu
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/LambdaClient/invoke.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/LambdaClient/invoke.md
@@ -49,6 +49,8 @@ InvocationResponse is an object that represents the response of an invocation. I
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/Bucket.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/Bucket.md
@@ -17,6 +17,8 @@ Bucket is returned by the S3Client.\* methods that query S3 buckets. Namely, `li
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/Object.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/Object.md
@@ -22,6 +22,8 @@ and [`deleteObject`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jsl
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/S3MultipartUpload.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/S3MultipartUpload.md
@@ -17,6 +17,8 @@ S3MultipartUpload is returned by the [`createMultipartUpload(bucketName, objectK
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/S3Part.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/S3Part.md
@@ -18,6 +18,8 @@ S3Part is returned by the [`uploadPart(bucketName, objectKey, uploadId, partNumb
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import crypto from 'k6/crypto';
 import exec from 'k6/execution';

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/_index.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/_index.md
@@ -42,6 +42,8 @@ S3 Client methods will throw errors in case of failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import { check } from 'k6';
 import exec from 'k6/execution';
@@ -107,6 +109,8 @@ export async function handleSummary(data) {
 #### Multipart uploads
 
 {{< code >}}
+
+<!-- md-k6:skip -->
 
 ```javascript
 import crypto from 'k6/crypto';

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
@@ -26,6 +26,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/copyObject.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/copyObject.md
@@ -27,6 +27,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
@@ -23,6 +23,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/deleteObject.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/deleteObject.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/getObject.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/getObject.md
@@ -32,6 +32,8 @@ receive the data as an `ArrayBuffer`, you can pass [`additionalHeaders`](#parame
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 
@@ -71,6 +73,8 @@ _A k6 script that will download an object from a bucket_
 #### Downloading a binary file from AWS S3
 
 {{< code >}}
+
+<!-- md-k6:skip -->
 
 ```javascript
 import exec from 'k6/execution';

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/listBuckets.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/listBuckets.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/listObjects.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/listObjects.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/uploadPart.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/S3Client/uploadPart.md
@@ -26,6 +26,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import crypto from 'k6/crypto';
 import exec from 'k6/execution';

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
@@ -24,6 +24,8 @@ Secret is returned by the SecretsManagerClient.\* methods that query secrets. Na
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
@@ -35,6 +35,8 @@ S3 Client methods will throw errors in case of failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
@@ -28,6 +28,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
@@ -22,6 +22,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SignatureV4/_index.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SignatureV4/_index.md
@@ -47,6 +47,8 @@ SignatureV4 methods throw errors on failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SignatureV4/presign.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SignatureV4/presign.md
@@ -45,6 +45,8 @@ The `presign` operation returns an Object with the following properties.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 import { check } from 'k6';

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SignatureV4/sign.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SignatureV4/sign.md
@@ -43,6 +43,8 @@ You can override SignatureV4 options in the context of this specific request. To
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
@@ -25,6 +25,8 @@ weight: 20
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
@@ -31,6 +31,8 @@ Both the dedicated `ssm.js` jslib bundle and the all-encompassing `aws.js` bundl
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
+++ b/docs/sources/k6/v0.48.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
@@ -31,6 +31,8 @@ EventBridgeClient methods will throw errors in case of failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
@@ -41,6 +41,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
@@ -21,6 +21,8 @@ For instance, the [`generateDataKey`](https://grafana.com/docs/k6/<K6_VERSION>/j
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
@@ -17,6 +17,8 @@ weight: 20
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/KMSClient/_index.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/KMSClient/_index.md
@@ -34,6 +34,8 @@ Both the dedicated `kms.js` jslib bundle and the all-encompassing `aws.js` bundl
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.2/index.js';
 

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/KMSClient/generateDataKey.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/KMSClient/generateDataKey.md
@@ -27,6 +27,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/KMSClient/listKeys.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/KMSClient/listKeys.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/LambdaClient/_index.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/LambdaClient/_index.md
@@ -31,6 +31,8 @@ Both the dedicated `lambda.js` jslib bundle and the all-encompassing `aws.js` bu
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/LambdaClient/invoke.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/LambdaClient/invoke.md
@@ -49,6 +49,8 @@ InvocationResponse is an object that represents the response of an invocation. I
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/Bucket.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/Bucket.md
@@ -17,6 +17,8 @@ Bucket is returned by the S3Client.\* methods that query S3 buckets. Namely, `li
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/Object.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/Object.md
@@ -22,6 +22,8 @@ and [`deleteObject`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jsl
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/S3MultipartUpload.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/S3MultipartUpload.md
@@ -17,6 +17,8 @@ S3MultipartUpload is returned by the [`createMultipartUpload(bucketName, objectK
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/S3Part.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/S3Part.md
@@ -18,6 +18,8 @@ S3Part is returned by the [`uploadPart(bucketName, objectKey, uploadId, partNumb
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import crypto from 'k6/crypto';
 import exec from 'k6/execution';

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/_index.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/_index.md
@@ -42,6 +42,8 @@ S3 Client methods will throw errors in case of failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import { check } from 'k6';
 import exec from 'k6/execution';
@@ -107,6 +109,8 @@ export async function handleSummary(data) {
 #### Multipart uploads
 
 {{< code >}}
+
+<!-- md-k6:skip -->
 
 ```javascript
 import crypto from 'k6/crypto';

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
@@ -26,6 +26,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/copyObject.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/copyObject.md
@@ -27,6 +27,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
@@ -23,6 +23,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/deleteObject.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/deleteObject.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/getObject.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/getObject.md
@@ -32,6 +32,8 @@ receive the data as an `ArrayBuffer`, you can pass [`additionalHeaders`](#parame
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 
@@ -71,6 +73,8 @@ _A k6 script that will download an object from a bucket_
 #### Downloading a binary file from AWS S3
 
 {{< code >}}
+
+<!-- md-k6:skip -->
 
 ```javascript
 import exec from 'k6/execution';

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/listBuckets.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/listBuckets.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/listObjects.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/listObjects.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/uploadPart.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/S3Client/uploadPart.md
@@ -26,6 +26,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import crypto from 'k6/crypto';
 import exec from 'k6/execution';

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
@@ -24,6 +24,8 @@ Secret is returned by the SecretsManagerClient.\* methods that query secrets. Na
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
@@ -35,6 +35,8 @@ S3 Client methods will throw errors in case of failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
@@ -28,6 +28,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
@@ -22,6 +22,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SignatureV4/_index.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SignatureV4/_index.md
@@ -47,6 +47,8 @@ SignatureV4 methods throw errors on failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SignatureV4/presign.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SignatureV4/presign.md
@@ -45,6 +45,8 @@ The `presign` operation returns an Object with the following properties.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 import { check } from 'k6';

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SignatureV4/sign.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SignatureV4/sign.md
@@ -43,6 +43,8 @@ You can override SignatureV4 options in the context of this specific request. To
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
@@ -25,6 +25,8 @@ weight: 20
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
@@ -31,6 +31,8 @@ Both the dedicated `ssm.js` jslib bundle and the all-encompassing `aws.js` bundl
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
+++ b/docs/sources/k6/v0.49.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
@@ -31,6 +31,8 @@ EventBridgeClient methods will throw errors in case of failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
@@ -41,6 +41,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
@@ -21,6 +21,8 @@ For instance, the [`generateDataKey`](https://grafana.com/docs/k6/<K6_VERSION>/j
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
@@ -17,6 +17,8 @@ weight: 20
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/KMSClient/_index.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/KMSClient/_index.md
@@ -34,6 +34,8 @@ Both the dedicated `kms.js` jslib bundle and the all-encompassing `aws.js` bundl
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.2/index.js';
 

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/KMSClient/generateDataKey.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/KMSClient/generateDataKey.md
@@ -27,6 +27,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/KMSClient/listKeys.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/KMSClient/listKeys.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/LambdaClient/_index.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/LambdaClient/_index.md
@@ -31,6 +31,8 @@ Both the dedicated `lambda.js` jslib bundle and the all-encompassing `aws.js` bu
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/LambdaClient/invoke.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/LambdaClient/invoke.md
@@ -49,6 +49,8 @@ InvocationResponse is an object that represents the response of an invocation. I
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/Bucket.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/Bucket.md
@@ -17,6 +17,8 @@ Bucket is returned by the S3Client.\* methods that query S3 buckets. Namely, `li
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/Object.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/Object.md
@@ -22,6 +22,8 @@ and [`deleteObject`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jsl
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/S3MultipartUpload.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/S3MultipartUpload.md
@@ -17,6 +17,8 @@ S3MultipartUpload is returned by the [`createMultipartUpload(bucketName, objectK
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/S3Part.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/S3Part.md
@@ -18,6 +18,8 @@ S3Part is returned by the [`uploadPart(bucketName, objectKey, uploadId, partNumb
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import crypto from 'k6/crypto';
 import exec from 'k6/execution';

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/_index.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/_index.md
@@ -42,6 +42,8 @@ S3 Client methods will throw errors in case of failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import { check } from 'k6';
 import exec from 'k6/execution';
@@ -107,6 +109,8 @@ export async function handleSummary(data) {
 #### Multipart uploads
 
 {{< code >}}
+
+<!-- md-k6:skip -->
 
 ```javascript
 import crypto from 'k6/crypto';

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
@@ -26,6 +26,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/copyObject.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/copyObject.md
@@ -27,6 +27,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
@@ -23,6 +23,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/deleteObject.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/deleteObject.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/getObject.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/getObject.md
@@ -32,6 +32,8 @@ receive the data as an `ArrayBuffer`, you can pass [`additionalHeaders`](#parame
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 
@@ -71,6 +73,8 @@ _A k6 script that will download an object from a bucket_
 #### Downloading a binary file from AWS S3
 
 {{< code >}}
+
+<!-- md-k6:skip -->
 
 ```javascript
 import exec from 'k6/execution';

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/listBuckets.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/listBuckets.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/listObjects.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/listObjects.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/uploadPart.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/S3Client/uploadPart.md
@@ -26,6 +26,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import crypto from 'k6/crypto';
 import exec from 'k6/execution';

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
@@ -24,6 +24,8 @@ Secret is returned by the SecretsManagerClient.\* methods that query secrets. Na
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
@@ -35,6 +35,8 @@ S3 Client methods will throw errors in case of failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
@@ -28,6 +28,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
@@ -22,6 +22,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SignatureV4/_index.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SignatureV4/_index.md
@@ -47,6 +47,8 @@ SignatureV4 methods throw errors on failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SignatureV4/presign.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SignatureV4/presign.md
@@ -45,6 +45,8 @@ The `presign` operation returns an Object with the following properties.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 import { check } from 'k6';

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SignatureV4/sign.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SignatureV4/sign.md
@@ -43,6 +43,8 @@ You can override SignatureV4 options in the context of this specific request. To
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
@@ -25,6 +25,8 @@ weight: 20
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
@@ -31,6 +31,8 @@ Both the dedicated `ssm.js` jslib bundle and the all-encompassing `aws.js` bundl
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
+++ b/docs/sources/k6/v0.50.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
@@ -31,6 +31,8 @@ EventBridgeClient methods will throw errors in case of failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
@@ -41,6 +41,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
@@ -21,6 +21,8 @@ For instance, the [`generateDataKey`](https://grafana.com/docs/k6/<K6_VERSION>/j
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
@@ -17,6 +17,8 @@ weight: 20
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/KMSClient/_index.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/KMSClient/_index.md
@@ -34,6 +34,8 @@ Both the dedicated `kms.js` jslib bundle and the all-encompassing `aws.js` bundl
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.2/index.js';
 

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/KMSClient/generateDataKey.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/KMSClient/generateDataKey.md
@@ -27,6 +27,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/KMSClient/listKeys.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/KMSClient/listKeys.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/LambdaClient/_index.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/LambdaClient/_index.md
@@ -31,6 +31,8 @@ Both the dedicated `lambda.js` jslib bundle and the all-encompassing `aws.js` bu
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/LambdaClient/invoke.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/LambdaClient/invoke.md
@@ -49,6 +49,8 @@ InvocationResponse is an object that represents the response of an invocation. I
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/Bucket.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/Bucket.md
@@ -17,6 +17,8 @@ Bucket is returned by the S3Client.\* methods that query S3 buckets. Namely, `li
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/Object.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/Object.md
@@ -22,6 +22,8 @@ and [`deleteObject`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jsl
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/S3MultipartUpload.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/S3MultipartUpload.md
@@ -17,6 +17,8 @@ S3MultipartUpload is returned by the [`createMultipartUpload(bucketName, objectK
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/S3Part.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/S3Part.md
@@ -18,6 +18,8 @@ S3Part is returned by the [`uploadPart(bucketName, objectKey, uploadId, partNumb
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import crypto from 'k6/crypto';
 import exec from 'k6/execution';

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/_index.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/_index.md
@@ -42,6 +42,8 @@ S3 Client methods will throw errors in case of failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import { check } from 'k6';
 import exec from 'k6/execution';
@@ -107,6 +109,8 @@ export async function handleSummary(data) {
 #### Multipart uploads
 
 {{< code >}}
+
+<!-- md-k6:skip -->
 
 ```javascript
 import crypto from 'k6/crypto';

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
@@ -26,6 +26,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/copyObject.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/copyObject.md
@@ -27,6 +27,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
@@ -23,6 +23,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/deleteObject.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/deleteObject.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/getObject.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/getObject.md
@@ -32,6 +32,8 @@ receive the data as an `ArrayBuffer`, you can pass [`additionalHeaders`](#parame
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 
@@ -71,6 +73,8 @@ _A k6 script that will download an object from a bucket_
 #### Downloading a binary file from AWS S3
 
 {{< code >}}
+
+<!-- md-k6:skip -->
 
 ```javascript
 import exec from 'k6/execution';

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/listBuckets.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/listBuckets.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/listObjects.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/listObjects.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/uploadPart.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/S3Client/uploadPart.md
@@ -26,6 +26,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import crypto from 'k6/crypto';
 import exec from 'k6/execution';

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
@@ -24,6 +24,8 @@ Secret is returned by the SecretsManagerClient.\* methods that query secrets. Na
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
@@ -35,6 +35,8 @@ S3 Client methods will throw errors in case of failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
@@ -28,6 +28,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
@@ -22,6 +22,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SignatureV4/_index.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SignatureV4/_index.md
@@ -47,6 +47,8 @@ SignatureV4 methods throw errors on failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SignatureV4/presign.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SignatureV4/presign.md
@@ -45,6 +45,8 @@ The `presign` operation returns an Object with the following properties.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 import { check } from 'k6';

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SignatureV4/sign.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SignatureV4/sign.md
@@ -43,6 +43,8 @@ You can override SignatureV4 options in the context of this specific request. To
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
@@ -25,6 +25,8 @@ weight: 20
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
@@ -31,6 +31,8 @@ Both the dedicated `ssm.js` jslib bundle and the all-encompassing `aws.js` bundl
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
+++ b/docs/sources/k6/v0.51.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
@@ -31,6 +31,8 @@ EventBridgeClient methods will throw errors in case of failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
@@ -41,6 +41,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
@@ -21,6 +21,8 @@ For instance, the [`generateDataKey`](https://grafana.com/docs/k6/<K6_VERSION>/j
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
@@ -17,6 +17,8 @@ weight: 20
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/KMSClient/_index.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/KMSClient/_index.md
@@ -34,6 +34,8 @@ Both the dedicated `kms.js` jslib bundle and the all-encompassing `aws.js` bundl
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.2/index.js';
 

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/KMSClient/generateDataKey.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/KMSClient/generateDataKey.md
@@ -27,6 +27,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/KMSClient/listKeys.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/KMSClient/listKeys.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/LambdaClient/_index.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/LambdaClient/_index.md
@@ -31,6 +31,8 @@ Both the dedicated `lambda.js` jslib bundle and the all-encompassing `aws.js` bu
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/LambdaClient/invoke.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/LambdaClient/invoke.md
@@ -49,6 +49,8 @@ InvocationResponse is an object that represents the response of an invocation. I
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/Bucket.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/Bucket.md
@@ -17,6 +17,8 @@ Bucket is returned by the S3Client.\* methods that query S3 buckets. Namely, `li
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/Object.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/Object.md
@@ -22,6 +22,8 @@ and [`deleteObject`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jsl
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/S3MultipartUpload.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/S3MultipartUpload.md
@@ -17,6 +17,8 @@ S3MultipartUpload is returned by the [`createMultipartUpload(bucketName, objectK
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/S3Part.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/S3Part.md
@@ -18,6 +18,8 @@ S3Part is returned by the [`uploadPart(bucketName, objectKey, uploadId, partNumb
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import crypto from 'k6/crypto';
 import exec from 'k6/execution';

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/_index.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/_index.md
@@ -42,6 +42,8 @@ S3 Client methods will throw errors in case of failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import { check } from 'k6';
 import exec from 'k6/execution';
@@ -107,6 +109,8 @@ export async function handleSummary(data) {
 #### Multipart uploads
 
 {{< code >}}
+
+<!-- md-k6:skip -->
 
 ```javascript
 import crypto from 'k6/crypto';

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
@@ -26,6 +26,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/copyObject.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/copyObject.md
@@ -27,6 +27,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
@@ -23,6 +23,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/deleteObject.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/deleteObject.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/getObject.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/getObject.md
@@ -32,6 +32,8 @@ receive the data as an `ArrayBuffer`, you can pass [`additionalHeaders`](#parame
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 
@@ -71,6 +73,8 @@ _A k6 script that will download an object from a bucket_
 #### Downloading a binary file from AWS S3
 
 {{< code >}}
+
+<!-- md-k6:skip -->
 
 ```javascript
 import exec from 'k6/execution';

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/listBuckets.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/listBuckets.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/listObjects.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/listObjects.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/uploadPart.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/S3Client/uploadPart.md
@@ -26,6 +26,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import crypto from 'k6/crypto';
 import exec from 'k6/execution';

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
@@ -24,6 +24,8 @@ Secret is returned by the SecretsManagerClient.\* methods that query secrets. Na
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
@@ -35,6 +35,8 @@ S3 Client methods will throw errors in case of failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
@@ -28,6 +28,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
@@ -22,6 +22,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SignatureV4/_index.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SignatureV4/_index.md
@@ -47,6 +47,8 @@ SignatureV4 methods throw errors on failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SignatureV4/presign.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SignatureV4/presign.md
@@ -45,6 +45,8 @@ The `presign` operation returns an Object with the following properties.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 import { check } from 'k6';

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SignatureV4/sign.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SignatureV4/sign.md
@@ -43,6 +43,8 @@ You can override SignatureV4 options in the context of this specific request. To
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
@@ -25,6 +25,8 @@ weight: 20
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
@@ -31,6 +31,8 @@ Both the dedicated `ssm.js` jslib bundle and the all-encompassing `aws.js` bundl
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
+++ b/docs/sources/k6/v0.52.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
@@ -31,6 +31,8 @@ EventBridgeClient methods will throw errors in case of failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
@@ -41,6 +41,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
@@ -21,6 +21,8 @@ For instance, the [`generateDataKey`](https://grafana.com/docs/k6/<K6_VERSION>/j
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
@@ -17,6 +17,8 @@ weight: 20
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/KMSClient/_index.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/KMSClient/_index.md
@@ -34,6 +34,8 @@ Both the dedicated `kms.js` jslib bundle and the all-encompassing `aws.js` bundl
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.2/index.js';
 

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/KMSClient/generateDataKey.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/KMSClient/generateDataKey.md
@@ -27,6 +27,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/KMSClient/listKeys.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/KMSClient/listKeys.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/LambdaClient/_index.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/LambdaClient/_index.md
@@ -31,6 +31,8 @@ Both the dedicated `lambda.js` jslib bundle and the all-encompassing `aws.js` bu
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/LambdaClient/invoke.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/LambdaClient/invoke.md
@@ -49,6 +49,8 @@ InvocationResponse is an object that represents the response of an invocation. I
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/Bucket.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/Bucket.md
@@ -17,6 +17,8 @@ Bucket is returned by the S3Client.\* methods that query S3 buckets. Namely, `li
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/Object.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/Object.md
@@ -22,6 +22,8 @@ and [`deleteObject`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jsl
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/S3MultipartUpload.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/S3MultipartUpload.md
@@ -17,6 +17,8 @@ S3MultipartUpload is returned by the [`createMultipartUpload(bucketName, objectK
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/S3Part.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/S3Part.md
@@ -18,6 +18,8 @@ S3Part is returned by the [`uploadPart(bucketName, objectKey, uploadId, partNumb
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import crypto from 'k6/crypto';
 import exec from 'k6/execution';

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/_index.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/_index.md
@@ -42,6 +42,8 @@ S3 Client methods will throw errors in case of failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import { check } from 'k6';
 import exec from 'k6/execution';
@@ -107,6 +109,8 @@ export async function handleSummary(data) {
 #### Multipart uploads
 
 {{< code >}}
+
+<!-- md-k6:skip -->
 
 ```javascript
 import crypto from 'k6/crypto';

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
@@ -26,6 +26,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/copyObject.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/copyObject.md
@@ -27,6 +27,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
@@ -23,6 +23,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/deleteObject.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/deleteObject.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/getObject.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/getObject.md
@@ -32,6 +32,8 @@ receive the data as an `ArrayBuffer`, you can pass [`additionalHeaders`](#parame
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 
@@ -71,6 +73,8 @@ _A k6 script that will download an object from a bucket_
 #### Downloading a binary file from AWS S3
 
 {{< code >}}
+
+<!-- md-k6:skip -->
 
 ```javascript
 import exec from 'k6/execution';

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/listBuckets.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/listBuckets.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/listObjects.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/listObjects.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/uploadPart.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/S3Client/uploadPart.md
@@ -26,6 +26,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import crypto from 'k6/crypto';
 import exec from 'k6/execution';

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
@@ -24,6 +24,8 @@ Secret is returned by the SecretsManagerClient.\* methods that query secrets. Na
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
@@ -35,6 +35,8 @@ S3 Client methods will throw errors in case of failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
@@ -28,6 +28,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
@@ -22,6 +22,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SignatureV4/_index.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SignatureV4/_index.md
@@ -47,6 +47,8 @@ SignatureV4 methods throw errors on failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SignatureV4/presign.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SignatureV4/presign.md
@@ -45,6 +45,8 @@ The `presign` operation returns an Object with the following properties.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 import { check } from 'k6';

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SignatureV4/sign.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SignatureV4/sign.md
@@ -43,6 +43,8 @@ You can override SignatureV4 options in the context of this specific request. To
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
@@ -25,6 +25,8 @@ weight: 20
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
@@ -31,6 +31,8 @@ Both the dedicated `ssm.js` jslib bundle and the all-encompassing `aws.js` bundl
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
+++ b/docs/sources/k6/v0.53.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
@@ -31,6 +31,8 @@ EventBridgeClient methods will throw errors in case of failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
@@ -41,6 +41,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
@@ -21,6 +21,8 @@ For instance, the [`generateDataKey`](https://grafana.com/docs/k6/<K6_VERSION>/j
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
@@ -17,6 +17,8 @@ weight: 20
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/KMSClient/_index.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/KMSClient/_index.md
@@ -34,6 +34,8 @@ Both the dedicated `kms.js` jslib bundle and the all-encompassing `aws.js` bundl
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.2/index.js';
 

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/KMSClient/generateDataKey.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/KMSClient/generateDataKey.md
@@ -27,6 +27,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/KMSClient/listKeys.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/KMSClient/listKeys.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/LambdaClient/_index.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/LambdaClient/_index.md
@@ -31,6 +31,8 @@ Both the dedicated `lambda.js` jslib bundle and the all-encompassing `aws.js` bu
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/LambdaClient/invoke.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/LambdaClient/invoke.md
@@ -49,6 +49,8 @@ InvocationResponse is an object that represents the response of an invocation. I
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/Bucket.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/Bucket.md
@@ -17,6 +17,8 @@ Bucket is returned by the S3Client.\* methods that query S3 buckets. Namely, `li
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/Object.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/Object.md
@@ -22,6 +22,8 @@ and [`deleteObject`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jsl
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/S3MultipartUpload.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/S3MultipartUpload.md
@@ -17,6 +17,8 @@ S3MultipartUpload is returned by the [`createMultipartUpload(bucketName, objectK
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/S3Part.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/S3Part.md
@@ -18,6 +18,8 @@ S3Part is returned by the [`uploadPart(bucketName, objectKey, uploadId, partNumb
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import crypto from 'k6/crypto';
 import exec from 'k6/execution';

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/_index.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/_index.md
@@ -42,6 +42,8 @@ S3 Client methods will throw errors in case of failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import { check } from 'k6';
 import exec from 'k6/execution';
@@ -107,6 +109,8 @@ export async function handleSummary(data) {
 #### Multipart uploads
 
 {{< code >}}
+
+<!-- md-k6:skip -->
 
 ```javascript
 import crypto from 'k6/crypto';

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
@@ -26,6 +26,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/copyObject.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/copyObject.md
@@ -27,6 +27,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
@@ -23,6 +23,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/deleteObject.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/deleteObject.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/getObject.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/getObject.md
@@ -32,6 +32,8 @@ receive the data as an `ArrayBuffer`, you can pass [`additionalHeaders`](#parame
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 
@@ -71,6 +73,8 @@ _A k6 script that will download an object from a bucket_
 #### Downloading a binary file from AWS S3
 
 {{< code >}}
+
+<!-- md-k6:skip -->
 
 ```javascript
 import exec from 'k6/execution';

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/listBuckets.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/listBuckets.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/listObjects.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/listObjects.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/uploadPart.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/S3Client/uploadPart.md
@@ -26,6 +26,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import crypto from 'k6/crypto';
 import exec from 'k6/execution';

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
@@ -24,6 +24,8 @@ Secret is returned by the SecretsManagerClient.\* methods that query secrets. Na
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
@@ -35,6 +35,8 @@ S3 Client methods will throw errors in case of failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
@@ -28,6 +28,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
@@ -22,6 +22,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SignatureV4/_index.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SignatureV4/_index.md
@@ -47,6 +47,8 @@ SignatureV4 methods throw errors on failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SignatureV4/presign.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SignatureV4/presign.md
@@ -45,6 +45,8 @@ The `presign` operation returns an Object with the following properties.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 import { check } from 'k6';

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SignatureV4/sign.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SignatureV4/sign.md
@@ -43,6 +43,8 @@ You can override SignatureV4 options in the context of this specific request. To
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
@@ -25,6 +25,8 @@ weight: 20
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
@@ -31,6 +31,8 @@ Both the dedicated `ssm.js` jslib bundle and the all-encompassing `aws.js` bundl
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
@@ -31,6 +31,8 @@ EventBridgeClient methods will throw errors in case of failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
@@ -41,6 +41,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
@@ -21,6 +21,8 @@ For instance, the [`generateDataKey`](https://grafana.com/docs/k6/<K6_VERSION>/j
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
@@ -17,6 +17,8 @@ weight: 20
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/KMSClient/_index.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/KMSClient/_index.md
@@ -34,6 +34,8 @@ Both the dedicated `kms.js` jslib bundle and the all-encompassing `aws.js` bundl
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.2/index.js';
 

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/KMSClient/generateDataKey.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/KMSClient/generateDataKey.md
@@ -27,6 +27,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/KMSClient/listKeys.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/KMSClient/listKeys.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/LambdaClient/_index.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/LambdaClient/_index.md
@@ -31,6 +31,8 @@ Both the dedicated `lambda.js` jslib bundle and the all-encompassing `aws.js` bu
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/LambdaClient/invoke.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/LambdaClient/invoke.md
@@ -49,6 +49,8 @@ InvocationResponse is an object that represents the response of an invocation. I
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/Bucket.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/Bucket.md
@@ -17,6 +17,8 @@ Bucket is returned by the S3Client.\* methods that query S3 buckets. Namely, `li
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/Object.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/Object.md
@@ -22,6 +22,8 @@ and [`deleteObject`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jsl
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/S3MultipartUpload.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/S3MultipartUpload.md
@@ -17,6 +17,8 @@ S3MultipartUpload is returned by the [`createMultipartUpload(bucketName, objectK
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/S3Part.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/S3Part.md
@@ -18,6 +18,8 @@ S3Part is returned by the [`uploadPart(bucketName, objectKey, uploadId, partNumb
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import crypto from 'k6/crypto';
 import exec from 'k6/execution';

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/_index.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/_index.md
@@ -42,6 +42,8 @@ S3 Client methods will throw errors in case of failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import { check } from 'k6';
 import exec from 'k6/execution';
@@ -107,6 +109,8 @@ export async function handleSummary(data) {
 #### Multipart uploads
 
 {{< code >}}
+
+<!-- md-k6:skip -->
 
 ```javascript
 import crypto from 'k6/crypto';

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
@@ -26,6 +26,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/copyObject.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/copyObject.md
@@ -27,6 +27,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
@@ -23,6 +23,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/deleteObject.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/deleteObject.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/getObject.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/getObject.md
@@ -32,6 +32,8 @@ receive the data as an `ArrayBuffer`, you can pass [`additionalHeaders`](#parame
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 
@@ -71,6 +73,8 @@ _A k6 script that will download an object from a bucket_
 #### Downloading a binary file from AWS S3
 
 {{< code >}}
+
+<!-- md-k6:skip -->
 
 ```javascript
 import exec from 'k6/execution';

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/listBuckets.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/listBuckets.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/listObjects.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/listObjects.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/uploadPart.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/S3Client/uploadPart.md
@@ -26,6 +26,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import crypto from 'k6/crypto';
 import exec from 'k6/execution';

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
@@ -24,6 +24,8 @@ Secret is returned by the SecretsManagerClient.\* methods that query secrets. Na
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
@@ -35,6 +35,8 @@ S3 Client methods will throw errors in case of failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
@@ -28,6 +28,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
@@ -22,6 +22,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SignatureV4/_index.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SignatureV4/_index.md
@@ -47,6 +47,8 @@ SignatureV4 methods throw errors on failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SignatureV4/presign.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SignatureV4/presign.md
@@ -45,6 +45,8 @@ The `presign` operation returns an Object with the following properties.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 import { check } from 'k6';

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SignatureV4/sign.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SignatureV4/sign.md
@@ -43,6 +43,8 @@ You can override SignatureV4 options in the context of this specific request. To
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
@@ -25,6 +25,8 @@ weight: 20
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
@@ -31,6 +31,8 @@ Both the dedicated `ssm.js` jslib bundle and the all-encompassing `aws.js` bundl
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
@@ -31,6 +31,8 @@ EventBridgeClient methods will throw errors in case of failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
@@ -41,6 +41,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
@@ -21,6 +21,8 @@ For instance, the [`generateDataKey`](https://grafana.com/docs/k6/<K6_VERSION>/j
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
@@ -17,6 +17,8 @@ weight: 20
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/KMSClient/_index.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/KMSClient/_index.md
@@ -34,6 +34,8 @@ Both the dedicated `kms.js` jslib bundle and the all-encompassing `aws.js` bundl
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.2/index.js';
 

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/KMSClient/generateDataKey.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/KMSClient/generateDataKey.md
@@ -27,6 +27,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/KMSClient/listKeys.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/KMSClient/listKeys.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/LambdaClient/_index.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/LambdaClient/_index.md
@@ -31,6 +31,8 @@ Both the dedicated `lambda.js` jslib bundle and the all-encompassing `aws.js` bu
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/LambdaClient/invoke.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/LambdaClient/invoke.md
@@ -49,6 +49,8 @@ InvocationResponse is an object that represents the response of an invocation. I
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/Bucket.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/Bucket.md
@@ -17,6 +17,8 @@ Bucket is returned by the S3Client.\* methods that query S3 buckets. Namely, `li
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/Object.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/Object.md
@@ -22,6 +22,8 @@ and [`deleteObject`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jsl
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/S3MultipartUpload.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/S3MultipartUpload.md
@@ -17,6 +17,8 @@ S3MultipartUpload is returned by the [`createMultipartUpload(bucketName, objectK
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/S3Part.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/S3Part.md
@@ -18,6 +18,8 @@ S3Part is returned by the [`uploadPart(bucketName, objectKey, uploadId, partNumb
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import crypto from 'k6/crypto';
 import exec from 'k6/execution';

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/_index.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/_index.md
@@ -42,6 +42,8 @@ S3 Client methods will throw errors in case of failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import { check } from 'k6';
 import exec from 'k6/execution';
@@ -107,6 +109,8 @@ export async function handleSummary(data) {
 #### Multipart uploads
 
 {{< code >}}
+
+<!-- md-k6:skip -->
 
 ```javascript
 import crypto from 'k6/crypto';

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
@@ -26,6 +26,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/copyObject.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/copyObject.md
@@ -27,6 +27,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
@@ -23,6 +23,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/deleteObject.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/deleteObject.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/getObject.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/getObject.md
@@ -32,6 +32,8 @@ receive the data as an `ArrayBuffer`, you can pass [`additionalHeaders`](#parame
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 
@@ -71,6 +73,8 @@ _A k6 script that will download an object from a bucket_
 #### Downloading a binary file from AWS S3
 
 {{< code >}}
+
+<!-- md-k6:skip -->
 
 ```javascript
 import exec from 'k6/execution';

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/listBuckets.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/listBuckets.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/listObjects.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/listObjects.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/uploadPart.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/S3Client/uploadPart.md
@@ -26,6 +26,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import crypto from 'k6/crypto';
 import exec from 'k6/execution';

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
@@ -24,6 +24,8 @@ Secret is returned by the SecretsManagerClient.\* methods that query secrets. Na
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
@@ -35,6 +35,8 @@ S3 Client methods will throw errors in case of failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
@@ -28,6 +28,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
@@ -22,6 +22,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SignatureV4/_index.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SignatureV4/_index.md
@@ -47,6 +47,8 @@ SignatureV4 methods throw errors on failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SignatureV4/presign.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SignatureV4/presign.md
@@ -45,6 +45,8 @@ The `presign` operation returns an Object with the following properties.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 import { check } from 'k6';

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SignatureV4/sign.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SignatureV4/sign.md
@@ -43,6 +43,8 @@ You can override SignatureV4 options in the context of this specific request. To
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
@@ -25,6 +25,8 @@ weight: 20
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
@@ -31,6 +31,8 @@ Both the dedicated `ssm.js` jslib bundle and the all-encompassing `aws.js` bundl
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
@@ -31,6 +31,8 @@ EventBridgeClient methods will throw errors in case of failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
@@ -41,6 +41,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
@@ -21,6 +21,8 @@ For instance, the [`generateDataKey`](https://grafana.com/docs/k6/<K6_VERSION>/j
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
@@ -17,6 +17,8 @@ weight: 20
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/KMSClient/_index.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/KMSClient/_index.md
@@ -34,6 +34,8 @@ Both the dedicated `kms.js` jslib bundle and the all-encompassing `aws.js` bundl
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.2/index.js';
 

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/KMSClient/generateDataKey.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/KMSClient/generateDataKey.md
@@ -27,6 +27,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/KMSClient/listKeys.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/KMSClient/listKeys.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/LambdaClient/_index.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/LambdaClient/_index.md
@@ -31,6 +31,8 @@ Both the dedicated `lambda.js` jslib bundle and the all-encompassing `aws.js` bu
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/LambdaClient/invoke.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/LambdaClient/invoke.md
@@ -49,6 +49,8 @@ InvocationResponse is an object that represents the response of an invocation. I
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/Bucket.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/Bucket.md
@@ -17,6 +17,8 @@ Bucket is returned by the S3Client.\* methods that query S3 buckets. Namely, `li
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/Object.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/Object.md
@@ -22,6 +22,8 @@ and [`deleteObject`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jsl
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/S3MultipartUpload.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/S3MultipartUpload.md
@@ -17,6 +17,8 @@ S3MultipartUpload is returned by the [`createMultipartUpload(bucketName, objectK
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/S3Part.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/S3Part.md
@@ -18,6 +18,8 @@ S3Part is returned by the [`uploadPart(bucketName, objectKey, uploadId, partNumb
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import crypto from 'k6/crypto';
 import exec from 'k6/execution';

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/_index.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/_index.md
@@ -42,6 +42,8 @@ S3 Client methods will throw errors in case of failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import { check } from 'k6';
 import exec from 'k6/execution';
@@ -107,6 +109,8 @@ export async function handleSummary(data) {
 #### Multipart uploads
 
 {{< code >}}
+
+<!-- md-k6:skip -->
 
 ```javascript
 import crypto from 'k6/crypto';

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
@@ -26,6 +26,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/copyObject.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/copyObject.md
@@ -27,6 +27,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
@@ -23,6 +23,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/deleteObject.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/deleteObject.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/getObject.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/getObject.md
@@ -32,6 +32,8 @@ receive the data as an `ArrayBuffer`, you can pass [`additionalHeaders`](#parame
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 
@@ -71,6 +73,8 @@ _A k6 script that will download an object from a bucket_
 #### Downloading a binary file from AWS S3
 
 {{< code >}}
+
+<!-- md-k6:skip -->
 
 ```javascript
 import exec from 'k6/execution';

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/listBuckets.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/listBuckets.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/listObjects.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/listObjects.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/uploadPart.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/S3Client/uploadPart.md
@@ -26,6 +26,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import crypto from 'k6/crypto';
 import exec from 'k6/execution';

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
@@ -24,6 +24,8 @@ Secret is returned by the SecretsManagerClient.\* methods that query secrets. Na
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
@@ -35,6 +35,8 @@ S3 Client methods will throw errors in case of failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
@@ -28,6 +28,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
@@ -22,6 +22,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SignatureV4/_index.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SignatureV4/_index.md
@@ -47,6 +47,8 @@ SignatureV4 methods throw errors on failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SignatureV4/presign.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SignatureV4/presign.md
@@ -45,6 +45,8 @@ The `presign` operation returns an Object with the following properties.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 import { check } from 'k6';

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SignatureV4/sign.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SignatureV4/sign.md
@@ -43,6 +43,8 @@ You can override SignatureV4 options in the context of this specific request. To
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
@@ -25,6 +25,8 @@ weight: 20
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
@@ -31,6 +31,8 @@ Both the dedicated `ssm.js` jslib bundle and the all-encompassing `aws.js` bundl
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
@@ -31,6 +31,8 @@ EventBridgeClient methods will throw errors in case of failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
@@ -41,6 +41,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
@@ -21,6 +21,8 @@ For instance, the [`generateDataKey`](https://grafana.com/docs/k6/<K6_VERSION>/j
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
@@ -17,6 +17,8 @@ weight: 20
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/KMSClient/_index.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/KMSClient/_index.md
@@ -34,6 +34,8 @@ Both the dedicated `kms.js` jslib bundle and the all-encompassing `aws.js` bundl
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.2/index.js';
 

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/KMSClient/generateDataKey.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/KMSClient/generateDataKey.md
@@ -27,6 +27,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/KMSClient/listKeys.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/KMSClient/listKeys.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/LambdaClient/_index.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/LambdaClient/_index.md
@@ -31,6 +31,8 @@ Both the dedicated `lambda.js` jslib bundle and the all-encompassing `aws.js` bu
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/LambdaClient/invoke.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/LambdaClient/invoke.md
@@ -49,6 +49,8 @@ InvocationResponse is an object that represents the response of an invocation. I
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/Bucket.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/Bucket.md
@@ -17,6 +17,8 @@ Bucket is returned by the S3Client.\* methods that query S3 buckets. Namely, `li
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/Object.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/Object.md
@@ -22,6 +22,8 @@ and [`deleteObject`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jsl
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/S3MultipartUpload.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/S3MultipartUpload.md
@@ -17,6 +17,8 @@ S3MultipartUpload is returned by the [`createMultipartUpload(bucketName, objectK
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/S3Part.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/S3Part.md
@@ -18,6 +18,8 @@ S3Part is returned by the [`uploadPart(bucketName, objectKey, uploadId, partNumb
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import crypto from 'k6/crypto';
 import exec from 'k6/execution';

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/_index.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/_index.md
@@ -42,6 +42,8 @@ S3 Client methods will throw errors in case of failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import { check } from 'k6';
 import exec from 'k6/execution';
@@ -107,6 +109,8 @@ export async function handleSummary(data) {
 #### Multipart uploads
 
 {{< code >}}
+
+<!-- md-k6:skip -->
 
 ```javascript
 import crypto from 'k6/crypto';

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
@@ -26,6 +26,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/copyObject.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/copyObject.md
@@ -27,6 +27,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
@@ -23,6 +23,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/deleteObject.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/deleteObject.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/getObject.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/getObject.md
@@ -32,6 +32,8 @@ receive the data as an `ArrayBuffer`, you can pass [`additionalHeaders`](#parame
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 
@@ -71,6 +73,8 @@ _A k6 script that will download an object from a bucket_
 #### Downloading a binary file from AWS S3
 
 {{< code >}}
+
+<!-- md-k6:skip -->
 
 ```javascript
 import exec from 'k6/execution';

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/listBuckets.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/listBuckets.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/listObjects.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/listObjects.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/uploadPart.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/S3Client/uploadPart.md
@@ -26,6 +26,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import crypto from 'k6/crypto';
 import exec from 'k6/execution';

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
@@ -24,6 +24,8 @@ Secret is returned by the SecretsManagerClient.\* methods that query secrets. Na
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
@@ -35,6 +35,8 @@ S3 Client methods will throw errors in case of failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
@@ -28,6 +28,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
@@ -22,6 +22,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SignatureV4/_index.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SignatureV4/_index.md
@@ -47,6 +47,8 @@ SignatureV4 methods throw errors on failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SignatureV4/presign.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SignatureV4/presign.md
@@ -45,6 +45,8 @@ The `presign` operation returns an Object with the following properties.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 import { check } from 'k6';

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SignatureV4/sign.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SignatureV4/sign.md
@@ -43,6 +43,8 @@ You can override SignatureV4 options in the context of this specific request. To
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
@@ -25,6 +25,8 @@ weight: 20
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
@@ -31,6 +31,8 @@ Both the dedicated `ssm.js` jslib bundle and the all-encompassing `aws.js` bundl
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/EventBridgeClient/_index.md
@@ -31,6 +31,8 @@ EventBridgeClient methods will throw errors in case of failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/EventBridgeClient/putEvents.md
@@ -41,6 +41,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/KMSClient/KMSDataKey.md
@@ -21,6 +21,8 @@ For instance, the [`generateDataKey`](https://grafana.com/docs/k6/<K6_VERSION>/j
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/KMSClient/KMSKey.md
@@ -17,6 +17,8 @@ weight: 20
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/KMSClient/_index.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/KMSClient/_index.md
@@ -34,6 +34,8 @@ Both the dedicated `kms.js` jslib bundle and the all-encompassing `aws.js` bundl
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.2/index.js';
 

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/KMSClient/generateDataKey.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/KMSClient/generateDataKey.md
@@ -27,6 +27,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/KMSClient/listKeys.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/KMSClient/listKeys.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/LambdaClient/_index.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/LambdaClient/_index.md
@@ -31,6 +31,8 @@ Both the dedicated `lambda.js` jslib bundle and the all-encompassing `aws.js` bu
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/LambdaClient/invoke.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/LambdaClient/invoke.md
@@ -49,6 +49,8 @@ InvocationResponse is an object that represents the response of an invocation. I
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/Bucket.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/Bucket.md
@@ -17,6 +17,8 @@ Bucket is returned by the S3Client.\* methods that query S3 buckets. Namely, `li
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/Object.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/Object.md
@@ -22,6 +22,8 @@ and [`deleteObject`](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/jsl
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/S3MultipartUpload.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/S3MultipartUpload.md
@@ -17,6 +17,8 @@ S3MultipartUpload is returned by the [`createMultipartUpload(bucketName, objectK
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/S3Part.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/S3Part.md
@@ -18,6 +18,8 @@ S3Part is returned by the [`uploadPart(bucketName, objectKey, uploadId, partNumb
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import crypto from 'k6/crypto';
 import exec from 'k6/execution';

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/_index.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/_index.md
@@ -42,6 +42,8 @@ S3 Client methods will throw errors in case of failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import { check } from 'k6';
 import exec from 'k6/execution';
@@ -107,6 +109,8 @@ export async function handleSummary(data) {
 #### Multipart uploads
 
 {{< code >}}
+
+<!-- md-k6:skip -->
 
 ```javascript
 import crypto from 'k6/crypto';

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/abortMultipartUpload.md
@@ -26,6 +26,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/copyObject.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/copyObject.md
@@ -27,6 +27,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/createMultipartUpload.md
@@ -23,6 +23,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/deleteObject.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/deleteObject.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/getObject.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/getObject.md
@@ -32,6 +32,8 @@ receive the data as an `ArrayBuffer`, you can pass [`additionalHeaders`](#parame
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 
@@ -71,6 +73,8 @@ _A k6 script that will download an object from a bucket_
 #### Downloading a binary file from AWS S3
 
 {{< code >}}
+
+<!-- md-k6:skip -->
 
 ```javascript
 import exec from 'k6/execution';

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/listBuckets.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/listBuckets.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/listObjects.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/listObjects.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/uploadPart.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/S3Client/uploadPart.md
@@ -26,6 +26,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import crypto from 'k6/crypto';
 import exec from 'k6/execution';

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SecretsManagerClient/Secret.md
@@ -24,6 +24,8 @@ Secret is returned by the SecretsManagerClient.\* methods that query secrets. Na
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SecretsManagerClient/_index.md
@@ -35,6 +35,8 @@ S3 Client methods will throw errors in case of failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SecretsManagerClient/createSecret.md
@@ -28,6 +28,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SecretsManagerClient/deleteSecret.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import {
   AWSConfig,

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SecretsManagerClient/getSecret.md
@@ -22,6 +22,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SecretsManagerClient/listSecrets.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SecretsManagerClient/putSecretValue.md
@@ -25,6 +25,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SignatureV4/_index.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SignatureV4/_index.md
@@ -47,6 +47,8 @@ SignatureV4 methods throw errors on failure.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SignatureV4/presign.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SignatureV4/presign.md
@@ -45,6 +45,8 @@ The `presign` operation returns an Object with the following properties.
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 import { check } from 'k6';

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SignatureV4/sign.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SignatureV4/sign.md
@@ -43,6 +43,8 @@ You can override SignatureV4 options in the context of this specific request. To
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import http from 'k6/http';
 

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SystemsManagerClient/SystemsManagerParameter.md
@@ -25,6 +25,8 @@ weight: 20
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SystemsManagerClient/_index.md
@@ -31,6 +31,8 @@ Both the dedicated `ssm.js` jslib bundle and the all-encompassing `aws.js` bundl
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 

--- a/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/jslib/aws/SystemsManagerClient/getParameter.md
@@ -18,6 +18,8 @@ weight: 10
 
 {{< code >}}
 
+<!-- md-k6:skip -->
+
 ```javascript
 import exec from 'k6/execution';
 


### PR DESCRIPTION
## What?

This PR ensures jslib-aws examples are preceded with a `<!-- md-k6:skip -->` statement to keep CI green, and ensure we don't ever try to actually run them, as we don't expect any actual aws environment to be set; hence, most likely consistently leading to test execution failures.

## Checklist

- [X] I have used a meaningful title for the PR.
- [X] I have described the changes I've made in the "What?" section above.
- [X] I have performed a self-review of my changes.
- [X] I have run the `npm start` command locally and verified that the changes look good.
- [X] I have made my changes in the `docs/sources/k6/next` folder of the documentation.
- [X] I have reflected my changes in the `docs/sources/k6/v{most_recent_release}` folder of the documentation.
- [X] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
