### PR TITLE
Add Lint docs workflow to check Markdown formatting

### DIFF
--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -1,0 +1,28 @@
+name: Lint docs
+
+on:
+  pull_request:
+    paths:
+      - 'docs/sources/**/*.md'
+
+permissions:
+  contents: read
+
+jobs:
+  prettier:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Check Markdown formatting
+        run: npx prettier --check --list-different=false --log-level=warn "docs/sources/**/*.md"


### PR DESCRIPTION
Adds a GitHub Actions workflow that runs `prettier --check` on `docs/sources/**/*.md` for pull requests that touch Markdown files.

We should run `prettier` on all the current files once before merging this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)