### PR TITLE
docs: link OSS k6 docs to learning paths and course

### DIFF
--- a/docs/sources/k6/next/_index.md
+++ b/docs/sources/k6/next/_index.md
@@ -19,6 +19,10 @@ cards:
       href: ./get-started/
       description: Learn how to install the k6 CLI, run your first k6 test, and view metric results in the terminal.
       height: 24
+    - title: Getting started with k6 performance testing
+      href: https://grafana.com/docs/learning-hub/k6-performance-testing/
+      description: Take a hands-on Learning Hub course from your first script to automated baselines with Grafana Cloud.
+      height: 24
     - title: Using k6
       href: ./using-k6/
       description: Learn about k6 options and concepts such as thresholds, metrics, lifecycle hooks, and more.

--- a/docs/sources/k6/next/_index.md
+++ b/docs/sources/k6/next/_index.md
@@ -21,7 +21,7 @@ cards:
       height: 24
     - title: Getting started with k6 performance testing
       href: https://grafana.com/docs/learning-hub/k6-performance-testing/
-      description: Take a hands-on Learning Hub course from your first script to automated baselines with Grafana Cloud.
+      description: Take a hands-on Learning Hub course that walks you from your first script to automated baselines with Grafana Cloud.
       height: 24
     - title: Using k6
       href: ./using-k6/

--- a/docs/sources/k6/next/get-started/resources.md
+++ b/docs/sources/k6/next/get-started/resources.md
@@ -14,8 +14,8 @@ These resources help you write and run k6 tests in a safe environment and explor
 
 ## Learning
 
-- [Getting started with k6 performance testing](/docs/learning-hub/k6-performance-testing/). A Learning Hub course that walks you from your first script to automated baselines with Grafana Cloud.
-- [Run your first k6 performance test](/docs/learning-paths/run-first-k6-test/). A hands-on learning path to write, run, and analyze your first test.
+- [Getting started with k6 performance testing](https://grafana.com/docs/learning-hub/k6-performance-testing/). A Learning Hub course that walks you from your first script to automated baselines with Grafana Cloud.
+- [Run your first k6 performance test](https://grafana.com/docs/learning-paths/run-first-k6-test/). A hands-on learning path to write, run, and analyze your first test.
 - [Get started with k6 tutorial](https://grafana.com/docs/k6/<K6_VERSION>/examples/get-started-with-k6). The getting started tutorial provides some procedures for common real-life uses of k6 and does not require prior knowledge of k6 or JavaScript.
 - [k6 Learn](https://github.com/grafana/k6-learn). A repository with a course and a ton of learning resources.
 - [k6 OSS workshop](https://github.com/grafana/k6-oss-workshop). A 2-3 hour k6 workshop with practical k6 examples using the QuickPizza demo app.

--- a/docs/sources/k6/next/get-started/resources.md
+++ b/docs/sources/k6/next/get-started/resources.md
@@ -14,6 +14,8 @@ These resources help you write and run k6 tests in a safe environment and explor
 
 ## Learning
 
+- [Getting started with k6 performance testing](/docs/learning-hub/k6-performance-testing/). A Learning Hub course that walks you from your first script to automated baselines with Grafana Cloud.
+- [Run your first k6 performance test](/docs/learning-paths/run-first-k6-test/). A hands-on learning path to write, run, and analyze your first test.
 - [Get started with k6 tutorial](https://grafana.com/docs/k6/<K6_VERSION>/examples/get-started-with-k6). The getting started tutorial provides some procedures for common real-life uses of k6 and does not require prior knowledge of k6 or JavaScript.
 - [k6 Learn](https://github.com/grafana/k6-learn). A repository with a course and a ton of learning resources.
 - [k6 OSS workshop](https://github.com/grafana/k6-oss-workshop). A 2-3 hour k6 workshop with practical k6 examples using the QuickPizza demo app.

--- a/docs/sources/k6/next/get-started/write-your-first-test.md
+++ b/docs/sources/k6/next/get-started/write-your-first-test.md
@@ -14,6 +14,8 @@ k6 tests are written using the JavaScript or TypeScript programming language, ma
 
 Follow along and learn how to write your first test script, and start testing the reliability of your application.
 
+{{< docs/learning-paths title="Run your first k6 performance test" url="/docs/learning-paths/run-first-k6-test/" >}}
+
 ## Before you start
 
 To write k6 scripts, you'll need:

--- a/docs/sources/k6/next/get-started/write-your-first-test.md
+++ b/docs/sources/k6/next/get-started/write-your-first-test.md
@@ -14,7 +14,7 @@ k6 tests are written using the JavaScript or TypeScript programming language, ma
 
 Follow along and learn how to write your first test script, and start testing the reliability of your application.
 
-{{< docs/learning-paths title="Run your first k6 performance test" url="/docs/learning-paths/run-first-k6-test/" >}}
+{{< docs/learning-paths title="Run your first k6 performance test" url="https://grafana.com/docs/learning-paths/run-first-k6-test/" >}}
 
 ## Before you start
 

--- a/docs/sources/k6/next/testing-guides/automated-performance-testing.md
+++ b/docs/sources/k6/next/testing-guides/automated-performance-testing.md
@@ -20,9 +20,9 @@ This guide provides general recommendations to help you plan and define a strate
 
 Please note that this guide assumes you are familiar with k6 and already have performance tests. If you are new to performance testing or k6, we recommend looking at our [get-started resources](https://grafana.com/docs/k6/<K6_VERSION>/get-started/resources#learning).
 
-{{< docs/learning-paths title="Establish a performance baseline with k6" url="https://grafana.com/docs/learning-paths/establish-k6-baseline/" >}}
-
 Before we dive in, let's consider the "why" behind automation and how it unlocks the full benefits of your performance testing efforts.
+
+{{< docs/learning-paths title="Establish a performance baseline with k6" url="https://grafana.com/docs/learning-paths/establish-k6-baseline/" >}}
 
 ## Why automate performance tests
 

--- a/docs/sources/k6/next/testing-guides/automated-performance-testing.md
+++ b/docs/sources/k6/next/testing-guides/automated-performance-testing.md
@@ -20,6 +20,8 @@ This guide provides general recommendations to help you plan and define a strate
 
 Please note that this guide assumes you are familiar with k6 and already have performance tests. If you are new to performance testing or k6, we recommend looking at our [get-started resources](https://grafana.com/docs/k6/<K6_VERSION>/get-started/resources#learning).
 
+{{< docs/learning-paths title="Establish a performance baseline with k6" url="/docs/learning-paths/establish-k6-baseline/" >}}
+
 Before we dive in, let's consider the "why" behind automation and how it unlocks the full benefits of your performance testing efforts.
 
 ## Why automate performance tests

--- a/docs/sources/k6/next/testing-guides/automated-performance-testing.md
+++ b/docs/sources/k6/next/testing-guides/automated-performance-testing.md
@@ -20,7 +20,7 @@ This guide provides general recommendations to help you plan and define a strate
 
 Please note that this guide assumes you are familiar with k6 and already have performance tests. If you are new to performance testing or k6, we recommend looking at our [get-started resources](https://grafana.com/docs/k6/<K6_VERSION>/get-started/resources#learning).
 
-{{< docs/learning-paths title="Establish a performance baseline with k6" url="/docs/learning-paths/establish-k6-baseline/" >}}
+{{< docs/learning-paths title="Establish a performance baseline with k6" url="https://grafana.com/docs/learning-paths/establish-k6-baseline/" >}}
 
 Before we dive in, let's consider the "why" behind automation and how it unlocks the full benefits of your performance testing efforts.
 

--- a/docs/sources/k6/next/testing-guides/test-types/breakpoint-testing.md
+++ b/docs/sources/k6/next/testing-guides/test-types/breakpoint-testing.md
@@ -21,7 +21,7 @@ This test commonly has to be stopped manually or automatically as thresholds sta
 The breakpoint test is another test type with no clear naming consensus.
 In some testing conversation, it's also known as capacity, point load, and limit testing.
 
-{{< docs/learning-paths title="Find your system's limits with k6" url="/docs/learning-paths/find-k6-limits/" >}}
+{{< docs/learning-paths title="Find your system's limits with k6" url="https://grafana.com/docs/learning-paths/find-k6-limits/" >}}
 
 ## When to run a breakpoint test
 

--- a/docs/sources/k6/next/testing-guides/test-types/breakpoint-testing.md
+++ b/docs/sources/k6/next/testing-guides/test-types/breakpoint-testing.md
@@ -21,6 +21,8 @@ This test commonly has to be stopped manually or automatically as thresholds sta
 The breakpoint test is another test type with no clear naming consensus.
 In some testing conversation, it's also known as capacity, point load, and limit testing.
 
+{{< docs/learning-paths title="Find your system's limits with k6" url="/docs/learning-paths/find-k6-limits/" >}}
+
 ## When to run a breakpoint test
 
 Teams execute a breakpoint test whenever they must know their system's diverse limits. Some conditions that may warrant a breakpoint test include the following:

--- a/docs/sources/k6/next/testing-guides/test-types/load-testing.md
+++ b/docs/sources/k6/next/testing-guides/test-types/load-testing.md
@@ -16,7 +16,7 @@ Average-load tests simulate the number of concurrent users and requests per seco
 Since “load test” might refer to all types of tests that simulate traffic, this guide uses the name _average-load test_ to avoid confusion.
 In some testing conversation, this test also might be called a day-in-life test or volume test.
 
-{{< docs/learning-paths title="Establish a performance baseline with k6" url="/docs/learning-paths/establish-k6-baseline/" >}}
+{{< docs/learning-paths title="Establish a performance baseline with k6" url="https://grafana.com/docs/learning-paths/establish-k6-baseline/" >}}
 
 ## When to run an average-load test
 

--- a/docs/sources/k6/next/testing-guides/test-types/load-testing.md
+++ b/docs/sources/k6/next/testing-guides/test-types/load-testing.md
@@ -16,6 +16,8 @@ Average-load tests simulate the number of concurrent users and requests per seco
 Since “load test” might refer to all types of tests that simulate traffic, this guide uses the name _average-load test_ to avoid confusion.
 In some testing conversation, this test also might be called a day-in-life test or volume test.
 
+{{< docs/learning-paths title="Establish a performance baseline with k6" url="/docs/learning-paths/establish-k6-baseline/" >}}
+
 ## When to run an average-load test
 
 Average-Load testing helps understand whether a system meets performance goals on a typical day (commonplace load). _Typical day_ here means when an average number of users access the application at the same time, doing normal, average work.

--- a/docs/sources/k6/next/testing-guides/test-types/soak-testing.md
+++ b/docs/sources/k6/next/testing-guides/test-types/soak-testing.md
@@ -19,7 +19,7 @@ Though the duration is considerably longer, the ramp-up and ramp-down periods of
 
 In some testing conversation, a soak test might be called an endurance, constant high load, or stamina test.
 
-{{< docs/learning-paths title="Test system endurance with k6 soak testing" url="/docs/learning-paths/k6-soak-testing/" >}}
+{{< docs/learning-paths title="Test system endurance with k6 soak testing" url="https://grafana.com/docs/learning-paths/k6-soak-testing/" >}}
 
 ## When to perform a Soak test
 

--- a/docs/sources/k6/next/testing-guides/test-types/soak-testing.md
+++ b/docs/sources/k6/next/testing-guides/test-types/soak-testing.md
@@ -19,6 +19,8 @@ Though the duration is considerably longer, the ramp-up and ramp-down periods of
 
 In some testing conversation, a soak test might be called an endurance, constant high load, or stamina test.
 
+{{< docs/learning-paths title="Test system endurance with k6 soak testing" url="/docs/learning-paths/k6-soak-testing/" >}}
+
 ## When to perform a Soak test
 
 Most systems must stay turned on and keep working for days, weeks, and months without intervention. This test verifies the system stability and reliability over extended periods of use.

--- a/docs/sources/k6/next/testing-guides/test-types/spike-testing.md
+++ b/docs/sources/k6/next/testing-guides/test-types/spike-testing.md
@@ -20,7 +20,7 @@ Occasionally, teams should revamp the system to allow or prioritize resources fo
 
 ![Overview of a spike test](/media/docs/k6-oss/chart-spike-test-overview.png)
 
-{{< docs/learning-paths title="Test resilience with k6 spike testing" url="/docs/learning-paths/k6-spike-testing/" >}}
+{{< docs/learning-paths title="Test resilience with k6 spike testing" url="https://grafana.com/docs/learning-paths/k6-spike-testing/" >}}
 
 ## When to perform a spike test
 

--- a/docs/sources/k6/next/testing-guides/test-types/spike-testing.md
+++ b/docs/sources/k6/next/testing-guides/test-types/spike-testing.md
@@ -20,6 +20,8 @@ Occasionally, teams should revamp the system to allow or prioritize resources fo
 
 ![Overview of a spike test](/media/docs/k6-oss/chart-spike-test-overview.png)
 
+{{< docs/learning-paths title="Test resilience with k6 spike testing" url="/docs/learning-paths/k6-spike-testing/" >}}
+
 ## When to perform a spike test
 
 This test must be executed when the system expects to receive a sudden rush of activity.

--- a/docs/sources/k6/next/testing-guides/test-types/stress-testing.md
+++ b/docs/sources/k6/next/testing-guides/test-types/stress-testing.md
@@ -17,6 +17,8 @@ Similarly, after the test reaches the desired load, it might last for slightly l
 
 In some testing conversation, stress tests might also be called rush-hour, surge, or scale tests.
 
+{{< docs/learning-paths title="Find your system's limits with k6" url="/docs/learning-paths/find-k6-limits/" >}}
+
 ## When to perform a Stress test
 
 Stress tests verify the stability and reliability of the system under conditions of heavy use.

--- a/docs/sources/k6/next/testing-guides/test-types/stress-testing.md
+++ b/docs/sources/k6/next/testing-guides/test-types/stress-testing.md
@@ -17,7 +17,7 @@ Similarly, after the test reaches the desired load, it might last for slightly l
 
 In some testing conversation, stress tests might also be called rush-hour, surge, or scale tests.
 
-{{< docs/learning-paths title="Find your system's limits with k6" url="/docs/learning-paths/find-k6-limits/" >}}
+{{< docs/learning-paths title="Find your system's limits with k6" url="https://grafana.com/docs/learning-paths/find-k6-limits/" >}}
 
 ## When to perform a Stress test
 

--- a/docs/sources/k6/v2.1.x/_index.md
+++ b/docs/sources/k6/v2.1.x/_index.md
@@ -19,6 +19,10 @@ cards:
       href: ./get-started/
       description: Learn how to install the k6 CLI, run your first k6 test, and view metric results in the terminal.
       height: 24
+    - title: Getting started with k6 performance testing
+      href: https://grafana.com/docs/learning-hub/k6-performance-testing/
+      description: Take a hands-on Learning Hub course from your first script to automated baselines with Grafana Cloud.
+      height: 24
     - title: Using k6
       href: ./using-k6/
       description: Learn about k6 options and concepts such as thresholds, metrics, lifecycle hooks, and more.

--- a/docs/sources/k6/v2.1.x/_index.md
+++ b/docs/sources/k6/v2.1.x/_index.md
@@ -21,7 +21,7 @@ cards:
       height: 24
     - title: Getting started with k6 performance testing
       href: https://grafana.com/docs/learning-hub/k6-performance-testing/
-      description: Take a hands-on Learning Hub course from your first script to automated baselines with Grafana Cloud.
+      description: Take a hands-on Learning Hub course that walks you from your first script to automated baselines with Grafana Cloud.
       height: 24
     - title: Using k6
       href: ./using-k6/

--- a/docs/sources/k6/v2.1.x/get-started/resources.md
+++ b/docs/sources/k6/v2.1.x/get-started/resources.md
@@ -14,8 +14,8 @@ These resources help you write and run k6 tests in a safe environment and explor
 
 ## Learning
 
-- [Getting started with k6 performance testing](/docs/learning-hub/k6-performance-testing/). A Learning Hub course that walks you from your first script to automated baselines with Grafana Cloud.
-- [Run your first k6 performance test](/docs/learning-paths/run-first-k6-test/). A hands-on learning path to write, run, and analyze your first test.
+- [Getting started with k6 performance testing](https://grafana.com/docs/learning-hub/k6-performance-testing/). A Learning Hub course that walks you from your first script to automated baselines with Grafana Cloud.
+- [Run your first k6 performance test](https://grafana.com/docs/learning-paths/run-first-k6-test/). A hands-on learning path to write, run, and analyze your first test.
 - [Get started with k6 tutorial](https://grafana.com/docs/k6/<K6_VERSION>/examples/get-started-with-k6). The getting started tutorial provides some procedures for common real-life uses of k6 and does not require prior knowledge of k6 or JavaScript.
 - [k6 Learn](https://github.com/grafana/k6-learn). A repository with a course and a ton of learning resources.
 - [k6 OSS workshop](https://github.com/grafana/k6-oss-workshop). A 2-3 hour k6 workshop with practical k6 examples using the QuickPizza demo app.

--- a/docs/sources/k6/v2.1.x/get-started/resources.md
+++ b/docs/sources/k6/v2.1.x/get-started/resources.md
@@ -14,6 +14,8 @@ These resources help you write and run k6 tests in a safe environment and explor
 
 ## Learning
 
+- [Getting started with k6 performance testing](/docs/learning-hub/k6-performance-testing/). A Learning Hub course that walks you from your first script to automated baselines with Grafana Cloud.
+- [Run your first k6 performance test](/docs/learning-paths/run-first-k6-test/). A hands-on learning path to write, run, and analyze your first test.
 - [Get started with k6 tutorial](https://grafana.com/docs/k6/<K6_VERSION>/examples/get-started-with-k6). The getting started tutorial provides some procedures for common real-life uses of k6 and does not require prior knowledge of k6 or JavaScript.
 - [k6 Learn](https://github.com/grafana/k6-learn). A repository with a course and a ton of learning resources.
 - [k6 OSS workshop](https://github.com/grafana/k6-oss-workshop). A 2-3 hour k6 workshop with practical k6 examples using the QuickPizza demo app.

--- a/docs/sources/k6/v2.1.x/get-started/write-your-first-test.md
+++ b/docs/sources/k6/v2.1.x/get-started/write-your-first-test.md
@@ -14,6 +14,8 @@ k6 tests are written using the JavaScript or TypeScript programming language, ma
 
 Follow along and learn how to write your first test script, and start testing the reliability of your application.
 
+{{< docs/learning-paths title="Run your first k6 performance test" url="/docs/learning-paths/run-first-k6-test/" >}}
+
 ## Before you start
 
 To write k6 scripts, you'll need:

--- a/docs/sources/k6/v2.1.x/get-started/write-your-first-test.md
+++ b/docs/sources/k6/v2.1.x/get-started/write-your-first-test.md
@@ -14,7 +14,7 @@ k6 tests are written using the JavaScript or TypeScript programming language, ma
 
 Follow along and learn how to write your first test script, and start testing the reliability of your application.
 
-{{< docs/learning-paths title="Run your first k6 performance test" url="/docs/learning-paths/run-first-k6-test/" >}}
+{{< docs/learning-paths title="Run your first k6 performance test" url="https://grafana.com/docs/learning-paths/run-first-k6-test/" >}}
 
 ## Before you start
 

--- a/docs/sources/k6/v2.1.x/testing-guides/automated-performance-testing.md
+++ b/docs/sources/k6/v2.1.x/testing-guides/automated-performance-testing.md
@@ -20,9 +20,9 @@ This guide provides general recommendations to help you plan and define a strate
 
 Please note that this guide assumes you are familiar with k6 and already have performance tests. If you are new to performance testing or k6, we recommend looking at our [get-started resources](https://grafana.com/docs/k6/<K6_VERSION>/get-started/resources#learning).
 
-{{< docs/learning-paths title="Establish a performance baseline with k6" url="https://grafana.com/docs/learning-paths/establish-k6-baseline/" >}}
-
 Before we dive in, let's consider the "why" behind automation and how it unlocks the full benefits of your performance testing efforts.
+
+{{< docs/learning-paths title="Establish a performance baseline with k6" url="https://grafana.com/docs/learning-paths/establish-k6-baseline/" >}}
 
 ## Why automate performance tests
 

--- a/docs/sources/k6/v2.1.x/testing-guides/automated-performance-testing.md
+++ b/docs/sources/k6/v2.1.x/testing-guides/automated-performance-testing.md
@@ -20,6 +20,8 @@ This guide provides general recommendations to help you plan and define a strate
 
 Please note that this guide assumes you are familiar with k6 and already have performance tests. If you are new to performance testing or k6, we recommend looking at our [get-started resources](https://grafana.com/docs/k6/<K6_VERSION>/get-started/resources#learning).
 
+{{< docs/learning-paths title="Establish a performance baseline with k6" url="/docs/learning-paths/establish-k6-baseline/" >}}
+
 Before we dive in, let's consider the "why" behind automation and how it unlocks the full benefits of your performance testing efforts.
 
 ## Why automate performance tests

--- a/docs/sources/k6/v2.1.x/testing-guides/automated-performance-testing.md
+++ b/docs/sources/k6/v2.1.x/testing-guides/automated-performance-testing.md
@@ -20,7 +20,7 @@ This guide provides general recommendations to help you plan and define a strate
 
 Please note that this guide assumes you are familiar with k6 and already have performance tests. If you are new to performance testing or k6, we recommend looking at our [get-started resources](https://grafana.com/docs/k6/<K6_VERSION>/get-started/resources#learning).
 
-{{< docs/learning-paths title="Establish a performance baseline with k6" url="/docs/learning-paths/establish-k6-baseline/" >}}
+{{< docs/learning-paths title="Establish a performance baseline with k6" url="https://grafana.com/docs/learning-paths/establish-k6-baseline/" >}}
 
 Before we dive in, let's consider the "why" behind automation and how it unlocks the full benefits of your performance testing efforts.
 

--- a/docs/sources/k6/v2.1.x/testing-guides/test-types/breakpoint-testing.md
+++ b/docs/sources/k6/v2.1.x/testing-guides/test-types/breakpoint-testing.md
@@ -21,7 +21,7 @@ This test commonly has to be stopped manually or automatically as thresholds sta
 The breakpoint test is another test type with no clear naming consensus.
 In some testing conversation, it's also known as capacity, point load, and limit testing.
 
-{{< docs/learning-paths title="Find your system's limits with k6" url="/docs/learning-paths/find-k6-limits/" >}}
+{{< docs/learning-paths title="Find your system's limits with k6" url="https://grafana.com/docs/learning-paths/find-k6-limits/" >}}
 
 ## When to run a breakpoint test
 

--- a/docs/sources/k6/v2.1.x/testing-guides/test-types/breakpoint-testing.md
+++ b/docs/sources/k6/v2.1.x/testing-guides/test-types/breakpoint-testing.md
@@ -21,6 +21,8 @@ This test commonly has to be stopped manually or automatically as thresholds sta
 The breakpoint test is another test type with no clear naming consensus.
 In some testing conversation, it's also known as capacity, point load, and limit testing.
 
+{{< docs/learning-paths title="Find your system's limits with k6" url="/docs/learning-paths/find-k6-limits/" >}}
+
 ## When to run a breakpoint test
 
 Teams execute a breakpoint test whenever they must know their system's diverse limits. Some conditions that may warrant a breakpoint test include the following:

--- a/docs/sources/k6/v2.1.x/testing-guides/test-types/load-testing.md
+++ b/docs/sources/k6/v2.1.x/testing-guides/test-types/load-testing.md
@@ -16,7 +16,7 @@ Average-load tests simulate the number of concurrent users and requests per seco
 Since “load test” might refer to all types of tests that simulate traffic, this guide uses the name _average-load test_ to avoid confusion.
 In some testing conversation, this test also might be called a day-in-life test or volume test.
 
-{{< docs/learning-paths title="Establish a performance baseline with k6" url="/docs/learning-paths/establish-k6-baseline/" >}}
+{{< docs/learning-paths title="Establish a performance baseline with k6" url="https://grafana.com/docs/learning-paths/establish-k6-baseline/" >}}
 
 ## When to run an average-load test
 

--- a/docs/sources/k6/v2.1.x/testing-guides/test-types/load-testing.md
+++ b/docs/sources/k6/v2.1.x/testing-guides/test-types/load-testing.md
@@ -16,6 +16,8 @@ Average-load tests simulate the number of concurrent users and requests per seco
 Since “load test” might refer to all types of tests that simulate traffic, this guide uses the name _average-load test_ to avoid confusion.
 In some testing conversation, this test also might be called a day-in-life test or volume test.
 
+{{< docs/learning-paths title="Establish a performance baseline with k6" url="/docs/learning-paths/establish-k6-baseline/" >}}
+
 ## When to run an average-load test
 
 Average-Load testing helps understand whether a system meets performance goals on a typical day (commonplace load). _Typical day_ here means when an average number of users access the application at the same time, doing normal, average work.

--- a/docs/sources/k6/v2.1.x/testing-guides/test-types/soak-testing.md
+++ b/docs/sources/k6/v2.1.x/testing-guides/test-types/soak-testing.md
@@ -19,7 +19,7 @@ Though the duration is considerably longer, the ramp-up and ramp-down periods of
 
 In some testing conversation, a soak test might be called an endurance, constant high load, or stamina test.
 
-{{< docs/learning-paths title="Test system endurance with k6 soak testing" url="/docs/learning-paths/k6-soak-testing/" >}}
+{{< docs/learning-paths title="Test system endurance with k6 soak testing" url="https://grafana.com/docs/learning-paths/k6-soak-testing/" >}}
 
 ## When to perform a Soak test
 

--- a/docs/sources/k6/v2.1.x/testing-guides/test-types/soak-testing.md
+++ b/docs/sources/k6/v2.1.x/testing-guides/test-types/soak-testing.md
@@ -19,6 +19,8 @@ Though the duration is considerably longer, the ramp-up and ramp-down periods of
 
 In some testing conversation, a soak test might be called an endurance, constant high load, or stamina test.
 
+{{< docs/learning-paths title="Test system endurance with k6 soak testing" url="/docs/learning-paths/k6-soak-testing/" >}}
+
 ## When to perform a Soak test
 
 Most systems must stay turned on and keep working for days, weeks, and months without intervention. This test verifies the system stability and reliability over extended periods of use.

--- a/docs/sources/k6/v2.1.x/testing-guides/test-types/spike-testing.md
+++ b/docs/sources/k6/v2.1.x/testing-guides/test-types/spike-testing.md
@@ -20,7 +20,7 @@ Occasionally, teams should revamp the system to allow or prioritize resources fo
 
 ![Overview of a spike test](/media/docs/k6-oss/chart-spike-test-overview.png)
 
-{{< docs/learning-paths title="Test resilience with k6 spike testing" url="/docs/learning-paths/k6-spike-testing/" >}}
+{{< docs/learning-paths title="Test resilience with k6 spike testing" url="https://grafana.com/docs/learning-paths/k6-spike-testing/" >}}
 
 ## When to perform a spike test
 

--- a/docs/sources/k6/v2.1.x/testing-guides/test-types/spike-testing.md
+++ b/docs/sources/k6/v2.1.x/testing-guides/test-types/spike-testing.md
@@ -20,6 +20,8 @@ Occasionally, teams should revamp the system to allow or prioritize resources fo
 
 ![Overview of a spike test](/media/docs/k6-oss/chart-spike-test-overview.png)
 
+{{< docs/learning-paths title="Test resilience with k6 spike testing" url="/docs/learning-paths/k6-spike-testing/" >}}
+
 ## When to perform a spike test
 
 This test must be executed when the system expects to receive a sudden rush of activity.

--- a/docs/sources/k6/v2.1.x/testing-guides/test-types/stress-testing.md
+++ b/docs/sources/k6/v2.1.x/testing-guides/test-types/stress-testing.md
@@ -17,6 +17,8 @@ Similarly, after the test reaches the desired load, it might last for slightly l
 
 In some testing conversation, stress tests might also be called rush-hour, surge, or scale tests.
 
+{{< docs/learning-paths title="Find your system's limits with k6" url="/docs/learning-paths/find-k6-limits/" >}}
+
 ## When to perform a Stress test
 
 Stress tests verify the stability and reliability of the system under conditions of heavy use.

--- a/docs/sources/k6/v2.1.x/testing-guides/test-types/stress-testing.md
+++ b/docs/sources/k6/v2.1.x/testing-guides/test-types/stress-testing.md
@@ -17,7 +17,7 @@ Similarly, after the test reaches the desired load, it might last for slightly l
 
 In some testing conversation, stress tests might also be called rush-hour, surge, or scale tests.
 
-{{< docs/learning-paths title="Find your system's limits with k6" url="/docs/learning-paths/find-k6-limits/" >}}
+{{< docs/learning-paths title="Find your system's limits with k6" url="https://grafana.com/docs/learning-paths/find-k6-limits/" >}}
 
 ## When to perform a Stress test
 


### PR DESCRIPTION
## Summary
- Add the Getting started with k6 performance testing course and first-test learning path on the get-started resources page (`next` and `v2.1.x`).
- Add topic learning-path CTAs on matching test-type pages (average-load, stress, breakpoint, spike, soak), without repeating the same links on the test-types index.

## Test plan
- [ ] Confirm resources Learning section lists course + first-test path
- [ ] Confirm each linked test-type page shows one matching learning-path CTA
- [ ] Confirm test-types index has no duplicate learning-path list


Made with [Cursor](https://cursor.com)