### PR TITLE
Hts/fix heading js compatibility

### DIFF
--- a/docs/sources/k6/next/using-k6/javascript-typescript-compatibility-mode.md
+++ b/docs/sources/k6/next/using-k6/javascript-typescript-compatibility-mode.md
@@ -70,7 +70,7 @@ k6 uses [esbuild](https://esbuild.github.io/) to transpile TypeScript (TS) code 
 
 TypeScript support is partial as it strips the type information but doesn't provide type safety.
 
-### CommonJS Example
+## CommonJS Example
 
 ```javascript
 const http = require('k6/http');

--- a/docs/sources/k6/v1.8.x/using-k6/javascript-typescript-compatibility-mode.md
+++ b/docs/sources/k6/v1.8.x/using-k6/javascript-typescript-compatibility-mode.md
@@ -70,7 +70,7 @@ k6 uses [esbuild](https://esbuild.github.io/) to transpile TypeScript (TS) code 
 
 TypeScript support is partial as it strips the type information but doesn't provide type safety.
 
-### CommonJS Example
+## CommonJS Example
 
 ```javascript
 const http = require('k6/http');

--- a/docs/sources/k6/v2.0.x/using-k6/javascript-typescript-compatibility-mode.md
+++ b/docs/sources/k6/v2.0.x/using-k6/javascript-typescript-compatibility-mode.md
@@ -70,7 +70,7 @@ k6 uses [esbuild](https://esbuild.github.io/) to transpile TypeScript (TS) code 
 
 TypeScript support is partial as it strips the type information but doesn't provide type safety.
 
-### CommonJS Example
+## CommonJS Example
 
 ```javascript
 const http = require('k6/http');


### PR DESCRIPTION
## What?

Fix the CommonJS example heading from H3 -> H2 on the JS TS compatibility mode page.

## Checklist

<!-- Please fill in this template: -->
- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.

<!-- Select one of the options below and delete the other -->

<!-- 1. If updating the documentation for the most recent release of k6:  -->
- [x] I have made my changes in the `docs/sources/k6/next` folder of the documentation.
- [x] I have reflected my changes in the `docs/sources/k6/v{most_recent_release}` folder of the documentation.
- [x] I have reflected my changes in the relevant folders of the two previous k6 versions of the documentation (if still applicable to previous versions).
<!-- You can use the scripts/apply-patch scripts to help you port changes from one version folder to another. For more details, refer to [Use the `apply-patch` script](../CONTRIBUTING/README.md#use-the-apply-patch-script). -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->
<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->