### PR TITLE
Add new page for how to run a k6 test

### DIFF
--- a/docs/sources/k6/next/using-k6/assertions.md
+++ b/docs/sources/k6/next/using-k6/assertions.md
@@ -1,7 +1,7 @@
 ---
 title: 'Assertions'
 description: 'Test assertions in k6 using the k6-testing library for both protocol and browser testing'
-weight: 04
+weight: 500
 ---
 
 {{< docs/shared source="k6" lookup="preview-feature.md" version="<K6_VERSION>" >}}

--- a/docs/sources/k6/next/using-k6/checks.md
+++ b/docs/sources/k6/next/using-k6/checks.md
@@ -1,7 +1,7 @@
 ---
 title: 'Checks'
 description: 'Checks are like asserts but differ in that they do not halt the execution, instead, they just store the result of the check, pass or fail, and let the script execution continue.'
-weight: 03
+weight: 400
 ---
 
 # Checks

--- a/docs/sources/k6/next/using-k6/cookies.md
+++ b/docs/sources/k6/next/using-k6/cookies.md
@@ -1,7 +1,7 @@
 ---
 title: 'Cookies'
 description: 'k6 will transparently manage the receiving, storage and sending of cookies as described above, so that testing of your cookie-based web site or app will just work.'
-weight: 09
+weight: 1100
 ---
 
 # Cookies

--- a/docs/sources/k6/next/using-k6/environment-variables.md
+++ b/docs/sources/k6/next/using-k6/environment-variables.md
@@ -1,7 +1,7 @@
 ---
 title: 'Environment variables'
 description: 'You can access any environment variables from your k6 script code and use this to supply your VUs with configuration information.'
-weight: 11
+weight: 1300
 ---
 
 # Environment variables

--- a/docs/sources/k6/next/using-k6/execution-context-variables.md
+++ b/docs/sources/k6/next/using-k6/execution-context-variables.md
@@ -1,7 +1,7 @@
 ---
 title: 'Execution context variables'
 description: 'k6/execution module provides the capability to get information about the current test execution state inside the test script'
-weight: 12
+weight: 1400
 ---
 
 # Execution context variables

--- a/docs/sources/k6/next/using-k6/http-requests.md
+++ b/docs/sources/k6/next/using-k6/http-requests.md
@@ -1,7 +1,7 @@
 ---
 title: 'HTTP Requests'
 description: 'Define the HTTP requests and methods you want to use. k6 adds tags to the requests, making it easier to filter results. You can customize tags as you wish.'
-weight: 01
+weight: 200
 ---
 
 # HTTP Requests

--- a/docs/sources/k6/next/using-k6/javascript-typescript-compatibility-mode.md
+++ b/docs/sources/k6/next/using-k6/javascript-typescript-compatibility-mode.md
@@ -4,7 +4,7 @@ aliases:
 title: JavaScript and TypeScript compatibility mode
 menuTitle: JavaScript and TypeScript mode
 excerpt: 'k6 supports running test scripts with different compatibility modes using --compatibility-mode'
-weight: 19
+weight: 1800
 ---
 
 # JavaScript compatibility mode

--- a/docs/sources/k6/next/using-k6/k6-options/_index.md
+++ b/docs/sources/k6/next/using-k6/k6-options/_index.md
@@ -2,7 +2,7 @@
 title: 'Options'
 slug: '/k6-options'
 description: 'Options configure test-run behavior. You can set options in multiple locations. Examples for how to use options, and a complete reference.'
-weight: 05
+weight: 700
 ---
 
 # Options

--- a/docs/sources/k6/next/using-k6/metrics/_index.md
+++ b/docs/sources/k6/next/using-k6/metrics/_index.md
@@ -1,7 +1,7 @@
 ---
 title: 'Metrics'
 description: 'This section covers the important aspect of metrics management in k6. How and what kind of metrics k6 collects automatically (_built-in_ metrics), and what custom metrics you can make k6 collect.'
-weight: 02
+weight: 300
 ---
 
 # Metrics

--- a/docs/sources/k6/next/using-k6/modules.md
+++ b/docs/sources/k6/next/using-k6/modules.md
@@ -2,7 +2,7 @@
 title: 'Modules'
 description: 'While writing test scripts, it is common to import different modules, or part of modules, for
 usage throughout the script. In k6, it is possible to import three different kinds of modules.'
-weight: 07
+weight: 900
 ---
 
 # Modules

--- a/docs/sources/k6/next/using-k6/protocols/_index.md
+++ b/docs/sources/k6/next/using-k6/protocols/_index.md
@@ -1,7 +1,7 @@
 ---
 title: 'Protocols'
 description: 'Out of the box k6 comes with support for a few protocols: HTTP / WebSockets / gRPC / ...'
-weight: 10
+weight: 1200
 ---
 
 # Protocols

--- a/docs/sources/k6/next/using-k6/run-k6-test-script.md
+++ b/docs/sources/k6/next/using-k6/run-k6-test-script.md
@@ -53,6 +53,14 @@ To run a test locally and stream the results to Grafana Cloud k6, use the `k6 cl
 k6 cloud run --local-execution cloud_demo.js
 ```
 
+{{< admonition type="note" >}}
+
+The `k6 cloud run --local-execution` command uploads the test archive k6 produces from your test script and resources to Grafana Cloud.
+
+You can change this behavior by adding the `--no-archive-upload` option to your command. For example: `k6 cloud run --local-execution --no-archive-upload script.js`.
+
+{{< /admonition >}}
+
 To learn more about Grafana Cloud k6, refer to:
 
 - [Grafana Cloud k6 documentation](https://grafana.com/docs/grafana-cloud/testing/k6/).

--- a/docs/sources/k6/next/using-k6/run-k6-test-script.md
+++ b/docs/sources/k6/next/using-k6/run-k6-test-script.md
@@ -1,0 +1,64 @@
+---
+title: 'Run a k6 test script'
+description: 'Learn the different ways you can run a k6 test script'
+weight: 100
+---
+
+# Run a k6 test script
+
+There are several ways you can use the Grafana k6 command-line tool (CLI) to run a k6 performance test. In this page, you'll learn how to use each method and how they differ from each other.
+
+## Before you begin
+
+To run a CLI test, you'll need:
+
+- A machine with [k6 installed](https://grafana.com/docs/k6/<K6_VERSION>/get-started/installation/).
+- A test file.
+
+## Run a test on your local machine
+
+Running tests locally is a great way to incrementally test your script as you write it. For example, you can make sure that your [checks](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/checks/) and [thresholds](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/thresholds/) are configured correctly before you run a test with more VUs in Grafana Cloud k6.
+
+To run a test locally, use the `k6 run` command:
+
+```bash
+k6 run script.js
+```
+
+## Run a test using Grafana Cloud k6
+
+Grafana Cloud k6 is a performance testing application that's part of Grafana Cloud, and it's powered by k6 OSS. It allows you to leverage all of the Grafana k6 OSS capabilities while managing the infrastructure needed for scaling servers, running load tests from multiple locations, storing test results, and providing dashboards to detect performance errors and regressions.
+
+Grafana Cloud k6 makes it easier to visualize and compare test results by providing you with built-in dashboards, while also making it easier to share and collaborate on test data with other teams in your organization.
+
+To run a cloud test from the CLI, you'll need an [API token](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/tokens-and-cli-authentication/) for authenticating the k6 CLI with the Grafana Cloud k6 application.
+
+With the CLI authentication configured, you can run cloud tests by using the `k6 cloud` command:
+
+```bash
+k6 cloud run cloud_demo.js
+```
+
+You can also run a test from a local machine and stream the results for storage and visualization on Grafana Cloud. A common use case for this feature is to run load tests in a CI/CD environment, or on networks that aren't accessible from the public internet.
+
+To run a test locally and stream the results to Grafana Cloud k6, use the `k6 cloud run --local-execution`:
+
+```bash
+k6 cloud run --local-execution cloud_demo.js
+```
+
+To learn more about Grafana Cloud k6, refer to:
+
+- [Grafana Cloud k6 documentation](https://grafana.com/docs/grafana-cloud/testing/k6/).
+- [Use the CLI](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/use-the-cli/) - Learn about the different methods available to run a k6 test in Grafana Cloud.
+
+## Run a test in your infrastructure with the k6 Operator
+
+k6 Operator is a Kubernetes operator that you can use to run distributed k6 tests in your Kubernetes cluster.
+
+A couple of reasons why you might want to do this:
+
+- You run your application in Kubernetes and would like k6 to be executed in the same fashion as all your other infrastructure components.
+- You want to run your tests within your private network for security or privacy reasons.
+
+To set up and run a test using the k6 Operator, refer to [Set up distributed k6](https://grafana.com/docs/k6/<K6_VERSION>/set-up/set-up-distributed-k6/).

--- a/docs/sources/k6/next/using-k6/run-k6-test-script.md
+++ b/docs/sources/k6/next/using-k6/run-k6-test-script.md
@@ -13,7 +13,7 @@ There are several ways you can use the Grafana k6 command-line tool (CLI) to run
 To run a CLI test, you'll need:
 
 - A machine with [k6 installed](https://grafana.com/docs/k6/<K6_VERSION>/get-started/installation/).
-- A test file.
+- A [test file](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-authoring/create-test-script-using-the-cli/).
 
 ## Run a test on your local machine
 

--- a/docs/sources/k6/next/using-k6/run-k6-test-script.md
+++ b/docs/sources/k6/next/using-k6/run-k6-test-script.md
@@ -33,6 +33,12 @@ Grafana Cloud k6 makes it easier to visualize and compare test results by provid
 
 To run a cloud test from the CLI, you'll need an [API token](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/tokens-and-cli-authentication/) for authenticating the k6 CLI with the Grafana Cloud k6 application.
 
+After you retrieve an API token, you can authenticate with the CLI by running the following command:
+
+```bash
+k6 cloud login --token <API_TOKEN>
+```
+
 With the CLI authentication configured, you can run cloud tests by using the `k6 cloud` command:
 
 ```bash

--- a/docs/sources/k6/next/using-k6/scenarios/_index.md
+++ b/docs/sources/k6/next/using-k6/scenarios/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Scenarios
 description: 'Scenarios allow us to make in-depth configurations to how VUs and iterations are scheduled. This makes it possible to model diverse traffic patterns in load tests.'
-weight: 13
+weight: 1500
 ---
 
 # Scenarios

--- a/docs/sources/k6/next/using-k6/secret-source/_index.md
+++ b/docs/sources/k6/next/using-k6/secret-source/_index.md
@@ -1,7 +1,7 @@
 ---
-title: Secret Source
+title: Secret source
 description: 'Secret source are used so k6 can get and use secrets in a secure way'
-weight: 14
+weight: 1600
 ---
 
 # Secret source

--- a/docs/sources/k6/next/using-k6/tags-and-groups.md
+++ b/docs/sources/k6/next/using-k6/tags-and-groups.md
@@ -2,7 +2,7 @@
 title: 'Tags and Groups'
 description: 'k6 provides the Tags and Groups APIs to help you during the analysis and easily visualize, sort and
 filter your test results.'
-weight: 08
+weight: 1000
 ---
 
 # Tags and Groups

--- a/docs/sources/k6/next/using-k6/test-authoring/_index.md
+++ b/docs/sources/k6/next/using-k6/test-authoring/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Test authoring
-weight: 14
+weight: 1700
 ---
 
 # Test authoring

--- a/docs/sources/k6/next/using-k6/test-lifecycle.md
+++ b/docs/sources/k6/next/using-k6/test-lifecycle.md
@@ -1,7 +1,7 @@
 ---
 title: 'Test lifecycle'
 description: 'The four distinct lifecycle stages in a k6 test are "init", "setup", "VU", and "teardown".'
-weight: 06
+weight: 800
 ---
 
 # Test lifecycle

--- a/docs/sources/k6/next/using-k6/thresholds.md
+++ b/docs/sources/k6/next/using-k6/thresholds.md
@@ -1,7 +1,7 @@
 ---
 title: 'Thresholds'
 description: 'Thresholds are a pass/fail criteria used to specify the performance expectations of the system under test.'
-weight: 04
+weight: 600
 ---
 
 # Thresholds

--- a/docs/sources/k6/v1.2.x/using-k6/assertions.md
+++ b/docs/sources/k6/v1.2.x/using-k6/assertions.md
@@ -1,7 +1,7 @@
 ---
 title: 'Assertions'
 description: 'Test assertions in k6 using the k6-testing library for both protocol and browser testing'
-weight: 04
+weight: 500
 ---
 
 {{< docs/shared source="k6" lookup="preview-feature.md" version="<K6_VERSION>" >}}

--- a/docs/sources/k6/v1.2.x/using-k6/checks.md
+++ b/docs/sources/k6/v1.2.x/using-k6/checks.md
@@ -1,7 +1,7 @@
 ---
 title: 'Checks'
 description: 'Checks are like asserts but differ in that they do not halt the execution, instead, they just store the result of the check, pass or fail, and let the script execution continue.'
-weight: 03
+weight: 400
 ---
 
 # Checks

--- a/docs/sources/k6/v1.2.x/using-k6/cookies.md
+++ b/docs/sources/k6/v1.2.x/using-k6/cookies.md
@@ -1,7 +1,7 @@
 ---
 title: 'Cookies'
 description: 'k6 will transparently manage the receiving, storage and sending of cookies as described above, so that testing of your cookie-based web site or app will just work.'
-weight: 09
+weight: 1100
 ---
 
 # Cookies

--- a/docs/sources/k6/v1.2.x/using-k6/environment-variables.md
+++ b/docs/sources/k6/v1.2.x/using-k6/environment-variables.md
@@ -1,7 +1,7 @@
 ---
 title: 'Environment variables'
 description: 'You can access any environment variables from your k6 script code and use this to supply your VUs with configuration information.'
-weight: 11
+weight: 1300
 ---
 
 # Environment variables

--- a/docs/sources/k6/v1.2.x/using-k6/execution-context-variables.md
+++ b/docs/sources/k6/v1.2.x/using-k6/execution-context-variables.md
@@ -1,7 +1,7 @@
 ---
 title: 'Execution context variables'
 description: 'k6/execution module provides the capability to get information about the current test execution state inside the test script'
-weight: 12
+weight: 1400
 ---
 
 # Execution context variables

--- a/docs/sources/k6/v1.2.x/using-k6/http-requests.md
+++ b/docs/sources/k6/v1.2.x/using-k6/http-requests.md
@@ -1,7 +1,7 @@
 ---
 title: 'HTTP Requests'
 description: 'Define the HTTP requests and methods you want to use. k6 adds tags to the requests, making it easier to filter results. You can customize tags as you wish.'
-weight: 01
+weight: 200
 ---
 
 # HTTP Requests

--- a/docs/sources/k6/v1.2.x/using-k6/javascript-typescript-compatibility-mode.md
+++ b/docs/sources/k6/v1.2.x/using-k6/javascript-typescript-compatibility-mode.md
@@ -4,7 +4,7 @@ aliases:
 title: JavaScript and TypeScript compatibility mode
 menuTitle: JavaScript and TypeScript mode
 excerpt: 'k6 supports running test scripts with different compatibility modes using --compatibility-mode'
-weight: 19
+weight: 1800
 ---
 
 # JavaScript compatibility mode

--- a/docs/sources/k6/v1.2.x/using-k6/k6-options/_index.md
+++ b/docs/sources/k6/v1.2.x/using-k6/k6-options/_index.md
@@ -2,7 +2,7 @@
 title: 'Options'
 slug: '/k6-options'
 description: 'Options configure test-run behavior. You can set options in multiple locations. Examples for how to use options, and a complete reference.'
-weight: 05
+weight: 700
 ---
 
 # Options

--- a/docs/sources/k6/v1.2.x/using-k6/metrics/_index.md
+++ b/docs/sources/k6/v1.2.x/using-k6/metrics/_index.md
@@ -1,7 +1,7 @@
 ---
 title: 'Metrics'
 description: 'This section covers the important aspect of metrics management in k6. How and what kind of metrics k6 collects automatically (_built-in_ metrics), and what custom metrics you can make k6 collect.'
-weight: 02
+weight: 300
 ---
 
 # Metrics

--- a/docs/sources/k6/v1.2.x/using-k6/modules.md
+++ b/docs/sources/k6/v1.2.x/using-k6/modules.md
@@ -2,7 +2,7 @@
 title: 'Modules'
 description: 'While writing test scripts, it is common to import different modules, or part of modules, for
 usage throughout the script. In k6, it is possible to import three different kinds of modules.'
-weight: 07
+weight: 900
 ---
 
 # Modules

--- a/docs/sources/k6/v1.2.x/using-k6/protocols/_index.md
+++ b/docs/sources/k6/v1.2.x/using-k6/protocols/_index.md
@@ -1,7 +1,7 @@
 ---
 title: 'Protocols'
 description: 'Out of the box k6 comes with support for a few protocols: HTTP / WebSockets / gRPC / ...'
-weight: 10
+weight: 1200
 ---
 
 # Protocols

--- a/docs/sources/k6/v1.2.x/using-k6/run-k6-test-script.md
+++ b/docs/sources/k6/v1.2.x/using-k6/run-k6-test-script.md
@@ -1,0 +1,78 @@
+---
+title: 'Run a k6 test script'
+description: 'Learn the different ways you can run a k6 test script'
+weight: 100
+---
+
+# Run a k6 test script
+
+There are several ways you can use the Grafana k6 command-line tool (CLI) to run a k6 performance test. In this page, you'll learn how to use each method and how they differ from each other.
+
+## Before you begin
+
+To run a CLI test, you'll need:
+
+- A machine with [k6 installed](https://grafana.com/docs/k6/<K6_VERSION>/get-started/installation/).
+- A [test file](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-authoring/create-test-script-using-the-cli/).
+
+## Run a test on your local machine
+
+Running tests locally is a great way to incrementally test your script as you write it. For example, you can make sure that your [checks](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/checks/) and [thresholds](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/thresholds/) are configured correctly before you run a test with more VUs in Grafana Cloud k6.
+
+To run a test locally, use the `k6 run` command:
+
+```bash
+k6 run script.js
+```
+
+## Run a test using Grafana Cloud k6
+
+Grafana Cloud k6 is a performance testing application that's part of Grafana Cloud, and it's powered by k6 OSS. It allows you to leverage all of the Grafana k6 OSS capabilities while managing the infrastructure needed for scaling servers, running load tests from multiple locations, storing test results, and providing dashboards to detect performance errors and regressions.
+
+Grafana Cloud k6 makes it easier to visualize and compare test results by providing you with built-in dashboards, while also making it easier to share and collaborate on test data with other teams in your organization.
+
+To run a cloud test from the CLI, you'll need an [API token](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/tokens-and-cli-authentication/) for authenticating the k6 CLI with the Grafana Cloud k6 application.
+
+After you retrieve an API token, you can authenticate with the CLI by running the following command:
+
+```bash
+k6 cloud login --token <API_TOKEN>
+```
+
+With the CLI authentication configured, you can run cloud tests by using the `k6 cloud` command:
+
+```bash
+k6 cloud run cloud_demo.js
+```
+
+You can also run a test from a local machine and stream the results for storage and visualization on Grafana Cloud. A common use case for this feature is to run load tests in a CI/CD environment, or on networks that aren't accessible from the public internet.
+
+To run a test locally and stream the results to Grafana Cloud k6, use the `k6 cloud run --local-execution`:
+
+```bash
+k6 cloud run --local-execution cloud_demo.js
+```
+
+{{< admonition type="note" >}}
+
+The `k6 cloud run --local-execution` command uploads the test archive k6 produces from your test script and resources to Grafana Cloud.
+
+You can change this behavior by adding the `--no-archive-upload` option to your command. For example: `k6 cloud run --local-execution --no-archive-upload script.js`.
+
+{{< /admonition >}}
+
+To learn more about Grafana Cloud k6, refer to:
+
+- [Grafana Cloud k6 documentation](https://grafana.com/docs/grafana-cloud/testing/k6/).
+- [Use the CLI](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/use-the-cli/) - Learn about the different methods available to run a k6 test in Grafana Cloud.
+
+## Run a test in your infrastructure with the k6 Operator
+
+k6 Operator is a Kubernetes operator that you can use to run distributed k6 tests in your Kubernetes cluster.
+
+A couple of reasons why you might want to do this:
+
+- You run your application in Kubernetes and would like k6 to be executed in the same fashion as all your other infrastructure components.
+- You want to run your tests within your private network for security or privacy reasons.
+
+To set up and run a test using the k6 Operator, refer to [Set up distributed k6](https://grafana.com/docs/k6/<K6_VERSION>/set-up/set-up-distributed-k6/).

--- a/docs/sources/k6/v1.2.x/using-k6/scenarios/_index.md
+++ b/docs/sources/k6/v1.2.x/using-k6/scenarios/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Scenarios
 description: 'Scenarios allow us to make in-depth configurations to how VUs and iterations are scheduled. This makes it possible to model diverse traffic patterns in load tests.'
-weight: 13
+weight: 1500
 ---
 
 # Scenarios

--- a/docs/sources/k6/v1.2.x/using-k6/secret-source/_index.md
+++ b/docs/sources/k6/v1.2.x/using-k6/secret-source/_index.md
@@ -1,7 +1,7 @@
 ---
-title: Secret Source
+title: Secret source
 description: 'Secret source are used so k6 can get and use secrets in a secure way'
-weight: 14
+weight: 1600
 ---
 
 # Secret source

--- a/docs/sources/k6/v1.2.x/using-k6/tags-and-groups.md
+++ b/docs/sources/k6/v1.2.x/using-k6/tags-and-groups.md
@@ -2,7 +2,7 @@
 title: 'Tags and Groups'
 description: 'k6 provides the Tags and Groups APIs to help you during the analysis and easily visualize, sort and
 filter your test results.'
-weight: 08
+weight: 1000
 ---
 
 # Tags and Groups

--- a/docs/sources/k6/v1.2.x/using-k6/test-authoring/_index.md
+++ b/docs/sources/k6/v1.2.x/using-k6/test-authoring/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Test authoring
-weight: 14
+weight: 1700
 ---
 
 # Test authoring

--- a/docs/sources/k6/v1.2.x/using-k6/test-lifecycle.md
+++ b/docs/sources/k6/v1.2.x/using-k6/test-lifecycle.md
@@ -1,7 +1,7 @@
 ---
 title: 'Test lifecycle'
 description: 'The four distinct lifecycle stages in a k6 test are "init", "setup", "VU", and "teardown".'
-weight: 06
+weight: 800
 ---
 
 # Test lifecycle

--- a/docs/sources/k6/v1.2.x/using-k6/thresholds.md
+++ b/docs/sources/k6/v1.2.x/using-k6/thresholds.md
@@ -1,7 +1,7 @@
 ---
 title: 'Thresholds'
 description: 'Thresholds are a pass/fail criteria used to specify the performance expectations of the system under test.'
-weight: 04
+weight: 600
 ---
 
 # Thresholds

--- a/docs/sources/k6/v1.3.x/using-k6/assertions.md
+++ b/docs/sources/k6/v1.3.x/using-k6/assertions.md
@@ -1,7 +1,7 @@
 ---
 title: 'Assertions'
 description: 'Test assertions in k6 using the k6-testing library for both protocol and browser testing'
-weight: 04
+weight: 500
 ---
 
 {{< docs/shared source="k6" lookup="preview-feature.md" version="<K6_VERSION>" >}}

--- a/docs/sources/k6/v1.3.x/using-k6/checks.md
+++ b/docs/sources/k6/v1.3.x/using-k6/checks.md
@@ -1,7 +1,7 @@
 ---
 title: 'Checks'
 description: 'Checks are like asserts but differ in that they do not halt the execution, instead, they just store the result of the check, pass or fail, and let the script execution continue.'
-weight: 03
+weight: 400
 ---
 
 # Checks

--- a/docs/sources/k6/v1.3.x/using-k6/cookies.md
+++ b/docs/sources/k6/v1.3.x/using-k6/cookies.md
@@ -1,7 +1,7 @@
 ---
 title: 'Cookies'
 description: 'k6 will transparently manage the receiving, storage and sending of cookies as described above, so that testing of your cookie-based web site or app will just work.'
-weight: 09
+weight: 1100
 ---
 
 # Cookies

--- a/docs/sources/k6/v1.3.x/using-k6/environment-variables.md
+++ b/docs/sources/k6/v1.3.x/using-k6/environment-variables.md
@@ -1,7 +1,7 @@
 ---
 title: 'Environment variables'
 description: 'You can access any environment variables from your k6 script code and use this to supply your VUs with configuration information.'
-weight: 11
+weight: 1300
 ---
 
 # Environment variables

--- a/docs/sources/k6/v1.3.x/using-k6/execution-context-variables.md
+++ b/docs/sources/k6/v1.3.x/using-k6/execution-context-variables.md
@@ -1,7 +1,7 @@
 ---
 title: 'Execution context variables'
 description: 'k6/execution module provides the capability to get information about the current test execution state inside the test script'
-weight: 12
+weight: 1400
 ---
 
 # Execution context variables

--- a/docs/sources/k6/v1.3.x/using-k6/http-requests.md
+++ b/docs/sources/k6/v1.3.x/using-k6/http-requests.md
@@ -1,7 +1,7 @@
 ---
 title: 'HTTP Requests'
 description: 'Define the HTTP requests and methods you want to use. k6 adds tags to the requests, making it easier to filter results. You can customize tags as you wish.'
-weight: 01
+weight: 200
 ---
 
 # HTTP Requests

--- a/docs/sources/k6/v1.3.x/using-k6/javascript-typescript-compatibility-mode.md
+++ b/docs/sources/k6/v1.3.x/using-k6/javascript-typescript-compatibility-mode.md
@@ -4,7 +4,7 @@ aliases:
 title: JavaScript and TypeScript compatibility mode
 menuTitle: JavaScript and TypeScript mode
 excerpt: 'k6 supports running test scripts with different compatibility modes using --compatibility-mode'
-weight: 19
+weight: 1800
 ---
 
 # JavaScript compatibility mode

--- a/docs/sources/k6/v1.3.x/using-k6/k6-options/_index.md
+++ b/docs/sources/k6/v1.3.x/using-k6/k6-options/_index.md
@@ -2,7 +2,7 @@
 title: 'Options'
 slug: '/k6-options'
 description: 'Options configure test-run behavior. You can set options in multiple locations. Examples for how to use options, and a complete reference.'
-weight: 05
+weight: 700
 ---
 
 # Options

--- a/docs/sources/k6/v1.3.x/using-k6/metrics/_index.md
+++ b/docs/sources/k6/v1.3.x/using-k6/metrics/_index.md
@@ -1,7 +1,7 @@
 ---
 title: 'Metrics'
 description: 'This section covers the important aspect of metrics management in k6. How and what kind of metrics k6 collects automatically (_built-in_ metrics), and what custom metrics you can make k6 collect.'
-weight: 02
+weight: 300
 ---
 
 # Metrics

--- a/docs/sources/k6/v1.3.x/using-k6/modules.md
+++ b/docs/sources/k6/v1.3.x/using-k6/modules.md
@@ -2,7 +2,7 @@
 title: 'Modules'
 description: 'While writing test scripts, it is common to import different modules, or part of modules, for
 usage throughout the script. In k6, it is possible to import three different kinds of modules.'
-weight: 07
+weight: 900
 ---
 
 # Modules

--- a/docs/sources/k6/v1.3.x/using-k6/protocols/_index.md
+++ b/docs/sources/k6/v1.3.x/using-k6/protocols/_index.md
@@ -1,7 +1,7 @@
 ---
 title: 'Protocols'
 description: 'Out of the box k6 comes with support for a few protocols: HTTP / WebSockets / gRPC / ...'
-weight: 10
+weight: 1200
 ---
 
 # Protocols

--- a/docs/sources/k6/v1.3.x/using-k6/run-k6-test-script.md
+++ b/docs/sources/k6/v1.3.x/using-k6/run-k6-test-script.md
@@ -1,0 +1,78 @@
+---
+title: 'Run a k6 test script'
+description: 'Learn the different ways you can run a k6 test script'
+weight: 100
+---
+
+# Run a k6 test script
+
+There are several ways you can use the Grafana k6 command-line tool (CLI) to run a k6 performance test. In this page, you'll learn how to use each method and how they differ from each other.
+
+## Before you begin
+
+To run a CLI test, you'll need:
+
+- A machine with [k6 installed](https://grafana.com/docs/k6/<K6_VERSION>/get-started/installation/).
+- A [test file](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/test-authoring/create-test-script-using-the-cli/).
+
+## Run a test on your local machine
+
+Running tests locally is a great way to incrementally test your script as you write it. For example, you can make sure that your [checks](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/checks/) and [thresholds](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/thresholds/) are configured correctly before you run a test with more VUs in Grafana Cloud k6.
+
+To run a test locally, use the `k6 run` command:
+
+```bash
+k6 run script.js
+```
+
+## Run a test using Grafana Cloud k6
+
+Grafana Cloud k6 is a performance testing application that's part of Grafana Cloud, and it's powered by k6 OSS. It allows you to leverage all of the Grafana k6 OSS capabilities while managing the infrastructure needed for scaling servers, running load tests from multiple locations, storing test results, and providing dashboards to detect performance errors and regressions.
+
+Grafana Cloud k6 makes it easier to visualize and compare test results by providing you with built-in dashboards, while also making it easier to share and collaborate on test data with other teams in your organization.
+
+To run a cloud test from the CLI, you'll need an [API token](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/tokens-and-cli-authentication/) for authenticating the k6 CLI with the Grafana Cloud k6 application.
+
+After you retrieve an API token, you can authenticate with the CLI by running the following command:
+
+```bash
+k6 cloud login --token <API_TOKEN>
+```
+
+With the CLI authentication configured, you can run cloud tests by using the `k6 cloud` command:
+
+```bash
+k6 cloud run cloud_demo.js
+```
+
+You can also run a test from a local machine and stream the results for storage and visualization on Grafana Cloud. A common use case for this feature is to run load tests in a CI/CD environment, or on networks that aren't accessible from the public internet.
+
+To run a test locally and stream the results to Grafana Cloud k6, use the `k6 cloud run --local-execution`:
+
+```bash
+k6 cloud run --local-execution cloud_demo.js
+```
+
+{{< admonition type="note" >}}
+
+The `k6 cloud run --local-execution` command uploads the test archive k6 produces from your test script and resources to Grafana Cloud.
+
+You can change this behavior by adding the `--no-archive-upload` option to your command. For example: `k6 cloud run --local-execution --no-archive-upload script.js`.
+
+{{< /admonition >}}
+
+To learn more about Grafana Cloud k6, refer to:
+
+- [Grafana Cloud k6 documentation](https://grafana.com/docs/grafana-cloud/testing/k6/).
+- [Use the CLI](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/use-the-cli/) - Learn about the different methods available to run a k6 test in Grafana Cloud.
+
+## Run a test in your infrastructure with the k6 Operator
+
+k6 Operator is a Kubernetes operator that you can use to run distributed k6 tests in your Kubernetes cluster.
+
+A couple of reasons why you might want to do this:
+
+- You run your application in Kubernetes and would like k6 to be executed in the same fashion as all your other infrastructure components.
+- You want to run your tests within your private network for security or privacy reasons.
+
+To set up and run a test using the k6 Operator, refer to [Set up distributed k6](https://grafana.com/docs/k6/<K6_VERSION>/set-up/set-up-distributed-k6/).

--- a/docs/sources/k6/v1.3.x/using-k6/scenarios/_index.md
+++ b/docs/sources/k6/v1.3.x/using-k6/scenarios/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Scenarios
 description: 'Scenarios allow us to make in-depth configurations to how VUs and iterations are scheduled. This makes it possible to model diverse traffic patterns in load tests.'
-weight: 13
+weight: 1500
 ---
 
 # Scenarios

--- a/docs/sources/k6/v1.3.x/using-k6/secret-source/_index.md
+++ b/docs/sources/k6/v1.3.x/using-k6/secret-source/_index.md
@@ -1,7 +1,7 @@
 ---
-title: Secret Source
+title: Secret source
 description: 'Secret source are used so k6 can get and use secrets in a secure way'
-weight: 14
+weight: 1600
 ---
 
 # Secret source

--- a/docs/sources/k6/v1.3.x/using-k6/tags-and-groups.md
+++ b/docs/sources/k6/v1.3.x/using-k6/tags-and-groups.md
@@ -2,7 +2,7 @@
 title: 'Tags and Groups'
 description: 'k6 provides the Tags and Groups APIs to help you during the analysis and easily visualize, sort and
 filter your test results.'
-weight: 08
+weight: 1000
 ---
 
 # Tags and Groups

--- a/docs/sources/k6/v1.3.x/using-k6/test-authoring/_index.md
+++ b/docs/sources/k6/v1.3.x/using-k6/test-authoring/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Test authoring
-weight: 14
+weight: 1700
 ---
 
 # Test authoring

--- a/docs/sources/k6/v1.3.x/using-k6/test-lifecycle.md
+++ b/docs/sources/k6/v1.3.x/using-k6/test-lifecycle.md
@@ -1,7 +1,7 @@
 ---
 title: 'Test lifecycle'
 description: 'The four distinct lifecycle stages in a k6 test are "init", "setup", "VU", and "teardown".'
-weight: 06
+weight: 800
 ---
 
 # Test lifecycle

--- a/docs/sources/k6/v1.3.x/using-k6/thresholds.md
+++ b/docs/sources/k6/v1.3.x/using-k6/thresholds.md
@@ -1,7 +1,7 @@
 ---
 title: 'Thresholds'
 description: 'Thresholds are a pass/fail criteria used to specify the performance expectations of the system under test.'
-weight: 04
+weight: 600
 ---
 
 # Thresholds


### PR DESCRIPTION
## What?

Add a new page on how to run a k6 test script. This is similar to what we have in the Grafana Cloud k6 docs, [Use the CLI](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/use-the-cli/).

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [x] I have made my changes in the `docs/sources/k6/next` folder of the documentation.
- [ ] I have reflected my changes in the `docs/sources/k6/v{most_recent_release}` folder of the documentation.
- [ ] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->