### PR TITLE
Docs: Add cost attribution label management for Grafana Cloud k6

### DIFF
--- a/docs/sources/k6/next/grafana-cloud-k6/_index.md
+++ b/docs/sources/k6/next/grafana-cloud-k6/_index.md
@@ -8,3 +8,11 @@ title: Grafana Cloud k6
 Grafana Cloud k6 is a performance-testing application that's part of Grafana Cloud. It lets you leverage all of the k6 capabilities, while Grafana handles the infrastructure work of scaling servers, handling distributed load zones, and storing and aggregating metrics from your tests.
 
 Visit the [Grafana Cloud k6 documentation](https://grafana.com/docs/grafana-cloud/testing/k6/) for more information.
+
+## Cost attribution
+
+With cost attribution, you can assign labels to your k6 projects to track Virtual User Hours (VUh) consumption by team, department, or cost center. Your organization gains financial transparency into k6 usage and can implement accurate chargebacks and budget planning.
+
+To learn more, refer to the following topics:
+
+{{< section >}}

--- a/docs/sources/k6/next/grafana-cloud-k6/cost-attribution.md
+++ b/docs/sources/k6/next/grafana-cloud-k6/cost-attribution.md
@@ -1,0 +1,62 @@
+---
+title: 'Cost attribution'
+description: 'Learn how cost attribution works in Grafana Cloud k6 and how labels help you track VUh usage across teams and projects.'
+weight: 100
+---
+
+# Cost attribution
+
+With cost attribution in Grafana Cloud k6, you can track how your organization consumes Virtual User Hours (VUh) across different teams, departments, or cost centers. By assigning labels to k6 projects, you gain visibility into which groups drive usage, making it possible to implement chargebacks, allocate budgets, and plan capacity.
+
+## How cost attribution works
+
+Cost attribution is based on **labels** that you assign to k6 projects. When a test runs under a labeled project, the VUh consumed by that test run is associated with the project's labels. You can then view and filter usage data by these labels in the Cost Management and Billing app.
+
+The workflow has three main parts:
+
+1. **Define labels.** Organization administrators create labels in the Grafana Cloud k6 settings. Each label represents a category, such as `team` or `environment`. When you assign a label to a project, you provide a specific value. For example, a label named `environment` might have the value `staging` for one project and `production` for another.
+
+1. **Assign labels to projects.** After labels exist, you assign them to k6 projects. All future test runs in a labeled project inherit the project's labels for usage tracking.
+
+1. **View usage by label.** The [Cost Management and Billing app](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/) shows VUh consumption broken down by label, so you can see how usage distributes across your organization.
+
+## Labels and the Grafana labels plugin
+
+Grafana Cloud k6 integrates with the [Grafana labels plugin](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/cost-attributions/) for centralized label management. Labels you define in the Grafana labels plugin sync automatically with Grafana Cloud k6, so you can manage labels across Grafana Cloud products from a single place.
+
+You can also create and manage labels directly in the Grafana Cloud k6 settings without using the labels plugin. Labels created in k6 sync back to the centralized label system.
+
+## What cost attribution tracks
+
+Cost attribution currently tracks **VUh consumption only**. Each test run's VUh is attributed to the labels assigned to its parent project. This covers:
+
+- Cloud test runs executed from the Grafana Cloud k6 infrastructure
+- Test runs streamed to Grafana Cloud k6 with `k6 cloud run --local-execution`
+
+{{< admonition type="note" >}}
+
+Cost attribution does not currently track labels for generated k6 metrics. Only VUh usage is attributed to labels.
+
+{{< /admonition >}}
+
+## When to use cost attribution
+
+Cost attribution is useful when your organization needs to:
+
+- **Charge back usage** to specific teams or business units based on actual VUh consumption.
+- **Allocate budgets** for performance testing across departments.
+- **Gain financial transparency** into which teams or projects consume the most testing resources.
+- **Track usage across stacks** when your organization uses multiple Grafana Cloud stacks.
+
+## Scope and limitations
+
+Keep the following in mind when you use cost attribution:
+
+- Cost attribution begins tracking usage from the moment you assign labels. It doesn't apply retroactively to past test runs.
+- Only VUh consumption is tracked. Generated k6 test metrics aren't labeled for cost attribution in the initial release.
+- Labels are assigned at the project level. Individual test runs within a project all share the same labels.
+
+## Next steps
+
+- [Manage cost attribution labels](https://grafana.com/docs/k6/<K6_VERSION>/grafana-cloud-k6/manage-cost-attribution-labels/) to set up labels and assign them to your projects.
+- Learn more about [cost attribution in Grafana Cloud](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/cost-attributions/).

--- a/docs/sources/k6/next/grafana-cloud-k6/manage-cost-attribution-labels.md
+++ b/docs/sources/k6/next/grafana-cloud-k6/manage-cost-attribution-labels.md
@@ -1,0 +1,107 @@
+---
+title: 'Manage cost attribution labels'
+description: 'Learn how to create labels and assign them to k6 projects for cost attribution in Grafana Cloud k6.'
+weight: 200
+---
+
+# Manage cost attribution labels
+
+You manage cost attribution labels from within Grafana Cloud k6. You can create labels, assign them to projects with specific values, and update or remove labels as your organization's needs change.
+
+## Before you begin
+
+To manage labels, you need:
+
+- A Grafana Cloud account with access to Grafana Cloud k6.
+- Organization administrator permissions to create or modify labels.
+- At least one k6 project to assign labels to.
+
+## Create labels
+
+Each label has a **key** and a **description**. The key represents a category, such as `team` or `environment`. The description explains the label's purpose. When you assign a label to a project, you provide a value for that label. For example, a label with the key `environment` might have the value `staging` on one project and `production` on another.
+
+### Label naming guidelines
+
+When you create labels, follow these guidelines for consistency:
+
+- Use lowercase, descriptive keys, such as `team`, `department`, or `environment`.
+- Keep label values consistent across your organization. For example, use `frontend` everywhere instead of mixing `frontend`, `Frontend`, and `FE`.
+- Avoid changing label values frequently, because changes can affect historical usage tracking.
+
+### Create a label
+
+To create a label:
+
+1. In Grafana Cloud, go to **Testing & synthetics** > **Performance** > **Settings** > **Labels**.
+1. Click **New label**.
+1. In the **Name** field, enter a key for the label.
+1. Enter a description for the label.
+1. Click **Submit**.
+
+After you create labels, they're available to assign to any k6 project in your organization.
+
+{{< admonition type="note" >}}
+
+Labels you create in Grafana Cloud k6 sync with the Grafana labels plugin. If your organization manages labels centrally through the [Cost Management and Billing app](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/cost-attributions/), labels sync automatically between both systems.
+
+{{< /admonition >}}
+
+## Assign labels to a project
+
+After you create labels, assign them to projects so that future test runs are tracked under those labels. You can assign up to 30 labels per project.
+
+To assign labels to a project:
+
+1. In Grafana Cloud, go to **Testing & synthetics** > **Performance** > **Projects**.
+1. Select the project you want to label.
+1. Click the menu icon in the upper-right corner of the project page.
+1. Select **Manage labels**. The **Edit project labels** dialog box opens.
+1. Click **Add Label**.
+1. From the **Label Name** drop-down, select a label.
+1. In the **Label Value** field, enter a value for the project.
+1. To add more labels, click **Add Label** again and repeat the previous steps.
+1. Click **Save**.
+
+All future test runs in this project are attributed to the selected labels. Existing past test runs aren't retroactively labeled.
+
+## Update labels on a project
+
+To change the labels assigned to a project:
+
+1. From the project page, click the menu icon in the upper-right corner.
+1. Select **Manage labels**.
+1. In the dialog box, update the label values as needed. You can add new labels, change values, or remove labels.
+1. Click **Save**.
+
+Updated labels apply to future test runs only. Past test runs retain the labels that were assigned at the time they ran.
+
+## Remove labels from a project
+
+To remove labels from a project:
+
+1. From the project page, click the menu icon in the upper-right corner.
+1. Select **Manage labels**. The **Edit project labels** dialog box opens.
+1. Click the delete icon next to each label you want to remove.
+1. Click **Save**.
+
+After you remove labels, future test runs in this project are no longer attributed to any cost labels.
+
+## Edit or delete stack-level labels
+
+To modify or remove label definitions that apply across all projects:
+
+1. In Grafana Cloud, go to **Testing & synthetics** > **Performance** > **Settings** > **Labels**.
+1. Find the label you want to modify.
+1. Edit the label key or description, or delete the label.
+1. Click **Save**.
+
+{{< admonition type="caution" >}}
+
+Deleting a label removes it from all projects that use it. This doesn't affect historical usage data, but future test runs in those projects are no longer attributed to the deleted label.
+
+{{< /admonition >}}
+
+## Next steps
+
+- Learn more about [cost attribution in Grafana Cloud k6](https://grafana.com/docs/k6/<K6_VERSION>/grafana-cloud-k6/cost-attribution/).
+- Refer to [cost attribution in Grafana Cloud](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/cost-attributions/) for centralized label management.


### PR DESCRIPTION
## Summary

- Add conceptual overview of cost attribution in Grafana Cloud k6 (`cost-attribution.md`)
- Add how-to guide for the label management UI (`manage-cost-attribution-labels.md`)
- Update `grafana-cloud-k6/_index.md` with cost attribution section and child page navigation

These docs support the label management UI built in https://github.com/grafana/k6-cloud/issues/3917, part of [Cost Attribution for Grafana Cloud k6](https://github.com/grafana/k6-cloud/issues/3642).

## Pending UI issues that may affect docs

The following UI issues were identified during the docs review. If resolved, the docs should be updated to match:

| Issue | Description | Docs impact |
|-------|-------------|-------------|
| [k6-cloud#4327](https://github.com/grafana/k6-cloud/issues/4327) | Rename "Create new label" dialog to "Create label" | No docs change needed |
| [k6-cloud#4328](https://github.com/grafana/k6-cloud/issues/4328) | Inconsistent field naming: "Name" in dialog vs "Key" in list vs "identifier" in info text | Docs use "key" as primary term and note the **Name** field in the creation steps |
| [k6-cloud#4329](https://github.com/grafana/k6-cloud/issues/4329) | Sentence case: "Add Label", "Label Name", "Label Value" | Docs reference current UI text; update if UI changes |
| [k6-cloud#4330](https://github.com/grafana/k6-cloud/issues/4330) | No confirmation feedback after saving project labels | No docs change needed |

## Not yet included

- **View usage by label** section: Removed because the k6 backend integration with the Cost Management and Billing app is still pending. Add this section when the integration is complete.

## Test plan

- [x] ESLint passes
- [x] Local docs build succeeds
- [ ] Review conceptual overview for technical accuracy
- [ ] Review how-to steps against the live UI
- [ ] Verify label sync behavior with Grafana labels plugin


Made with [Cursor](https://cursor.com)