### PR TITLE
docs(cloud): document --local-execution log streaming

### DIFF
--- a/docs/sources/k6/next/results-output/real-time/cloud.md
+++ b/docs/sources/k6/next/results-output/real-time/cloud.md
@@ -102,3 +102,13 @@ This behavior can be deactivated by adding the `--no-archive-upload` option to y
 command: `k6 cloud run --local-execution --no-archive-upload script.js`.
 
 {{< /admonition >}}
+
+## Stream logs to the cloud
+
+Starting in k6 v2.2.0, `k6 cloud run --local-execution` also streams k6's logs to Grafana Cloud k6. You can view them in the test run alongside the results, the same as a test that runs on cloud servers. Your local log output is unaffected.
+
+To stop streaming logs to the cloud, pass `--no-cloud-logs`:
+
+```bash
+K6_CLOUD_TOKEN=<YOUR_API_TOKEN> K6_CLOUD_STACK_ID=<YOUR_STACK_ID> k6 cloud run --local-execution --no-cloud-logs script.js
+```

--- a/docs/sources/k6/next/results-output/real-time/cloud.md
+++ b/docs/sources/k6/next/results-output/real-time/cloud.md
@@ -110,5 +110,5 @@ Starting in k6 v2.2.0, `k6 cloud run --local-execution` also streams k6's logs t
 To stop streaming logs to the cloud, pass `--no-cloud-logs`:
 
 ```bash
-K6_CLOUD_TOKEN=<YOUR_API_TOKEN> K6_CLOUD_STACK_ID=<YOUR_STACK_ID> k6 cloud run --local-execution --no-cloud-logs script.js
+k6 cloud run --local-execution --no-cloud-logs script.js
 ```


### PR DESCRIPTION
## What?

Documents that `k6 cloud run --local-execution` streams k6's logs to Grafana Cloud k6, and the `--no-cloud-logs` opt-out. Applies to `next` only.

## Why?

k6 now streams `--local-execution` logs to the cloud run (grafana/k6#6171).

## Related PR(s)/Issue(s)

- Related to grafana/k6#6171