### PR TITLE
ci(run-code-blocks): pin Go 1.25 for k6 master install

### DIFF
--- a/.github/workflows/run-code-blocks.yml
+++ b/.github/workflows/run-code-blocks.yml
@@ -25,6 +25,8 @@ jobs:
           files: |
             docs/sources/k6/next/**/*.md
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: '1.25'
       - name: Install k6 from github master
         run: go install go.k6.io/k6@master
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6


### PR DESCRIPTION
## What

Pin `go-version: '1.25'` on the `actions/setup-go` step in `.github/workflows/run-code-blocks.yml`.

## Why

k6 master now requires Go >= 1.25. The `setup-go` step pinned no version, so the runner used Go 1.24.x with `GOTOOLCHAIN=local`, and the `Install k6 from github master` step failed:

```
go: go.k6.io/k6@master: go.k6.io/k6@v1.7.1-... requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)
```

Because this step runs before any documentation code blocks are checked, the `run-code-blocks` check has been failing on every open PR in the repo, regardless of content. Pinning Go 1.25 restores the install step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)