### PR TITLE
Fix k6 Studio link in Install k6

### DIFF
--- a/docs/sources/k6/next/set-up/install-k6/_index.md
+++ b/docs/sources/k6/next/set-up/install-k6/_index.md
@@ -11,7 +11,7 @@ weight: 01
 
 k6 has packages for Linux, Mac, and Windows. Alternatively, you can use a Docker container or a standalone binary.
 
-You can also use the k6 Studio desktop application to help you generate k6 scripts from a browser recording. Refer to [k6 Studio] for more details.
+You can also use the k6 Studio desktop application to help you generate k6 scripts from a browser recording. Refer to [k6 Studio](#k6-studio) for more details.
 
 ## Linux
 

--- a/docs/sources/k6/v1.0.x/set-up/install-k6/_index.md
+++ b/docs/sources/k6/v1.0.x/set-up/install-k6/_index.md
@@ -11,7 +11,7 @@ weight: 01
 
 k6 has packages for Linux, Mac, and Windows. Alternatively, you can use a Docker container or a standalone binary.
 
-You can also use the k6 Studio desktop application to help you generate k6 scripts from a browser recording. Refer to [k6 Studio] for more details.
+You can also use the k6 Studio desktop application to help you generate k6 scripts from a browser recording. Refer to [k6 Studio](#k6-studio) for more details.
 
 ## Linux
 

--- a/docs/sources/k6/v1.1.x/set-up/install-k6/_index.md
+++ b/docs/sources/k6/v1.1.x/set-up/install-k6/_index.md
@@ -11,7 +11,7 @@ weight: 01
 
 k6 has packages for Linux, Mac, and Windows. Alternatively, you can use a Docker container or a standalone binary.
 
-You can also use the k6 Studio desktop application to help you generate k6 scripts from a browser recording. Refer to [k6 Studio] for more details.
+You can also use the k6 Studio desktop application to help you generate k6 scripts from a browser recording. Refer to [k6 Studio](#k6-studio) for more details.
 
 ## Linux
 

--- a/docs/sources/k6/v1.2.x/set-up/install-k6/_index.md
+++ b/docs/sources/k6/v1.2.x/set-up/install-k6/_index.md
@@ -11,7 +11,7 @@ weight: 01
 
 k6 has packages for Linux, Mac, and Windows. Alternatively, you can use a Docker container or a standalone binary.
 
-You can also use the k6 Studio desktop application to help you generate k6 scripts from a browser recording. Refer to [k6 Studio] for more details.
+You can also use the k6 Studio desktop application to help you generate k6 scripts from a browser recording. Refer to [k6 Studio](#k6-studio) for more details.
 
 ## Linux
 


### PR DESCRIPTION
## What?

Fix a missing link in Install k6 to the new k6 Studio section. Reported by @tom-miseur. 🙇 

## Checklist

<!-- Please fill in this template: -->
- [ ] I have used a meaningful title for the PR.
- [ ] I have described the changes I've made in the "What?" section above.
- [ ] I have performed a self-review of my changes.
- [ ] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [ ] I have made my changes in the `docs/sources/k6/next` folder of the documentation.
- [ ] I have reflected my changes in the `docs/sources/k6/v{most_recent_release}` folder of the documentation.
- [ ] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->