### PR TITLE
docs(rest-api): server off by default in k6 v2.0.0

### DIFF
--- a/docs/sources/k6/next/reference/k6-rest-api.md
+++ b/docs/sources/k6/next/reference/k6-rest-api.md
@@ -12,9 +12,21 @@ weight: 04
 
 # k6 REST API
 
-When k6 starts, it spins up an HTTP server with a REST API that can be used to control some
-parameters of the test execution. By default, that server listens on `localhost:6565`, but
-that can be modified by the `--address` CLI flag.
+k6 can expose an HTTP server with a REST API that can be used to control some parameters of
+the test execution.
+
+Starting in k6 v2.0.0, this server is **off by default**. To enable it, opt in by passing the
+`--address` CLI flag (or setting the `K6_ADDRESS` environment variable) when starting k6:
+
+```bash
+k6 run --address=localhost:6565 script.js
+```
+
+The address you pass is where the REST API listens. The examples below assume you started k6
+with `--address=localhost:6565`; if you use a different address, substitute it in the URLs.
+
+In earlier versions of k6, this server was on by default and listened on `localhost:6565` unless
+you opted out. The flag itself (`--address`) is unchanged.
 
 With this API you can see and control different execution aspects like number of VUs, Max
 VUs, pause or resume the test, list groups, set and get the setup data and so on.

--- a/docs/sources/k6/next/using-k6/k6-options/reference.md
+++ b/docs/sources/k6/next/using-k6/k6-options/reference.md
@@ -88,17 +88,19 @@ and `k6 cloud run ...`, which you can use to override options specified in the c
 
 ## Address
 
-Address of the API server. When executing scripts with `k6 run`, an HTTP server with a REST API is spun up,
-which can be used to control some of the parameters of the test execution.
+Address of the API server. When set, k6 starts an HTTP server with a REST API that can be used to
+control some of the parameters of the test execution.
 
-By default, the server listens on `localhost:6565`. Read more on [k6 REST API](https://grafana.com/docs/k6/<K6_VERSION>/reference/k6-rest-api). You can disable the HTTP server by setting the address value to an empty string, for example: `k6 run -a '' script.js`.
+Starting in k6 v2.0.0, the REST API server is **off by default**. To enable it, pass `--address`
+(or set `K6_ADDRESS`) with the address you want it to listen on. Read more on
+[k6 REST API](https://grafana.com/docs/k6/<K6_VERSION>/reference/k6-rest-api).
 
-| Env | CLI               | Code / Config file | Default          |
-| --- | ----------------- | ------------------ | ---------------- |
-| N/A | `--address`, `-a` | N/A                | `localhost:6565` |
+| Env          | CLI               | Code / Config file | Default                    |
+| ------------ | ----------------- | ------------------ | -------------------------- |
+| `K6_ADDRESS` | `--address`, `-a` | N/A                | _(unset; server disabled)_ |
 
 ```bash
-k6 run --address "localhost:3000" script.js
+k6 run --address "localhost:6565" script.js
 ```
 
 ## Batch
@@ -770,7 +772,8 @@ Enables profiling endpoints under the [k6 REST API [address](#address) to help d
 * [pprof](https://pkg.go.dev/net/http/pprof) profiling endpoints for CPU and memory profiling
 * Prometheus [/metrics](https://prometheus.io/docs/guides/go-application/#how-go-exposition-works) endpoint for exporting Go runtime metrics
 
-The k6 REST API must be enabled for these endpoints to be available (this is the default behavior).
+The k6 REST API must be enabled for these endpoints to be available. Starting in k6 v2.0.0, the
+REST API is off by default — pass [`--address`](#address) (or set `K6_ADDRESS`) when starting k6.
 
 | Env                    | CLI                   | Code / Config file | Default                              |
 | ---------------------- | --------------------- | ------------------ | ------------------------------------ |


### PR DESCRIPTION
## Summary

- The k6 REST API HTTP server no longer starts automatically as of k6 v2.0.0. Users must opt in by passing `--address` (or setting `K6_ADDRESS`).
- Updates the [k6 REST API](docs/sources/k6/next/reference/k6-rest-api.md) page intro to reflect the opt-in behavior and the previous default.
- Updates the [Address option reference](docs/sources/k6/next/using-k6/k6-options/reference.md#address) to add `K6_ADDRESS`, change the default to "unset; server disabled", and adjust the example.
- Updates the profiling-enabled note to point out that the REST API must now be turned on explicitly.

The `--address` / `-a` flag itself is unchanged.

Closes #2240

## Related

- k6 PR: https://github.com/grafana/k6/pull/5876
- Flag-name revert (kept `--address`/`K6_ADDRESS`): https://github.com/grafana/k6/commit/a4da91dc1

🤖 Generated with [Claude Code](https://claude.com/claude-code)