### PR TITLE
Remove the admonition on waitFor

### DIFF
--- a/docs/sources/k6/next/javascript-api/k6-browser/locator/waitfor.md
+++ b/docs/sources/k6/next/javascript-api/k6-browser/locator/waitfor.md
@@ -5,13 +5,6 @@ description: 'Browser module: locator.waitFor method'
 
 # waitFor([options])
 
-{{< admonition type="caution" >}}
-
-This feature has **known issues**. For details,
-refer to [#472](https://github.com/grafana/xk6-browser/issues/472).
-
-{{< /admonition >}}
-
 Wait for the element to be in a particular state e.g. `visible`.
 
 <TableWithNestedRows>

--- a/docs/sources/k6/v0.54.x/javascript-api/k6-browser/locator/waitfor.md
+++ b/docs/sources/k6/v0.54.x/javascript-api/k6-browser/locator/waitfor.md
@@ -5,13 +5,6 @@ description: 'Browser module: locator.waitFor method'
 
 # waitFor([options])
 
-{{< admonition type="caution" >}}
-
-This feature has **known issues**. For details,
-refer to [#472](https://github.com/grafana/xk6-browser/issues/472).
-
-{{< /admonition >}}
-
 Wait for the element to be in a particular state e.g. `visible`.
 
 <TableWithNestedRows>

--- a/docs/sources/k6/v0.55.x/javascript-api/k6-browser/locator/waitfor.md
+++ b/docs/sources/k6/v0.55.x/javascript-api/k6-browser/locator/waitfor.md
@@ -5,13 +5,6 @@ description: 'Browser module: locator.waitFor method'
 
 # waitFor([options])
 
-{{< admonition type="caution" >}}
-
-This feature has **known issues**. For details,
-refer to [#472](https://github.com/grafana/xk6-browser/issues/472).
-
-{{< /admonition >}}
-
 Wait for the element to be in a particular state e.g. `visible`.
 
 <TableWithNestedRows>

--- a/docs/sources/k6/v0.56.x/javascript-api/k6-browser/locator/waitfor.md
+++ b/docs/sources/k6/v0.56.x/javascript-api/k6-browser/locator/waitfor.md
@@ -5,13 +5,6 @@ description: 'Browser module: locator.waitFor method'
 
 # waitFor([options])
 
-{{< admonition type="caution" >}}
-
-This feature has **known issues**. For details,
-refer to [#472](https://github.com/grafana/xk6-browser/issues/472).
-
-{{< /admonition >}}
-
 Wait for the element to be in a particular state e.g. `visible`.
 
 <TableWithNestedRows>

--- a/docs/sources/k6/v0.57.x/javascript-api/k6-browser/locator/waitfor.md
+++ b/docs/sources/k6/v0.57.x/javascript-api/k6-browser/locator/waitfor.md
@@ -5,13 +5,6 @@ description: 'Browser module: locator.waitFor method'
 
 # waitFor([options])
 
-{{< admonition type="caution" >}}
-
-This feature has **known issues**. For details,
-refer to [#472](https://github.com/grafana/xk6-browser/issues/472).
-
-{{< /admonition >}}
-
 Wait for the element to be in a particular state e.g. `visible`.
 
 <TableWithNestedRows>

--- a/docs/sources/k6/v1.0.x/javascript-api/k6-browser/locator/waitfor.md
+++ b/docs/sources/k6/v1.0.x/javascript-api/k6-browser/locator/waitfor.md
@@ -5,13 +5,6 @@ description: 'Browser module: locator.waitFor method'
 
 # waitFor([options])
 
-{{< admonition type="caution" >}}
-
-This feature has **known issues**. For details,
-refer to [#472](https://github.com/grafana/xk6-browser/issues/472).
-
-{{< /admonition >}}
-
 Wait for the element to be in a particular state e.g. `visible`.
 
 <TableWithNestedRows>

--- a/docs/sources/k6/v1.1.x/javascript-api/k6-browser/locator/waitfor.md
+++ b/docs/sources/k6/v1.1.x/javascript-api/k6-browser/locator/waitfor.md
@@ -5,13 +5,6 @@ description: 'Browser module: locator.waitFor method'
 
 # waitFor([options])
 
-{{< admonition type="caution" >}}
-
-This feature has **known issues**. For details,
-refer to [#472](https://github.com/grafana/xk6-browser/issues/472).
-
-{{< /admonition >}}
-
 Wait for the element to be in a particular state e.g. `visible`.
 
 <TableWithNestedRows>

--- a/docs/sources/k6/v1.2.x/javascript-api/k6-browser/locator/waitfor.md
+++ b/docs/sources/k6/v1.2.x/javascript-api/k6-browser/locator/waitfor.md
@@ -5,13 +5,6 @@ description: 'Browser module: locator.waitFor method'
 
 # waitFor([options])
 
-{{< admonition type="caution" >}}
-
-This feature has **known issues**. For details,
-refer to [#472](https://github.com/grafana/xk6-browser/issues/472).
-
-{{< /admonition >}}
-
 Wait for the element to be in a particular state e.g. `visible`.
 
 <TableWithNestedRows>

--- a/docs/sources/k6/v1.3.x/javascript-api/k6-browser/locator/waitfor.md
+++ b/docs/sources/k6/v1.3.x/javascript-api/k6-browser/locator/waitfor.md
@@ -5,13 +5,6 @@ description: 'Browser module: locator.waitFor method'
 
 # waitFor([options])
 
-{{< admonition type="caution" >}}
-
-This feature has **known issues**. For details,
-refer to [#472](https://github.com/grafana/xk6-browser/issues/472).
-
-{{< /admonition >}}
-
 Wait for the element to be in a particular state e.g. `visible`.
 
 <TableWithNestedRows>


### PR DESCRIPTION
<!-- 
Please make sure you have read the contribution guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md as well as the
the code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md before opening a PR.
-->

## What?

Removes the admonition on `waitFor`. The issue mentioned in the admonition was fixed in `v0.45.0` of k6, so we can remove the admonition on all `waitFor` pages.

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [x] I have made my changes in the `docs/sources/k6/next` folder of the documentation.
- [x] I have reflected my changes in the `docs/sources/k6/v{most_recent_release}` folder of the documentation.
- [x] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->
<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->