### PR TITLE
docs: update default user agent header

### DIFF
--- a/docs/sources/k6/next/using-k6/k6-options/reference.md
+++ b/docs/sources/k6/next/using-k6/k6-options/reference.md
@@ -1615,9 +1615,9 @@ requests.
 If you pass an empty string, no `User-Agent` header is sent.
 Available in `k6 run` and `k6 cloud` commands
 
-| Env             | CLI            | Code / Config file | Default                                                               |
-| --------------- | -------------- | ------------------ | --------------------------------------------------------------------- |
-| `K6_USER_AGENT` | `--user-agent` | `userAgent`        | `k6/0.27.0 (https://k6.io/)` (depending on the version you're using)` |
+| Env             | CLI            | Code / Config file | Default                   |
+| --------------- | -------------- | ------------------ | ------------------------- |
+| `K6_USER_AGENT` | `--user-agent` | `userAgent`        | `Grafana k6/<K6_VERSION>` |
 
 {{< code >}}
 

--- a/docs/sources/k6/v1.0.x/using-k6/k6-options/reference.md
+++ b/docs/sources/k6/v1.0.x/using-k6/k6-options/reference.md
@@ -1573,9 +1573,9 @@ requests.
 If you pass an empty string, no `User-Agent` header is sent.
 Available in `k6 run` and `k6 cloud` commands
 
-| Env             | CLI            | Code / Config file | Default                                                               |
-| --------------- | -------------- | ------------------ | --------------------------------------------------------------------- |
-| `K6_USER_AGENT` | `--user-agent` | `userAgent`        | `k6/0.27.0 (https://k6.io/)` (depending on the version you're using)` |
+| Env             | CLI            | Code / Config file | Default                   |
+| --------------- | -------------- | ------------------ | ------------------------- |
+| `K6_USER_AGENT` | `--user-agent` | `userAgent`        | `Grafana k6/<K6_VERSION>` |
 
 {{< code >}}
 

--- a/docs/sources/k6/v1.1.x/using-k6/k6-options/reference.md
+++ b/docs/sources/k6/v1.1.x/using-k6/k6-options/reference.md
@@ -1572,9 +1572,9 @@ requests.
 If you pass an empty string, no `User-Agent` header is sent.
 Available in `k6 run` and `k6 cloud` commands
 
-| Env             | CLI            | Code / Config file | Default                                                               |
-| --------------- | -------------- | ------------------ | --------------------------------------------------------------------- |
-| `K6_USER_AGENT` | `--user-agent` | `userAgent`        | `k6/0.27.0 (https://k6.io/)` (depending on the version you're using)` |
+| Env             | CLI            | Code / Config file | Default                   |
+| --------------- | -------------- | ------------------ | ------------------------- |
+| `K6_USER_AGENT` | `--user-agent` | `userAgent`        | `Grafana k6/<K6_VERSION>` |
 
 {{< code >}}
 

--- a/docs/sources/k6/v1.2.x/using-k6/k6-options/reference.md
+++ b/docs/sources/k6/v1.2.x/using-k6/k6-options/reference.md
@@ -1577,9 +1577,9 @@ requests.
 If you pass an empty string, no `User-Agent` header is sent.
 Available in `k6 run` and `k6 cloud` commands
 
-| Env             | CLI            | Code / Config file | Default                                                               |
-| --------------- | -------------- | ------------------ | --------------------------------------------------------------------- |
-| `K6_USER_AGENT` | `--user-agent` | `userAgent`        | `k6/0.27.0 (https://k6.io/)` (depending on the version you're using)` |
+| Env             | CLI            | Code / Config file | Default                   |
+| --------------- | -------------- | ------------------ | ------------------------- |
+| `K6_USER_AGENT` | `--user-agent` | `userAgent`        | `Grafana k6/<K6_VERSION>` |
 
 {{< code >}}
 

--- a/docs/sources/k6/v1.3.x/using-k6/k6-options/reference.md
+++ b/docs/sources/k6/v1.3.x/using-k6/k6-options/reference.md
@@ -1615,9 +1615,9 @@ requests.
 If you pass an empty string, no `User-Agent` header is sent.
 Available in `k6 run` and `k6 cloud` commands
 
-| Env             | CLI            | Code / Config file | Default                                                               |
-| --------------- | -------------- | ------------------ | --------------------------------------------------------------------- |
-| `K6_USER_AGENT` | `--user-agent` | `userAgent`        | `k6/0.27.0 (https://k6.io/)` (depending on the version you're using)` |
+| Env             | CLI            | Code / Config file | Default                   |
+| --------------- | -------------- | ------------------ | ------------------------- |
+| `K6_USER_AGENT` | `--user-agent` | `userAgent`        | `Grafana k6/<K6_VERSION>` |
 
 {{< code >}}
 

--- a/docs/sources/k6/v1.4.x/using-k6/k6-options/reference.md
+++ b/docs/sources/k6/v1.4.x/using-k6/k6-options/reference.md
@@ -1615,9 +1615,9 @@ requests.
 If you pass an empty string, no `User-Agent` header is sent.
 Available in `k6 run` and `k6 cloud` commands
 
-| Env             | CLI            | Code / Config file | Default                                                               |
-| --------------- | -------------- | ------------------ | --------------------------------------------------------------------- |
-| `K6_USER_AGENT` | `--user-agent` | `userAgent`        | `k6/0.27.0 (https://k6.io/)` (depending on the version you're using)` |
+| Env             | CLI            | Code / Config file | Default                   |
+| --------------- | -------------- | ------------------ | ------------------------- |
+| `K6_USER_AGENT` | `--user-agent` | `userAgent`        | `Grafana k6/<K6_VERSION>` |
 
 {{< code >}}
 


### PR DESCRIPTION
Update docs for https://github.com/grafana/k6/pull/4699

Relates to https://github.com/grafana/website/pull/28215