### PR TITLE
Document tlsAIAFetch option for AIA chain fetching

### DIFF
--- a/docs/sources/k6/next/using-k6/k6-options/reference.md
+++ b/docs/sources/k6/next/using-k6/k6-options/reference.md
@@ -75,6 +75,7 @@ Each option has its own detailed reference in a separate section.
 | [Teardown timeout](#teardown-timeout)                        | Specify how long the teardown() function is allowed to run before it's terminated                                                                                                                                                                                                                                                                |
 | [Thresholds](#thresholds)                                    | Configure under what conditions a test is successful or not                                                                                                                                                                                                                                                                                      |
 | [Throw](#throw)                                              | A boolean specifying whether to throw errors on failed HTTP requests                                                                                                                                                                                                                                                                             |
+| [TLS AIA fetch](#tls-aia-fetch)                              | A boolean that lets k6 fetch missing intermediate CA certificates via the Authority Information Access (AIA) extension                                                                                                                                                                                                                           |
 | [TLS auth](#tls-auth)                                        | A list of TLS client certificate configuration objects                                                                                                                                                                                                                                                                                           |
 | [TLS cipher suites](#tls-cipher-suites)                      | A list of cipher suites allowed to be used by in SSL/TLS interactions with a server                                                                                                                                                                                                                                                              |
 | [TLS version](#tls-version)                                  | String or object representing the only SSL/TLS version allowed                                                                                                                                                                                                                                                                                   |
@@ -1265,6 +1266,22 @@ Available in `k6 run` and `k6 cloud` commands.
 ```javascript
 export const options = {
   throw: true,
+};
+```
+
+## TLS AIA fetch
+
+A boolean, true or false. When enabled, k6 follows the Authority Information Access (AIA) extension on server-presented certificates to fetch missing intermediate CA certificates over HTTP. This lets k6 verify TLS chains against servers that don't bundle the full chain in their handshake, which browsers do by default but Go's `crypto/tls` does not.
+
+Fetched intermediates are cached and reused for the lifetime of the test, and AIA fetches respect the same blocking, host override, and DNS rules as regular test traffic. This option has no effect when `insecureSkipTLSVerify` is enabled.
+
+| Env                | CLI | Code / Config file | Default |
+| ------------------ | --- | ------------------ | ------- |
+| `K6_TLS_AIA_FETCH` | N/A | `tlsAIAFetch`      | `false` |
+
+```javascript
+export const options = {
+  tlsAIAFetch: true,
 };
 ```
 

--- a/docs/sources/k6/next/using-k6/protocols/ssl-tls/_index.md
+++ b/docs/sources/k6/next/using-k6/protocols/ssl-tls/_index.md
@@ -35,4 +35,5 @@ Each is worth discussing in more detail:
 - [TLS version and ciphers](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/protocols/ssl-tls/ssl-tls-version-and-ciphers) (restricting as
   well as checking what was used for a HTTP request by checking response object properties)
 - [Online Certificate Status Protocol (OCSP)](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/protocols/ssl-tls/online-certificate-status-protocol--ocsp)
+- [AIA fetching for missing intermediates](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference/#tls-aia-fetch) (opt-in via `tlsAIAFetch`, for servers that rely on Authority Information Access rather than bundling the full chain)
 - [Response.timings.tls_handshaking](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-http/response)


### PR DESCRIPTION
## What?

Adds documentation for the new `tlsAIAFetch` option landing in [grafana/k6#6137](https://github.com/grafana/k6/pull/6137). The option lets k6 follow the Authority Information Access (AIA) extension on server-presented certificates to fetch missing intermediate CA certificates over HTTP — behavior browsers do by default but Go's `crypto/tls` does not.

Changes:

- **`docs/sources/k6/next/using-k6/k6-options/reference.md`** — quick-reference table row and a full `## TLS AIA fetch` section (alphabetically before `TLS auth`), mirroring the shape of sibling TLS options (`tlsAuth`, `tlsCipherSuites`, `tlsVersion`).
- **`docs/sources/k6/next/using-k6/protocols/ssl-tls/_index.md`** — one bullet in the "supports the following" list so the feature is discoverable from the SSL/TLS landing page.

<img width="780" height="570" alt="Screenshot 2026-08-06 at 10 50 24" src="https://github.com/user-attachments/assets/a260fe75-70d5-4f90-88d3-2a750affec8f" />
<img width="824" height="215" alt="Screenshot 2026-08-06 at 10 49 56" src="https://github.com/user-attachments/assets/59c6aee5-7a08-4316-8b5f-11a7d40e63f2" />


## Checklist

- [x] I have used a meaningful title for the PR.
- [x] I have described the changes I've made in the "What?" section above.
- [x] I have performed a self-review of my changes.
- [x] I have run the `npm start` command locally and verified that the changes look good.

<!-- next release only -->

- [x] I have made my changes in the `docs/sources/k6/next` folder of the documentation.

## Related PR(s)/Issue(s)

- grafana/k6#6137 (feature implementation)