### PR TITLE
Revise k6 installation instructions for Debian/Ubuntu

### DIFF
--- a/docs/sources/k6/next/set-up/install-k6/_index.md
+++ b/docs/sources/k6/next/set-up/install-k6/_index.md
@@ -18,8 +18,7 @@ You can also use the k6 Studio desktop application to help you generate k6 scrip
 ### Debian/Ubuntu
 
 ```bash
-sudo gpg -k
-sudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
+curl -fsSL https://dl.k6.io/key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/k6-archive-keyring.gpg
 echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
 sudo apt-get update
 sudo apt-get install k6

--- a/docs/sources/k6/v2.0.x/set-up/install-k6/_index.md
+++ b/docs/sources/k6/v2.0.x/set-up/install-k6/_index.md
@@ -18,12 +18,18 @@ You can also use the k6 Studio desktop application to help you generate k6 scrip
 ### Debian/Ubuntu
 
 ```bash
-sudo gpg -k
-sudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
+curl -fsSL https://dl.k6.io/key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/k6-archive-keyring.gpg
 echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
 sudo apt-get update
 sudo apt-get install k6
 ```
+
+> ℹ️ Note:
+> Previous versions of the installation instructions used a keyserver-based method:
+> 
+> `gpg --recv-keys ...`
+> 
+> This approach is deprecated due to reliability issues and incompatibility with newer APT versions (e.g., Debian trixie using `sqv`). The current method uses a direct key download and `--dearmor` to ensure a valid binary keyring.
 
 ### Fedora/CentOS
 

--- a/docs/sources/k6/v2.0.x/set-up/install-k6/_index.md
+++ b/docs/sources/k6/v2.0.x/set-up/install-k6/_index.md
@@ -24,13 +24,6 @@ sudo apt-get update
 sudo apt-get install k6
 ```
 
-> ℹ️ Note:
-> Previous versions of the installation instructions used a keyserver-based method:
-> 
-> `gpg --recv-keys ...`
-> 
-> This approach is deprecated due to reliability issues and incompatibility with newer APT versions (e.g., Debian trixie using `sqv`). The current method uses a direct key download and `--dearmor` to ensure a valid binary keyring.
-
 ### Fedora/CentOS
 
 Using `dnf` (or `yum` on older versions):


### PR DESCRIPTION
## What?

Replaces the keyserver-based GPG key retrieval method (`gpg --recv-keys`) with a direct key download + `gpg --dearmor` approach for Debian/Ubuntu installation.

## Why?

The existing keyserver-based method can produce invalid or empty keyrings on newer Debian/Ubuntu systems (e.g., Debian trixie), leading to APT failures such as:

`Failed to parse keyring ... EOF`

This is due to stricter signature verification (`sqv`) and unreliable keyserver interactions.

The updated approach:
- ensures a valid binary keyring via `--dearmor`
- removes dependency on external keyservers (improves reliability)
- aligns with modern APT best practices

## Impact

- Improves first-run installation success rate
- Makes installation deterministic and CI-friendly
- Prevents common APT signature verification failures on newer systems