### PR TITLE
docs: add common browser arguments

### DIFF
--- a/docs/sources/k6/next/shared/browser/env-var-options.md
+++ b/docs/sources/k6/next/shared/browser/env-var-options.md
@@ -46,7 +46,7 @@ $env:K6_BROWSER_HEADLESS="false" ; $env:K6_BROWSER_ARGS='show-property-changed-r
 
 ### Browser arguments
 
-The following table highlights commonly useful arguments you can pass via the `K6_BROWSER_ARGS` environment variable. For the full list of arguments, refer to [Chromium command line switches](https://peter.sh/experiments/chromium-command-line-switches/).
+The following table highlights commonly useful arguments you can pass via the `K6_BROWSER_ARGS` environment variable. Most tests run without extra arguments, because the browser module already uses sensible [defaults](#default-arguments). Set these extra arguments only when you need to debug or adapt to your environment. For a complete list, refer to [Chromium command line switches](https://peter.sh/experiments/chromium-command-line-switches/).
 
 {{< admonition type="note" >}}
 

--- a/docs/sources/k6/next/shared/browser/env-var-options.md
+++ b/docs/sources/k6/next/shared/browser/env-var-options.md
@@ -4,7 +4,7 @@ title: browser/options
 
 | Environment Variable           | Description                                                                                                                                                                                                                                                                                                                                                              |
 | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| K6_BROWSER_ARGS                | Extra command line arguments to include when launching browser process. See [this link](https://peter.sh/experiments/chromium-command-line-switches/) for a list of Chromium arguments. Note that arguments should not start with `--` (see the command example below).                                                                                                  |
+| K6_BROWSER_ARGS                | Extra command line arguments to include when launching browser process. See the [browser arguments](https://grafana.com/docs/k6/<K6_VERSION>/using-k6-browser/options/#browser-arguments) for usage and common arguments.                                                                                                                                                |
 | K6_BROWSER_DEBUG               | All CDP messages and internal fine grained logs will be logged if set to `true`.                                                                                                                                                                                                                                                                                         |
 | K6_BROWSER_EXECUTABLE_PATH     | Override search for browser executable in favor of specified absolute path.                                                                                                                                                                                                                                                                                              |
 | K6_BROWSER_HEADLESS            | Show browser GUI or not. `true` by default.                                                                                                                                                                                                                                                                                                                              |
@@ -40,6 +40,45 @@ set "K6_BROWSER_HEADLESS=false" && set "K6_BROWSER_ARGS='show-property-changed-r
 
 ```windows-powershell
 $env:K6_BROWSER_HEADLESS="false" ; $env:K6_BROWSER_ARGS='show-property-changed-rects' ; k6 run script.js
+```
+
+{{< /code >}}
+
+### Browser arguments
+
+The following table highlights commonly useful arguments you can pass via the `K6_BROWSER_ARGS` environment variable. For the full list of arguments, refer to [Chromium command line switches](https://peter.sh/experiments/chromium-command-line-switches/).
+
+{{< admonition type="note" >}}
+
+Arguments should not start with `--` when passing them to `K6_BROWSER_ARGS`.
+
+{{< /admonition >}}
+
+| Argument                  | Type    | Description                                                                                                                                                                             |
+| ------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| disable-web-security      | boolean | Disables the same-origin policy. Useful when testing a site whose CORS configuration blocks the browser from interacting with cross-origin iframes or assets.                           |
+| ignore-certificate-errors | boolean | Ignores TLS certificate errors. Useful when testing against hosts with self-signed or otherwise invalid certificates.                                                                   |
+| no-sandbox                | boolean | Disables the Chromium sandbox. Needed when running as root inside Docker, CI, or Kubernetes. Only use with trustworthy targets.                                                         |
+| proxy-server              | string  | Routes browser traffic through an HTTP or SOCKS proxy. Pass the proxy address (`host:port`) as the value. Useful for corporate proxies or inspecting traffic with tools like mitmproxy. |
+
+For example, pass the following arguments to the `K6_BROWSER_ARGS` environment variable to ignore TLS certificate errors and route browser traffic through a proxy when running a browser test:
+
+{{< code >}}
+
+```bash
+K6_BROWSER_ARGS='ignore-certificate-errors,proxy-server=127.0.0.1:8080' k6 run script.js
+```
+
+```docker
+docker run --rm -i -e K6_BROWSER_ARGS='ignore-certificate-errors,proxy-server=127.0.0.1:8080' grafana/k6:master-with-browser run - <script.js
+```
+
+```windows
+set "K6_BROWSER_ARGS='ignore-certificate-errors,proxy-server=127.0.0.1:8080'" && k6 run script.js
+```
+
+```windows-powershell
+$env:K6_BROWSER_ARGS='ignore-certificate-errors,proxy-server=127.0.0.1:8080' ; k6 run script.js
 ```
 
 {{< /code >}}


### PR DESCRIPTION
## What?

Surfaces the most common browser arguments in the browser options.

## Why?

Users looking for a specific argument previously had to scan a long external list or ask on the community forum.

## Note

If this PR is approved, I'll backport the change to earlier versions.