### PR TITLE
Add deploy preview workflow

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -7,7 +7,7 @@ on:
       - synchronize
       - closed
     paths:
-      - "docs/sources/k6/**"
+      - "docs/sources/k6/next/**"
 
 jobs:
   deploy-pr-preview:
@@ -21,10 +21,11 @@ jobs:
       sources: |
         [
           {
-            "relative_prefix": "/docs/k6/",
+            "index_file": "content/docs/k6/_index.md",
+            "relative_prefix": "/docs/k6/next/",
             "repo": "k6-docs",
-            "source_directory": "docs/sources/k6",
             "source_directory": "docs/sources/k6/next",
             "website_directory": "content/docs/k6/next"
+          }
         ]
       title: ${{ github.event.pull_request.title }}

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -1,0 +1,30 @@
+name: Deploy pr preview
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - closed
+    paths:
+      - "docs/sources/k6/**"
+
+jobs:
+  deploy-pr-preview:
+    if: "!github.event.pull_request.head.repo.fork"
+    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@main
+    with:
+      branch: ${{ github.head_ref }}
+      event_number: ${{ github.event.number }}
+      repo: k6-docs
+      sha: ${{ github.event.pull_request.head.sha }}
+      sources: |
+        [
+          {
+            "relative_prefix": "/docs/grafana-cloud/k6-docs/",
+            "repo": k6-docs,
+            "source_directory": "docs/sources/k6",
+            "website_directory": "content/docs/k6"
+          }
+        ]
+      title: ${{ github.event.pull_request.title }}

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -24,7 +24,7 @@ jobs:
             "relative_prefix": "/docs/k6/",
             "repo": "k6-docs",
             "source_directory": "docs/sources/k6",
-            "website_directory": "content/docs/k6"
-          }
+            "source_directory": "docs/sources/k6/next",
+            "website_directory": "content/docs/k6/next"
         ]
       title: ${{ github.event.pull_request.title }}

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -21,7 +21,7 @@ jobs:
       sources: |
         [
           {
-            "relative_prefix": "/docs/grafana-cloud/k6-docs/",
+            "relative_prefix": "/docs/k6/",
             "repo": "k6-docs",
             "source_directory": "docs/sources/k6",
             "website_directory": "content/docs/k6"

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -7,7 +7,7 @@ on:
       - synchronize
       - closed
     paths:
-      - "docs/sources/k6/next/**"
+      - "docs/sources/k6/**"
 
 jobs:
   deploy-pr-preview:
@@ -21,11 +21,16 @@ jobs:
       sources: |
         [
           {
-            "index_file": "content/docs/k6/_index.md",
-            "relative_prefix": "/docs/k6/next/",
+            "relative_prefix": "/docs/k6/",
+            "repo": "k6-docs",
+            "source_directory": "docs/sources/k6",
+            "website_directory": "content/docs/k6"
+          },
+          {
+            "relative_prefix": "/docs/k6/latest",
             "repo": "k6-docs",
             "source_directory": "docs/sources/k6/next",
-            "website_directory": "content/docs/k6/next"
+            "website_directory": "content/docs/k6/latest"
           }
         ]
       title: ${{ github.event.pull_request.title }}

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -22,7 +22,7 @@ jobs:
         [
           {
             "relative_prefix": "/docs/grafana-cloud/k6-docs/",
-            "repo": k6-docs,
+            "repo": "k6-docs",
             "source_directory": "docs/sources/k6",
             "website_directory": "content/docs/k6"
           }

--- a/docs/sources/k6/next/get-started/resources.md
+++ b/docs/sources/k6/next/get-started/resources.md
@@ -27,11 +27,15 @@ These resources help you write and run k6 tests in a safe environment and explor
 
 ## Test servers
 
-If you need a place to learn k6 and test your scripts, you can use these playground/demo applications:
+If you need a place to learn k6 and test your scripts, you can use these demo applications:
 
-- [grafana/quickpizza](https://github.com/grafana/quickpizza). A simple demo web application.
+- [`grafana/quickpizza`](https://github.com/grafana/quickpizza). A demo web application.
 
-Note that these are shared testing environments - please avoid high-load tests. Alternatively, you can deploy and host them on your infrastructure and run the examples in the repository.
+{{< admonition type="note" >}}
+These are testing environments shared by everyone - avoid high-load tests.
+
+If you want to run tests with high loads, you can deploy and host them on your infrastructure and run the examples in the repository.
+{{< /admonition >}}
 
 ## k6 + your favorite tool
 


### PR DESCRIPTION
One notable caveat with this implementation is that "latest" actually serves "next" documentation.

If this caveat is too awkward, I can make changes to the workflow to facilitate a true "latest". The current implementation is a bit of a quirk specific to running the workflow in this multi-versioned repository.

Closes https://github.com/grafana/website/issues/23734

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
