### PR TITLE
Make browser docs owned by k6-core

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,10 +6,6 @@
 /docs/sources/k6 @grafana/k6-core @heitortsergent
 /docs/sources/k6-studio @grafana/k6-Studio @heitortsergent
 
-# k6 Browser documentation
-/docs/sources/k6/*/using-k6-browser @grafana/k6-browser @heitortsergent
-/docs/sources/k6/*/javascript-api/k6-browser @grafana/k6-browser @heitortsergent
-
 # k6 Operator documentation
 /docs/sources/k6/*/set-up/set-up-distributed-k6 @yorugac @heitortsergent
 /docs/sources/k6/*/shared/k6-operator @yorugac @heitortsergent


### PR DESCRIPTION
## What?

The Browser API has been merged into k6. This change updates CODEOWNERS to assign k6 maintainers as owners of the Browser API docs.

## Checklist

- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.