### PR TITLE
Mount actual latest semantic version at /docs/k6/latest/

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   deploy-pr-preview:
     if: "!github.event.pull_request.head.repo.fork"
-    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@main
+    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@jdb/deploy-preview
     with:
       branch: ${{ github.head_ref }}
       event_number: ${{ github.event.number }}

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   deploy-pr-preview:
     if: "!github.event.pull_request.head.repo.fork"
-    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@jdb/deploy-preview
+    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@main
     with:
       branch: ${{ github.head_ref }}
       event_number: ${{ github.event.number }}

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -29,7 +29,7 @@ jobs:
           {
             "relative_prefix": "/docs/k6/latest",
             "repo": "k6-docs",
-            "source_directory": "docs/sources/k6/next",
+            "source_directory": "docs/sources/k6/<LATEST>",
             "website_directory": "content/docs/k6/latest"
           }
         ]

--- a/docs/sources/k6/v1.2.x/_index.md
+++ b/docs/sources/k6/v1.2.x/_index.md
@@ -2,7 +2,7 @@
 aliases:
   - /docs/k6/
 description: 'The k6 documentation covers everything you need to know about k6 OSS, load testing, and performance testing.'
-nmenuTitle: Grafana k6
+menuTitle: Grafana k6
 title: Grafana k6
 weight: -10
 hero:
@@ -89,8 +89,6 @@ Engineering teams, including Developers, QA Engineers, SDETs, and SREs, commonly
 Watch the video below to learn more about k6 and why it could be the missing puzzle in your Grafana stack.
 
 {{< youtube id="1mtYVDA2_iQ" >}}
-
-TESTING AGAIN
 
 ## Explore
 

--- a/docs/sources/k6/v1.2.x/_index.md
+++ b/docs/sources/k6/v1.2.x/_index.md
@@ -2,7 +2,7 @@
 aliases:
   - /docs/k6/
 description: 'The k6 documentation covers everything you need to know about k6 OSS, load testing, and performance testing.'
-menuTitle: Grafana k6
+nmenuTitle: Grafana k6
 title: Grafana k6
 weight: -10
 hero:
@@ -89,6 +89,8 @@ Engineering teams, including Developers, QA Engineers, SDETs, and SREs, commonly
 Watch the video below to learn more about k6 and why it could be the missing puzzle in your Grafana stack.
 
 {{< youtube id="1mtYVDA2_iQ" >}}
+
+TESTING AGAIN
 
 ## Explore
 


### PR DESCRIPTION
The introduction of this workflow in #2014 mounted the "next" documentation at the `/docs/k6/latest/` location and @heitortsergent pointed out that this could confuse people.

This version of the workflow mounts the latest version semantic-version-like directory at that location instead for an experience that matches the website behavior.

The behavior was implemented in https://github.com/grafana/writers-toolkit/pull/1217.

I'll drop the CI triggering test commit before merge

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
