### PR TITLE
docs: document the k6 x mcp command and workflow

### DIFF
--- a/docs/sources/k6/next/extensions/create/subcommand-extensions.md
+++ b/docs/sources/k6/next/extensions/create/subcommand-extensions.md
@@ -96,6 +96,8 @@ K6_ENABLE_COMMUNITY_EXTENSIONS=true k6 x mytool
 
 {{< /admonition >}}
 
+For a real-world example of an official subcommand extension that ships through this exact path, see [the k6 MCP server](https://grafana.com/docs/k6/<K6_VERSION>/set-up/configure-ai-assistant/), which is exposed as `k6 x mcp`.
+
 ### Disable automatic extension resolution
 
 You can disable this feature by setting the environment variable `K6_AUTO_EXTENSION_RESOLUTION` to `false`:

--- a/docs/sources/k6/next/set-up/configure-ai-assistant/_index.md
+++ b/docs/sources/k6/next/set-up/configure-ai-assistant/_index.md
@@ -1,17 +1,17 @@
 ---
 title: Configure your AI assistant
-description: Connect mcp-k6 to your AI assistant or editor to get help writing, validating, and running k6 scripts.
+description: Connect the k6 MCP server to your AI assistant or editor to get help writing, validating, and running k6 scripts.
 weight: 110
 ---
 
 # Configure your AI assistant
 
-`mcp-k6` is an experimental [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server for k6.
+The k6 MCP server is an experimental [Model Context Protocol](https://modelcontextprotocol.io/) server for k6.
 Once connected to your AI assistant or MCP-compatible editor, it helps you write better k6 scripts faster and run them with confidence.
 
 ## What your assistant can do for you
 
-With `mcp-k6`, your AI assistant can:
+With the k6 MCP server, your AI assistant can:
 
 - **Write accurate scripts:** Create up-to-date scripts by **referring to** embedded k6 documentation and TypeScript definitions to reduce API hallucinations.
 - **Validate scripts:** Catch syntax errors, missing imports, and `export default function` declarations before execution.
@@ -20,11 +20,31 @@ With `mcp-k6`, your AI assistant can:
 - **Convert browser tests:** Transform Playwright tests into k6 browser scripts while preserving test logic.
 - **Automate provisioning:** Discover Terraform resources in your project to automate Grafana Cloud k6 setup.
 
-## Install mcp-k6
+## Run the k6 MCP server
 
-Choose one of the following installation methods.
+The simplest path is to invoke the server through k6 itself. To pin a specific version or run without a k6 install on the host, use the standalone `mcp-k6` distribution instead.
 
-### Docker (recommended)
+### k6 subcommand (recommended)
+
+If you already have [k6 installed](../install-k6/), you also have the k6 MCP server — invoke it as a subcommand:
+
+```sh
+k6 x mcp
+```
+
+The server is registered as an [official subcommand extension](../../extensions/create/subcommand-extensions/#use-automatic-extension-resolution). The first time you run `k6 x mcp`, k6 transparently fetches and runs the extension; subsequent invocations start immediately. By default the server speaks the **stdio** transport that every MCP client expects.
+
+Verify the command works:
+
+```sh
+k6 x mcp --help
+```
+
+{{< admonition type="note" >}}
+Auto-extension resolution runs the latest released version. To pin a specific version, use the standalone `mcp-k6` distribution below.
+{{< /admonition >}}
+
+### Docker
 
 Pull the image:
 
@@ -120,18 +140,45 @@ cd mcp-k6
 make install
 ```
 
+## Server flags
+
+The k6 MCP server accepts the following flags, whether you launch it via `k6 x mcp` or the standalone `mcp-k6` binary:
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--transport` | `stdio` | Transport to use: `stdio` or `http`. |
+| `--addr` | `:8080` | Listen address (HTTP transport only). |
+| `--endpoint` | `/mcp` | HTTP endpoint path (HTTP transport only). |
+| `--stateless` | `false` | Disable session tracking (HTTP transport only). |
+| `--preload` | `false` | Download all embedded documentation bundles at startup. |
+
+### Run over HTTP
+
+For shared development hosts where multiple clients connect to one server, start the k6 MCP server with the streamable HTTP transport:
+
+```sh
+k6 x mcp --transport=http --addr=:8080
+```
+
+Clients then connect to `http://<host>:8080/mcp`.
+
+{{< admonition type="caution" >}}
+The HTTP transport has no built-in authentication. Don't expose it on a public network — bind it to localhost or a trusted internal interface, and put it behind your own auth proxy if multiple users need access.
+{{< /admonition >}}
+
 ## Troubleshooting
 
 If your AI assistant cannot connect to the server:
 
 - **Check the logs:** Most editors (like Cursor or VS Code) have an "MCP Output" or "Logs" tab. Check there for "command not found" errors.
-- **Verify PATH:** If running natively, run `which k6` in your terminal to ensure k6 is globally accessible.
-- **Docker Permissions:** Ensure the Docker daemon is running and that your user has permission to execute `docker run`.
+- **Verify k6 is on PATH:** If running via `k6 x mcp`, run `which k6` to confirm k6 is globally accessible. If running natively, also run `which mcp-k6`.
+- **Check k6 version:** Auto-extension resolution requires a recent k6 release. Run `k6 version` and confirm you're on a version that supports `k6 x` subcommands.
+- **Docker permissions:** Ensure the Docker daemon is running and that your user has permission to execute `docker run`.
 - **Use MCP Inspector:** Use the [MCP Inspector](https://modelcontextprotocol.io/docs/tools/inspector) to debug the connection independently of your editor.
 
 ### Configure your editor
 
-After you install `mcp-k6`, refer to [Configure MCP clients](./configure-mcp-clients.md) to register the server with your editor and establish a connection.
+Once `k6 x mcp` runs (or you've installed `mcp-k6` standalone), refer to [Configure MCP clients](./configure-mcp-clients/) to register the server with your editor and establish a connection.
 
 - [Configure MCP clients](./configure-mcp-clients/)
 

--- a/docs/sources/k6/next/set-up/configure-ai-assistant/configure-mcp-clients.md
+++ b/docs/sources/k6/next/set-up/configure-ai-assistant/configure-mcp-clients.md
@@ -1,24 +1,40 @@
 ---
 title: Configure MCP clients
-description: Configure VS Code, Cursor, Claude Code, Codex, and other MCP clients to launch mcp-k6 over stdio.
+description: Configure VS Code, Cursor, Claude Code, Codex, and other MCP clients to launch the k6 MCP server via `k6 x mcp`, natively, or with Docker.
 weight: 100
 ---
 
 # Configure MCP clients
 
-`mcp-k6` communicates over **stdio** (stdin/stdout). Your MCP client registers mcp-k6 (or docker run ...) as a subprocess to establish a connection.
+The k6 MCP server communicates over **stdio** (stdin/stdout). Your MCP client registers it as a subprocess (`k6 x mcp`, the standalone `mcp-k6` binary, or `docker run ...`) to establish a connection.
 
 ## Prerequisites
 
-- If you run `mcp-k6` **natively**, ensure `mcp-k6` and `k6` are available on your `PATH`.
-- If you run `mcp-k6` **in Docker**, ensure Docker is installed and running.
+- If you launch the server via the **k6 subcommand** (`k6 x mcp`), ensure `k6` is available on your `PATH`.
+- If you launch the **standalone** `mcp-k6` binary, ensure `mcp-k6` and `k6` are available on your `PATH`.
+- If you launch the server **in Docker**, ensure Docker is installed and running.
 
 ## VS Code
 
-VS Code supports MCP servers through the GitHub Copilot extension. To use `mcp-k6` tools, you must use **Copilot Edits** (agent mode), which allows the assistant to call k6 commands and read test results.
+VS Code supports MCP servers through the GitHub Copilot extension. To use the k6 MCP server, you must use **Copilot Edits** (agent mode), which allows the assistant to call k6 commands and read test results.
 
 1. Open your user or workspace settings JSON (`settings.json`).
 2. Add the MCP server configuration.
+
+### k6 subcommand
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "k6": {
+        "command": "k6",
+        "args": ["x", "mcp"]
+      }
+    }
+  }
+}
+```
 
 ### Docker
 
@@ -51,9 +67,22 @@ VS Code supports MCP servers through the GitHub Copilot extension. To use `mcp-k
 
 ## Cursor
 
-Cursor reads MCP server definitions from your configuration. Add an entry to register mcp-k6 as a local MCP server using the stdio transport.
+Cursor reads MCP server definitions from your configuration. Add an entry to register the k6 MCP server as a local server using the stdio transport.
 
 Create or update your global configuration file (**~/.cursor/mcp.json**) or your project-specific file (**.cursor/mcp.json**):
+
+### k6 subcommand
+
+```json
+{
+  "mcpServers": {
+    "k6": {
+      "command": "k6",
+      "args": ["x", "mcp"]
+    }
+  }
+}
+```
 
 ### Docker
 
@@ -84,7 +113,15 @@ Restart Cursor or reload MCP servers, then verify the connection by invoking the
 
 ## Claude Code (CLI)
 
-Add `mcp-k6` to Claude Code using the `claude mcp add` command.
+Add the k6 MCP server to Claude Code using the `claude mcp add` command.
+
+### k6 subcommand
+
+```sh
+claude mcp add --scope=user --transport=stdio k6 -- k6 x mcp
+```
+
+The trailing `--` separates Claude Code's flags from the command it should launch, so `x` is passed to k6 instead of being parsed by `claude`.
 
 ### Docker
 
@@ -109,6 +146,19 @@ Codex CLI supports MCP servers over stdio.
 1. Locate your Codex configuration file. 
 If you are unsure of the location, run codex help config to find the file path.
 1. Add the MCP server configuration under the `mcpServers` key.
+
+### k6 subcommand
+
+```json
+{
+  "mcpServers": {
+    "k6": {
+      "command": "k6",
+      "args": ["x", "mcp"]
+    }
+  }
+}
+```
 
 ### Docker
 
@@ -139,7 +189,7 @@ Restart Codex or reload its configuration to activate the server.
 
 ## Other MCP clients
 
-If your MCP client is not in the previous list, you can use mcp-k6 with any client that supports stdio-based MCP servers.
+If your MCP client is not in the previous list, you can use the k6 MCP server with any client that supports stdio-based MCP servers.
 
 ### How MCP works
 
@@ -158,8 +208,8 @@ Most MCP clients require the following information:
 | Field | Description |
 |-------|-------------|
 | **name** | An identifier for the server (for example, `k6`). |
-| **command** | The program to run. For native installs, this is `mcp-k6`. For Docker, this is `docker`. |
-| **args** | Command-line arguments. For Docker, include `run`, `--rm`, `-i`, and the image name. |
+| **command** | The program to run. For `k6 x mcp`, this is `k6`. For native installs, `mcp-k6`. For Docker, `docker`. |
+| **args** | Command-line arguments. For `k6 x mcp`, this is `["x", "mcp"]`. For Docker, include `run`, `--rm`, `-i`, and the image name. |
 | **env** | Optional environment variables to pass to the server. |
 | **transport** | Usually `stdio` (some clients assume this by default). |
 

--- a/docs/sources/k6/next/set-up/configure-ai-assistant/tools-prompts-resources.md
+++ b/docs/sources/k6/next/set-up/configure-ai-assistant/tools-prompts-resources.md
@@ -1,26 +1,28 @@
 ---
 title: Tools, prompts, and resources
-description: Learn what MCP tools, prompts, and resources mcp-k6 provides, and how to use them.
+description: Learn what MCP tools, prompts, and resources the k6 MCP server provides, and how to use them.
 weight: 200
 ---
 
 # Tools, prompts, and resources
 
-`mcp-k6` exposes three kinds of MCP primitives:
+The k6 MCP server exposes three kinds of MCP primitives:
 
 - **Tools**: Allow your AI assistant to perform actions, such as validating or running a script.
 - **Prompts**: Guided workflows that help you generate scripts or convert existing tests.
 - **Resources**: Reference data, which includes docs and type definitions, that your assistant can consult for accurate answers.
 
+These primitives behave identically regardless of how you launch the server — via `k6 x mcp`, the standalone `mcp-k6` binary, or Docker.
+
 ## Tools
 
-Tools are the core capability of `mcp-k6`. Your AI assistant calls them automatically when it needs to validate code, run a test, or look up documentation.
+Tools are the core capability of the k6 MCP server. Your AI assistant calls them automatically when it needs to validate code, run a test, or look up documentation.
 
 ### info
 
 Returns runtime information about the server and local environment:
 
-- `mcp-k6` version
+- Server version
 - Detected `k6` version
 - Login status for Grafana Cloud k6 (via the k6 CLI)
 

--- a/docs/sources/k6/next/set-up/configure-your-code-editor.md
+++ b/docs/sources/k6/next/set-up/configure-your-code-editor.md
@@ -41,7 +41,7 @@ You can also find k6 code editor extensions for Visual Studio Code and IntelliJ 
 
 ## AI assistants (MCP)
 
-Connect k6 authoring and execution tools to MCP-compatible editors or assistants through `mcp-k6`.
+Connect k6 authoring and execution tools to MCP-compatible editors or assistants through the k6 MCP server. If you already have k6 installed, you can launch it directly with `k6 x mcp` — no extra install required.
 
 - [Configure your AI assistant](https://grafana.com/docs/k6/<K6_VERSION>/set-up/configure-ai-assistant/)
 


### PR DESCRIPTION
## What?

<!-- A description of the changes this PR brings to the documentation. -->
This PR updates the relevant documentation pages to account for v2.0's `k6 x mcp` command which allows to run the mcp server directly from k6 itself.

## Checklist

<!-- Please fill in this template: -->
- [X] I have used a meaningful title for the PR.
- [X] I have described the changes I've made in the "What?" section above.
- [X] I have performed a self-review of my changes.
- [X] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [X] I have made my changes in the `docs/sources/k6/next` folder of the documentation.

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->
<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->