### PR TITLE
Update "Create a JS extension" guide

### DIFF
--- a/docs/sources/k6/next/extensions/create/javascript-extensions.md
+++ b/docs/sources/k6/next/extensions/create/javascript-extensions.md
@@ -161,6 +161,14 @@ INFO[0000] false, 1 is NOT greater than 3                source=console
 
 ## Use the advanced module API
 
+{{< admonition type="caution" >}}
+
+The advanced module API adds significant complexity to your extension. Consider whether you actually need access to internal
+k6 objects before implementing this pattern. For simple modules that don't need VU state or runtime access, the basic approach
+shown above is sufficient.
+
+{{< /admonition >}}
+
 Suppose your extension needs access to internal k6 objects to, for example, inspect the state of the test during execution.
 We will need to make slightly more complicated changes to the above example.
 
@@ -173,12 +181,6 @@ to access the [`modules.VU`](https://pkg.go.dev/go.k6.io/k6/js/modules#VU) to in
 
 Additionally, there should be a root module implementation of the [`modules.Module`](https://pkg.go.dev/go.k6.io/k6/js/modules#Module)
 interface to serve as a factory of `Compare` instances for each VU.
-
-{{< admonition type="caution" >}}
-
-The significance depends on the size of your module.
-
-{{< /admonition >}}
 
 Here's what that would look like:
 

--- a/docs/sources/k6/next/extensions/create/javascript-extensions.md
+++ b/docs/sources/k6/next/extensions/create/javascript-extensions.md
@@ -325,9 +325,6 @@ INFO[0000] Active VUs: 2, Iteration: 1, VU ID: 1, VU ID from runtime: 1  source=
 INFO[0000] Active VUs: 2, Iteration: 2, VU ID: 2, VU ID from runtime: 2  source=console
 ```
 
-> For a more extensive usage example of this API, look at the
-> [`k6/execution`](https://github.com/grafana/k6/blob/master/js/modules/k6/execution/execution.go) module.
-
 ## Things to keep in mind
 
 - The code in the `default` function (or another function specified by

--- a/docs/sources/k6/v1.0.x/extensions/create/javascript-extensions.md
+++ b/docs/sources/k6/v1.0.x/extensions/create/javascript-extensions.md
@@ -161,6 +161,14 @@ INFO[0000] false, 1 is NOT greater than 3                source=console
 
 ## Use the advanced module API
 
+{{< admonition type="caution" >}}
+
+The advanced module API adds significant complexity to your extension. Consider whether you actually need access to internal
+k6 objects before implementing this pattern. For simple modules that don't need VU state or runtime access, the basic approach
+shown above is sufficient.
+
+{{< /admonition >}}
+
 Suppose your extension needs access to internal k6 objects to, for example, inspect the state of the test during execution.
 We will need to make slightly more complicated changes to the above example.
 
@@ -173,12 +181,6 @@ to access the [`modules.VU`](https://pkg.go.dev/go.k6.io/k6/js/modules#VU) to in
 
 Additionally, there should be a root module implementation of the [`modules.Module`](https://pkg.go.dev/go.k6.io/k6/js/modules#Module)
 interface to serve as a factory of `Compare` instances for each VU.
-
-{{< admonition type="caution" >}}
-
-The significance depends on the size of your module.
-
-{{< /admonition >}}
 
 Here's what that would look like:
 
@@ -322,9 +324,6 @@ INFO[0000] Active VUs: 2, Iteration: 1, VU ID: 2, VU ID from runtime: 2  source=
 INFO[0000] Active VUs: 2, Iteration: 1, VU ID: 1, VU ID from runtime: 1  source=console
 INFO[0000] Active VUs: 2, Iteration: 2, VU ID: 2, VU ID from runtime: 2  source=console
 ```
-
-> For a more extensive usage example of this API, look at the
-> [`k6/execution`](https://github.com/grafana/k6/blob/master/js/modules/k6/execution/execution.go) module.
 
 ## Things to keep in mind
 

--- a/docs/sources/k6/v1.1.x/extensions/create/javascript-extensions.md
+++ b/docs/sources/k6/v1.1.x/extensions/create/javascript-extensions.md
@@ -161,6 +161,14 @@ INFO[0000] false, 1 is NOT greater than 3                source=console
 
 ## Use the advanced module API
 
+{{< admonition type="caution" >}}
+
+The advanced module API adds significant complexity to your extension. Consider whether you actually need access to internal
+k6 objects before implementing this pattern. For simple modules that don't need VU state or runtime access, the basic approach
+shown above is sufficient.
+
+{{< /admonition >}}
+
 Suppose your extension needs access to internal k6 objects to, for example, inspect the state of the test during execution.
 We will need to make slightly more complicated changes to the above example.
 
@@ -173,12 +181,6 @@ to access the [`modules.VU`](https://pkg.go.dev/go.k6.io/k6/js/modules#VU) to in
 
 Additionally, there should be a root module implementation of the [`modules.Module`](https://pkg.go.dev/go.k6.io/k6/js/modules#Module)
 interface to serve as a factory of `Compare` instances for each VU.
-
-{{< admonition type="caution" >}}
-
-The significance depends on the size of your module.
-
-{{< /admonition >}}
 
 Here's what that would look like:
 
@@ -322,9 +324,6 @@ INFO[0000] Active VUs: 2, Iteration: 1, VU ID: 2, VU ID from runtime: 2  source=
 INFO[0000] Active VUs: 2, Iteration: 1, VU ID: 1, VU ID from runtime: 1  source=console
 INFO[0000] Active VUs: 2, Iteration: 2, VU ID: 2, VU ID from runtime: 2  source=console
 ```
-
-> For a more extensive usage example of this API, look at the
-> [`k6/execution`](https://github.com/grafana/k6/blob/master/js/modules/k6/execution/execution.go) module.
 
 ## Things to keep in mind
 


### PR DESCRIPTION
## What?

Removed a broken link that referenced extension API that is not available after v1.0 and refined the admonition about using advanced extensions API.

## Checklist

- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.
- [x] I have made my changes in the `docs/sources/k6/next` folder of the documentation.
- [x] I have reflected my changes in the `docs/sources/k6/v{most_recent_release}` folder of the documentation.
- [x] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).