### PR TITLE
Transfer extension docs ownership to grafana/k6-core

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,13 +2,10 @@
 # the repo.
 *       @heitortsergent
 
-# k6-engine (former k6-core) maintain open-source documentation
+# k6-core maintain open-source documentation
 /docs/sources/k6 @grafana/k6-core @heitortsergent
 /docs/sources/k6-studio @grafana/k6-Studio @heitortsergent
 
 # k6 Operator documentation
 /docs/sources/k6/*/set-up/set-up-distributed-k6 @yorugac @heitortsergent
 /docs/sources/k6/*/shared/k6-operator @yorugac @heitortsergent
-
-# k6 Extensions documentation
-/docs/sources/k6/*/extensions @grafana/k6-extensions @heitortsergent


### PR DESCRIPTION
Updates CODEOWNERS to set grafana/k6-core the owner of all OSS components of k6