### PR TITLE
docs: update "Create test generator" button label to "Create test"

### DIFF
--- a/docs/sources/k6-studio/components/recorder.md
+++ b/docs/sources/k6-studio/components/recorder.md
@@ -21,7 +21,7 @@ The Recorder window is composed of:
    - **New recording**: Starts a new recording.
    - **Stop recording**: Stops the existing recording.
    - **Discard**: Discard the existing recording and starts a new one.
-   - **Create test generator**: Creates a test generator from the selected test recording.
+   - **Create test**: Creates a test generator from the selected test recording.
 3. **Recorder options**: Below the test recording name, you can see:
    - **Requests**: The total number of requests in the recording
    - **Show static assets**: A toggle that controls whether you can see all static assets requests in the Requests list. The static assets requests are hidden by default.

--- a/docs/sources/k6-studio/components/recorder.md
+++ b/docs/sources/k6-studio/components/recorder.md
@@ -21,7 +21,9 @@ The Recorder window is composed of:
    - **New recording**: Starts a new recording.
    - **Stop recording**: Stops the existing recording.
    - **Discard**: Discard the existing recording and starts a new one.
-   - **Create test**: Creates a test generator from the selected test recording.
+   - **Create test**: Opens a menu with two options:
+     - **HTTP test**: Creates a test generator from the selected test recording.
+     - **Browser test**: Creates a browser test script from the recorded browser events.
 3. **Recorder options**: Below the test recording name, you can see:
    - **Requests**: The total number of requests in the recording
    - **Show static assets**: A toggle that controls whether you can see all static assets requests in the Requests list. The static assets requests are hidden by default.

--- a/docs/sources/k6-studio/record-browser-events.md
+++ b/docs/sources/k6-studio/record-browser-events.md
@@ -52,18 +52,14 @@ To create a text assertion:
 
 After you create the assertion, an event is added to the browser events list.
 
-## Export a browser event test script
+## Create a browser test script
 
 Browser events generate a separate test script from the default protocol-level test created by Grafana k6 Studio, as they test different aspects of an application.
 
-To export a browser event test script:
+You can create a browser test script in two ways:
 
-- Open a test recording.
-- Click the **Browser events** tab at the top.
-- Click **Export script** on the top right.
-- In the **Export script** dialog box:
-  - Type in a name for your script.
-  - Click **Export**.
+- From the Recorder, click **Create test** > **Browser test** on the top-right.
+- From the **Browser events** tab, click **Export script** on the top-right, type a name for your script, and click **Export**.
 
 After you save your script, you can view it under the **Scripts** section. Refer to [Using k6 browser](https://grafana.com/docs/k6/latest/using-k6-browser/) for more details on how to customize your browser test script.
 

--- a/docs/sources/k6-studio/record-your-first-script.md
+++ b/docs/sources/k6-studio/record-your-first-script.md
@@ -101,7 +101,7 @@ The Request and Response panels have tabs where you can view the headers, payloa
 
 To generate a script from a test recording:
 
-- If you still have the test recording open from the last step, click **Create test** on the top-right.
+- If you still have the test recording open from the last step, click **Create test** > **HTTP test** on the top-right.
 - You can also click **+** next to Generator on the left side, and then select your recording on the top-right.
 
 A dialog box shows up that lets you select the hosts to use from the recording for generating the script. Select `quickpizza.grafana.com` and press **Continue**.

--- a/docs/sources/k6-studio/record-your-first-script.md
+++ b/docs/sources/k6-studio/record-your-first-script.md
@@ -101,7 +101,7 @@ The Request and Response panels have tabs where you can view the headers, payloa
 
 To generate a script from a test recording:
 
-- If you still have the test recording open from the last step, click **Create test generator** on the top-right.
+- If you still have the test recording open from the last step, click **Create test** on the top-right.
 - You can also click **+** next to Generator on the left side, and then select your recording on the top-right.
 
 A dialog box shows up that lets you select the hosts to use from the recording for generating the script. Select `quickpizza.grafana.com` and press **Continue**.


### PR DESCRIPTION
## Summary

- Updates the k6 Studio Recorder docs to reflect the renamed UI button: **Create test generator** → **Create test**.
- Fixes two references: one in `record-your-first-script.md` and one in `components/recorder.md`.

Closes #2210

## Test plan

- [ ] Verify the button label matches the current k6 Studio UI
- [ ] Build locally and check both pages render correctly


Made with [Cursor](https://cursor.com)