### PR TITLE
docs: update removed summary options

### DIFF
--- a/docs/sources/k6/next/extensions/create/output-extensions.md
+++ b/docs/sources/k6/next/extensions/create/output-extensions.md
@@ -204,13 +204,13 @@ export default function () {
 1. Now, run the test.
 
 ```bash
-./k6 run test.js --out logger --quiet --no-summary --iterations 2
+./k6 run test.js --out logger --quiet --summary-mode=disabled --iterations 2
 ```
 
 {{< admonition type="note" >}}
 
 The `--out logger` argument tells k6 to use your custom output. The flag
-`--quiet --no-summary` configures k6 to show only custom output.
+`--quiet --summary-mode=disabled` configures k6 to show only custom output.
 
 {{< /admonition >}}
 

--- a/docs/sources/k6/next/extensions/create/secret-source_extensions.md
+++ b/docs/sources/k6/next/extensions/create/secret-source_extensions.md
@@ -196,13 +196,13 @@ export default async () => {
 1. Now, run the test.
 
 ```bash
-./k6 run test.js --secret-source=cli=cool=some,else=console --quiet --no-summary
+./k6 run test.js --secret-source=cli=cool=some,else=console --quiet --summary-mode=disabled
 ```
 
 {{< admonition type="note" >}}
 
 The `--secret-source=cli=cool=some,else=console` argument tells k6 to use your custom secret source and gives its configuration.
-The flag `--quiet --no-summary` configures k6 to show only custom output.
+The flag `--quiet --summary-mode=disabled` configures k6 to show only custom output.
 
 {{< /admonition >}}
 

--- a/docs/sources/k6/next/results-output/end-of-test/_index.md
+++ b/docs/sources/k6/next/results-output/end-of-test/_index.md
@@ -14,7 +14,7 @@ k6 provides three different ways to display test results through the [`--summary
 
 - **compact** (default): Displays the most relevant test results in a concise format.
 - **full**: Includes everything from the compact format, plus additional k6 metrics and detailed results for each group and scenario.
-- **legacy**: Uses the pre-v1.0.0 summary format for backward compatibility.
+- **disabled**: Disables the end-of-test summary.
 
 ### Compact mode (default)
 
@@ -216,10 +216,11 @@ When using full mode, you'll see additional sections:
 
 Customize the summary output with these options:
 
-- [`--summary-mode`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-mode): Choose between compact, full, or legacy display
-- [`--no-summary`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#no-summary): Disable the end-of-test report
+- [`--summary-mode`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-mode): Choose between compact, full, or disabled display
 - [`--summary-trend-stats`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-trend-stats): Select which statistics to show for Trend metrics
 - [`--summary-time-unit`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-time-unit): Set a consistent time unit for all values
+
+The `--no-summary` flag and the `legacy` summary mode were removed in k6 v2.0.0. Use `--summary-mode=disabled` to disable the summary. There is no direct equivalent for the `legacy` mode; use `compact` or `full` instead.
 
 ## Going further
 

--- a/docs/sources/k6/next/testing-guides/injecting-faults-with-xk6-disruptor/examples/inject-http-faults-into-pod.md
+++ b/docs/sources/k6/next/testing-guides/injecting-faults-with-xk6-disruptor/examples/inject-http-faults-into-pod.md
@@ -140,11 +140,11 @@ We will first execute the test without introducing faults to have an baseline us
 {{< code >}}
 
 ```bash
-xk6-disruptor run --env SKIP_FAULTS=1 --env SVC_IP=$SVC_IP --summary-mode=legacy disrupt-pod.js
+xk6-disruptor run --env SKIP_FAULTS=1 --env SVC_IP=$SVC_IP --summary-mode=compact disrupt-pod.js
 ```
 
 ```windows-powershell
-xk6-disruptor run --env SKIP_FAULTS=1 --env "SVC_IP=$Env:SVC_IP" --summary-mode=legacy disrupt-pod.js
+xk6-disruptor run --env SKIP_FAULTS=1 --env "SVC_IP=$Env:SVC_IP" --summary-mode=compact disrupt-pod.js
 ```
 
 {{< /code >}}
@@ -199,11 +199,11 @@ We repeat the execution injecting the faults. Notice we have removed the `--env 
 {{< code >}}
 
 ```bash
-xk6-disruptor run --env SVC_IP=$SVC_IP --summary-mode=legacy disrupt-pod.js
+xk6-disruptor run --env SVC_IP=$SVC_IP --summary-mode=compact disrupt-pod.js
 ```
 
 ```windows-powershell
-xk6-disruptor run --env "SVC_IP=$Env:SVC_IP" --summary-mode=legacy disrupt-pod.js
+xk6-disruptor run --env "SVC_IP=$Env:SVC_IP" --summary-mode=compact disrupt-pod.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/next/testing-guides/injecting-faults-with-xk6-disruptor/examples/inject-http-faults-into-pod.md
+++ b/docs/sources/k6/next/testing-guides/injecting-faults-with-xk6-disruptor/examples/inject-http-faults-into-pod.md
@@ -140,11 +140,11 @@ We will first execute the test without introducing faults to have an baseline us
 {{< code >}}
 
 ```bash
-xk6-disruptor run --env SKIP_FAULTS=1 --env SVC_IP=$SVC_IP --summary-mode=compact disrupt-pod.js
+xk6-disruptor run --env SKIP_FAULTS=1 --env SVC_IP=$SVC_IP disrupt-pod.js
 ```
 
 ```windows-powershell
-xk6-disruptor run --env SKIP_FAULTS=1 --env "SVC_IP=$Env:SVC_IP" --summary-mode=compact disrupt-pod.js
+xk6-disruptor run --env SKIP_FAULTS=1 --env "SVC_IP=$Env:SVC_IP" disrupt-pod.js
 ```
 
 {{< /code >}}
@@ -199,11 +199,11 @@ We repeat the execution injecting the faults. Notice we have removed the `--env 
 {{< code >}}
 
 ```bash
-xk6-disruptor run --env SVC_IP=$SVC_IP --summary-mode=compact disrupt-pod.js
+xk6-disruptor run --env SVC_IP=$SVC_IP disrupt-pod.js
 ```
 
 ```windows-powershell
-xk6-disruptor run --env "SVC_IP=$Env:SVC_IP" --summary-mode=compact disrupt-pod.js
+xk6-disruptor run --env "SVC_IP=$Env:SVC_IP" disrupt-pod.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/next/testing-guides/running-large-tests.md
+++ b/docs/sources/k6/next/testing-guides/running-large-tests.md
@@ -174,7 +174,7 @@ export const options = {
 
 If you need the response body for some requests, override the option with [Params.responseType](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-http/params).
 
-### When streaming, use `--no-thresholds` and `--no-summary`
+### When streaming, use `--no-thresholds` and `--summary-mode=disabled`
 
 If you're running a local test and streaming results to the cloud (`k6 cloud run script.js --local-execution`), you might want to disable the terminal summary and local threshold calculation, because the cloud service will display the summary and calculate the thresholds.
 
@@ -189,7 +189,7 @@ k6 cloud run scripts/website.js \
   --vus=20000 \
   --duration=10m \
   --no-thresholds \
-  --no-summary
+  --summary-mode=disabled
 ```
 
 ## Script optimizations

--- a/docs/sources/k6/next/using-k6/assertions.md
+++ b/docs/sources/k6/next/using-k6/assertions.md
@@ -366,7 +366,7 @@ export default async function () {
 For tests that primarily use assertions to validate system state, such as tests verifying a successful deployment in CI pipelines, run k6 tests with assertions in quiet mode:
 
 ```bash
-k6 run --quiet --no-summary script.ts
+k6 run --quiet --summary-mode=disabled script.ts
 ```
 
 This approach eliminates unnecessary output and focuses on the assertion results, making it ideal for automated testing environments.

--- a/docs/sources/k6/v1.3.x/extensions/create/output-extensions.md
+++ b/docs/sources/k6/v1.3.x/extensions/create/output-extensions.md
@@ -204,13 +204,13 @@ export default function () {
 1. Now, run the test.
 
 ```bash
-./k6 run test.js --out logger --quiet --no-summary --iterations 2
+./k6 run test.js --out logger --quiet --summary-mode=disabled --iterations 2
 ```
 
 {{< admonition type="note" >}}
 
 The `--out logger` argument tells k6 to use your custom output. The flag
-`--quiet --no-summary` configures k6 to show only custom output.
+`--quiet --summary-mode=disabled` configures k6 to show only custom output.
 
 {{< /admonition >}}
 

--- a/docs/sources/k6/v1.3.x/extensions/create/secret-source_extensions.md
+++ b/docs/sources/k6/v1.3.x/extensions/create/secret-source_extensions.md
@@ -196,13 +196,13 @@ export default async () => {
 1. Now, run the test.
 
 ```bash
-./k6 run test.js --secret-source=cli=cool=some,else=console --quiet --no-summary
+./k6 run test.js --secret-source=cli=cool=some,else=console --quiet --summary-mode=disabled
 ```
 
 {{< admonition type="note" >}}
 
 The `--secret-source=cli=cool=some,else=console` argument tells k6 to use your custom secret source and gives its configuration.
-The flag `--quiet --no-summary` configures k6 to show only custom output.
+The flag `--quiet --summary-mode=disabled` configures k6 to show only custom output.
 
 {{< /admonition >}}
 

--- a/docs/sources/k6/v1.3.x/results-output/end-of-test/_index.md
+++ b/docs/sources/k6/v1.3.x/results-output/end-of-test/_index.md
@@ -10,11 +10,12 @@ When a test finishes, k6 prints a summary of the aggregated results to `stdout`.
 
 ## Summary modes
 
-k6 provides three different ways to display test results through the [`--summary-mode` option](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-mode):
+k6 provides four different ways to display test results through the [`--summary-mode` option](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-mode):
 
 - **compact** (default): Displays the most relevant test results in a concise format.
 - **full**: Includes everything from the compact format, plus additional k6 metrics and detailed results for each group and scenario.
-- **legacy**: Uses the pre-v1.0.0 summary format for backward compatibility.
+- **disabled**: Disables the end-of-test summary.
+- **legacy** (*deprecated*): Uses the pre-v1.0.0 summary format for backward compatibility. This mode will be removed in k6 v2.0.0.
 
 ### Compact mode (default)
 
@@ -216,8 +217,8 @@ When using full mode, you'll see additional sections:
 
 Customize the summary output with these options:
 
-- [`--summary-mode`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-mode): Choose between compact, full, or legacy display
-- [`--no-summary`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#no-summary): Disable the end-of-test report
+- [`--summary-mode`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-mode): Choose between compact, full, disabled, or legacy display. The `legacy` mode is deprecated and will be removed in k6 v2.0.0.
+- [`--no-summary`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#no-summary): Disable the end-of-test report. This option is deprecated since k6 v1.3.0; use `--summary-mode=disabled` instead.
 - [`--summary-trend-stats`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-trend-stats): Select which statistics to show for Trend metrics
 - [`--summary-time-unit`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-time-unit): Set a consistent time unit for all values
 

--- a/docs/sources/k6/v1.3.x/testing-guides/injecting-faults-with-xk6-disruptor/examples/inject-http-faults-into-pod.md
+++ b/docs/sources/k6/v1.3.x/testing-guides/injecting-faults-with-xk6-disruptor/examples/inject-http-faults-into-pod.md
@@ -140,11 +140,11 @@ We will first execute the test without introducing faults to have an baseline us
 {{< code >}}
 
 ```bash
-xk6-disruptor run --env SKIP_FAULTS=1 --env SVC_IP=$SVC_IP --summary-mode=legacy disrupt-pod.js
+xk6-disruptor run --env SKIP_FAULTS=1 --env SVC_IP=$SVC_IP --summary-mode=compact disrupt-pod.js
 ```
 
 ```windows-powershell
-xk6-disruptor run --env SKIP_FAULTS=1 --env "SVC_IP=$Env:SVC_IP" --summary-mode=legacy disrupt-pod.js
+xk6-disruptor run --env SKIP_FAULTS=1 --env "SVC_IP=$Env:SVC_IP" --summary-mode=compact disrupt-pod.js
 ```
 
 {{< /code >}}
@@ -199,11 +199,11 @@ We repeat the execution injecting the faults. Notice we have removed the `--env 
 {{< code >}}
 
 ```bash
-xk6-disruptor run --env SVC_IP=$SVC_IP --summary-mode=legacy disrupt-pod.js
+xk6-disruptor run --env SVC_IP=$SVC_IP --summary-mode=compact disrupt-pod.js
 ```
 
 ```windows-powershell
-xk6-disruptor run --env "SVC_IP=$Env:SVC_IP" --summary-mode=legacy disrupt-pod.js
+xk6-disruptor run --env "SVC_IP=$Env:SVC_IP" --summary-mode=compact disrupt-pod.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v1.3.x/testing-guides/injecting-faults-with-xk6-disruptor/examples/inject-http-faults-into-pod.md
+++ b/docs/sources/k6/v1.3.x/testing-guides/injecting-faults-with-xk6-disruptor/examples/inject-http-faults-into-pod.md
@@ -140,11 +140,11 @@ We will first execute the test without introducing faults to have an baseline us
 {{< code >}}
 
 ```bash
-xk6-disruptor run --env SKIP_FAULTS=1 --env SVC_IP=$SVC_IP --summary-mode=compact disrupt-pod.js
+xk6-disruptor run --env SKIP_FAULTS=1 --env SVC_IP=$SVC_IP disrupt-pod.js
 ```
 
 ```windows-powershell
-xk6-disruptor run --env SKIP_FAULTS=1 --env "SVC_IP=$Env:SVC_IP" --summary-mode=compact disrupt-pod.js
+xk6-disruptor run --env SKIP_FAULTS=1 --env "SVC_IP=$Env:SVC_IP" disrupt-pod.js
 ```
 
 {{< /code >}}
@@ -199,11 +199,11 @@ We repeat the execution injecting the faults. Notice we have removed the `--env 
 {{< code >}}
 
 ```bash
-xk6-disruptor run --env SVC_IP=$SVC_IP --summary-mode=compact disrupt-pod.js
+xk6-disruptor run --env SVC_IP=$SVC_IP disrupt-pod.js
 ```
 
 ```windows-powershell
-xk6-disruptor run --env "SVC_IP=$Env:SVC_IP" --summary-mode=compact disrupt-pod.js
+xk6-disruptor run --env "SVC_IP=$Env:SVC_IP" disrupt-pod.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v1.3.x/testing-guides/running-large-tests.md
+++ b/docs/sources/k6/v1.3.x/testing-guides/running-large-tests.md
@@ -174,7 +174,7 @@ export const options = {
 
 If you need the response body for some requests, override the option with [Params.responseType](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-http/params).
 
-### When streaming, use `--no-thresholds` and `--no-summary`
+### When streaming, use `--no-thresholds` and `--summary-mode=disabled`
 
 If you're running a local test and streaming results to the cloud (`k6 cloud run script.js --local-execution`), you might want to disable the terminal summary and local threshold calculation, because the cloud service will display the summary and calculate the thresholds.
 
@@ -189,7 +189,7 @@ k6 cloud run scripts/website.js \
   --vus=20000 \
   --duration=10m \
   --no-thresholds \
-  --no-summary
+  --summary-mode=disabled
 ```
 
 ## Script optimizations

--- a/docs/sources/k6/v1.3.x/using-k6/assertions.md
+++ b/docs/sources/k6/v1.3.x/using-k6/assertions.md
@@ -366,7 +366,7 @@ export default async function () {
 For tests that primarily use assertions to validate system state, such as tests verifying a successful deployment in CI pipelines, run k6 tests with assertions in quiet mode:
 
 ```bash
-k6 run --quiet --no-summary script.ts
+k6 run --quiet --summary-mode=disabled script.ts
 ```
 
 This approach eliminates unnecessary output and focuses on the assertion results, making it ideal for automated testing environments.

--- a/docs/sources/k6/v1.4.x/extensions/create/output-extensions.md
+++ b/docs/sources/k6/v1.4.x/extensions/create/output-extensions.md
@@ -204,13 +204,13 @@ export default function () {
 1. Now, run the test.
 
 ```bash
-./k6 run test.js --out logger --quiet --no-summary --iterations 2
+./k6 run test.js --out logger --quiet --summary-mode=disabled --iterations 2
 ```
 
 {{< admonition type="note" >}}
 
 The `--out logger` argument tells k6 to use your custom output. The flag
-`--quiet --no-summary` configures k6 to show only custom output.
+`--quiet --summary-mode=disabled` configures k6 to show only custom output.
 
 {{< /admonition >}}
 

--- a/docs/sources/k6/v1.4.x/extensions/create/secret-source_extensions.md
+++ b/docs/sources/k6/v1.4.x/extensions/create/secret-source_extensions.md
@@ -196,13 +196,13 @@ export default async () => {
 1. Now, run the test.
 
 ```bash
-./k6 run test.js --secret-source=cli=cool=some,else=console --quiet --no-summary
+./k6 run test.js --secret-source=cli=cool=some,else=console --quiet --summary-mode=disabled
 ```
 
 {{< admonition type="note" >}}
 
 The `--secret-source=cli=cool=some,else=console` argument tells k6 to use your custom secret source and gives its configuration.
-The flag `--quiet --no-summary` configures k6 to show only custom output.
+The flag `--quiet --summary-mode=disabled` configures k6 to show only custom output.
 
 {{< /admonition >}}
 

--- a/docs/sources/k6/v1.4.x/results-output/end-of-test/_index.md
+++ b/docs/sources/k6/v1.4.x/results-output/end-of-test/_index.md
@@ -10,11 +10,12 @@ When a test finishes, k6 prints a summary of the aggregated results to `stdout`.
 
 ## Summary modes
 
-k6 provides three different ways to display test results through the [`--summary-mode` option](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-mode):
+k6 provides four different ways to display test results through the [`--summary-mode` option](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-mode):
 
 - **compact** (default): Displays the most relevant test results in a concise format.
 - **full**: Includes everything from the compact format, plus additional k6 metrics and detailed results for each group and scenario.
-- **legacy**: Uses the pre-v1.0.0 summary format for backward compatibility.
+- **disabled**: Disables the end-of-test summary.
+- **legacy** (*deprecated*): Uses the pre-v1.0.0 summary format for backward compatibility. This mode will be removed in k6 v2.0.0.
 
 ### Compact mode (default)
 
@@ -216,8 +217,8 @@ When using full mode, you'll see additional sections:
 
 Customize the summary output with these options:
 
-- [`--summary-mode`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-mode): Choose between compact, full, or legacy display
-- [`--no-summary`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#no-summary): Disable the end-of-test report
+- [`--summary-mode`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-mode): Choose between compact, full, disabled, or legacy display. The `legacy` mode is deprecated and will be removed in k6 v2.0.0.
+- [`--no-summary`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#no-summary): Disable the end-of-test report. This option is deprecated since k6 v1.3.0; use `--summary-mode=disabled` instead.
 - [`--summary-trend-stats`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-trend-stats): Select which statistics to show for Trend metrics
 - [`--summary-time-unit`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-time-unit): Set a consistent time unit for all values
 

--- a/docs/sources/k6/v1.4.x/testing-guides/injecting-faults-with-xk6-disruptor/examples/inject-http-faults-into-pod.md
+++ b/docs/sources/k6/v1.4.x/testing-guides/injecting-faults-with-xk6-disruptor/examples/inject-http-faults-into-pod.md
@@ -140,11 +140,11 @@ We will first execute the test without introducing faults to have an baseline us
 {{< code >}}
 
 ```bash
-xk6-disruptor run --env SKIP_FAULTS=1 --env SVC_IP=$SVC_IP --summary-mode=legacy disrupt-pod.js
+xk6-disruptor run --env SKIP_FAULTS=1 --env SVC_IP=$SVC_IP --summary-mode=compact disrupt-pod.js
 ```
 
 ```windows-powershell
-xk6-disruptor run --env SKIP_FAULTS=1 --env "SVC_IP=$Env:SVC_IP" --summary-mode=legacy disrupt-pod.js
+xk6-disruptor run --env SKIP_FAULTS=1 --env "SVC_IP=$Env:SVC_IP" --summary-mode=compact disrupt-pod.js
 ```
 
 {{< /code >}}
@@ -199,11 +199,11 @@ We repeat the execution injecting the faults. Notice we have removed the `--env 
 {{< code >}}
 
 ```bash
-xk6-disruptor run --env SVC_IP=$SVC_IP --summary-mode=legacy disrupt-pod.js
+xk6-disruptor run --env SVC_IP=$SVC_IP --summary-mode=compact disrupt-pod.js
 ```
 
 ```windows-powershell
-xk6-disruptor run --env "SVC_IP=$Env:SVC_IP" --summary-mode=legacy disrupt-pod.js
+xk6-disruptor run --env "SVC_IP=$Env:SVC_IP" --summary-mode=compact disrupt-pod.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v1.4.x/testing-guides/injecting-faults-with-xk6-disruptor/examples/inject-http-faults-into-pod.md
+++ b/docs/sources/k6/v1.4.x/testing-guides/injecting-faults-with-xk6-disruptor/examples/inject-http-faults-into-pod.md
@@ -140,11 +140,11 @@ We will first execute the test without introducing faults to have an baseline us
 {{< code >}}
 
 ```bash
-xk6-disruptor run --env SKIP_FAULTS=1 --env SVC_IP=$SVC_IP --summary-mode=compact disrupt-pod.js
+xk6-disruptor run --env SKIP_FAULTS=1 --env SVC_IP=$SVC_IP disrupt-pod.js
 ```
 
 ```windows-powershell
-xk6-disruptor run --env SKIP_FAULTS=1 --env "SVC_IP=$Env:SVC_IP" --summary-mode=compact disrupt-pod.js
+xk6-disruptor run --env SKIP_FAULTS=1 --env "SVC_IP=$Env:SVC_IP" disrupt-pod.js
 ```
 
 {{< /code >}}
@@ -199,11 +199,11 @@ We repeat the execution injecting the faults. Notice we have removed the `--env 
 {{< code >}}
 
 ```bash
-xk6-disruptor run --env SVC_IP=$SVC_IP --summary-mode=compact disrupt-pod.js
+xk6-disruptor run --env SVC_IP=$SVC_IP disrupt-pod.js
 ```
 
 ```windows-powershell
-xk6-disruptor run --env "SVC_IP=$Env:SVC_IP" --summary-mode=compact disrupt-pod.js
+xk6-disruptor run --env "SVC_IP=$Env:SVC_IP" disrupt-pod.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v1.4.x/testing-guides/running-large-tests.md
+++ b/docs/sources/k6/v1.4.x/testing-guides/running-large-tests.md
@@ -174,7 +174,7 @@ export const options = {
 
 If you need the response body for some requests, override the option with [Params.responseType](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-http/params).
 
-### When streaming, use `--no-thresholds` and `--no-summary`
+### When streaming, use `--no-thresholds` and `--summary-mode=disabled`
 
 If you're running a local test and streaming results to the cloud (`k6 cloud run script.js --local-execution`), you might want to disable the terminal summary and local threshold calculation, because the cloud service will display the summary and calculate the thresholds.
 
@@ -189,7 +189,7 @@ k6 cloud run scripts/website.js \
   --vus=20000 \
   --duration=10m \
   --no-thresholds \
-  --no-summary
+  --summary-mode=disabled
 ```
 
 ## Script optimizations

--- a/docs/sources/k6/v1.4.x/using-k6/assertions.md
+++ b/docs/sources/k6/v1.4.x/using-k6/assertions.md
@@ -366,7 +366,7 @@ export default async function () {
 For tests that primarily use assertions to validate system state, such as tests verifying a successful deployment in CI pipelines, run k6 tests with assertions in quiet mode:
 
 ```bash
-k6 run --quiet --no-summary script.ts
+k6 run --quiet --summary-mode=disabled script.ts
 ```
 
 This approach eliminates unnecessary output and focuses on the assertion results, making it ideal for automated testing environments.

--- a/docs/sources/k6/v1.5.x/extensions/create/output-extensions.md
+++ b/docs/sources/k6/v1.5.x/extensions/create/output-extensions.md
@@ -204,13 +204,13 @@ export default function () {
 1. Now, run the test.
 
 ```bash
-./k6 run test.js --out logger --quiet --no-summary --iterations 2
+./k6 run test.js --out logger --quiet --summary-mode=disabled --iterations 2
 ```
 
 {{< admonition type="note" >}}
 
 The `--out logger` argument tells k6 to use your custom output. The flag
-`--quiet --no-summary` configures k6 to show only custom output.
+`--quiet --summary-mode=disabled` configures k6 to show only custom output.
 
 {{< /admonition >}}
 

--- a/docs/sources/k6/v1.5.x/extensions/create/secret-source_extensions.md
+++ b/docs/sources/k6/v1.5.x/extensions/create/secret-source_extensions.md
@@ -196,13 +196,13 @@ export default async () => {
 1. Now, run the test.
 
 ```bash
-./k6 run test.js --secret-source=cli=cool=some,else=console --quiet --no-summary
+./k6 run test.js --secret-source=cli=cool=some,else=console --quiet --summary-mode=disabled
 ```
 
 {{< admonition type="note" >}}
 
 The `--secret-source=cli=cool=some,else=console` argument tells k6 to use your custom secret source and gives its configuration.
-The flag `--quiet --no-summary` configures k6 to show only custom output.
+The flag `--quiet --summary-mode=disabled` configures k6 to show only custom output.
 
 {{< /admonition >}}
 

--- a/docs/sources/k6/v1.5.x/results-output/end-of-test/_index.md
+++ b/docs/sources/k6/v1.5.x/results-output/end-of-test/_index.md
@@ -10,11 +10,12 @@ When a test finishes, k6 prints a summary of the aggregated results to `stdout`.
 
 ## Summary modes
 
-k6 provides three different ways to display test results through the [`--summary-mode` option](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-mode):
+k6 provides four different ways to display test results through the [`--summary-mode` option](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-mode):
 
 - **compact** (default): Displays the most relevant test results in a concise format.
 - **full**: Includes everything from the compact format, plus additional k6 metrics and detailed results for each group and scenario.
-- **legacy**: Uses the pre-v1.0.0 summary format for backward compatibility.
+- **disabled**: Disables the end-of-test summary.
+- **legacy** (*deprecated*): Uses the pre-v1.0.0 summary format for backward compatibility. This mode will be removed in k6 v2.0.0.
 
 ### Compact mode (default)
 
@@ -216,8 +217,8 @@ When using full mode, you'll see additional sections:
 
 Customize the summary output with these options:
 
-- [`--summary-mode`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-mode): Choose between compact, full, or legacy display
-- [`--no-summary`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#no-summary): Disable the end-of-test report
+- [`--summary-mode`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-mode): Choose between compact, full, disabled, or legacy display. The `legacy` mode is deprecated and will be removed in k6 v2.0.0.
+- [`--no-summary`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#no-summary): Disable the end-of-test report. This option is deprecated since k6 v1.3.0; use `--summary-mode=disabled` instead.
 - [`--summary-trend-stats`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-trend-stats): Select which statistics to show for Trend metrics
 - [`--summary-time-unit`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-time-unit): Set a consistent time unit for all values
 

--- a/docs/sources/k6/v1.5.x/testing-guides/injecting-faults-with-xk6-disruptor/examples/inject-http-faults-into-pod.md
+++ b/docs/sources/k6/v1.5.x/testing-guides/injecting-faults-with-xk6-disruptor/examples/inject-http-faults-into-pod.md
@@ -140,11 +140,11 @@ We will first execute the test without introducing faults to have an baseline us
 {{< code >}}
 
 ```bash
-xk6-disruptor run --env SKIP_FAULTS=1 --env SVC_IP=$SVC_IP --summary-mode=legacy disrupt-pod.js
+xk6-disruptor run --env SKIP_FAULTS=1 --env SVC_IP=$SVC_IP --summary-mode=compact disrupt-pod.js
 ```
 
 ```windows-powershell
-xk6-disruptor run --env SKIP_FAULTS=1 --env "SVC_IP=$Env:SVC_IP" --summary-mode=legacy disrupt-pod.js
+xk6-disruptor run --env SKIP_FAULTS=1 --env "SVC_IP=$Env:SVC_IP" --summary-mode=compact disrupt-pod.js
 ```
 
 {{< /code >}}
@@ -199,11 +199,11 @@ We repeat the execution injecting the faults. Notice we have removed the `--env 
 {{< code >}}
 
 ```bash
-xk6-disruptor run --env SVC_IP=$SVC_IP --summary-mode=legacy disrupt-pod.js
+xk6-disruptor run --env SVC_IP=$SVC_IP --summary-mode=compact disrupt-pod.js
 ```
 
 ```windows-powershell
-xk6-disruptor run --env "SVC_IP=$Env:SVC_IP" --summary-mode=legacy disrupt-pod.js
+xk6-disruptor run --env "SVC_IP=$Env:SVC_IP" --summary-mode=compact disrupt-pod.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v1.5.x/testing-guides/injecting-faults-with-xk6-disruptor/examples/inject-http-faults-into-pod.md
+++ b/docs/sources/k6/v1.5.x/testing-guides/injecting-faults-with-xk6-disruptor/examples/inject-http-faults-into-pod.md
@@ -140,11 +140,11 @@ We will first execute the test without introducing faults to have an baseline us
 {{< code >}}
 
 ```bash
-xk6-disruptor run --env SKIP_FAULTS=1 --env SVC_IP=$SVC_IP --summary-mode=compact disrupt-pod.js
+xk6-disruptor run --env SKIP_FAULTS=1 --env SVC_IP=$SVC_IP disrupt-pod.js
 ```
 
 ```windows-powershell
-xk6-disruptor run --env SKIP_FAULTS=1 --env "SVC_IP=$Env:SVC_IP" --summary-mode=compact disrupt-pod.js
+xk6-disruptor run --env SKIP_FAULTS=1 --env "SVC_IP=$Env:SVC_IP" disrupt-pod.js
 ```
 
 {{< /code >}}
@@ -199,11 +199,11 @@ We repeat the execution injecting the faults. Notice we have removed the `--env 
 {{< code >}}
 
 ```bash
-xk6-disruptor run --env SVC_IP=$SVC_IP --summary-mode=compact disrupt-pod.js
+xk6-disruptor run --env SVC_IP=$SVC_IP disrupt-pod.js
 ```
 
 ```windows-powershell
-xk6-disruptor run --env "SVC_IP=$Env:SVC_IP" --summary-mode=compact disrupt-pod.js
+xk6-disruptor run --env "SVC_IP=$Env:SVC_IP" disrupt-pod.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v1.5.x/testing-guides/running-large-tests.md
+++ b/docs/sources/k6/v1.5.x/testing-guides/running-large-tests.md
@@ -174,7 +174,7 @@ export const options = {
 
 If you need the response body for some requests, override the option with [Params.responseType](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-http/params).
 
-### When streaming, use `--no-thresholds` and `--no-summary`
+### When streaming, use `--no-thresholds` and `--summary-mode=disabled`
 
 If you're running a local test and streaming results to the cloud (`k6 cloud run script.js --local-execution`), you might want to disable the terminal summary and local threshold calculation, because the cloud service will display the summary and calculate the thresholds.
 
@@ -189,7 +189,7 @@ k6 cloud run scripts/website.js \
   --vus=20000 \
   --duration=10m \
   --no-thresholds \
-  --no-summary
+  --summary-mode=disabled
 ```
 
 ## Script optimizations

--- a/docs/sources/k6/v1.5.x/using-k6/assertions.md
+++ b/docs/sources/k6/v1.5.x/using-k6/assertions.md
@@ -366,7 +366,7 @@ export default async function () {
 For tests that primarily use assertions to validate system state, such as tests verifying a successful deployment in CI pipelines, run k6 tests with assertions in quiet mode:
 
 ```bash
-k6 run --quiet --no-summary script.ts
+k6 run --quiet --summary-mode=disabled script.ts
 ```
 
 This approach eliminates unnecessary output and focuses on the assertion results, making it ideal for automated testing environments.

--- a/docs/sources/k6/v1.6.x/extensions/create/output-extensions.md
+++ b/docs/sources/k6/v1.6.x/extensions/create/output-extensions.md
@@ -204,13 +204,13 @@ export default function () {
 1. Now, run the test.
 
 ```bash
-./k6 run test.js --out logger --quiet --no-summary --iterations 2
+./k6 run test.js --out logger --quiet --summary-mode=disabled --iterations 2
 ```
 
 {{< admonition type="note" >}}
 
 The `--out logger` argument tells k6 to use your custom output. The flag
-`--quiet --no-summary` configures k6 to show only custom output.
+`--quiet --summary-mode=disabled` configures k6 to show only custom output.
 
 {{< /admonition >}}
 

--- a/docs/sources/k6/v1.6.x/extensions/create/secret-source_extensions.md
+++ b/docs/sources/k6/v1.6.x/extensions/create/secret-source_extensions.md
@@ -196,13 +196,13 @@ export default async () => {
 1. Now, run the test.
 
 ```bash
-./k6 run test.js --secret-source=cli=cool=some,else=console --quiet --no-summary
+./k6 run test.js --secret-source=cli=cool=some,else=console --quiet --summary-mode=disabled
 ```
 
 {{< admonition type="note" >}}
 
 The `--secret-source=cli=cool=some,else=console` argument tells k6 to use your custom secret source and gives its configuration.
-The flag `--quiet --no-summary` configures k6 to show only custom output.
+The flag `--quiet --summary-mode=disabled` configures k6 to show only custom output.
 
 {{< /admonition >}}
 

--- a/docs/sources/k6/v1.6.x/results-output/end-of-test/_index.md
+++ b/docs/sources/k6/v1.6.x/results-output/end-of-test/_index.md
@@ -10,11 +10,12 @@ When a test finishes, k6 prints a summary of the aggregated results to `stdout`.
 
 ## Summary modes
 
-k6 provides three different ways to display test results through the [`--summary-mode` option](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-mode):
+k6 provides four different ways to display test results through the [`--summary-mode` option](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-mode):
 
 - **compact** (default): Displays the most relevant test results in a concise format.
 - **full**: Includes everything from the compact format, plus additional k6 metrics and detailed results for each group and scenario.
-- **legacy**: Uses the pre-v1.0.0 summary format for backward compatibility.
+- **disabled**: Disables the end-of-test summary.
+- **legacy** (*deprecated*): Uses the pre-v1.0.0 summary format for backward compatibility. This mode will be removed in k6 v2.0.0.
 
 ### Compact mode (default)
 
@@ -216,8 +217,8 @@ When using full mode, you'll see additional sections:
 
 Customize the summary output with these options:
 
-- [`--summary-mode`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-mode): Choose between compact, full, or legacy display
-- [`--no-summary`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#no-summary): Disable the end-of-test report
+- [`--summary-mode`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-mode): Choose between compact, full, disabled, or legacy display. The `legacy` mode is deprecated and will be removed in k6 v2.0.0.
+- [`--no-summary`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#no-summary): Disable the end-of-test report. This option is deprecated since k6 v1.3.0; use `--summary-mode=disabled` instead.
 - [`--summary-trend-stats`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-trend-stats): Select which statistics to show for Trend metrics
 - [`--summary-time-unit`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-time-unit): Set a consistent time unit for all values
 

--- a/docs/sources/k6/v1.6.x/testing-guides/injecting-faults-with-xk6-disruptor/examples/inject-http-faults-into-pod.md
+++ b/docs/sources/k6/v1.6.x/testing-guides/injecting-faults-with-xk6-disruptor/examples/inject-http-faults-into-pod.md
@@ -140,11 +140,11 @@ We will first execute the test without introducing faults to have an baseline us
 {{< code >}}
 
 ```bash
-xk6-disruptor run --env SKIP_FAULTS=1 --env SVC_IP=$SVC_IP --summary-mode=legacy disrupt-pod.js
+xk6-disruptor run --env SKIP_FAULTS=1 --env SVC_IP=$SVC_IP --summary-mode=compact disrupt-pod.js
 ```
 
 ```windows-powershell
-xk6-disruptor run --env SKIP_FAULTS=1 --env "SVC_IP=$Env:SVC_IP" --summary-mode=legacy disrupt-pod.js
+xk6-disruptor run --env SKIP_FAULTS=1 --env "SVC_IP=$Env:SVC_IP" --summary-mode=compact disrupt-pod.js
 ```
 
 {{< /code >}}
@@ -199,11 +199,11 @@ We repeat the execution injecting the faults. Notice we have removed the `--env 
 {{< code >}}
 
 ```bash
-xk6-disruptor run --env SVC_IP=$SVC_IP --summary-mode=legacy disrupt-pod.js
+xk6-disruptor run --env SVC_IP=$SVC_IP --summary-mode=compact disrupt-pod.js
 ```
 
 ```windows-powershell
-xk6-disruptor run --env "SVC_IP=$Env:SVC_IP" --summary-mode=legacy disrupt-pod.js
+xk6-disruptor run --env "SVC_IP=$Env:SVC_IP" --summary-mode=compact disrupt-pod.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v1.6.x/testing-guides/injecting-faults-with-xk6-disruptor/examples/inject-http-faults-into-pod.md
+++ b/docs/sources/k6/v1.6.x/testing-guides/injecting-faults-with-xk6-disruptor/examples/inject-http-faults-into-pod.md
@@ -140,11 +140,11 @@ We will first execute the test without introducing faults to have an baseline us
 {{< code >}}
 
 ```bash
-xk6-disruptor run --env SKIP_FAULTS=1 --env SVC_IP=$SVC_IP --summary-mode=compact disrupt-pod.js
+xk6-disruptor run --env SKIP_FAULTS=1 --env SVC_IP=$SVC_IP disrupt-pod.js
 ```
 
 ```windows-powershell
-xk6-disruptor run --env SKIP_FAULTS=1 --env "SVC_IP=$Env:SVC_IP" --summary-mode=compact disrupt-pod.js
+xk6-disruptor run --env SKIP_FAULTS=1 --env "SVC_IP=$Env:SVC_IP" disrupt-pod.js
 ```
 
 {{< /code >}}
@@ -199,11 +199,11 @@ We repeat the execution injecting the faults. Notice we have removed the `--env 
 {{< code >}}
 
 ```bash
-xk6-disruptor run --env SVC_IP=$SVC_IP --summary-mode=compact disrupt-pod.js
+xk6-disruptor run --env SVC_IP=$SVC_IP disrupt-pod.js
 ```
 
 ```windows-powershell
-xk6-disruptor run --env "SVC_IP=$Env:SVC_IP" --summary-mode=compact disrupt-pod.js
+xk6-disruptor run --env "SVC_IP=$Env:SVC_IP" disrupt-pod.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v1.6.x/testing-guides/running-large-tests.md
+++ b/docs/sources/k6/v1.6.x/testing-guides/running-large-tests.md
@@ -174,7 +174,7 @@ export const options = {
 
 If you need the response body for some requests, override the option with [Params.responseType](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-http/params).
 
-### When streaming, use `--no-thresholds` and `--no-summary`
+### When streaming, use `--no-thresholds` and `--summary-mode=disabled`
 
 If you're running a local test and streaming results to the cloud (`k6 cloud run script.js --local-execution`), you might want to disable the terminal summary and local threshold calculation, because the cloud service will display the summary and calculate the thresholds.
 
@@ -189,7 +189,7 @@ k6 cloud run scripts/website.js \
   --vus=20000 \
   --duration=10m \
   --no-thresholds \
-  --no-summary
+  --summary-mode=disabled
 ```
 
 ## Script optimizations

--- a/docs/sources/k6/v1.6.x/using-k6/assertions.md
+++ b/docs/sources/k6/v1.6.x/using-k6/assertions.md
@@ -366,7 +366,7 @@ export default async function () {
 For tests that primarily use assertions to validate system state, such as tests verifying a successful deployment in CI pipelines, run k6 tests with assertions in quiet mode:
 
 ```bash
-k6 run --quiet --no-summary script.ts
+k6 run --quiet --summary-mode=disabled script.ts
 ```
 
 This approach eliminates unnecessary output and focuses on the assertion results, making it ideal for automated testing environments.

--- a/docs/sources/k6/v1.7.x/extensions/create/output-extensions.md
+++ b/docs/sources/k6/v1.7.x/extensions/create/output-extensions.md
@@ -204,13 +204,13 @@ export default function () {
 1. Now, run the test.
 
 ```bash
-./k6 run test.js --out logger --quiet --no-summary --iterations 2
+./k6 run test.js --out logger --quiet --summary-mode=disabled --iterations 2
 ```
 
 {{< admonition type="note" >}}
 
 The `--out logger` argument tells k6 to use your custom output. The flag
-`--quiet --no-summary` configures k6 to show only custom output.
+`--quiet --summary-mode=disabled` configures k6 to show only custom output.
 
 {{< /admonition >}}
 

--- a/docs/sources/k6/v1.7.x/extensions/create/secret-source_extensions.md
+++ b/docs/sources/k6/v1.7.x/extensions/create/secret-source_extensions.md
@@ -196,13 +196,13 @@ export default async () => {
 1. Now, run the test.
 
 ```bash
-./k6 run test.js --secret-source=cli=cool=some,else=console --quiet --no-summary
+./k6 run test.js --secret-source=cli=cool=some,else=console --quiet --summary-mode=disabled
 ```
 
 {{< admonition type="note" >}}
 
 The `--secret-source=cli=cool=some,else=console` argument tells k6 to use your custom secret source and gives its configuration.
-The flag `--quiet --no-summary` configures k6 to show only custom output.
+The flag `--quiet --summary-mode=disabled` configures k6 to show only custom output.
 
 {{< /admonition >}}
 

--- a/docs/sources/k6/v1.7.x/results-output/end-of-test/_index.md
+++ b/docs/sources/k6/v1.7.x/results-output/end-of-test/_index.md
@@ -10,11 +10,12 @@ When a test finishes, k6 prints a summary of the aggregated results to `stdout`.
 
 ## Summary modes
 
-k6 provides three different ways to display test results through the [`--summary-mode` option](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-mode):
+k6 provides four different ways to display test results through the [`--summary-mode` option](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-mode):
 
 - **compact** (default): Displays the most relevant test results in a concise format.
 - **full**: Includes everything from the compact format, plus additional k6 metrics and detailed results for each group and scenario.
-- **legacy**: Uses the pre-v1.0.0 summary format for backward compatibility.
+- **disabled**: Disables the end-of-test summary.
+- **legacy** (*deprecated*): Uses the pre-v1.0.0 summary format for backward compatibility. This mode will be removed in k6 v2.0.0.
 
 ### Compact mode (default)
 
@@ -216,8 +217,8 @@ When using full mode, you'll see additional sections:
 
 Customize the summary output with these options:
 
-- [`--summary-mode`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-mode): Choose between compact, full, or legacy display
-- [`--no-summary`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#no-summary): Disable the end-of-test report
+- [`--summary-mode`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-mode): Choose between compact, full, disabled, or legacy display. The `legacy` mode is deprecated and will be removed in k6 v2.0.0.
+- [`--no-summary`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#no-summary): Disable the end-of-test report. This option is deprecated since k6 v1.3.0; use `--summary-mode=disabled` instead.
 - [`--summary-trend-stats`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-trend-stats): Select which statistics to show for Trend metrics
 - [`--summary-time-unit`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-time-unit): Set a consistent time unit for all values
 

--- a/docs/sources/k6/v1.7.x/testing-guides/injecting-faults-with-xk6-disruptor/examples/inject-http-faults-into-pod.md
+++ b/docs/sources/k6/v1.7.x/testing-guides/injecting-faults-with-xk6-disruptor/examples/inject-http-faults-into-pod.md
@@ -140,11 +140,11 @@ We will first execute the test without introducing faults to have an baseline us
 {{< code >}}
 
 ```bash
-xk6-disruptor run --env SKIP_FAULTS=1 --env SVC_IP=$SVC_IP --summary-mode=legacy disrupt-pod.js
+xk6-disruptor run --env SKIP_FAULTS=1 --env SVC_IP=$SVC_IP --summary-mode=compact disrupt-pod.js
 ```
 
 ```windows-powershell
-xk6-disruptor run --env SKIP_FAULTS=1 --env "SVC_IP=$Env:SVC_IP" --summary-mode=legacy disrupt-pod.js
+xk6-disruptor run --env SKIP_FAULTS=1 --env "SVC_IP=$Env:SVC_IP" --summary-mode=compact disrupt-pod.js
 ```
 
 {{< /code >}}
@@ -199,11 +199,11 @@ We repeat the execution injecting the faults. Notice we have removed the `--env 
 {{< code >}}
 
 ```bash
-xk6-disruptor run --env SVC_IP=$SVC_IP --summary-mode=legacy disrupt-pod.js
+xk6-disruptor run --env SVC_IP=$SVC_IP --summary-mode=compact disrupt-pod.js
 ```
 
 ```windows-powershell
-xk6-disruptor run --env "SVC_IP=$Env:SVC_IP" --summary-mode=legacy disrupt-pod.js
+xk6-disruptor run --env "SVC_IP=$Env:SVC_IP" --summary-mode=compact disrupt-pod.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v1.7.x/testing-guides/injecting-faults-with-xk6-disruptor/examples/inject-http-faults-into-pod.md
+++ b/docs/sources/k6/v1.7.x/testing-guides/injecting-faults-with-xk6-disruptor/examples/inject-http-faults-into-pod.md
@@ -140,11 +140,11 @@ We will first execute the test without introducing faults to have an baseline us
 {{< code >}}
 
 ```bash
-xk6-disruptor run --env SKIP_FAULTS=1 --env SVC_IP=$SVC_IP --summary-mode=compact disrupt-pod.js
+xk6-disruptor run --env SKIP_FAULTS=1 --env SVC_IP=$SVC_IP disrupt-pod.js
 ```
 
 ```windows-powershell
-xk6-disruptor run --env SKIP_FAULTS=1 --env "SVC_IP=$Env:SVC_IP" --summary-mode=compact disrupt-pod.js
+xk6-disruptor run --env SKIP_FAULTS=1 --env "SVC_IP=$Env:SVC_IP" disrupt-pod.js
 ```
 
 {{< /code >}}
@@ -199,11 +199,11 @@ We repeat the execution injecting the faults. Notice we have removed the `--env 
 {{< code >}}
 
 ```bash
-xk6-disruptor run --env SVC_IP=$SVC_IP --summary-mode=compact disrupt-pod.js
+xk6-disruptor run --env SVC_IP=$SVC_IP disrupt-pod.js
 ```
 
 ```windows-powershell
-xk6-disruptor run --env "SVC_IP=$Env:SVC_IP" --summary-mode=compact disrupt-pod.js
+xk6-disruptor run --env "SVC_IP=$Env:SVC_IP" disrupt-pod.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v1.7.x/testing-guides/running-large-tests.md
+++ b/docs/sources/k6/v1.7.x/testing-guides/running-large-tests.md
@@ -174,7 +174,7 @@ export const options = {
 
 If you need the response body for some requests, override the option with [Params.responseType](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-http/params).
 
-### When streaming, use `--no-thresholds` and `--no-summary`
+### When streaming, use `--no-thresholds` and `--summary-mode=disabled`
 
 If you're running a local test and streaming results to the cloud (`k6 cloud run script.js --local-execution`), you might want to disable the terminal summary and local threshold calculation, because the cloud service will display the summary and calculate the thresholds.
 
@@ -189,7 +189,7 @@ k6 cloud run scripts/website.js \
   --vus=20000 \
   --duration=10m \
   --no-thresholds \
-  --no-summary
+  --summary-mode=disabled
 ```
 
 ## Script optimizations

--- a/docs/sources/k6/v1.7.x/using-k6/assertions.md
+++ b/docs/sources/k6/v1.7.x/using-k6/assertions.md
@@ -366,7 +366,7 @@ export default async function () {
 For tests that primarily use assertions to validate system state, such as tests verifying a successful deployment in CI pipelines, run k6 tests with assertions in quiet mode:
 
 ```bash
-k6 run --quiet --no-summary script.ts
+k6 run --quiet --summary-mode=disabled script.ts
 ```
 
 This approach eliminates unnecessary output and focuses on the assertion results, making it ideal for automated testing environments.

--- a/docs/sources/k6/v1.8.x/extensions/create/output-extensions.md
+++ b/docs/sources/k6/v1.8.x/extensions/create/output-extensions.md
@@ -204,13 +204,13 @@ export default function () {
 1. Now, run the test.
 
 ```bash
-./k6 run test.js --out logger --quiet --no-summary --iterations 2
+./k6 run test.js --out logger --quiet --summary-mode=disabled --iterations 2
 ```
 
 {{< admonition type="note" >}}
 
 The `--out logger` argument tells k6 to use your custom output. The flag
-`--quiet --no-summary` configures k6 to show only custom output.
+`--quiet --summary-mode=disabled` configures k6 to show only custom output.
 
 {{< /admonition >}}
 

--- a/docs/sources/k6/v1.8.x/extensions/create/secret-source_extensions.md
+++ b/docs/sources/k6/v1.8.x/extensions/create/secret-source_extensions.md
@@ -196,13 +196,13 @@ export default async () => {
 1. Now, run the test.
 
 ```bash
-./k6 run test.js --secret-source=cli=cool=some,else=console --quiet --no-summary
+./k6 run test.js --secret-source=cli=cool=some,else=console --quiet --summary-mode=disabled
 ```
 
 {{< admonition type="note" >}}
 
 The `--secret-source=cli=cool=some,else=console` argument tells k6 to use your custom secret source and gives its configuration.
-The flag `--quiet --no-summary` configures k6 to show only custom output.
+The flag `--quiet --summary-mode=disabled` configures k6 to show only custom output.
 
 {{< /admonition >}}
 

--- a/docs/sources/k6/v1.8.x/results-output/end-of-test/_index.md
+++ b/docs/sources/k6/v1.8.x/results-output/end-of-test/_index.md
@@ -10,11 +10,12 @@ When a test finishes, k6 prints a summary of the aggregated results to `stdout`.
 
 ## Summary modes
 
-k6 provides three different ways to display test results through the [`--summary-mode` option](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-mode):
+k6 provides four different ways to display test results through the [`--summary-mode` option](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-mode):
 
 - **compact** (default): Displays the most relevant test results in a concise format.
 - **full**: Includes everything from the compact format, plus additional k6 metrics and detailed results for each group and scenario.
-- **legacy**: Uses the pre-v1.0.0 summary format for backward compatibility.
+- **disabled**: Disables the end-of-test summary.
+- **legacy** (*deprecated*): Uses the pre-v1.0.0 summary format for backward compatibility. This mode will be removed in k6 v2.0.0.
 
 ### Compact mode (default)
 
@@ -216,8 +217,8 @@ When using full mode, you'll see additional sections:
 
 Customize the summary output with these options:
 
-- [`--summary-mode`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-mode): Choose between compact, full, or legacy display
-- [`--no-summary`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#no-summary): Disable the end-of-test report
+- [`--summary-mode`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-mode): Choose between compact, full, disabled, or legacy display. The `legacy` mode is deprecated and will be removed in k6 v2.0.0.
+- [`--no-summary`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#no-summary): Disable the end-of-test report. This option is deprecated since k6 v1.3.0; use `--summary-mode=disabled` instead.
 - [`--summary-trend-stats`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-trend-stats): Select which statistics to show for Trend metrics
 - [`--summary-time-unit`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-time-unit): Set a consistent time unit for all values
 

--- a/docs/sources/k6/v1.8.x/testing-guides/injecting-faults-with-xk6-disruptor/examples/inject-http-faults-into-pod.md
+++ b/docs/sources/k6/v1.8.x/testing-guides/injecting-faults-with-xk6-disruptor/examples/inject-http-faults-into-pod.md
@@ -140,11 +140,11 @@ We will first execute the test without introducing faults to have an baseline us
 {{< code >}}
 
 ```bash
-xk6-disruptor run --env SKIP_FAULTS=1 --env SVC_IP=$SVC_IP --summary-mode=legacy disrupt-pod.js
+xk6-disruptor run --env SKIP_FAULTS=1 --env SVC_IP=$SVC_IP --summary-mode=compact disrupt-pod.js
 ```
 
 ```windows-powershell
-xk6-disruptor run --env SKIP_FAULTS=1 --env "SVC_IP=$Env:SVC_IP" --summary-mode=legacy disrupt-pod.js
+xk6-disruptor run --env SKIP_FAULTS=1 --env "SVC_IP=$Env:SVC_IP" --summary-mode=compact disrupt-pod.js
 ```
 
 {{< /code >}}
@@ -199,11 +199,11 @@ We repeat the execution injecting the faults. Notice we have removed the `--env 
 {{< code >}}
 
 ```bash
-xk6-disruptor run --env SVC_IP=$SVC_IP --summary-mode=legacy disrupt-pod.js
+xk6-disruptor run --env SVC_IP=$SVC_IP --summary-mode=compact disrupt-pod.js
 ```
 
 ```windows-powershell
-xk6-disruptor run --env "SVC_IP=$Env:SVC_IP" --summary-mode=legacy disrupt-pod.js
+xk6-disruptor run --env "SVC_IP=$Env:SVC_IP" --summary-mode=compact disrupt-pod.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v1.8.x/testing-guides/injecting-faults-with-xk6-disruptor/examples/inject-http-faults-into-pod.md
+++ b/docs/sources/k6/v1.8.x/testing-guides/injecting-faults-with-xk6-disruptor/examples/inject-http-faults-into-pod.md
@@ -140,11 +140,11 @@ We will first execute the test without introducing faults to have an baseline us
 {{< code >}}
 
 ```bash
-xk6-disruptor run --env SKIP_FAULTS=1 --env SVC_IP=$SVC_IP --summary-mode=compact disrupt-pod.js
+xk6-disruptor run --env SKIP_FAULTS=1 --env SVC_IP=$SVC_IP disrupt-pod.js
 ```
 
 ```windows-powershell
-xk6-disruptor run --env SKIP_FAULTS=1 --env "SVC_IP=$Env:SVC_IP" --summary-mode=compact disrupt-pod.js
+xk6-disruptor run --env SKIP_FAULTS=1 --env "SVC_IP=$Env:SVC_IP" disrupt-pod.js
 ```
 
 {{< /code >}}
@@ -199,11 +199,11 @@ We repeat the execution injecting the faults. Notice we have removed the `--env 
 {{< code >}}
 
 ```bash
-xk6-disruptor run --env SVC_IP=$SVC_IP --summary-mode=compact disrupt-pod.js
+xk6-disruptor run --env SVC_IP=$SVC_IP disrupt-pod.js
 ```
 
 ```windows-powershell
-xk6-disruptor run --env "SVC_IP=$Env:SVC_IP" --summary-mode=compact disrupt-pod.js
+xk6-disruptor run --env "SVC_IP=$Env:SVC_IP" disrupt-pod.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v1.8.x/testing-guides/running-large-tests.md
+++ b/docs/sources/k6/v1.8.x/testing-guides/running-large-tests.md
@@ -174,7 +174,7 @@ export const options = {
 
 If you need the response body for some requests, override the option with [Params.responseType](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-http/params).
 
-### When streaming, use `--no-thresholds` and `--no-summary`
+### When streaming, use `--no-thresholds` and `--summary-mode=disabled`
 
 If you're running a local test and streaming results to the cloud (`k6 cloud run script.js --local-execution`), you might want to disable the terminal summary and local threshold calculation, because the cloud service will display the summary and calculate the thresholds.
 
@@ -189,7 +189,7 @@ k6 cloud run scripts/website.js \
   --vus=20000 \
   --duration=10m \
   --no-thresholds \
-  --no-summary
+  --summary-mode=disabled
 ```
 
 ## Script optimizations

--- a/docs/sources/k6/v1.8.x/using-k6/assertions.md
+++ b/docs/sources/k6/v1.8.x/using-k6/assertions.md
@@ -366,7 +366,7 @@ export default async function () {
 For tests that primarily use assertions to validate system state, such as tests verifying a successful deployment in CI pipelines, run k6 tests with assertions in quiet mode:
 
 ```bash
-k6 run --quiet --no-summary script.ts
+k6 run --quiet --summary-mode=disabled script.ts
 ```
 
 This approach eliminates unnecessary output and focuses on the assertion results, making it ideal for automated testing environments.

--- a/docs/sources/k6/v2.0.x/extensions/create/output-extensions.md
+++ b/docs/sources/k6/v2.0.x/extensions/create/output-extensions.md
@@ -204,13 +204,13 @@ export default function () {
 1. Now, run the test.
 
 ```bash
-./k6 run test.js --out logger --quiet --no-summary --iterations 2
+./k6 run test.js --out logger --quiet --summary-mode=disabled --iterations 2
 ```
 
 {{< admonition type="note" >}}
 
 The `--out logger` argument tells k6 to use your custom output. The flag
-`--quiet --no-summary` configures k6 to show only custom output.
+`--quiet --summary-mode=disabled` configures k6 to show only custom output.
 
 {{< /admonition >}}
 

--- a/docs/sources/k6/v2.0.x/extensions/create/secret-source_extensions.md
+++ b/docs/sources/k6/v2.0.x/extensions/create/secret-source_extensions.md
@@ -196,13 +196,13 @@ export default async () => {
 1. Now, run the test.
 
 ```bash
-./k6 run test.js --secret-source=cli=cool=some,else=console --quiet --no-summary
+./k6 run test.js --secret-source=cli=cool=some,else=console --quiet --summary-mode=disabled
 ```
 
 {{< admonition type="note" >}}
 
 The `--secret-source=cli=cool=some,else=console` argument tells k6 to use your custom secret source and gives its configuration.
-The flag `--quiet --no-summary` configures k6 to show only custom output.
+The flag `--quiet --summary-mode=disabled` configures k6 to show only custom output.
 
 {{< /admonition >}}
 

--- a/docs/sources/k6/v2.0.x/results-output/end-of-test/_index.md
+++ b/docs/sources/k6/v2.0.x/results-output/end-of-test/_index.md
@@ -14,7 +14,7 @@ k6 provides three different ways to display test results through the [`--summary
 
 - **compact** (default): Displays the most relevant test results in a concise format.
 - **full**: Includes everything from the compact format, plus additional k6 metrics and detailed results for each group and scenario.
-- **legacy**: Uses the pre-v1.0.0 summary format for backward compatibility.
+- **disabled**: Disables the end-of-test summary.
 
 ### Compact mode (default)
 
@@ -216,10 +216,11 @@ When using full mode, you'll see additional sections:
 
 Customize the summary output with these options:
 
-- [`--summary-mode`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-mode): Choose between compact, full, or legacy display
-- [`--no-summary`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#no-summary): Disable the end-of-test report
+- [`--summary-mode`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-mode): Choose between compact, full, or disabled display
 - [`--summary-trend-stats`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-trend-stats): Select which statistics to show for Trend metrics
 - [`--summary-time-unit`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-time-unit): Set a consistent time unit for all values
+
+The `--no-summary` flag and the `legacy` summary mode were removed in k6 v2.0.0. Use `--summary-mode=disabled` to disable the summary. There is no direct equivalent for the `legacy` mode; use `compact` or `full` instead.
 
 ## Going further
 

--- a/docs/sources/k6/v2.0.x/testing-guides/injecting-faults-with-xk6-disruptor/examples/inject-http-faults-into-pod.md
+++ b/docs/sources/k6/v2.0.x/testing-guides/injecting-faults-with-xk6-disruptor/examples/inject-http-faults-into-pod.md
@@ -140,11 +140,11 @@ We will first execute the test without introducing faults to have an baseline us
 {{< code >}}
 
 ```bash
-xk6-disruptor run --env SKIP_FAULTS=1 --env SVC_IP=$SVC_IP --summary-mode=legacy disrupt-pod.js
+xk6-disruptor run --env SKIP_FAULTS=1 --env SVC_IP=$SVC_IP --summary-mode=compact disrupt-pod.js
 ```
 
 ```windows-powershell
-xk6-disruptor run --env SKIP_FAULTS=1 --env "SVC_IP=$Env:SVC_IP" --summary-mode=legacy disrupt-pod.js
+xk6-disruptor run --env SKIP_FAULTS=1 --env "SVC_IP=$Env:SVC_IP" --summary-mode=compact disrupt-pod.js
 ```
 
 {{< /code >}}
@@ -199,11 +199,11 @@ We repeat the execution injecting the faults. Notice we have removed the `--env 
 {{< code >}}
 
 ```bash
-xk6-disruptor run --env SVC_IP=$SVC_IP --summary-mode=legacy disrupt-pod.js
+xk6-disruptor run --env SVC_IP=$SVC_IP --summary-mode=compact disrupt-pod.js
 ```
 
 ```windows-powershell
-xk6-disruptor run --env "SVC_IP=$Env:SVC_IP" --summary-mode=legacy disrupt-pod.js
+xk6-disruptor run --env "SVC_IP=$Env:SVC_IP" --summary-mode=compact disrupt-pod.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v2.0.x/testing-guides/injecting-faults-with-xk6-disruptor/examples/inject-http-faults-into-pod.md
+++ b/docs/sources/k6/v2.0.x/testing-guides/injecting-faults-with-xk6-disruptor/examples/inject-http-faults-into-pod.md
@@ -140,11 +140,11 @@ We will first execute the test without introducing faults to have an baseline us
 {{< code >}}
 
 ```bash
-xk6-disruptor run --env SKIP_FAULTS=1 --env SVC_IP=$SVC_IP --summary-mode=compact disrupt-pod.js
+xk6-disruptor run --env SKIP_FAULTS=1 --env SVC_IP=$SVC_IP disrupt-pod.js
 ```
 
 ```windows-powershell
-xk6-disruptor run --env SKIP_FAULTS=1 --env "SVC_IP=$Env:SVC_IP" --summary-mode=compact disrupt-pod.js
+xk6-disruptor run --env SKIP_FAULTS=1 --env "SVC_IP=$Env:SVC_IP" disrupt-pod.js
 ```
 
 {{< /code >}}
@@ -199,11 +199,11 @@ We repeat the execution injecting the faults. Notice we have removed the `--env 
 {{< code >}}
 
 ```bash
-xk6-disruptor run --env SVC_IP=$SVC_IP --summary-mode=compact disrupt-pod.js
+xk6-disruptor run --env SVC_IP=$SVC_IP disrupt-pod.js
 ```
 
 ```windows-powershell
-xk6-disruptor run --env "SVC_IP=$Env:SVC_IP" --summary-mode=compact disrupt-pod.js
+xk6-disruptor run --env "SVC_IP=$Env:SVC_IP" disrupt-pod.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v2.0.x/testing-guides/running-large-tests.md
+++ b/docs/sources/k6/v2.0.x/testing-guides/running-large-tests.md
@@ -174,7 +174,7 @@ export const options = {
 
 If you need the response body for some requests, override the option with [Params.responseType](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-http/params).
 
-### When streaming, use `--no-thresholds` and `--no-summary`
+### When streaming, use `--no-thresholds` and `--summary-mode=disabled`
 
 If you're running a local test and streaming results to the cloud (`k6 cloud run script.js --local-execution`), you might want to disable the terminal summary and local threshold calculation, because the cloud service will display the summary and calculate the thresholds.
 
@@ -189,7 +189,7 @@ k6 cloud run scripts/website.js \
   --vus=20000 \
   --duration=10m \
   --no-thresholds \
-  --no-summary
+  --summary-mode=disabled
 ```
 
 ## Script optimizations

--- a/docs/sources/k6/v2.0.x/using-k6/assertions.md
+++ b/docs/sources/k6/v2.0.x/using-k6/assertions.md
@@ -366,7 +366,7 @@ export default async function () {
 For tests that primarily use assertions to validate system state, such as tests verifying a successful deployment in CI pipelines, run k6 tests with assertions in quiet mode:
 
 ```bash
-k6 run --quiet --no-summary script.ts
+k6 run --quiet --summary-mode=disabled script.ts
 ```
 
 This approach eliminates unnecessary output and focuses on the assertion results, making it ideal for automated testing environments.

--- a/docs/sources/k6/v2.1.x/extensions/create/output-extensions.md
+++ b/docs/sources/k6/v2.1.x/extensions/create/output-extensions.md
@@ -204,13 +204,13 @@ export default function () {
 1. Now, run the test.
 
 ```bash
-./k6 run test.js --out logger --quiet --no-summary --iterations 2
+./k6 run test.js --out logger --quiet --summary-mode=disabled --iterations 2
 ```
 
 {{< admonition type="note" >}}
 
 The `--out logger` argument tells k6 to use your custom output. The flag
-`--quiet --no-summary` configures k6 to show only custom output.
+`--quiet --summary-mode=disabled` configures k6 to show only custom output.
 
 {{< /admonition >}}
 

--- a/docs/sources/k6/v2.1.x/extensions/create/secret-source_extensions.md
+++ b/docs/sources/k6/v2.1.x/extensions/create/secret-source_extensions.md
@@ -196,13 +196,13 @@ export default async () => {
 1. Now, run the test.
 
 ```bash
-./k6 run test.js --secret-source=cli=cool=some,else=console --quiet --no-summary
+./k6 run test.js --secret-source=cli=cool=some,else=console --quiet --summary-mode=disabled
 ```
 
 {{< admonition type="note" >}}
 
 The `--secret-source=cli=cool=some,else=console` argument tells k6 to use your custom secret source and gives its configuration.
-The flag `--quiet --no-summary` configures k6 to show only custom output.
+The flag `--quiet --summary-mode=disabled` configures k6 to show only custom output.
 
 {{< /admonition >}}
 

--- a/docs/sources/k6/v2.1.x/results-output/end-of-test/_index.md
+++ b/docs/sources/k6/v2.1.x/results-output/end-of-test/_index.md
@@ -14,7 +14,7 @@ k6 provides three different ways to display test results through the [`--summary
 
 - **compact** (default): Displays the most relevant test results in a concise format.
 - **full**: Includes everything from the compact format, plus additional k6 metrics and detailed results for each group and scenario.
-- **legacy**: Uses the pre-v1.0.0 summary format for backward compatibility.
+- **disabled**: Disables the end-of-test summary.
 
 ### Compact mode (default)
 
@@ -216,10 +216,11 @@ When using full mode, you'll see additional sections:
 
 Customize the summary output with these options:
 
-- [`--summary-mode`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-mode): Choose between compact, full, or legacy display
-- [`--no-summary`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#no-summary): Disable the end-of-test report
+- [`--summary-mode`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-mode): Choose between compact, full, or disabled display
 - [`--summary-trend-stats`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-trend-stats): Select which statistics to show for Trend metrics
 - [`--summary-time-unit`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-time-unit): Set a consistent time unit for all values
+
+The `--no-summary` flag and the `legacy` summary mode were removed in k6 v2.0.0. Use `--summary-mode=disabled` to disable the summary. There is no direct equivalent for the `legacy` mode; use `compact` or `full` instead.
 
 ## Going further
 

--- a/docs/sources/k6/v2.1.x/testing-guides/injecting-faults-with-xk6-disruptor/examples/inject-http-faults-into-pod.md
+++ b/docs/sources/k6/v2.1.x/testing-guides/injecting-faults-with-xk6-disruptor/examples/inject-http-faults-into-pod.md
@@ -140,11 +140,11 @@ We will first execute the test without introducing faults to have an baseline us
 {{< code >}}
 
 ```bash
-xk6-disruptor run --env SKIP_FAULTS=1 --env SVC_IP=$SVC_IP --summary-mode=legacy disrupt-pod.js
+xk6-disruptor run --env SKIP_FAULTS=1 --env SVC_IP=$SVC_IP --summary-mode=compact disrupt-pod.js
 ```
 
 ```windows-powershell
-xk6-disruptor run --env SKIP_FAULTS=1 --env "SVC_IP=$Env:SVC_IP" --summary-mode=legacy disrupt-pod.js
+xk6-disruptor run --env SKIP_FAULTS=1 --env "SVC_IP=$Env:SVC_IP" --summary-mode=compact disrupt-pod.js
 ```
 
 {{< /code >}}
@@ -199,11 +199,11 @@ We repeat the execution injecting the faults. Notice we have removed the `--env 
 {{< code >}}
 
 ```bash
-xk6-disruptor run --env SVC_IP=$SVC_IP --summary-mode=legacy disrupt-pod.js
+xk6-disruptor run --env SVC_IP=$SVC_IP --summary-mode=compact disrupt-pod.js
 ```
 
 ```windows-powershell
-xk6-disruptor run --env "SVC_IP=$Env:SVC_IP" --summary-mode=legacy disrupt-pod.js
+xk6-disruptor run --env "SVC_IP=$Env:SVC_IP" --summary-mode=compact disrupt-pod.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v2.1.x/testing-guides/injecting-faults-with-xk6-disruptor/examples/inject-http-faults-into-pod.md
+++ b/docs/sources/k6/v2.1.x/testing-guides/injecting-faults-with-xk6-disruptor/examples/inject-http-faults-into-pod.md
@@ -140,11 +140,11 @@ We will first execute the test without introducing faults to have an baseline us
 {{< code >}}
 
 ```bash
-xk6-disruptor run --env SKIP_FAULTS=1 --env SVC_IP=$SVC_IP --summary-mode=compact disrupt-pod.js
+xk6-disruptor run --env SKIP_FAULTS=1 --env SVC_IP=$SVC_IP disrupt-pod.js
 ```
 
 ```windows-powershell
-xk6-disruptor run --env SKIP_FAULTS=1 --env "SVC_IP=$Env:SVC_IP" --summary-mode=compact disrupt-pod.js
+xk6-disruptor run --env SKIP_FAULTS=1 --env "SVC_IP=$Env:SVC_IP" disrupt-pod.js
 ```
 
 {{< /code >}}
@@ -199,11 +199,11 @@ We repeat the execution injecting the faults. Notice we have removed the `--env 
 {{< code >}}
 
 ```bash
-xk6-disruptor run --env SVC_IP=$SVC_IP --summary-mode=compact disrupt-pod.js
+xk6-disruptor run --env SVC_IP=$SVC_IP disrupt-pod.js
 ```
 
 ```windows-powershell
-xk6-disruptor run --env "SVC_IP=$Env:SVC_IP" --summary-mode=compact disrupt-pod.js
+xk6-disruptor run --env "SVC_IP=$Env:SVC_IP" disrupt-pod.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v2.1.x/testing-guides/running-large-tests.md
+++ b/docs/sources/k6/v2.1.x/testing-guides/running-large-tests.md
@@ -174,7 +174,7 @@ export const options = {
 
 If you need the response body for some requests, override the option with [Params.responseType](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-http/params).
 
-### When streaming, use `--no-thresholds` and `--no-summary`
+### When streaming, use `--no-thresholds` and `--summary-mode=disabled`
 
 If you're running a local test and streaming results to the cloud (`k6 cloud run script.js --local-execution`), you might want to disable the terminal summary and local threshold calculation, because the cloud service will display the summary and calculate the thresholds.
 
@@ -189,7 +189,7 @@ k6 cloud run scripts/website.js \
   --vus=20000 \
   --duration=10m \
   --no-thresholds \
-  --no-summary
+  --summary-mode=disabled
 ```
 
 ## Script optimizations

--- a/docs/sources/k6/v2.1.x/using-k6/assertions.md
+++ b/docs/sources/k6/v2.1.x/using-k6/assertions.md
@@ -366,7 +366,7 @@ export default async function () {
 For tests that primarily use assertions to validate system state, such as tests verifying a successful deployment in CI pipelines, run k6 tests with assertions in quiet mode:
 
 ```bash
-k6 run --quiet --no-summary script.ts
+k6 run --quiet --summary-mode=disabled script.ts
 ```
 
 This approach eliminates unnecessary output and focuses on the assertion results, making it ideal for automated testing environments.

--- a/docs/sources/k6/v2.2.x/extensions/create/output-extensions.md
+++ b/docs/sources/k6/v2.2.x/extensions/create/output-extensions.md
@@ -204,13 +204,13 @@ export default function () {
 1. Now, run the test.
 
 ```bash
-./k6 run test.js --out logger --quiet --no-summary --iterations 2
+./k6 run test.js --out logger --quiet --summary-mode=disabled --iterations 2
 ```
 
 {{< admonition type="note" >}}
 
 The `--out logger` argument tells k6 to use your custom output. The flag
-`--quiet --no-summary` configures k6 to show only custom output.
+`--quiet --summary-mode=disabled` configures k6 to show only custom output.
 
 {{< /admonition >}}
 

--- a/docs/sources/k6/v2.2.x/extensions/create/secret-source_extensions.md
+++ b/docs/sources/k6/v2.2.x/extensions/create/secret-source_extensions.md
@@ -196,13 +196,13 @@ export default async () => {
 1. Now, run the test.
 
 ```bash
-./k6 run test.js --secret-source=cli=cool=some,else=console --quiet --no-summary
+./k6 run test.js --secret-source=cli=cool=some,else=console --quiet --summary-mode=disabled
 ```
 
 {{< admonition type="note" >}}
 
 The `--secret-source=cli=cool=some,else=console` argument tells k6 to use your custom secret source and gives its configuration.
-The flag `--quiet --no-summary` configures k6 to show only custom output.
+The flag `--quiet --summary-mode=disabled` configures k6 to show only custom output.
 
 {{< /admonition >}}
 

--- a/docs/sources/k6/v2.2.x/results-output/end-of-test/_index.md
+++ b/docs/sources/k6/v2.2.x/results-output/end-of-test/_index.md
@@ -14,7 +14,7 @@ k6 provides three different ways to display test results through the [`--summary
 
 - **compact** (default): Displays the most relevant test results in a concise format.
 - **full**: Includes everything from the compact format, plus additional k6 metrics and detailed results for each group and scenario.
-- **legacy**: Uses the pre-v1.0.0 summary format for backward compatibility.
+- **disabled**: Disables the end-of-test summary.
 
 ### Compact mode (default)
 
@@ -216,10 +216,11 @@ When using full mode, you'll see additional sections:
 
 Customize the summary output with these options:
 
-- [`--summary-mode`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-mode): Choose between compact, full, or legacy display
-- [`--no-summary`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#no-summary): Disable the end-of-test report
+- [`--summary-mode`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-mode): Choose between compact, full, or disabled display
 - [`--summary-trend-stats`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-trend-stats): Select which statistics to show for Trend metrics
 - [`--summary-time-unit`](https://grafana.com/docs/k6/<K6_VERSION>/using-k6/k6-options/reference#summary-time-unit): Set a consistent time unit for all values
+
+The `--no-summary` flag and the `legacy` summary mode were removed in k6 v2.0.0. Use `--summary-mode=disabled` to disable the summary. There is no direct equivalent for the `legacy` mode; use `compact` or `full` instead.
 
 ## Going further
 

--- a/docs/sources/k6/v2.2.x/testing-guides/injecting-faults-with-xk6-disruptor/examples/inject-http-faults-into-pod.md
+++ b/docs/sources/k6/v2.2.x/testing-guides/injecting-faults-with-xk6-disruptor/examples/inject-http-faults-into-pod.md
@@ -140,11 +140,11 @@ We will first execute the test without introducing faults to have an baseline us
 {{< code >}}
 
 ```bash
-xk6-disruptor run --env SKIP_FAULTS=1 --env SVC_IP=$SVC_IP --summary-mode=legacy disrupt-pod.js
+xk6-disruptor run --env SKIP_FAULTS=1 --env SVC_IP=$SVC_IP --summary-mode=compact disrupt-pod.js
 ```
 
 ```windows-powershell
-xk6-disruptor run --env SKIP_FAULTS=1 --env "SVC_IP=$Env:SVC_IP" --summary-mode=legacy disrupt-pod.js
+xk6-disruptor run --env SKIP_FAULTS=1 --env "SVC_IP=$Env:SVC_IP" --summary-mode=compact disrupt-pod.js
 ```
 
 {{< /code >}}
@@ -199,11 +199,11 @@ We repeat the execution injecting the faults. Notice we have removed the `--env 
 {{< code >}}
 
 ```bash
-xk6-disruptor run --env SVC_IP=$SVC_IP --summary-mode=legacy disrupt-pod.js
+xk6-disruptor run --env SVC_IP=$SVC_IP --summary-mode=compact disrupt-pod.js
 ```
 
 ```windows-powershell
-xk6-disruptor run --env "SVC_IP=$Env:SVC_IP" --summary-mode=legacy disrupt-pod.js
+xk6-disruptor run --env "SVC_IP=$Env:SVC_IP" --summary-mode=compact disrupt-pod.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v2.2.x/testing-guides/injecting-faults-with-xk6-disruptor/examples/inject-http-faults-into-pod.md
+++ b/docs/sources/k6/v2.2.x/testing-guides/injecting-faults-with-xk6-disruptor/examples/inject-http-faults-into-pod.md
@@ -140,11 +140,11 @@ We will first execute the test without introducing faults to have an baseline us
 {{< code >}}
 
 ```bash
-xk6-disruptor run --env SKIP_FAULTS=1 --env SVC_IP=$SVC_IP --summary-mode=compact disrupt-pod.js
+xk6-disruptor run --env SKIP_FAULTS=1 --env SVC_IP=$SVC_IP disrupt-pod.js
 ```
 
 ```windows-powershell
-xk6-disruptor run --env SKIP_FAULTS=1 --env "SVC_IP=$Env:SVC_IP" --summary-mode=compact disrupt-pod.js
+xk6-disruptor run --env SKIP_FAULTS=1 --env "SVC_IP=$Env:SVC_IP" disrupt-pod.js
 ```
 
 {{< /code >}}
@@ -199,11 +199,11 @@ We repeat the execution injecting the faults. Notice we have removed the `--env 
 {{< code >}}
 
 ```bash
-xk6-disruptor run --env SVC_IP=$SVC_IP --summary-mode=compact disrupt-pod.js
+xk6-disruptor run --env SVC_IP=$SVC_IP disrupt-pod.js
 ```
 
 ```windows-powershell
-xk6-disruptor run --env "SVC_IP=$Env:SVC_IP" --summary-mode=compact disrupt-pod.js
+xk6-disruptor run --env "SVC_IP=$Env:SVC_IP" disrupt-pod.js
 ```
 
 {{< /code >}}

--- a/docs/sources/k6/v2.2.x/testing-guides/running-large-tests.md
+++ b/docs/sources/k6/v2.2.x/testing-guides/running-large-tests.md
@@ -174,7 +174,7 @@ export const options = {
 
 If you need the response body for some requests, override the option with [Params.responseType](https://grafana.com/docs/k6/<K6_VERSION>/javascript-api/k6-http/params).
 
-### When streaming, use `--no-thresholds` and `--no-summary`
+### When streaming, use `--no-thresholds` and `--summary-mode=disabled`
 
 If you're running a local test and streaming results to the cloud (`k6 cloud run script.js --local-execution`), you might want to disable the terminal summary and local threshold calculation, because the cloud service will display the summary and calculate the thresholds.
 
@@ -189,7 +189,7 @@ k6 cloud run scripts/website.js \
   --vus=20000 \
   --duration=10m \
   --no-thresholds \
-  --no-summary
+  --summary-mode=disabled
 ```
 
 ## Script optimizations

--- a/docs/sources/k6/v2.2.x/using-k6/assertions.md
+++ b/docs/sources/k6/v2.2.x/using-k6/assertions.md
@@ -366,7 +366,7 @@ export default async function () {
 For tests that primarily use assertions to validate system state, such as tests verifying a successful deployment in CI pipelines, run k6 tests with assertions in quiet mode:
 
 ```bash
-k6 run --quiet --no-summary script.ts
+k6 run --quiet --summary-mode=disabled script.ts
 ```
 
 This approach eliminates unnecessary output and focuses on the assertion results, making it ideal for automated testing environments.


### PR DESCRIPTION
## Summary

- Mark `--no-summary` and `--summary-mode=legacy` as deprecated in v1.x documentation.
- Document both as removed in v2.x and `next`.
- Update live examples to use `--summary-mode=disabled` or `--summary-mode=compact`.

## Validation

- `git diff --check`
- Focused checks confirmed no stale live examples remain in the affected versioned guides.