### PR TITLE
Transfer ownership to grafana/k6-core

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,14 +1,1 @@
-# These owners will be the default owners for everything in
-# the repo.
-*       @heitortsergent
-
-# k6-engine (former k6-core) maintain open-source documentation
-/docs/sources/k6 @grafana/k6-core @heitortsergent
-/docs/sources/k6-studio @grafana/k6-Studio @heitortsergent
-
-# k6 Operator documentation
-/docs/sources/k6/*/set-up/set-up-distributed-k6 @yorugac @heitortsergent
-/docs/sources/k6/*/shared/k6-operator @yorugac @heitortsergent
-
-# k6 Extensions documentation
-/docs/sources/k6/*/extensions @grafana/k6-extensions @heitortsergent
+# These owners will be the default owners for


### PR DESCRIPTION
Replaces @grafana/k6-extensions with @grafana/k6-core in CODEOWNERS.