### PR TITLE
Add deprecation notice to instruction for using Grafana k6 Browser Recorder

### DIFF
--- a/docs/sources/k6/next/using-k6/test-authoring/create-tests-from-recordings/using-the-browser-recorder.md
+++ b/docs/sources/k6/next/using-k6/test-authoring/create-tests-from-recordings/using-the-browser-recorder.md
@@ -6,6 +6,12 @@ weight: 01
 
 # Using the browser recorder
 
+{{< admonition type="caution" >}} 
+
+The Grafana k6 Browser Recorder extension is deprecated and will be removed in a future release. Use [k6 Studio](https://grafana.com/docs/k6-studio) to record network traffic.
+
+{{< /admonition >}}
+
 The browser recorder lets you generate a k6 script based on a browser session.
 It's available as an extension for [Chrome](https://chrome.google.com/webstore/detail/grafana-k6-browser-record/fbanjfonbcedhifbgikmjelkkckhhidl) and [Firefox](https://addons.mozilla.org/en-US/firefox/addon/grafana-k6-browser-recorder/).
 

--- a/docs/sources/k6/next/using-k6/test-authoring/create-tests-from-recordings/using-the-browser-recorder.md
+++ b/docs/sources/k6/next/using-k6/test-authoring/create-tests-from-recordings/using-the-browser-recorder.md
@@ -6,7 +6,7 @@ weight: 01
 
 # Using the browser recorder
 
-{{< admonition type="caution" >}} 
+{{< admonition type="caution" >}}
 
 The Grafana k6 Browser Recorder extension is deprecated and will be removed in a future release. Use [k6 Studio](https://grafana.com/docs/k6-studio) to record network traffic.
 

--- a/docs/sources/k6/v0.47.x/using-k6/test-authoring/create-tests-from-recordings/using-the-browser-recorder.md
+++ b/docs/sources/k6/v0.47.x/using-k6/test-authoring/create-tests-from-recordings/using-the-browser-recorder.md
@@ -6,6 +6,12 @@ weight: 01
 
 # Using the browser recorder
 
+{{< admonition type="caution" >}}
+
+The Grafana k6 Browser Recorder extension is deprecated and will be removed in a future release. Use [k6 Studio](https://grafana.com/docs/k6-studio) to record network traffic.
+
+{{< /admonition >}}
+
 The browser recorder lets you generate a k6 script based on a browser session.
 It's available as an extension for [Chrome](https://chrome.google.com/webstore/detail/grafana-k6-browser-record/fbanjfonbcedhifbgikmjelkkckhhidl) and [Firefox](https://addons.mozilla.org/en-US/firefox/addon/grafana-k6-browser-recorder/).
 

--- a/docs/sources/k6/v0.48.x/using-k6/test-authoring/create-tests-from-recordings/using-the-browser-recorder.md
+++ b/docs/sources/k6/v0.48.x/using-k6/test-authoring/create-tests-from-recordings/using-the-browser-recorder.md
@@ -6,6 +6,12 @@ weight: 01
 
 # Using the browser recorder
 
+{{< admonition type="caution" >}}
+
+The Grafana k6 Browser Recorder extension is deprecated and will be removed in a future release. Use [k6 Studio](https://grafana.com/docs/k6-studio) to record network traffic.
+
+{{< /admonition >}}
+
 The browser recorder lets you generate a k6 script based on a browser session.
 It's available as an extension for [Chrome](https://chrome.google.com/webstore/detail/grafana-k6-browser-record/fbanjfonbcedhifbgikmjelkkckhhidl) and [Firefox](https://addons.mozilla.org/en-US/firefox/addon/grafana-k6-browser-recorder/).
 

--- a/docs/sources/k6/v0.49.x/using-k6/test-authoring/create-tests-from-recordings/using-the-browser-recorder.md
+++ b/docs/sources/k6/v0.49.x/using-k6/test-authoring/create-tests-from-recordings/using-the-browser-recorder.md
@@ -6,6 +6,12 @@ weight: 01
 
 # Using the browser recorder
 
+{{< admonition type="caution" >}}
+
+The Grafana k6 Browser Recorder extension is deprecated and will be removed in a future release. Use [k6 Studio](https://grafana.com/docs/k6-studio) to record network traffic.
+
+{{< /admonition >}}
+
 The browser recorder lets you generate a k6 script based on a browser session.
 It's available as an extension for [Chrome](https://chrome.google.com/webstore/detail/grafana-k6-browser-record/fbanjfonbcedhifbgikmjelkkckhhidl) and [Firefox](https://addons.mozilla.org/en-US/firefox/addon/grafana-k6-browser-recorder/).
 

--- a/docs/sources/k6/v0.50.x/using-k6/test-authoring/create-tests-from-recordings/using-the-browser-recorder.md
+++ b/docs/sources/k6/v0.50.x/using-k6/test-authoring/create-tests-from-recordings/using-the-browser-recorder.md
@@ -6,6 +6,12 @@ weight: 01
 
 # Using the browser recorder
 
+{{< admonition type="caution" >}}
+
+The Grafana k6 Browser Recorder extension is deprecated and will be removed in a future release. Use [k6 Studio](https://grafana.com/docs/k6-studio) to record network traffic.
+
+{{< /admonition >}}
+
 The browser recorder lets you generate a k6 script based on a browser session.
 It's available as an extension for [Chrome](https://chrome.google.com/webstore/detail/grafana-k6-browser-record/fbanjfonbcedhifbgikmjelkkckhhidl) and [Firefox](https://addons.mozilla.org/en-US/firefox/addon/grafana-k6-browser-recorder/).
 

--- a/docs/sources/k6/v0.51.x/using-k6/test-authoring/create-tests-from-recordings/using-the-browser-recorder.md
+++ b/docs/sources/k6/v0.51.x/using-k6/test-authoring/create-tests-from-recordings/using-the-browser-recorder.md
@@ -6,6 +6,12 @@ weight: 01
 
 # Using the browser recorder
 
+{{< admonition type="caution" >}}
+
+The Grafana k6 Browser Recorder extension is deprecated and will be removed in a future release. Use [k6 Studio](https://grafana.com/docs/k6-studio) to record network traffic.
+
+{{< /admonition >}}
+
 The browser recorder lets you generate a k6 script based on a browser session.
 It's available as an extension for [Chrome](https://chrome.google.com/webstore/detail/grafana-k6-browser-record/fbanjfonbcedhifbgikmjelkkckhhidl) and [Firefox](https://addons.mozilla.org/en-US/firefox/addon/grafana-k6-browser-recorder/).
 

--- a/docs/sources/k6/v0.52.x/using-k6/test-authoring/create-tests-from-recordings/using-the-browser-recorder.md
+++ b/docs/sources/k6/v0.52.x/using-k6/test-authoring/create-tests-from-recordings/using-the-browser-recorder.md
@@ -6,6 +6,12 @@ weight: 01
 
 # Using the browser recorder
 
+{{< admonition type="caution" >}}
+
+The Grafana k6 Browser Recorder extension is deprecated and will be removed in a future release. Use [k6 Studio](https://grafana.com/docs/k6-studio) to record network traffic.
+
+{{< /admonition >}}
+
 The browser recorder lets you generate a k6 script based on a browser session.
 It's available as an extension for [Chrome](https://chrome.google.com/webstore/detail/grafana-k6-browser-record/fbanjfonbcedhifbgikmjelkkckhhidl) and [Firefox](https://addons.mozilla.org/en-US/firefox/addon/grafana-k6-browser-recorder/).
 

--- a/docs/sources/k6/v0.53.x/using-k6/test-authoring/create-tests-from-recordings/using-the-browser-recorder.md
+++ b/docs/sources/k6/v0.53.x/using-k6/test-authoring/create-tests-from-recordings/using-the-browser-recorder.md
@@ -6,6 +6,12 @@ weight: 01
 
 # Using the browser recorder
 
+{{< admonition type="caution" >}}
+
+The Grafana k6 Browser Recorder extension is deprecated and will be removed in a future release. Use [k6 Studio](https://grafana.com/docs/k6-studio) to record network traffic.
+
+{{< /admonition >}}
+
 The browser recorder lets you generate a k6 script based on a browser session.
 It's available as an extension for [Chrome](https://chrome.google.com/webstore/detail/grafana-k6-browser-record/fbanjfonbcedhifbgikmjelkkckhhidl) and [Firefox](https://addons.mozilla.org/en-US/firefox/addon/grafana-k6-browser-recorder/).
 

--- a/docs/sources/k6/v0.54.x/using-k6/test-authoring/create-tests-from-recordings/using-the-browser-recorder.md
+++ b/docs/sources/k6/v0.54.x/using-k6/test-authoring/create-tests-from-recordings/using-the-browser-recorder.md
@@ -6,6 +6,12 @@ weight: 01
 
 # Using the browser recorder
 
+{{< admonition type="caution" >}}
+
+The Grafana k6 Browser Recorder extension is deprecated and will be removed in a future release. Use [k6 Studio](https://grafana.com/docs/k6-studio) to record network traffic.
+
+{{< /admonition >}}
+
 The browser recorder lets you generate a k6 script based on a browser session.
 It's available as an extension for [Chrome](https://chrome.google.com/webstore/detail/grafana-k6-browser-record/fbanjfonbcedhifbgikmjelkkckhhidl) and [Firefox](https://addons.mozilla.org/en-US/firefox/addon/grafana-k6-browser-recorder/).
 

--- a/docs/sources/k6/v0.55.x/using-k6/test-authoring/create-tests-from-recordings/using-the-browser-recorder.md
+++ b/docs/sources/k6/v0.55.x/using-k6/test-authoring/create-tests-from-recordings/using-the-browser-recorder.md
@@ -6,6 +6,12 @@ weight: 01
 
 # Using the browser recorder
 
+{{< admonition type="caution" >}}
+
+The Grafana k6 Browser Recorder extension is deprecated and will be removed in a future release. Use [k6 Studio](https://grafana.com/docs/k6-studio) to record network traffic.
+
+{{< /admonition >}}
+
 The browser recorder lets you generate a k6 script based on a browser session.
 It's available as an extension for [Chrome](https://chrome.google.com/webstore/detail/grafana-k6-browser-record/fbanjfonbcedhifbgikmjelkkckhhidl) and [Firefox](https://addons.mozilla.org/en-US/firefox/addon/grafana-k6-browser-recorder/).
 

--- a/docs/sources/k6/v0.56.x/using-k6/test-authoring/create-tests-from-recordings/using-the-browser-recorder.md
+++ b/docs/sources/k6/v0.56.x/using-k6/test-authoring/create-tests-from-recordings/using-the-browser-recorder.md
@@ -6,6 +6,12 @@ weight: 01
 
 # Using the browser recorder
 
+{{< admonition type="caution" >}}
+
+The Grafana k6 Browser Recorder extension is deprecated and will be removed in a future release. Use [k6 Studio](https://grafana.com/docs/k6-studio) to record network traffic.
+
+{{< /admonition >}}
+
 The browser recorder lets you generate a k6 script based on a browser session.
 It's available as an extension for [Chrome](https://chrome.google.com/webstore/detail/grafana-k6-browser-record/fbanjfonbcedhifbgikmjelkkckhhidl) and [Firefox](https://addons.mozilla.org/en-US/firefox/addon/grafana-k6-browser-recorder/).
 

--- a/docs/sources/k6/v0.57.x/using-k6/test-authoring/create-tests-from-recordings/using-the-browser-recorder.md
+++ b/docs/sources/k6/v0.57.x/using-k6/test-authoring/create-tests-from-recordings/using-the-browser-recorder.md
@@ -6,6 +6,12 @@ weight: 01
 
 # Using the browser recorder
 
+{{< admonition type="caution" >}}
+
+The Grafana k6 Browser Recorder extension is deprecated and will be removed in a future release. Use [k6 Studio](https://grafana.com/docs/k6-studio) to record network traffic.
+
+{{< /admonition >}}
+
 The browser recorder lets you generate a k6 script based on a browser session.
 It's available as an extension for [Chrome](https://chrome.google.com/webstore/detail/grafana-k6-browser-record/fbanjfonbcedhifbgikmjelkkckhhidl) and [Firefox](https://addons.mozilla.org/en-US/firefox/addon/grafana-k6-browser-recorder/).
 

--- a/docs/sources/k6/v1.0.x/using-k6/test-authoring/create-tests-from-recordings/using-the-browser-recorder.md
+++ b/docs/sources/k6/v1.0.x/using-k6/test-authoring/create-tests-from-recordings/using-the-browser-recorder.md
@@ -6,6 +6,12 @@ weight: 01
 
 # Using the browser recorder
 
+{{< admonition type="caution" >}}
+
+The Grafana k6 Browser Recorder extension is deprecated and will be removed in a future release. Use [k6 Studio](https://grafana.com/docs/k6-studio) to record network traffic.
+
+{{< /admonition >}}
+
 The browser recorder lets you generate a k6 script based on a browser session.
 It's available as an extension for [Chrome](https://chrome.google.com/webstore/detail/grafana-k6-browser-record/fbanjfonbcedhifbgikmjelkkckhhidl) and [Firefox](https://addons.mozilla.org/en-US/firefox/addon/grafana-k6-browser-recorder/).
 

--- a/docs/sources/k6/v1.1.x/using-k6/test-authoring/create-tests-from-recordings/using-the-browser-recorder.md
+++ b/docs/sources/k6/v1.1.x/using-k6/test-authoring/create-tests-from-recordings/using-the-browser-recorder.md
@@ -6,6 +6,12 @@ weight: 01
 
 # Using the browser recorder
 
+{{< admonition type="caution" >}}
+
+The Grafana k6 Browser Recorder extension is deprecated and will be removed in a future release. Use [k6 Studio](https://grafana.com/docs/k6-studio) to record network traffic.
+
+{{< /admonition >}}
+
 The browser recorder lets you generate a k6 script based on a browser session.
 It's available as an extension for [Chrome](https://chrome.google.com/webstore/detail/grafana-k6-browser-record/fbanjfonbcedhifbgikmjelkkckhhidl) and [Firefox](https://addons.mozilla.org/en-US/firefox/addon/grafana-k6-browser-recorder/).
 

--- a/docs/sources/k6/v1.2.x/using-k6/test-authoring/create-tests-from-recordings/using-the-browser-recorder.md
+++ b/docs/sources/k6/v1.2.x/using-k6/test-authoring/create-tests-from-recordings/using-the-browser-recorder.md
@@ -6,6 +6,12 @@ weight: 01
 
 # Using the browser recorder
 
+{{< admonition type="caution" >}} 
+
+The Grafana k6 Browser Recorder extension is deprecated and will be removed in a future release. Use [k6 Studio](https://grafana.com/docs/k6-studio) to record network traffic.
+
+{{< /admonition >}}
+
 The browser recorder lets you generate a k6 script based on a browser session.
 It's available as an extension for [Chrome](https://chrome.google.com/webstore/detail/grafana-k6-browser-record/fbanjfonbcedhifbgikmjelkkckhhidl) and [Firefox](https://addons.mozilla.org/en-US/firefox/addon/grafana-k6-browser-recorder/).
 

--- a/docs/sources/k6/v1.2.x/using-k6/test-authoring/create-tests-from-recordings/using-the-browser-recorder.md
+++ b/docs/sources/k6/v1.2.x/using-k6/test-authoring/create-tests-from-recordings/using-the-browser-recorder.md
@@ -6,7 +6,7 @@ weight: 01
 
 # Using the browser recorder
 
-{{< admonition type="caution" >}} 
+{{< admonition type="caution" >}}
 
 The Grafana k6 Browser Recorder extension is deprecated and will be removed in a future release. Use [k6 Studio](https://grafana.com/docs/k6-studio) to record network traffic.
 


### PR DESCRIPTION
<!-- 
Please make sure you have read the contribution guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md as well as the
the code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md before opening a PR.
-->

## What?

This PR adds a deprecation notice on the "Create tests from recordings / Using the browser recorder" page. This extension will be removed soon and we want to drive people towards using k6 Studio instead.

## Checklist

<!-- Please fill in this template: -->
- [X] I have used a meaningful title for the PR.
- [X] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [x] I have made my changes in the `docs/sources/k6/next` folder of the documentation.
- [x] I have reflected my changes in the `docs/sources/k6/v{most_recent_release}` folder of the documentation.
- [ ] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->

## Related PR(s)/Issue(s)

Related to https://github.com/grafana/k6-cloud/issues/3814
<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->
<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->