### PR TITLE
[docs] Add cloud secret-source documentation

### DIFF
--- a/docs/sources/k6/next/using-k6/secret-source/_index.md
+++ b/docs/sources/k6/next/using-k6/secret-source/_index.md
@@ -16,7 +16,7 @@ Configure secret sources using the `--secret-source` CLI flag. You can configure
 
 ## Built-in secret sources
 
-The following built-in secret sources are available:
+The following built-in secret sources are available for local testing:
 
 - [`cloud`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/secret-source/cloud): Fetches secrets from Grafana Cloud k6.
 - [`file`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/secret-source/file): Reads secrets from a `key=value` file.

--- a/docs/sources/k6/next/using-k6/secret-source/_index.md
+++ b/docs/sources/k6/next/using-k6/secret-source/_index.md
@@ -24,7 +24,7 @@ The following built-in secret sources are available for local testing:
 
 The following built-in secret source is available for `k6 cloud run --local-execution`:
 
-- [`cloud`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/secret-source/cloud): Fetches secrets from Grafana Cloud k6.
+- [`cloud`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/secret-source/cloud): Fetches secrets from [Grafana Cloud k6](https://grafana.com/docs/k6/<K6_VERSION>/grafana-cloud-k6/).
 
 ## Secret source extensions
 

--- a/docs/sources/k6/next/using-k6/secret-source/_index.md
+++ b/docs/sources/k6/next/using-k6/secret-source/_index.md
@@ -18,10 +18,13 @@ Configure secret sources using the `--secret-source` CLI flag. You can configure
 
 The following built-in secret sources are available for local testing:
 
-- [`cloud`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/secret-source/cloud): Fetches secrets from Grafana Cloud k6.
 - [`file`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/secret-source/file): Reads secrets from a `key=value` file.
 - [`mock`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/secret-source/mock): Reads secrets from CLI arguments.
 - [`url`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/secret-source/url): Fetches secrets from HTTP endpoints.
+
+The following built-in secret source is available for `k6 cloud run --local-execution`:
+
+- [`cloud`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/secret-source/cloud): Fetches secrets from Grafana Cloud k6.
 
 ## Secret source extensions
 

--- a/docs/sources/k6/next/using-k6/secret-source/_index.md
+++ b/docs/sources/k6/next/using-k6/secret-source/_index.md
@@ -16,8 +16,9 @@ Configure secret sources using the `--secret-source` CLI flag. You can configure
 
 ## Built-in secret sources
 
-The following built-in secret sources are available for local testing:
+The following built-in secret sources are available:
 
+- [`cloud`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/secret-source/cloud): Fetches secrets from Grafana Cloud k6.
 - [`file`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/secret-source/file): Reads secrets from a `key=value` file.
 - [`mock`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/secret-source/mock): Reads secrets from CLI arguments.
 - [`url`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/secret-source/url): Fetches secrets from HTTP endpoints.

--- a/docs/sources/k6/next/using-k6/secret-source/cloud.md
+++ b/docs/sources/k6/next/using-k6/secret-source/cloud.md
@@ -1,7 +1,7 @@
 ---
 title: 'Cloud secret source'
 menuTitle: 'Cloud'
-description: 'The cloud secret source lets you access k6 Cloud secrets when running tests locally with k6 cloud run --local-execution'
+description: 'The cloud secret source lets you access Grafana Cloud k6 secrets when running tests locally with k6 cloud run --local-execution'
 weight: 04
 ---
 

--- a/docs/sources/k6/next/using-k6/secret-source/cloud.md
+++ b/docs/sources/k6/next/using-k6/secret-source/cloud.md
@@ -7,7 +7,7 @@ weight: 04
 
 # Cloud secret source
 
-When you run tests in Grafana Cloud using `k6 cloud run`, [k6 Cloud secrets management](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/manage-secrets/) is available automatically. The cloud secret source brings that same access to local execution runs with `k6 cloud run --local-execution`, so you can use the same secrets without managing credentials locally.
+When you run tests in Grafana Cloud using `k6 cloud run`, [secrets management](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/manage-secrets/) is available automatically. The cloud secret source brings that same access to local execution runs with `k6 cloud run --local-execution`, so you can use the same secrets without managing credentials locally.
 
 {{< admonition type="note" >}}
 

--- a/docs/sources/k6/next/using-k6/secret-source/cloud.md
+++ b/docs/sources/k6/next/using-k6/secret-source/cloud.md
@@ -24,13 +24,9 @@ The cloud secret source only works with `k6 cloud run --local-execution --secret
 
 Pass `--secret-source=cloud` when running your test with `k6 cloud run --local-execution`:
 
-{{< code >}}
-
 ```bash
 k6 cloud run --local-execution --secret-source=cloud script.js
 ```
-
-{{< /code >}}
 
 k6 automatically configures the credentials needed to fetch secrets from Grafana Cloud. No tokens, endpoints, or passwords are required on the command line.
 

--- a/docs/sources/k6/next/using-k6/secret-source/cloud.md
+++ b/docs/sources/k6/next/using-k6/secret-source/cloud.md
@@ -18,7 +18,7 @@ The cloud secret source only works with `k6 cloud run --local-execution --secret
 ## Before you begin
 
 - Authenticate with Grafana Cloud k6 using `k6 cloud login`.
-- Configure the secrets you want to use in [k6 Cloud secrets management](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/manage-secrets/).
+- Configure the secrets you want to use in [Grafana Cloud k6](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/manage-secrets/).
 
 ## Use the cloud secret source
 

--- a/docs/sources/k6/next/using-k6/secret-source/cloud.md
+++ b/docs/sources/k6/next/using-k6/secret-source/cloud.md
@@ -34,4 +34,4 @@ k6 cloud run --local-execution --secret-source=cloud script.js
 
 k6 automatically configures the credentials needed to fetch secrets from Grafana Cloud. No tokens, endpoints, or passwords are required on the command line.
 
-All secrets are automatically redacted from k6 logs.
+k6 automatically redacts all secrets from logs.

--- a/docs/sources/k6/next/using-k6/secret-source/cloud.md
+++ b/docs/sources/k6/next/using-k6/secret-source/cloud.md
@@ -1,0 +1,37 @@
+---
+title: 'Cloud secret source'
+menuTitle: 'Cloud'
+description: 'The cloud secret source lets you access k6 Cloud secrets when running tests locally with k6 cloud run --local-execution'
+weight: 04
+---
+
+# Cloud secret source
+
+When you run tests in Grafana Cloud using `k6 cloud run`, [k6 Cloud secrets management](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/manage-secrets/) is available automatically. The cloud secret source brings that same access to local execution runs with `k6 cloud run --local-execution`, so you can use the same secrets without managing credentials locally.
+
+{{< admonition type="note" >}}
+
+The cloud secret source only works with `k6 cloud run --local-execution --secret-source=cloud`. Using it with `k6 run` returns an error.
+
+{{< /admonition >}}
+
+## Before you begin
+
+- Authenticate with Grafana Cloud k6 using `k6 cloud login`.
+- Configure the secrets you want to use in [k6 Cloud secrets management](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/manage-secrets/).
+
+## Use the cloud secret source
+
+Pass `--secret-source=cloud` when running your test with `k6 cloud run --local-execution`:
+
+{{< code >}}
+
+```bash
+k6 cloud run --local-execution --secret-source=cloud script.js
+```
+
+{{< /code >}}
+
+k6 automatically configures the credentials needed to fetch secrets from Grafana Cloud. No tokens, endpoints, or passwords are required on the command line.
+
+All secrets are automatically redacted from k6 logs.


### PR DESCRIPTION
Closes https://github.com/grafana/k6-cloud/issues/4263

## What?

Adds `cloud` secret-source documentation implemented in https://github.com/grafana/k6/pull/5738

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [ ] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [ ] I have made my changes in the `docs/sources/k6/next` folder of the documentation.
- [ ] I have reflected my changes in the `docs/sources/k6/v{most_recent_release}` folder of the documentation.
- [ ] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->

<!-- 2. If updating the documentation for the next release of k6: -->
- [ ] I have made my changes in the `docs/sources/k6/next` folder of the documentation.

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->
<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->